### PR TITLE
Fix Public Favorite spotlight rotation timer

### DIFF
--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -575,10 +575,7 @@ export default function PublicFavoriteOverlay({
     [activePlayers, votes],
   );
   const spotlightItems = useMemo(() => buildHouseguestSpotlightItems(activePlayers), [activePlayers]);
-  const spotlightPoolKey = useMemo(
-    () => activePlayers.map((candidate) => candidate.id).join('|'),
-    [activePlayers],
-  );
+  const hasSpotlightItems = spotlightItems.length > 0;
   const spotlight = selectSpotlightItem(spotlightItems, spotlightRotation);
   const finalTwoNames =
     activePlayers.length === 2
@@ -587,15 +584,15 @@ export default function PublicFavoriteOverlay({
 
   useEffect(() => {
     setSpotlightRotation(0);
-  }, [spotlightPoolKey]);
+  }, [candidateIds]);
 
   useEffect(() => {
-    if (displayStep !== 'voting' || spotlightItems.length === 0) return;
+    if (displayStep !== 'voting' || !hasSpotlightItems) return;
     const id = window.setInterval(() => {
       setSpotlightRotation((rotation) => rotation + 1);
     }, SPOTLIGHT_ROTATION_MS);
     return () => window.clearInterval(id);
-  }, [displayStep, spotlightPoolKey, spotlightItems.length]);
+  }, [displayStep, hasSpotlightItems]);
 
   useEffect(() => {
     const firstActiveId = activePlayers[0]?.id ?? null;

--- a/tests/unit/publicFavoriteOverlay.test.tsx
+++ b/tests/unit/publicFavoriteOverlay.test.tsx
@@ -276,6 +276,56 @@ describe('PublicFavoriteOverlay', () => {
     expect(within(spotlight).getByRole('heading', { name: 'Taylor' })).toBeInTheDocument();
   });
 
+  it('does not restart the spotlight timer when vote eliminations change the active pool', () => {
+    let votingState = {
+      votes: { p1: 10, p2: 70, p3: 20 },
+      eliminated: [] as string[],
+      winnerId: null,
+      isComplete: false,
+    };
+    mockedUseBattleBackVoting.mockImplementation(() => votingState);
+
+    const { rerender } = render(
+      <PublicFavoriteOverlay
+        candidates={PLAYERS}
+        seed={1}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    let spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    expect(within(spotlight).getByRole('heading', { name: 'Jordan' })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3500);
+    });
+
+    votingState = {
+      votes: { p1: 0, p2: 62, p3: 38 },
+      eliminated: ['p1'],
+      winnerId: null,
+      isComplete: false,
+    };
+
+    rerender(
+      <PublicFavoriteOverlay
+        candidates={PLAYERS}
+        seed={2}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    expect(within(spotlight).getByRole('heading', { name: 'Taylor' })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    expect(within(spotlight).getByRole('heading', { name: 'Morgan' })).toBeInTheDocument();
+  });
+
   it('removes vote-eliminated players from the spotlight pool and marks the final two', () => {
     mockedUseBattleBackVoting.mockReturnValue({
       votes: { p1: 0, p2: 55, p3: 45 },


### PR DESCRIPTION
## Summary
- Keep the Houseguest Spotlight 4-second timer independent from vote-elimination pool changes.
- Reset spotlight rotation only when the candidate list itself changes, not whenever the active pool shrinks.
- Add a regression test covering an elimination at 3.5s followed by a spotlight rotation at the original 4s mark.

## Validation
- `npm test -- tests/unit/publicFavoriteOverlay.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`