### PR TITLE
[codex] Make Famous Figures hints gradual

### DIFF
--- a/src/games/famous-figures/README.md
+++ b/src/games/famous-figures/README.md
@@ -53,11 +53,11 @@ Hints are revealed one at a time; requesting more reduces the points available.
 |-------|--------|---------|
 | 0 | Dataset `hints[0]` | Vague — no direct identifying information |
 | 1 | Dataset `hints[1]` | General field or era |
-| 2 | Generated | First-name initial: `"First name starts with 'X'."` |
-| 3 | Generated | Last-name initial (or letter count for mononyms): `"Last name starts with 'Y'."` |
-| 4 | Generated | **Name reveal** — full first name + last-name initial for two-part names (`"First name: Marie. Last name starts with 'C'."`) or full name for mononyms (`"Name: Cleopatra"`) |
+| 2 | Dataset `hints[2]` | More specific behavior, role, or relationship |
+| 3 | Dataset `hints[3]` | Strong signature trait, object, catchphrase, or context |
+| 4 | Dataset `hints[4]` | Near-giveaway clue such as a rival, companion, title link, or final identifying detail |
 
-> **Note:** `hints[2]`, `hints[3]`, and `hints[4]` in the dataset JSON are **ignored at runtime** — indices 2–4 are always generated from `canonicalName`.
+> **Note:** All five dataset hints are shown at runtime. `getHintText` only falls back to generated name clues if an older row is missing a late hint.
 
 ---
 
@@ -74,9 +74,9 @@ Each figure in `src/games/famous-figures/data/famous_figures.json` follows this 
   "hints": [
     "Hint 1 — vague, no direct identifying info",
     "Hint 2 — general field or era",
-    "(ignored — hint 3 is generated from canonicalName)",
-    "(ignored — hint 4 is generated from canonicalName)",
-    "(ignored — hint 5 is generated from canonicalName)"
+    "Hint 3 - more specific behavior or relationship",
+    "Hint 4 - strong signature trait or context",
+    "Hint 5 - near-giveaway final clue"
   ],
   "baseClueFact": "A single sentence shown as the initial clue.",
   "difficulty": "easy",
@@ -93,7 +93,7 @@ Each figure in `src/games/famous-figures/data/famous_figures.json` follows this 
 | `normalizedName` | `string` | Output of `normalizeForMatching(canonicalName)` |
 | `acceptedAliases` | `string[]` | Alternative names players might use |
 | `normalizedAliases` | `string[]` | `normalizeForMatching` applied to each alias |
-| `hints` | `[string, string, string, string, string]` | Exactly 5 entries; only `hints[0]` and `hints[1]` are shown at runtime — indices 2–4 are generated |
+| `hints` | `[string, string, string, string, string]` | Exactly 5 entries, shown at runtime from broad to specific |
 | `baseClueFact` | `string` | Opening clue shown before any hint is requested |
 | `difficulty` | `"easy" \| "medium" \| "hard"` | Affects AI correct-answer probability |
 | `category` | `string` | Free-form (artist, scientist, ruler, leader, etc.) |
@@ -159,7 +159,7 @@ Full **Damerau-Levenshtein** distance (not restricted). Transpositions count as 
    import { normalizeForMatching } from 'src/games/famous-figures/fuzzy';
    console.log(normalizeForMatching('Joan of Arc')); // → "joan arc"
    ```
-4. Write 2 hints of increasing specificity for `hints[0]` and `hints[1]`. The remaining three entries (`hints[2–4]`) are ignored at runtime but must still be present for schema compliance; use placeholder strings.
+4. Write all five hints as a gradual ladder: broad category, general relationship or world, behavior or role, strong signature trait, then a near-giveaway final clue.
 5. Run tests: `npm run test:famous-figures`
 
 ---
@@ -171,7 +171,7 @@ Figures known by a single name (e.g. Michelangelo, Mozart, Cleopatra):
 - The `canonicalName` is the mononym and is **always a direct match target** — you do not need to add it to `acceptedAliases`.
 - Only add the mononym to `acceptedAliases` / `normalizedAliases` if you also want to list alternative spellings or variants of the mononym itself.
 - Short mononyms (≤4 chars) are matched by **exact** spelling only (no fuzzy distance allowed).
-- Hint 4 (index 4) for mononyms shows the full single name: `"Name: Cleopatra"`.
+- Mononym entries still need five curated hints; generated name clues are only a fallback for incomplete legacy rows.
 
 ### Regnal and title names
 - Caesar (alias for Julius Caesar), Gandhi (for Mahatma Gandhi).

--- a/src/games/famous-figures/data/famous_figures.json
+++ b/src/games/famous-figures/data/famous_figures.json
@@ -11,13 +11,13 @@
       "mickey mouse"
     ],
     "hints": [
-      "A classic Disney character created in the late 1920s.",
-      "He usually wears red shorts, white gloves, and yellow shoes.",
-      "His girlfriend is Minnie Mouse.",
-      "He is the official mascot of Disney.",
-      "First name: Mickey. Last name starts with 'M'."
+      "A classic animated character.",
+      "Part of a cheerful group of old-school cartoon friends.",
+      "Often seen with gloves, shorts, and round ears.",
+      "His longtime partner is Minnie.",
+      "Disney uses him as its main mascot."
     ],
-    "baseClueFact": "The world's most famous cartoon mouse.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -32,13 +32,13 @@
       "minnie mouse"
     ],
     "hints": [
-      "A classic Disney cartoon character often shown in a polka-dot outfit.",
-      "She is closely connected to Mickey Mouse.",
-      "She usually wears a bow on her head.",
-      "Her name rhymes with Mickey's name.",
-      "First name: Minnie. Last name starts with 'M'."
+      "A classic animated character.",
+      "Part of a cheerful group of old-school cartoon friends.",
+      "Known for bows, polka dots, and a warm personality.",
+      "Her longtime partner is Mickey.",
+      "Her first name rhymes with a very famous mouse."
     ],
-    "baseClueFact": "A famous Disney mouse known for her bow.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -53,13 +53,13 @@
       "donald duck"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A classic Disney character with a very recognizable voice.",
       "He is often angry, funny, and unlucky.",
       "His nephews are Huey, Dewey, and Louie.",
-      "He is a white duck who wears a sailor shirt.",
-      "First name: Donald. Last name starts with 'D'."
+      "He is a white duck who wears a sailor shirt."
     ],
-    "baseClueFact": "A famous Disney duck in a sailor outfit.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -74,13 +74,13 @@
       "daisy duck"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney duck character often shown with a bow and fashionable clothes.",
       "She is often Donald Duck's girlfriend.",
       "She appears in the Mickey and Donald universe.",
-      "Her first name is also a flower.",
-      "First name: Daisy. Last name starts with 'D'."
+      "Her first name is also a flower."
     ],
-    "baseClueFact": "A stylish Disney duck associated with Donald Duck.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Disney"
@@ -97,13 +97,13 @@
       "scrooge mcduck"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney character known for extreme wealth.",
       "He is Donald Duck's uncle.",
       "He often swims in a giant pile of gold coins.",
-      "He is central to DuckTales.",
-      "First name: Scrooge. Last name starts with 'M'."
+      "He is central to DuckTales."
     ],
-    "baseClueFact": "A very rich Disney duck who loves his money bin.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Disney"
@@ -118,13 +118,13 @@
       "goofy"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A classic Disney friend of Mickey Mouse.",
       "He is tall, silly, and very clumsy.",
       "He has a distinctive laugh and voice.",
-      "His name literally suggests being silly.",
-      "Name: Goofy."
+      "His name literally suggests being silly."
     ],
-    "baseClueFact": "A tall clumsy Disney character.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -141,13 +141,13 @@
       "pluto"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney animal character who does not speak like Goofy.",
       "He is Mickey Mouse's loyal pet.",
       "He is usually drawn as a yellow-orange dog.",
-      "His name is also the name of a dwarf planet.",
-      "Name: Pluto."
+      "His name is also the name of a dwarf planet."
     ],
-    "baseClueFact": "Mickey Mouse's pet dog.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Disney"
@@ -162,13 +162,13 @@
       "cinderella"
     ],
     "hints": [
+      "Comes from a story world built around wishes, danger, and transformation.",
       "A fairy-tale heroine made globally famous by Disney.",
       "She is treated badly by her stepmother and stepsisters.",
       "A fairy godmother helps her attend a royal ball.",
-      "She leaves behind a glass slipper.",
-      "Name: Cinderella."
+      "She leaves behind a glass slipper."
     ],
-    "baseClueFact": "A princess famous for a glass slipper.",
+    "baseClueFact": "A well-known fictional character from Fairy tale.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Fairy tale"
@@ -183,13 +183,13 @@
       "snow white"
     ],
     "hints": [
+      "Comes from a story world built around wishes, danger, and transformation.",
       "A classic fairy-tale princess.",
       "She is poisoned by an apple.",
       "Her story has an evil queen and a magic mirror.",
-      "She lives with the Seven Dwarfs.",
-      "First name: Snow. Last name starts with 'W'."
+      "She lives with the Seven Dwarfs."
     ],
-    "baseClueFact": "A princess associated with seven dwarfs.",
+    "baseClueFact": "A well-known fictional character from Fairy tale.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Fairy tale"
@@ -206,13 +206,13 @@
       "ariel"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney princess who lives under the sea.",
       "She has a beautiful singing voice.",
       "She dreams of becoming human.",
-      "She is the Little Mermaid.",
-      "Name: Ariel."
+      "She is this figure."
     ],
-    "baseClueFact": "A red-haired mermaid princess.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -229,13 +229,13 @@
       "belle"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney heroine who loves reading.",
       "She lives in a small French village.",
       "She enters a cursed castle.",
-      "Her story is Beauty and the Beast.",
-      "Name: Belle."
+      "Her story is Beauty and the Beast."
     ],
-    "baseClueFact": "A book-loving Disney princess.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -250,13 +250,13 @@
       "simba"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A young lion from a famous Disney film.",
       "His father is Mufasa.",
       "He runs away after a tragedy.",
-      "He later returns to reclaim Pride Rock.",
-      "Name: Simba."
+      "He later returns to reclaim Pride Rock."
     ],
-    "baseClueFact": "The lion prince from The Lion King.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -271,13 +271,13 @@
       "mufasa"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A wise lion ruler in a Disney film.",
       "He is Simba's father.",
       "His brother Scar betrays him.",
-      "He teaches about the circle of life.",
-      "Name: Mufasa."
+      "He teaches about the circle of life."
     ],
-    "baseClueFact": "The noble lion king from The Lion King.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Disney"
@@ -292,13 +292,13 @@
       "aladdin"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney hero from a Middle Eastern-inspired fantasy world.",
       "He discovers a magical lamp.",
       "He is helped by a blue Genie.",
-      "He falls in love with Princess Jasmine.",
-      "Name: Aladdin."
+      "He falls in love with Princess Jasmine."
     ],
-    "baseClueFact": "A street thief who finds a magic lamp.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -315,13 +315,13 @@
       "genie"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A magical Disney character who lives in a lamp.",
       "He grants three wishes.",
       "He is blue and extremely funny.",
-      "Robin Williams voiced him in the 1992 animated film.",
-      "Name: Genie."
+      "Robin Williams voiced him in the 1992 animated film."
     ],
-    "baseClueFact": "The blue wish-granting character from Aladdin.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -338,13 +338,13 @@
       "elsa"
     ],
     "hints": [
-      "A Disney queen with magical ice powers.",
-      "She has a sister named Anna.",
-      "She sings Let It Go.",
-      "She is from Frozen.",
-      "Name: Elsa."
+      "A royal character from an animated musical story.",
+      "Struggles with a power she tries to hide.",
+      "A sister relationship is central to her story.",
+      "Ice and snow appear whenever emotions run high.",
+      "She sings about letting it go."
     ],
-    "baseClueFact": "The Disney queen with ice powers.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -361,13 +361,13 @@
       "anna"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney princess known for bravery and optimism.",
       "She is Elsa's younger sister.",
       "She appears in Frozen.",
-      "Her sister controls ice and snow.",
-      "Name: Anna."
+      "Her sister controls ice and snow."
     ],
-    "baseClueFact": "Elsa's optimistic sister from Frozen.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -382,13 +382,13 @@
       "olaf"
     ],
     "hints": [
-      "A cheerful Disney snowman.",
-      "He dreams of experiencing summer.",
-      "He is created by Elsa's magic.",
-      "He loves warm hugs.",
-      "Name: Olaf."
+      "A comic side character from an animated musical story.",
+      "Innocent optimism is his main energy.",
+      "He dreams about warmth despite what he is made of.",
+      "A living snowman brought to life by magic.",
+      "Friends with Anna and Elsa."
     ],
-    "baseClueFact": "The friendly snowman from Frozen.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -403,13 +403,13 @@
       "moana"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney heroine from a Pacific island.",
       "She sails to save her people.",
       "She meets the demigod Maui.",
-      "Her film title is also her name.",
-      "Name: Moana."
+      "Her film title is also her name."
     ],
-    "baseClueFact": "A brave island girl who sails across the ocean.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Disney"
@@ -426,13 +426,13 @@
       "maui"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney demigod with a magical fishhook.",
       "He can shapeshift into animals.",
       "He helps Moana on her ocean journey.",
-      "Dwayne Johnson voiced him.",
-      "Name: Maui."
+      "Dwayne Johnson voiced him."
     ],
-    "baseClueFact": "The shapeshifting demigod from Moana.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Disney"
@@ -447,13 +447,13 @@
       "peter pan"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A magical boy from children's literature.",
       "He lives in Neverland.",
       "He can fly and is helped by Tinker Bell.",
-      "He fights Captain Hook.",
-      "First name: Peter. Last name starts with 'P'."
+      "He fights Captain Hook."
     ],
-    "baseClueFact": "The boy who never grows up.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Literature"
@@ -470,13 +470,13 @@
       "tinker bell"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A tiny fairy from the Peter Pan stories.",
       "She is often shown with wings and a green dress.",
       "She helps Peter Pan with pixie dust.",
-      "She became one of Disney's famous fairies.",
-      "First name: Tinker. Last name starts with 'B'."
+      "She became one of Disney's famous fairies."
     ],
-    "baseClueFact": "A tiny fairy associated with Peter Pan.",
+    "baseClueFact": "A well-known fictional character from Disney.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Disney"
@@ -491,13 +491,13 @@
       "pinocchio"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A wooden puppet from a famous children's story.",
       "He wants to become a real boy.",
       "His nose grows when he lies.",
-      "Jiminy Cricket often acts as his conscience.",
-      "Name: Pinocchio."
+      "Jiminy Cricket often acts as his conscience."
     ],
-    "baseClueFact": "A wooden puppet whose nose grows when he lies.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Literature"
@@ -516,13 +516,13 @@
       "winnie pooh"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A gentle bear from children's stories.",
       "He loves honey.",
       "His friends include Piglet, Tigger, and Eeyore.",
-      "He lives in the Hundred Acre Wood.",
-      "First name: Winnie. Last name starts with 'P'."
+      "He lives in the Hundred Acre Wood."
     ],
-    "baseClueFact": "A honey-loving bear from the Hundred Acre Wood.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Literature"
@@ -537,13 +537,13 @@
       "tigger"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A very energetic tiger from children's stories.",
       "He loves bouncing.",
       "He is friends with Winnie the Pooh.",
-      "His name sounds like tiger with a playful twist.",
-      "Name: Tigger."
+      "His name sounds like tiger with a playful twist."
     ],
-    "baseClueFact": "The bouncing tiger from Winnie the Pooh.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Literature"
@@ -560,13 +560,13 @@
       "spongebob squarepants"
     ],
     "hints": [
+      "Belongs to a colorful animated comedy world.",
       "A yellow animated sea sponge.",
       "He works at the Krusty Krab.",
       "His best friend is Patrick Star.",
-      "He lives in Bikini Bottom.",
-      "First name: SpongeBob. Last name starts with 'S'."
+      "He lives in Bikini Bottom."
     ],
-    "baseClueFact": "A yellow sponge who lives in a pineapple under the sea.",
+    "baseClueFact": "A well-known fictional character from Nickelodeon.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Nickelodeon"
@@ -583,13 +583,13 @@
       "patrick star"
     ],
     "hints": [
+      "Belongs to a colorful animated comedy world.",
       "A pink starfish from a famous animated series.",
       "He lives under a rock.",
       "He is SpongeBob's best friend.",
-      "He is lovable but not very smart.",
-      "First name: Patrick. Last name starts with 'S'."
+      "He is lovable but not very smart."
     ],
-    "baseClueFact": "SpongeBob's pink starfish best friend.",
+    "baseClueFact": "A well-known fictional character from Nickelodeon.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Nickelodeon"
@@ -606,13 +606,13 @@
       "squidward tentacles"
     ],
     "hints": [
+      "Belongs to a colorful animated comedy world.",
       "A grumpy character from SpongeBob SquarePants.",
       "He works as a cashier at the Krusty Krab.",
       "He plays the clarinet.",
-      "He is often annoyed by SpongeBob and Patrick.",
-      "First name: Squidward. Last name starts with 'T'."
+      "He is often annoyed by SpongeBob and Patrick."
     ],
-    "baseClueFact": "SpongeBob's grumpy neighbor.",
+    "baseClueFact": "A well-known fictional character from Nickelodeon.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Nickelodeon"
@@ -629,13 +629,13 @@
       "homer simpson"
     ],
     "hints": [
+      "Became widely known through television.",
       "A cartoon father from a long-running animated sitcom.",
       "He works at a nuclear power plant.",
       "He loves doughnuts and beer.",
-      "He often says 'D'oh!'.",
-      "First name: Homer. Last name starts with 'S'."
+      "He often says 'D'oh!'."
     ],
-    "baseClueFact": "The doughnut-loving father from The Simpsons.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Television"
@@ -652,13 +652,13 @@
       "bart simpson"
     ],
     "hints": [
+      "Became widely known through television.",
       "A mischievous cartoon boy.",
       "He rides a skateboard.",
       "He is Homer and Marge's son.",
-      "One catchphrase is 'Eat my shorts'.",
-      "First name: Bart. Last name starts with 'S'."
+      "One catchphrase is 'Eat my shorts'."
     ],
-    "baseClueFact": "The rebellious son from The Simpsons.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Television"
@@ -675,13 +675,13 @@
       "lisa simpson"
     ],
     "hints": [
+      "Became widely known through television.",
       "A smart cartoon girl from The Simpsons.",
-      "She plays the saxophone.",
-      "She is known for intelligence and strong opinions.",
-      "She is Bart's sister.",
-      "First name: Lisa. Last name starts with 'S'."
+      "He plays the saxophone.",
+      "He is known for intelligence and strong opinions.",
+      "He is Bart's sister."
     ],
-    "baseClueFact": "The smart saxophone-playing daughter from The Simpsons.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Television"
@@ -698,13 +698,13 @@
       "marge simpson"
     ],
     "hints": [
+      "Became widely known through television.",
       "A cartoon mother from The Simpsons.",
-      "She has very tall blue hair.",
-      "She is married to Homer Simpson.",
-      "She is often the voice of reason in the family.",
-      "First name: Marge. Last name starts with 'S'."
+      "He has very tall blue hair.",
+      "He is married to Homer Simpson.",
+      "He is often the voice of reason in the family."
     ],
-    "baseClueFact": "The blue-haired mother from The Simpsons.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Television"
@@ -721,13 +721,13 @@
       "bugs bunny"
     ],
     "hints": [
+      "Comes from fast-paced classic cartoon comedy.",
       "A famous Warner Bros. cartoon rabbit.",
       "He often eats carrots.",
       "He is one of the Looney Tunes characters.",
-      "His catchphrase is 'What's up, Doc?'.",
-      "First name: Bugs. Last name starts with 'B'."
+      "His catchphrase is 'What's up, Doc?'."
     ],
-    "baseClueFact": "A wisecracking rabbit who says 'What's up, Doc?'.",
+    "baseClueFact": "A well-known fictional character from Looney Tunes.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Looney Tunes"
@@ -744,13 +744,13 @@
       "daffy duck"
     ],
     "hints": [
+      "Comes from fast-paced classic cartoon comedy.",
       "A black cartoon duck from Warner Bros.",
       "He is often dramatic, jealous, and funny.",
       "He is frequently paired with Bugs Bunny.",
-      "His name suggests silly or crazy behavior.",
-      "First name: Daffy. Last name starts with 'D'."
+      "His name suggests silly or crazy behavior."
     ],
-    "baseClueFact": "A chaotic black duck from Looney Tunes.",
+    "baseClueFact": "A well-known fictional character from Looney Tunes.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Looney Tunes"
@@ -767,13 +767,13 @@
       "tweety"
     ],
     "hints": [
+      "Comes from fast-paced classic cartoon comedy.",
       "A tiny yellow Looney Tunes bird.",
       "He is often chased by Sylvester the Cat.",
       "He says 'I tawt I taw a puddy tat'.",
-      "He looks innocent but is clever.",
-      "Name: Tweety."
+      "He looks innocent but is clever."
     ],
-    "baseClueFact": "A small yellow bird chased by Sylvester.",
+    "baseClueFact": "A well-known fictional character from Looney Tunes.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Looney Tunes"
@@ -792,13 +792,13 @@
       "tom cat"
     ],
     "hints": [
-      "A grey cartoon cat from a classic chase cartoon.",
-      "He constantly tries to catch a mouse.",
-      "He is usually outsmarted by Jerry.",
-      "The show is called Tom and Jerry.",
-      "First name: Tom. Last name starts with 'C'."
+      "A popular cartoon animal.",
+      "Part of a very famous animated duo.",
+      "Usually plays the bigger but less successful pursuer.",
+      "A gray housecat whose plans often backfire painfully.",
+      "Rival name: Jerry."
     ],
-    "baseClueFact": "The cat from Tom and Jerry.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Animation"
@@ -817,13 +817,13 @@
       "jerry mouse"
     ],
     "hints": [
-      "A small brown cartoon mouse.",
-      "He constantly escapes from Tom Cat.",
-      "He is clever and mischievous.",
-      "He is the mouse in Tom and Jerry.",
-      "First name: Jerry. Last name starts with 'M'."
+      "A popular cartoon animal.",
+      "Part of a very famous animated duo.",
+      "Often survives chase scenes through speed and tricks.",
+      "Small, clever, and strongly associated with cheese.",
+      "Rival name: Tom."
     ],
-    "baseClueFact": "The mouse from Tom and Jerry.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Animation"
@@ -840,13 +840,13 @@
       "scoobydoo"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A talking dog from a mystery cartoon.",
       "He solves cases with Mystery Inc.",
       "He is easily scared but loves snacks.",
-      "His best friend is Shaggy.",
-      "First name: Scooby. Last name starts with 'D'."
+      "His best friend is Shaggy."
     ],
-    "baseClueFact": "A talking Great Dane who solves mysteries.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Animation"
@@ -863,13 +863,13 @@
       "shaggy rogers"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A laid-back cartoon mystery solver.",
       "He is Scooby-Doo's best friend.",
       "He is always hungry and easily scared.",
-      "He often wears a green shirt.",
-      "First name: Shaggy. Last name starts with 'R'."
+      "He often wears a green shirt."
     ],
-    "baseClueFact": "Scooby-Doo's hungry and nervous best friend.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Animation"
@@ -886,13 +886,13 @@
       "fred flintstone"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A cartoon father from a prehistoric sitcom.",
       "He lives in Bedrock.",
       "He works at a quarry.",
-      "He shouts 'Yabba-Dabba-Doo!'.",
-      "First name: Fred. Last name starts with 'F'."
+      "He shouts 'Yabba-Dabba-Doo!'."
     ],
-    "baseClueFact": "The Stone Age father from The Flintstones.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Animation"
@@ -907,13 +907,13 @@
       "garfield"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A lazy orange cartoon cat.",
       "He loves lasagna.",
       "He hates Mondays.",
-      "His owner is Jon Arbuckle.",
-      "Name: Garfield."
+      "His owner is Jon Arbuckle."
     ],
-    "baseClueFact": "The lasagna-loving orange cat who hates Mondays.",
+    "baseClueFact": "A well-known fictional character from Comics.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Comics"
@@ -930,13 +930,13 @@
       "popeye"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A cartoon sailor with huge forearms.",
       "He becomes stronger after eating spinach.",
       "He loves Olive Oyl.",
-      "His rival is Bluto or Brutus.",
-      "Name: Popeye."
+      "His rival is Bluto or Brutus."
     ],
-    "baseClueFact": "The spinach-powered cartoon sailor.",
+    "baseClueFact": "A well-known fictional character from Comics.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Comics"
@@ -955,13 +955,13 @@
       "super mario"
     ],
     "hints": [
-      "A famous Nintendo video game character.",
-      "He wears a red hat and blue overalls.",
-      "He often rescues Princess Peach.",
-      "He jumps on enemies and collects coins.",
-      "First name: Super. Last name starts with 'M'."
+      "A video game hero from colorful platform adventures.",
+      "Often travels through pipes, castles, and strange kingdoms.",
+      "Usually tries to stop a spiked fire-breathing ruler.",
+      "Red hat, mustache, and jumping are signature details.",
+      "His brother is Luigi."
     ],
-    "baseClueFact": "Nintendo's red-hatted plumber.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "easy",
     "category": "video game character",
     "era": "Video games"
@@ -976,13 +976,13 @@
       "luigi"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A Nintendo video game character.",
       "He is Mario's taller brother.",
       "He wears green.",
-      "He is often shown as nervous but loyal.",
-      "Name: Luigi."
+      "He is often shown as nervous but loyal."
     ],
-    "baseClueFact": "Mario's taller green-clad brother.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -999,13 +999,13 @@
       "princess peach"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A Nintendo princess from the Mario games.",
       "She rules the Mushroom Kingdom.",
       "She is often kidnapped by Bowser.",
-      "She usually wears a pink dress.",
-      "First name: Princess. Last name starts with 'P'."
+      "She usually wears a pink dress."
     ],
-    "baseClueFact": "The pink-dressed princess of the Mushroom Kingdom.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -1022,13 +1022,13 @@
       "bowser"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A large turtle-like villain from the Mario games.",
       "He often kidnaps Princess Peach.",
       "He breathes fire.",
-      "He is Mario's main enemy.",
-      "Name: Bowser."
+      "He is Mario's main enemy."
     ],
-    "baseClueFact": "Mario's fire-breathing turtle-like enemy.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -1045,13 +1045,13 @@
       "sonic hedgehog"
     ],
     "hints": [
-      "A blue video game character created by Sega.",
-      "He runs extremely fast.",
-      "He collects golden rings.",
-      "His enemy is Doctor Eggman.",
-      "First name: Sonic. Last name starts with 'H'."
+      "A video game mascot built around movement.",
+      "Usually races through bright obstacle-filled stages.",
+      "Collects rings while fighting mechanical enemies.",
+      "Blue coloring and red shoes are signature details.",
+      "Known as the hedgehog famous for speed."
     ],
-    "baseClueFact": "The blue hedgehog famous for speed.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -1066,13 +1066,13 @@
       "pikachu"
     ],
     "hints": [
-      "A small yellow creature from Pokémon.",
-      "It has red cheeks and electric powers.",
-      "It is Ash Ketchum's most famous partner.",
-      "It says its own name.",
-      "Name: Pikachu."
+      "A small creature from a huge collecting-and-battling franchise.",
+      "Often appears beside a young trainer.",
+      "Yellow coloring and electric powers are key traits.",
+      "Red cheeks and a repeated self-name make it recognizable.",
+      "Ash Ketchum's signature partner."
     ],
-    "baseClueFact": "The yellow electric Pokémon.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "easy",
     "category": "video game character",
     "era": "Video games"
@@ -1089,13 +1089,13 @@
       "ash ketchum"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "A young Pokémon trainer from Pallet Town.",
       "His partner is Pikachu.",
       "He wants to become a Pokémon Master.",
-      "He is the main hero of the Pokémon anime.",
-      "First name: Ash. Last name starts with 'K'."
+      "He is the main hero of the Pokémon anime."
     ],
-    "baseClueFact": "The Pokémon trainer with Pikachu.",
+    "baseClueFact": "A well-known fictional character from Anime.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Anime"
@@ -1110,13 +1110,13 @@
       "barbie"
     ],
     "hints": [
+      "Connected to Toy pop culture.",
       "A fashion doll first launched in 1959.",
-      "She has had many careers and styles.",
+      "He has had many careers and styles.",
       "Her boyfriend is Ken.",
-      "She became the lead character of a major 2023 film.",
-      "Name: Barbie."
+      "He became the lead character of a major 2023 film."
     ],
-    "baseClueFact": "The world's most famous fashion doll.",
+    "baseClueFact": "A well-known fictional character from Toy.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Toy"
@@ -1133,13 +1133,13 @@
       "ken"
     ],
     "hints": [
+      "Connected to Toy pop culture.",
       "A male fashion doll closely associated with Barbie.",
       "He is often presented as Barbie's boyfriend.",
       "Ryan Gosling played him in the 2023 Barbie film.",
-      "His name is short and simple.",
-      "Name: Ken."
+      "His name is short and simple."
     ],
-    "baseClueFact": "Barbie's famous male companion.",
+    "baseClueFact": "A well-known fictional character from Toy.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Toy"
@@ -1156,13 +1156,13 @@
       "superman"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A DC Comics superhero.",
       "He comes from the planet Krypton.",
-      "His secret identity is Clark Kent.",
-      "He wears a cape and has an S symbol on his chest.",
-      "Name: Superman."
+      "His secret identity is this figure.",
+      "He wears a cape and has an S symbol on his chest."
     ],
-    "baseClueFact": "The superhero from Krypton.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "easy",
     "category": "superhero",
     "era": "Comics"
@@ -1179,13 +1179,13 @@
       "batman"
     ],
     "hints": [
-      "A DC Comics superhero.",
-      "He is a billionaire from Gotham City.",
-      "He has no superpowers but uses gadgets and training.",
-      "His symbol is a bat.",
-      "Name: Batman."
+      "A dark superhero without traditional superpowers.",
+      "Uses fear, wealth, training, and detective work.",
+      "Operates mostly at night in a crime-heavy city.",
+      "Cape, cowl, cave, and gadgets are key clues.",
+      "Bruce Wayne is the person under the mask."
     ],
-    "baseClueFact": "The dark hero who protects Gotham City.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "easy",
     "category": "superhero",
     "era": "Comics"
@@ -1202,13 +1202,13 @@
       "wonder woman"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A DC superheroine and Amazon princess.",
       "She comes from Themyscira.",
       "She uses a lasso, bracelets, and a sword.",
-      "Her civilian name is Diana Prince.",
-      "First name: Wonder. Last name starts with 'W'."
+      "Her civilian name is this figure."
     ],
-    "baseClueFact": "The Amazon superheroine from DC Comics.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "easy",
     "category": "superhero",
     "era": "Comics"
@@ -1227,13 +1227,13 @@
       "spiderman"
     ],
     "hints": [
-      "A Marvel superhero from New York.",
-      "He was bitten by a radioactive spider.",
-      "He climbs walls and shoots webs.",
-      "His secret identity is Peter Parker.",
-      "First name: Spider. Last name starts with 'M'."
+      "A superhero who protects a busy city.",
+      "Balances ordinary personal problems with masked responsibility.",
+      "Acrobatics and sticky movement define the action.",
+      "Usually swings between buildings on webs.",
+      "Peter Parker is the person under the mask."
     ],
-    "baseClueFact": "The web-slinging Marvel superhero.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "easy",
     "category": "superhero",
     "era": "Comics"
@@ -1250,13 +1250,13 @@
       "iron man"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel superhero in high-tech armor.",
       "He is a billionaire inventor.",
-      "His real name is Tony Stark.",
-      "Robert Downey Jr. played him in the Marvel films.",
-      "First name: Iron. Last name starts with 'M'."
+      "His real name is this figure.",
+      "Robert Downey Jr. played him in the Marvel films."
     ],
-    "baseClueFact": "The armored Marvel hero created by Tony Stark.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "easy",
     "category": "superhero",
     "era": "Comics"
@@ -1273,13 +1273,13 @@
       "captain america"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel superhero created during World War II.",
       "He carries a circular shield.",
-      "His real name is Steve Rogers.",
-      "He is known as the First Avenger.",
-      "First name: Captain. Last name starts with 'A'."
+      "His real name is this figure.",
+      "He is known as the First Avenger."
     ],
-    "baseClueFact": "The patriotic Marvel hero with a shield.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1298,13 +1298,13 @@
       "hulk"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel character who transforms when angry.",
-      "His human identity is Bruce Banner.",
+      "His human identity is this figure.",
       "He is huge, green, and extremely strong.",
-      "A famous phrase is 'Hulk smash'.",
-      "Name: Hulk."
+      "A famous phrase is 'this figure smash'."
     ],
-    "baseClueFact": "The green Marvel hero powered by anger.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1321,13 +1321,13 @@
       "thor"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel superhero based on a Norse god.",
       "He wields the hammer Mjolnir.",
       "He is associated with thunder and Asgard.",
-      "Chris Hemsworth plays him in the Marvel films.",
-      "Name: Thor."
+      "Chris Hemsworth plays him in the Marvel films."
     ],
-    "baseClueFact": "The hammer-wielding god of thunder.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1346,13 +1346,13 @@
       "black panther"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel superhero and king.",
       "He rules Wakanda.",
       "His suit is made with vibranium.",
-      "Chadwick Boseman famously played him.",
-      "First name: Black. Last name starts with 'P'."
+      "Chadwick Boseman famously played him."
     ],
-    "baseClueFact": "The king of Wakanda and Marvel superhero.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1369,13 +1369,13 @@
       "wolverine"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel mutant known for claws and healing.",
       "He is a member of the X-Men.",
       "He has adamantium claws.",
-      "Hugh Jackman famously played him.",
-      "Name: Wolverine."
+      "Hugh Jackman famously played him."
     ],
-    "baseClueFact": "The clawed X-Men mutant.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1392,13 +1392,13 @@
       "deadpool"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A Marvel antihero known for jokes and chaos.",
       "He breaks the fourth wall.",
-      "His real name is Wade Wilson.",
-      "Ryan Reynolds plays him in the films.",
-      "Name: Deadpool."
+      "His real name is this figure.",
+      "Ryan Reynolds plays him in the films."
     ],
-    "baseClueFact": "The sarcastic Marvel antihero in a red suit.",
+    "baseClueFact": "A globally known superhero character.",
     "difficulty": "medium",
     "category": "superhero",
     "era": "Comics"
@@ -1415,13 +1415,13 @@
       "joker"
     ],
     "hints": [
-      "A famous comic-book villain.",
-      "He is Batman's most famous enemy.",
-      "He is associated with chaos and Gotham City.",
-      "He often has green hair and a sinister smile.",
-      "First name: The. Last name starts with 'J'."
+      "A famous fictional antagonist.",
+      "Chaos matters more to him than money or order.",
+      "Uses clown imagery in a very dangerous way.",
+      "Usually haunts Gotham stories.",
+      "Batman is his main enemy."
     ],
-    "baseClueFact": "Batman's chaotic clown-like enemy.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "easy",
     "category": "villain",
     "era": "Comics"
@@ -1438,13 +1438,13 @@
       "harley quinn"
     ],
     "hints": [
+      "Comes from a world of illustrated heroes, villains, and long-running lore.",
       "A DC character who began as the Joker's partner.",
-      "She was originally Dr. Harleen Quinzel.",
+      "She was originally Dr. this figure.",
       "She often carries a bat or mallet.",
-      "Margot Robbie played her in several films.",
-      "First name: Harley. Last name starts with 'Q'."
+      "Margot Robbie played her in several films."
     ],
-    "baseClueFact": "The chaotic DC character connected to the Joker.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "easy",
     "category": "villain",
     "era": "Comics"
@@ -1461,13 +1461,13 @@
       "darth vader"
     ],
     "hints": [
-      "A central villain from Star Wars.",
-      "He wears black armor and a breathing mask.",
-      "He is Luke Skywalker's father.",
-      "He was once Anakin Skywalker.",
-      "First name: Darth. Last name starts with 'V'."
+      "A masked figure from a space fantasy saga.",
+      "Serves an empire and inspires fear across the galaxy.",
+      "Recognizable by black armor and heavy breathing.",
+      "Uses a red lightsaber and the dark side.",
+      "Famously revealed as Luke Skywalker's father."
     ],
-    "baseClueFact": "The black-armored Sith Lord from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1484,13 +1484,13 @@
       "luke skywalker"
     ],
     "hints": [
+      "Belongs to a space fantasy story with wars, rebels, and strange worlds.",
       "A hero from Star Wars.",
       "He grows up on Tatooine.",
       "He trains as a Jedi.",
-      "He is the son of Darth Vader.",
-      "First name: Luke. Last name starts with 'S'."
+      "He is the son of Darth Vader."
     ],
-    "baseClueFact": "The Jedi hero of the original Star Wars trilogy.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1509,13 +1509,13 @@
       "princess leia"
     ],
     "hints": [
-      "A princess and rebel leader from Star Wars.",
-      "She is Luke Skywalker's twin sister.",
-      "She is famous for her white dress and side-bun hairstyle.",
-      "Carrie Fisher played her.",
-      "First name: Princess. Last name starts with 'L'."
+      "A leader from a space fantasy saga.",
+      "Connected to rebellion, royalty, and sharp courage.",
+      "Known for iconic hair and fearless diplomacy.",
+      "Sibling of a young hero from a desert planet.",
+      "Her first name is Leia."
     ],
-    "baseClueFact": "The Rebel princess from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1530,13 +1530,13 @@
       "yoda"
     ],
     "hints": [
+      "Belongs to a space fantasy story with wars, rebels, and strange worlds.",
       "A wise green Jedi Master from Star Wars.",
       "He speaks in unusual word order.",
       "He trains Luke Skywalker.",
-      "He is small but extremely powerful.",
-      "Name: Yoda."
+      "He is small but extremely powerful."
     ],
-    "baseClueFact": "The small green Jedi Master from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1553,13 +1553,13 @@
       "chewbacca"
     ],
     "hints": [
+      "Belongs to a space fantasy story with wars, rebels, and strange worlds.",
       "A tall furry character from Star Wars.",
       "He is a Wookiee.",
       "He is Han Solo's loyal co-pilot.",
-      "His nickname is Chewie.",
-      "Name: Chewbacca."
+      "His nickname is this figure."
     ],
-    "baseClueFact": "The tall Wookiee from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1578,13 +1578,13 @@
       "r2d2"
     ],
     "hints": [
+      "Belongs to a space fantasy story with wars, rebels, and strange worlds.",
       "A small droid from Star Wars.",
       "He communicates with beeps.",
       "He is blue and white.",
-      "He often appears with C-3PO.",
-      "First name: R2. Last name starts with 'D'."
+      "He often appears with C-3PO."
     ],
-    "baseClueFact": "The small blue-and-white droid from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1603,13 +1603,13 @@
       "c3po"
     ],
     "hints": [
+      "Belongs to a space fantasy story with wars, rebels, and strange worlds.",
       "A golden droid from Star Wars.",
       "He is fluent in many forms of communication.",
       "He is often anxious and formal.",
-      "He is usually paired with R2-D2.",
-      "First name: C. Last name starts with '3'."
+      "He is usually paired with R2-D2."
     ],
-    "baseClueFact": "The golden protocol droid from Star Wars.",
+    "baseClueFact": "A well-known fictional character from Star Wars.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Star Wars"
@@ -1624,13 +1624,13 @@
       "harry potter"
     ],
     "hints": [
-      "A young wizard from a famous book and film series.",
-      "He attends Hogwarts School of Witchcraft and Wizardry.",
-      "He has a lightning-shaped scar.",
-      "He fights Lord Voldemort.",
-      "First name: Harry. Last name starts with 'P'."
+      "A young fantasy hero connected to a hidden magical world.",
+      "School, friendship, and an old prophecy shape his story.",
+      "A scar and glasses are major visual clues.",
+      "He attends Hogwarts.",
+      "His enemy is Voldemort."
     ],
-    "baseClueFact": "The boy wizard with a lightning scar.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1647,13 +1647,13 @@
       "hermione granger"
     ],
     "hints": [
+      "Belongs to a fantasy story shaped by quests and dangerous power.",
       "A young witch from Harry Potter.",
       "She is one of Harry's best friends.",
       "She is known for intelligence and studying hard.",
-      "Emma Watson played her in the films.",
-      "First name: Hermione. Last name starts with 'G'."
+      "Emma Watson played her in the films."
     ],
-    "baseClueFact": "The brilliant witch from Harry Potter.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1670,13 +1670,13 @@
       "ron weasley"
     ],
     "hints": [
+      "Belongs to a fantasy story shaped by quests and dangerous power.",
       "A red-haired wizard from Harry Potter.",
       "He is one of Harry's best friends.",
       "He comes from the Weasley family.",
-      "Rupert Grint played him in the films.",
-      "First name: Ron. Last name starts with 'W'."
+      "Rupert Grint played him in the films."
     ],
-    "baseClueFact": "Harry Potter's loyal red-haired best friend.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1695,13 +1695,13 @@
       "lord voldemort"
     ],
     "hints": [
-      "The main villain of Harry Potter.",
-      "He is also known as Tom Riddle.",
-      "Many characters fear saying his name.",
-      "He is called He-Who-Must-Not-Be-Named.",
-      "First name: Lord. Last name starts with 'V'."
+      "A fantasy villain feared by an entire magical society.",
+      "Many characters avoid saying his name.",
+      "Obsessed with immortality and pure power.",
+      "Pale, snake-like imagery surrounds him.",
+      "Harry Potter is his chosen enemy."
     ],
-    "baseClueFact": "The dark wizard villain of Harry Potter.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "medium",
     "category": "villain",
     "era": "Fantasy"
@@ -1718,13 +1718,13 @@
       "frodo baggins"
     ],
     "hints": [
+      "Belongs to a fantasy story shaped by quests and dangerous power.",
       "A hobbit from The Lord of the Rings.",
       "He inherits a dangerous ring.",
       "He travels to Mordor.",
-      "His mission is to destroy the One Ring.",
-      "First name: Frodo. Last name starts with 'B'."
+      "His mission is to destroy the One Ring."
     ],
-    "baseClueFact": "The hobbit who carries the One Ring.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1743,13 +1743,13 @@
       "gandalf"
     ],
     "hints": [
+      "Belongs to a fantasy story shaped by quests and dangerous power.",
       "A wizard from The Lord of the Rings.",
       "He carries a staff and helps the Fellowship.",
       "He says 'You shall not pass!'.",
-      "He is first known as the Grey and later the White.",
-      "Name: Gandalf."
+      "He is first known as the Grey and later the White."
     ],
-    "baseClueFact": "The wise wizard from The Lord of the Rings.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1768,13 +1768,13 @@
       "gollum"
     ],
     "hints": [
+      "Belongs to a fantasy story shaped by quests and dangerous power.",
       "A tragic creature from The Lord of the Rings.",
       "He is obsessed with the One Ring.",
       "He calls the ring 'my precious'.",
-      "He was once known as Sméagol.",
-      "Name: Gollum."
+      "He was once known as this figure."
     ],
-    "baseClueFact": "The ring-obsessed creature who says 'my precious'.",
+    "baseClueFact": "A well-known fictional character from Fantasy.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Fantasy"
@@ -1791,13 +1791,13 @@
       "sherlock holmes"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A fictional detective created by Arthur Conan Doyle.",
       "He lives at 221B Baker Street.",
       "His friend is Dr. Watson.",
-      "He is famous for brilliant deduction.",
-      "First name: Sherlock. Last name starts with 'H'."
+      "He is famous for brilliant deduction."
     ],
-    "baseClueFact": "The famous detective from 221B Baker Street.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Literature"
@@ -1814,13 +1814,13 @@
       "dracula"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A famous vampire from Gothic literature.",
       "He was created by Bram Stoker.",
       "He comes from Transylvania.",
-      "He drinks blood and lives in a castle.",
-      "Name: Dracula."
+      "He drinks blood and lives in a castle."
     ],
-    "baseClueFact": "The famous vampire from Transylvania.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Literature"
@@ -1839,13 +1839,13 @@
       "frankenstein s monster"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A creature from Mary Shelley's novel.",
       "He is assembled from body parts.",
       "Many people mistakenly call the creature by his creator's name.",
-      "His creator is Victor Frankenstein.",
-      "First name: Frankensteins. Last name starts with 'M'."
+      "His creator is Victor this figure."
     ],
-    "baseClueFact": "The tragic creature from Mary Shelley's novel.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Literature"
@@ -1864,13 +1864,13 @@
       "james bond"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional British spy.",
       "He works for MI6.",
-      "His code number is 007.",
-      "He likes gadgets, cars, and 'shaken, not stirred'.",
-      "First name: James. Last name starts with 'B'."
+      "His code number is this figure.",
+      "He likes gadgets, cars, and 'shaken, not stirred'."
     ],
-    "baseClueFact": "The British spy known as 007.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Film"
@@ -1887,13 +1887,13 @@
       "indiana jones"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional archaeologist and adventurer.",
       "He wears a fedora and carries a whip.",
       "Harrison Ford played him.",
-      "He searches for ancient artifacts.",
-      "First name: Indiana. Last name starts with 'J'."
+      "He searches for ancient artifacts."
     ],
-    "baseClueFact": "The whip-carrying archaeologist adventurer.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -1910,13 +1910,13 @@
       "rocky balboa"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional boxer from Philadelphia.",
       "Sylvester Stallone played him.",
       "He runs up the steps of the Philadelphia Museum of Art.",
-      "He is the main character of the Rocky films.",
-      "First name: Rocky. Last name starts with 'B'."
+      "He is the main character of the this figure films."
     ],
-    "baseClueFact": "The underdog boxer from Philadelphia.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -1933,13 +1933,13 @@
       "forrest gump"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A film character played by Tom Hanks.",
       "He says life is like a box of chocolates.",
       "He runs across America.",
-      "He appears in many major historical moments.",
-      "First name: Forrest. Last name starts with 'G'."
+      "He appears in many major historical moments."
     ],
-    "baseClueFact": "The film character who says life is like a box of chocolates.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -1954,13 +1954,13 @@
       "shrek"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A green ogre from an animated film series.",
       "He lives in a swamp.",
       "His best friend is Donkey.",
-      "He marries Princess Fiona.",
-      "Name: Shrek."
+      "He marries Princess Fiona."
     ],
-    "baseClueFact": "The green ogre from the swamp.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Animation"
@@ -1977,13 +1977,13 @@
       "donkey"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A talking animal from Shrek.",
       "He is loud, funny, and loyal.",
       "He becomes friends with a green ogre.",
-      "Eddie Murphy voiced him.",
-      "Name: Donkey."
+      "Eddie Murphy voiced him."
     ],
-    "baseClueFact": "Shrek's loud and loyal best friend.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Animation"
@@ -2000,13 +2000,13 @@
       "gru"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A former supervillain from Despicable Me.",
       "He adopts three girls.",
       "He is surrounded by Minions.",
-      "He has a long nose and distinctive accent.",
-      "Name: Gru."
+      "He has a long nose and distinctive accent."
     ],
-    "baseClueFact": "The former supervillain from Despicable Me.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Animation"
@@ -2023,13 +2023,13 @@
       "minion"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "Small yellow creatures from Despicable Me.",
-      "They speak in a silly mixed language.",
-      "They wear goggles and blue overalls.",
-      "They serve Gru.",
-      "Name: Minion."
+      "He speak in a silly mixed language.",
+      "He wear goggles and blue overalls.",
+      "He serve Gru."
     ],
-    "baseClueFact": "A small yellow helper from Despicable Me.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Animation"
@@ -2046,13 +2046,13 @@
       "captain jack sparrow"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional pirate from Pirates of the Caribbean.",
       "He has dreadlocks, beads, and a strange walk.",
       "Johnny Depp played him.",
-      "He is captain of the Black Pearl.",
-      "First name: Captain. Last name starts with 'S'."
+      "He is captain of the Black Pearl."
     ],
-    "baseClueFact": "The pirate captain of the Black Pearl.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -2069,13 +2069,13 @@
       "wednesday addams"
     ],
     "hints": [
+      "Became widely known through television.",
       "A dark and deadpan girl from The Addams Family.",
       "She wears black and has braided hair.",
       "She became newly popular through a Netflix series.",
-      "Her name is a day of the week.",
-      "First name: Wednesday. Last name starts with 'A'."
+      "Her name is a day of the week."
     ],
-    "baseClueFact": "The gothic girl from The Addams Family.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Television"
@@ -2092,13 +2092,13 @@
       "morticia addams"
     ],
     "hints": [
+      "Became widely known through television.",
       "A gothic woman from The Addams Family.",
       "She wears long black dresses.",
       "She is married to Gomez Addams.",
-      "She is Wednesday's mother.",
-      "First name: Morticia. Last name starts with 'A'."
+      "She is Wednesday's mother."
     ],
-    "baseClueFact": "The elegant gothic mother from The Addams Family.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Television"
@@ -2115,13 +2115,13 @@
       "gomez addams"
     ],
     "hints": [
+      "Became widely known through television.",
       "An eccentric character from The Addams Family.",
       "He is married to Morticia.",
       "He is Wednesday and Pugsley's father.",
-      "He is known for dramatic affection and dark humor.",
-      "First name: Gomez. Last name starts with 'A'."
+      "He is known for dramatic affection and dark humor."
     ],
-    "baseClueFact": "The passionate father from The Addams Family.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Television"
@@ -2138,13 +2138,13 @@
       "grinch"
     ],
     "hints": [
+      "Strongly linked with a winter holiday story.",
       "A green fictional character from Dr. Seuss.",
       "He dislikes Christmas at first.",
       "He tries to steal Christmas from the Whos.",
-      "His heart grows three sizes.",
-      "First name: The. Last name starts with 'G'."
+      "His heart grows three sizes."
     ],
-    "baseClueFact": "The green character who tries to steal Christmas.",
+    "baseClueFact": "A well-known fictional character from Christmas.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Christmas"
@@ -2161,13 +2161,13 @@
       "rudolph"
     ],
     "hints": [
+      "Strongly linked with a winter holiday story.",
       "A Christmas reindeer from a famous song and story.",
       "He has a shiny red nose.",
       "Other reindeer laugh at him at first.",
-      "He guides Santa's sleigh through fog.",
-      "Name: Rudolph."
+      "He guides Santa's sleigh through fog."
     ],
-    "baseClueFact": "The red-nosed reindeer who guides Santa's sleigh.",
+    "baseClueFact": "A well-known fictional character from Christmas.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Christmas"
@@ -2186,13 +2186,13 @@
       "santa claus"
     ],
     "hints": [
+      "Comes from a story people recognize across generations.",
       "A legendary figure associated with Christmas.",
       "He is often shown in a red suit with a white beard.",
       "He travels with reindeer and a sleigh.",
-      "He brings gifts to children.",
-      "First name: Santa. Last name starts with 'C'."
+      "He brings gifts to children."
     ],
-    "baseClueFact": "The Christmas figure who brings gifts.",
+    "baseClueFact": "A famous figure from folklore and legend.",
     "difficulty": "easy",
     "category": "legendary figure",
     "era": "Folklore"
@@ -2209,13 +2209,13 @@
       "easter bunny"
     ],
     "hints": [
+      "Comes from a story people recognize across generations.",
       "A holiday character associated with Easter.",
       "It is often shown as a rabbit.",
       "It brings or hides colorful eggs.",
-      "Its name combines the holiday and the animal.",
-      "First name: Easter. Last name starts with 'B'."
+      "Its name combines the holiday and the animal."
     ],
-    "baseClueFact": "The rabbit associated with Easter eggs.",
+    "baseClueFact": "A famous figure from folklore and legend.",
     "difficulty": "easy",
     "category": "legendary figure",
     "era": "Folklore"
@@ -2230,13 +2230,13 @@
       "robin hood"
     ],
     "hints": [
+      "Comes from a story people recognize across generations.",
       "A legendary English outlaw.",
       "He lives in Sherwood Forest.",
       "He is an expert archer.",
-      "He steals from the rich and gives to the poor.",
-      "First name: Robin. Last name starts with 'H'."
+      "He steals from the rich and gives to the poor."
     ],
-    "baseClueFact": "The outlaw who steals from the rich and gives to the poor.",
+    "baseClueFact": "A famous figure from folklore and legend.",
     "difficulty": "medium",
     "category": "legendary figure",
     "era": "Folklore"
@@ -2251,13 +2251,13 @@
       "tarzan"
     ],
     "hints": [
+      "Connected to Literature pop culture.",
       "A fictional man raised in the jungle.",
       "He was created by Edgar Rice Burroughs.",
       "He swings on vines and communicates with animals.",
-      "He is known as the lord of the jungle.",
-      "Name: Tarzan."
+      "He is known as the lord of the jungle."
     ],
-    "baseClueFact": "The jungle hero raised by apes.",
+    "baseClueFact": "A well-known fictional character from Literature.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Literature"
@@ -2272,13 +2272,13 @@
       "king kong"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A giant movie monster.",
       "He is an enormous gorilla-like ape.",
       "He climbs the Empire State Building in a famous scene.",
-      "His name combines a royal title and a short repeated sound.",
-      "First name: King. Last name starts with 'K'."
+      "His name combines a royal title and a short repeated sound."
     ],
-    "baseClueFact": "The giant ape from classic monster movies.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -2293,13 +2293,13 @@
       "godzilla"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A giant monster from Japanese films.",
       "He is linked to radiation and city destruction.",
       "He fights other monsters.",
-      "He is often called the King of the Monsters.",
-      "Name: Godzilla."
+      "He is often called the King of the Monsters."
     ],
-    "baseClueFact": "The giant monster from Japanese cinema.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Film"
@@ -2318,13 +2318,13 @@
       "et"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A friendly alien from a Steven Spielberg film.",
       "He befriends a boy named Elliott.",
       "He wants to phone home.",
-      "His name is only two letters.",
-      "Name: E.T.."
+      "His name is only two letters."
     ],
-    "baseClueFact": "The friendly alien who wants to phone home.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Film"
@@ -2341,13 +2341,13 @@
       "neo"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional hacker from The Matrix.",
       "He discovers reality is a simulation.",
       "He is played by Keanu Reeves.",
-      "He dodges bullets in slow motion.",
-      "Name: Neo."
+      "He dodges bullets in slow motion."
     ],
-    "baseClueFact": "The chosen hacker hero from The Matrix.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Film"
@@ -2364,13 +2364,13 @@
       "morpheus"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A character from The Matrix.",
       "He is Neo's mentor.",
       "He offers the red pill and blue pill choice.",
-      "Laurence Fishburne played him.",
-      "Name: Morpheus."
+      "Laurence Fishburne played him."
     ],
-    "baseClueFact": "The mentor who offers the red pill.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Film"
@@ -2387,13 +2387,13 @@
       "jack dawson"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional character from Titanic.",
       "He wins a ticket onto the ship.",
       "He falls in love with Rose.",
-      "Leonardo DiCaprio played him.",
-      "First name: Jack. Last name starts with 'D'."
+      "Leonardo DiCaprio played him."
     ],
-    "baseClueFact": "The poor artist from Titanic.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Film"
@@ -2412,13 +2412,13 @@
       "rose dewitt bukater"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional character from Titanic.",
-      "She is engaged to Cal but falls in love with Jack.",
-      "She is played by Kate Winslet.",
-      "She survives the sinking.",
-      "First name: Rose. Last name starts with 'B'."
+      "He is engaged to Cal but falls in love with Jack.",
+      "He is played by Kate Winslet.",
+      "He survives the sinking."
     ],
-    "baseClueFact": "The heroine of Titanic.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Film"
@@ -2435,13 +2435,13 @@
       "hannibal lecter"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A fictional psychiatrist and serial killer.",
       "He is extremely intelligent and polite.",
       "He appears in The Silence of the Lambs.",
-      "Anthony Hopkins famously played him.",
-      "First name: Hannibal. Last name starts with 'L'."
+      "Anthony Hopkins famously played him."
     ],
-    "baseClueFact": "The brilliant and terrifying cannibal psychiatrist.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "hard",
     "category": "villain",
     "era": "Film"
@@ -2460,13 +2460,13 @@
       "terminator"
     ],
     "hints": [
+      "Became famous through major movie stories.",
       "A cyborg from a sci-fi action film series.",
       "Arnold Schwarzenegger played the most famous version.",
       "He says 'I'll be back'.",
-      "He is also known as the T-800.",
-      "Name: Terminator."
+      "He is also known as the this figure."
     ],
-    "baseClueFact": "The cyborg assassin who says 'I'll be back'.",
+    "baseClueFact": "A well-known fictional character from Film.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Film"
@@ -2483,13 +2483,13 @@
       "lara croft"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A video game and film heroine.",
-      "She is a British archaeologist and adventurer.",
-      "She is associated with Tomb Raider.",
-      "Angelina Jolie played her in films.",
-      "First name: Lara. Last name starts with 'C'."
+      "He is a British archaeologist and adventurer.",
+      "He is associated with this figure.",
+      "Angelina Jolie played her in films."
     ],
-    "baseClueFact": "The adventurer heroine of Tomb Raider.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -2506,13 +2506,13 @@
       "pacman"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A classic arcade game character.",
       "He moves through mazes eating dots.",
       "He is chased by ghosts.",
-      "He is a yellow circle with a mouth.",
-      "First name: Pac. Last name starts with 'M'."
+      "He is a yellow circle with a mouth."
     ],
-    "baseClueFact": "The yellow arcade character who eats dots.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -2527,13 +2527,13 @@
       "donkey kong"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A Nintendo character from classic arcade games.",
       "He is a large gorilla.",
       "He throws barrels in early games.",
-      "He is connected to Mario's early history.",
-      "First name: Donkey. Last name starts with 'K'."
+      "He is connected to Mario's early history."
     ],
-    "baseClueFact": "The famous Nintendo gorilla.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -2550,13 +2550,13 @@
       "link"
     ],
     "hints": [
-      "A Nintendo hero from a fantasy adventure series.",
-      "He often wears green and carries a sword and shield.",
-      "He saves Hyrule.",
-      "He is often mistakenly called Zelda.",
-      "Name: Link."
+      "A fantasy video game hero.",
+      "Usually explores dungeons, forests, temples, and ruins.",
+      "Often carries a sword, shield, and quiet courage.",
+      "Frequently protects a princess and a kingdom called Hyrule.",
+      "The Master Sword is strongly tied to him."
     ],
-    "baseClueFact": "The sword-carrying hero from The Legend of Zelda.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -2573,13 +2573,13 @@
       "zelda"
     ],
     "hints": [
-      "A princess from a Nintendo fantasy series.",
-      "She is connected to the kingdom of Hyrule.",
-      "People often confuse her name with the hero's.",
-      "She is the title princess of the series.",
-      "Name: Zelda."
+      "A royal figure from a fantasy video game world.",
+      "Connected to an ancient kingdom, magic, and recurring danger.",
+      "Often protected by a quiet sword-carrying hero.",
+      "People often mistake her for the playable hero.",
+      "The franchise title includes her name."
     ],
-    "baseClueFact": "The princess from The Legend of Zelda.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "medium",
     "category": "video game character",
     "era": "Video games"
@@ -2594,13 +2594,13 @@
       "master chief"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A video game hero from the Halo series.",
       "He wears green futuristic armor.",
       "He is a supersoldier.",
-      "His real name is John-117.",
-      "First name: Master. Last name starts with 'C'."
+      "His real name is John-117."
     ],
-    "baseClueFact": "The armored hero of Halo.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "hard",
     "category": "video game character",
     "era": "Video games"
@@ -2615,13 +2615,13 @@
       "kratos"
     ],
     "hints": [
+      "Players usually encounter this figure through interactive adventures.",
       "A video game character known for rage and mythology.",
       "He first fights Greek gods.",
       "He later appears in Norse mythology settings.",
-      "He has pale skin and red markings.",
-      "Name: Kratos."
+      "He has pale skin and red markings."
     ],
-    "baseClueFact": "The warrior hero from God of War.",
+    "baseClueFact": "A famous character from video games.",
     "difficulty": "hard",
     "category": "video game character",
     "era": "Video games"
@@ -2640,13 +2640,13 @@
       "luffy"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "An anime and manga pirate hero.",
       "He wears a straw hat.",
       "His body can stretch like rubber.",
-      "He wants to become King of the Pirates.",
-      "Name: Luffy."
+      "He wants to become King of the Pirates."
     ],
-    "baseClueFact": "The straw-hat pirate from One Piece.",
+    "baseClueFact": "A famous character from anime.",
     "difficulty": "medium",
     "category": "anime character",
     "era": "Anime"
@@ -2663,13 +2663,13 @@
       "naruto uzumaki"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "An anime and manga ninja.",
       "He has whisker-like marks on his cheeks.",
       "He dreams of becoming Hokage.",
-      "He contains the Nine-Tails fox.",
-      "First name: Naruto. Last name starts with 'U'."
+      "He contains the Nine-Tails fox."
     ],
-    "baseClueFact": "The ninja hero who wants to become Hokage.",
+    "baseClueFact": "A famous character from anime.",
     "difficulty": "medium",
     "category": "anime character",
     "era": "Anime"
@@ -2686,13 +2686,13 @@
       "goku"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "An anime hero known for martial arts and transformations.",
       "He is a Saiyan.",
       "He can become Super Saiyan.",
-      "He is the main character of Dragon Ball.",
-      "Name: Goku."
+      "He is the main character of Dragon Ball."
     ],
-    "baseClueFact": "The Saiyan hero from Dragon Ball.",
+    "baseClueFact": "A famous character from anime.",
     "difficulty": "easy",
     "category": "anime character",
     "era": "Anime"
@@ -2709,13 +2709,13 @@
       "sailor moon"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "An anime magical girl hero.",
-      "Her civilian name is Usagi Tsukino.",
+      "Her civilian name is this figure.",
       "She fights evil with other Sailor Guardians.",
-      "Her name includes the moon.",
-      "First name: Sailor. Last name starts with 'M'."
+      "Her name includes the moon."
     ],
-    "baseClueFact": "The magical girl heroine with a moon theme.",
+    "baseClueFact": "A famous character from anime.",
     "difficulty": "hard",
     "category": "anime character",
     "era": "Anime"
@@ -2732,13 +2732,13 @@
       "totoro"
     ],
     "hints": [
+      "Belongs to a Japanese animated or manga-linked story world.",
       "A large gentle creature from a Studio Ghibli film.",
       "He appears with two young sisters.",
       "He waits at a bus stop in a famous scene.",
-      "The film is My Neighbor Totoro.",
-      "Name: Totoro."
+      "The film is this figure."
     ],
-    "baseClueFact": "The gentle forest spirit from Studio Ghibli.",
+    "baseClueFact": "A famous character from anime.",
     "difficulty": "hard",
     "category": "anime character",
     "era": "Anime"
@@ -2755,13 +2755,13 @@
       "dora explorer"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A children's cartoon girl who goes on adventures.",
       "She often asks the audience questions.",
       "Her monkey friend is Boots.",
-      "She carries a Backpack and uses a Map.",
-      "First name: Dora. Last name starts with 'E'."
+      "She carries a Backpack and uses a Map."
     ],
-    "baseClueFact": "The children's cartoon explorer with Boots.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Animation"
@@ -2778,13 +2778,13 @@
       "peppa pig"
     ],
     "hints": [
+      "First became famous through animated stories.",
       "A small pink cartoon pig from a children's show.",
       "She lives with Mummy Pig, Daddy Pig, and George.",
       "She loves jumping in muddy puddles.",
-      "Her name starts with P.",
-      "First name: Peppa. Last name starts with 'P'."
+      "Her name starts with P."
     ],
-    "baseClueFact": "The British cartoon pig who loves muddy puddles.",
+    "baseClueFact": "A well-known fictional character from Animation.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Animation"
@@ -2799,13 +2799,13 @@
       "hello kitty"
     ],
     "hints": [
+      "Connected to Toy pop culture.",
       "A cute Japanese character created by Sanrio.",
       "She is usually shown as a white cat-like girl.",
       "She wears a bow near one ear.",
-      "She appears on countless toys and accessories.",
-      "First name: Hello. Last name starts with 'K'."
+      "She appears on countless toys and accessories."
     ],
-    "baseClueFact": "The cute Japanese character with a bow.",
+    "baseClueFact": "A well-known fictional character from Toy.",
     "difficulty": "medium",
     "category": "fictional character",
     "era": "Toy"
@@ -2820,13 +2820,13 @@
       "maleficent"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A powerful dark fairy from a Disney story.",
       "She curses Princess Aurora.",
       "She has horns and a dramatic black outfit.",
-      "Angelina Jolie played her in live-action films.",
-      "Name: Maleficent."
+      "Angelina Jolie played her in live-action films."
     ],
-    "baseClueFact": "The dark fairy villain from Sleeping Beauty.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "hard",
     "category": "villain",
     "era": "Disney"
@@ -2843,13 +2843,13 @@
       "cruella vil"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney villain known for dramatic fashion.",
       "She wants coats made from dalmatian puppies.",
       "She has black-and-white hair.",
-      "Her story is connected to 101 Dalmatians.",
-      "First name: Cruella. Last name starts with 'V'."
+      "Her story is connected to 101 Dalmatians."
     ],
-    "baseClueFact": "The Disney villain obsessed with dalmatian puppies.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "hard",
     "category": "villain",
     "era": "Disney"
@@ -2866,13 +2866,13 @@
       "ursula"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney sea witch.",
       "She takes Ariel's voice.",
       "She has tentacles and a dramatic villain style.",
-      "She appears in The Little Mermaid.",
-      "Name: Ursula."
+      "She appears in The Little Mermaid."
     ],
-    "baseClueFact": "The sea witch from The Little Mermaid.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "hard",
     "category": "villain",
     "era": "Disney"
@@ -2889,13 +2889,13 @@
       "scar"
     ],
     "hints": [
+      "Connected to a long-running family entertainment universe.",
       "A Disney villain from The Lion King.",
       "He is Mufasa's brother.",
       "He tricks Simba and takes over the Pride Lands.",
-      "His name refers to the mark on his face.",
-      "Name: Scar."
+      "His name refers to the mark on his face."
     ],
-    "baseClueFact": "The villainous lion from The Lion King.",
+    "baseClueFact": "A famous fictional antagonist.",
     "difficulty": "easy",
     "category": "villain",
     "era": "Disney"
@@ -2910,13 +2910,13 @@
       "hercules"
     ],
     "hints": [
+      "Comes from ancient stories about gods, monsters, and heroes.",
       "A legendary hero from Greek mythology.",
       "He is famous for great strength.",
       "He completed twelve labors.",
-      "Disney made an animated film about him.",
-      "Name: Hercules."
+      "Disney made an animated film about him."
     ],
-    "baseClueFact": "The legendary strong hero from Greek mythology.",
+    "baseClueFact": "A famous figure from mythology.",
     "difficulty": "medium",
     "category": "mythological figure",
     "era": "Mythology"
@@ -2931,13 +2931,13 @@
       "zeus"
     ],
     "hints": [
+      "Comes from ancient stories about gods, monsters, and heroes.",
       "A god from Greek mythology.",
       "He rules Mount Olympus.",
       "He is associated with thunder and lightning.",
-      "He is father of many gods and heroes.",
-      "Name: Zeus."
+      "He is father of many gods and heroes."
     ],
-    "baseClueFact": "The king of the Greek gods.",
+    "baseClueFact": "A famous figure from mythology.",
     "difficulty": "medium",
     "category": "mythological figure",
     "era": "Mythology"
@@ -2952,13 +2952,13 @@
       "athena"
     ],
     "hints": [
+      "Comes from ancient stories about gods, monsters, and heroes.",
       "A Greek goddess associated with wisdom.",
       "She is often linked to owls and helmets.",
       "The city of Athens is named after her.",
-      "She is a daughter of Zeus.",
-      "Name: Athena."
+      "She is a daughter of Zeus."
     ],
-    "baseClueFact": "The Greek goddess of wisdom.",
+    "baseClueFact": "A famous figure from mythology.",
     "difficulty": "hard",
     "category": "mythological figure",
     "era": "Mythology"
@@ -2973,13 +2973,13 @@
       "medusa"
     ],
     "hints": [
+      "Comes from ancient stories about gods, monsters, and heroes.",
       "A figure from Greek mythology.",
       "She has snakes instead of hair.",
       "People who look at her turn to stone.",
-      "Perseus kills her in the myth.",
-      "Name: Medusa."
+      "Perseus kills her in the myth."
     ],
-    "baseClueFact": "The mythological woman with snakes for hair.",
+    "baseClueFact": "A famous figure from mythology.",
     "difficulty": "hard",
     "category": "mythological figure",
     "era": "Mythology"
@@ -2998,13 +2998,13 @@
       "michael jackson"
     ],
     "hints": [
-      "An American pop star often called the King of Pop.",
+      "Built fame in the age of global mass media.",
+      "An American pop star often called the this figure.",
       "He released Thriller, one of the best-selling albums ever.",
       "He made the moonwalk dance move world famous.",
-      "His hits include Billie Jean, Beat It, and Smooth Criminal.",
-      "First name: Michael. Last name starts with 'J'."
+      "His hits include Billie Jean, Beat It, and Smooth Criminal."
     ],
-    "baseClueFact": "The King of Pop known for Thriller and the moonwalk.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3019,13 +3019,13 @@
       "whitney houston"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer known for one of pop music's strongest voices.",
       "She starred in The Bodyguard.",
       "Her version of I Will Always Love You became a global hit.",
-      "She was nicknamed The Voice.",
-      "First name: Whitney. Last name starts with 'H'."
+      "She was nicknamed The Voice."
     ],
-    "baseClueFact": "The singer known as The Voice.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3040,13 +3040,13 @@
       "mariah carey"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer with a famous vocal range.",
       "She is known for whistle notes.",
       "Her Christmas song returns to charts every year.",
-      "The song is All I Want for Christmas Is You.",
-      "First name: Mariah. Last name starts with 'C'."
+      "The song is All I Want for Christmas Is You."
     ],
-    "baseClueFact": "The pop diva famous for high notes and a Christmas hit.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3061,13 +3061,13 @@
       "shakira"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Colombian singer and dancer who became a global pop star.",
       "She is famous for belly-dance-inspired movement.",
       "Her hits include Hips Don't Lie and Whenever, Wherever.",
-      "She performed at the Super Bowl halftime show with Jennifer Lopez.",
-      "Name: Shakira."
+      "She performed at the Super Bowl halftime show with Jennifer Lopez."
     ],
-    "baseClueFact": "The Colombian singer famous for Hips Don't Lie.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3082,13 +3082,13 @@
       "cher"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer and actress with a career spanning decades.",
-      "She first became famous as part of Sonny and Cher.",
+      "She first became famous as part of Sonny and this figure.",
       "Her hit Believe became famous for its vocal effect.",
-      "She is often called the Goddess of Pop.",
-      "Name: Cher."
+      "She is often called the Goddess of Pop."
     ],
-    "baseClueFact": "The Goddess of Pop known for Believe.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "hard",
     "category": "singer",
     "era": "Modern"
@@ -3105,13 +3105,13 @@
       "madonna"
     ],
     "hints": [
-      "An American pop icon often called the Queen of Pop.",
+      "Built fame in the age of global mass media.",
+      "An American pop icon often called the this figure.",
       "She became huge in the 1980s.",
       "Her hits include Like a Virgin, Vogue, and Material Girl.",
-      "She is famous for constant reinvention.",
-      "Name: Madonna."
+      "She is famous for constant reinvention."
     ],
-    "baseClueFact": "The Queen of Pop known for constant reinvention.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3130,13 +3130,13 @@
       "beyonce"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer who first became famous with Destiny's Child.",
       "She is known for powerful vocals and elaborate performances.",
-      "Her fans often call her Queen Bey.",
-      "Her songs include Single Ladies and Halo.",
-      "Name: Beyonce."
+      "Her fans often call her this figure.",
+      "Her songs include Single Ladies and Halo."
     ],
-    "baseClueFact": "A global superstar known as Queen Bey.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "easy",
     "category": "singer",
     "era": "Modern"
@@ -3151,13 +3151,13 @@
       "lady gaga"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American pop star known for theatrical fashion.",
       "She released hits like Poker Face and Bad Romance.",
       "She also acted in A Star Is Born.",
-      "She famously wore a meat dress.",
-      "First name: Lady. Last name starts with 'G'."
+      "She famously wore a meat dress."
     ],
-    "baseClueFact": "A theatrical pop star known for Poker Face and Bad Romance.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3172,13 +3172,13 @@
       "taylor swift"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer-songwriter who began in country music.",
       "She is known for autobiographical lyrics and massive fan culture.",
       "Her albums include Fearless, 1989, and Midnights.",
-      "Her Eras Tour became a global cultural event.",
-      "First name: Taylor. Last name starts with 'S'."
+      "Her Eras Tour became a global cultural event."
     ],
-    "baseClueFact": "The singer-songwriter famous for eras and storytelling.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "easy",
     "category": "singer",
     "era": "Modern"
@@ -3193,13 +3193,13 @@
       "rihanna"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A singer from Barbados who became a global pop and R&B star.",
       "Her hits include Umbrella, Diamonds, and We Found Love.",
       "She founded the Fenty Beauty brand.",
-      "Her fans often call her RiRi.",
-      "Name: Rihanna."
+      "Her fans often call her RiRi."
     ],
-    "baseClueFact": "The Barbadian singer and Fenty founder.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3214,13 +3214,13 @@
       "britney spears"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American pop star who became famous as a teenager.",
       "Her debut single was ...Baby One More Time.",
       "She is strongly associated with late-1990s pop.",
-      "She was often called the Princess of Pop.",
-      "First name: Britney. Last name starts with 'S'."
+      "She was often called the Princess of Pop."
     ],
-    "baseClueFact": "The Princess of Pop famous for Baby One More Time.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3239,13 +3239,13 @@
       "elvis presley"
     ],
     "hints": [
-      "An American singer and actor often called The King.",
+      "Rose to fame before the internet era made celebrity instant.",
+      "An American singer and actor often called this figure.",
       "He helped popularize rock and roll.",
       "He lived at Graceland.",
-      "His hits include Jailhouse Rock and Can't Help Falling in Love.",
-      "First name: Elvis. Last name starts with 'P'."
+      "His hits include Jailhouse Rock and Can't Help Falling in Love."
     ],
-    "baseClueFact": "The King of Rock and Roll.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "easy",
     "category": "singer",
     "era": "20th Century"
@@ -3260,13 +3260,13 @@
       "freddie mercury"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "A British rock singer with a powerful stage presence.",
       "He was the lead singer of Queen.",
       "He performed at Live Aid in 1985.",
-      "His songs include Bohemian Rhapsody and We Are the Champions.",
-      "First name: Freddie. Last name starts with 'M'."
+      "His songs include Bohemian Rhapsody and We Are the Champions."
     ],
-    "baseClueFact": "The Queen frontman with a legendary voice.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "medium",
     "category": "singer",
     "era": "20th Century"
@@ -3281,13 +3281,13 @@
       "elton john"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British singer and pianist known for flamboyant style.",
       "He often performs wearing colorful glasses.",
       "His hits include Rocket Man and Your Song.",
-      "He helped create music for The Lion King.",
-      "First name: Elton. Last name starts with 'J'."
+      "He helped create music for The Lion King."
     ],
-    "baseClueFact": "The British singer-pianist famous for Rocket Man.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3302,13 +3302,13 @@
       "adele"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British singer known for emotional songs and a rich voice.",
       "Her albums are named after ages, such as 19, 21, 25, and 30.",
       "Her songs include Hello and Someone Like You.",
-      "She has won many Grammy Awards.",
-      "Name: Adele."
+      "She has won many Grammy Awards."
     ],
-    "baseClueFact": "The British singer known for emotional ballads.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3325,13 +3325,13 @@
       "celine dion"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Canadian singer with a powerful voice.",
       "She represented Switzerland at Eurovision in 1988.",
       "Her biggest global hit was from Titanic.",
-      "The song is My Heart Will Go On.",
-      "First name: Celine. Last name starts with 'D'."
+      "The song is My Heart Will Go On."
     ],
-    "baseClueFact": "The Canadian singer famous for Titanic's main song.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "hard",
     "category": "singer",
     "era": "Modern"
@@ -3346,13 +3346,13 @@
       "tina turner"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "An American-born singer with an explosive stage presence.",
       "She became famous with Ike Turner and later as a solo star.",
       "Her hits include What's Love Got to Do with It.",
-      "She was called the Queen of Rock 'n' Roll.",
-      "First name: Tina. Last name starts with 'T'."
+      "She was called the Queen of Rock 'n' Roll."
     ],
-    "baseClueFact": "The Queen of Rock 'n' Roll.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "medium",
     "category": "singer",
     "era": "20th Century"
@@ -3367,13 +3367,13 @@
       "dolly parton"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American country singer, songwriter, and actress.",
       "She wrote Jolene and I Will Always Love You.",
       "She starred in the film 9 to 5.",
-      "She founded the Imagination Library.",
-      "First name: Dolly. Last name starts with 'P'."
+      "She founded the Imagination Library."
     ],
-    "baseClueFact": "The country icon famous for Jolene and 9 to 5.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "hard",
     "category": "singer",
     "era": "Modern"
@@ -3388,13 +3388,13 @@
       "prince"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "An American musician known for genre-blending and flamboyant style.",
       "He was a singer, guitarist, producer, and performer.",
       "He was strongly associated with the color purple.",
-      "His famous album and film is Purple Rain.",
-      "Name: Prince."
+      "His famous album and film is Purple Rain."
     ],
-    "baseClueFact": "The music icon famous for Purple Rain.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "hard",
     "category": "singer",
     "era": "20th Century"
@@ -3409,13 +3409,13 @@
       "bob marley"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "A Jamaican singer who popularized reggae worldwide.",
       "He was associated with Rastafari culture.",
       "His songs include One Love and No Woman, No Cry.",
-      "He performed with The Wailers.",
-      "First name: Bob. Last name starts with 'M'."
+      "He performed with The Wailers."
     ],
-    "baseClueFact": "The Jamaican reggae icon.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "hard",
     "category": "singer",
     "era": "20th Century"
@@ -3434,13 +3434,13 @@
       "eminem"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American rapper from Detroit.",
-      "He is also known as Slim Shady.",
-      "His real name is Marshall Mathers.",
-      "His songs include Lose Yourself and Without Me.",
-      "Name: Eminem."
+      "He is also known as this figure.",
+      "His real name is this figure.",
+      "His songs include Lose Yourself and Without Me."
     ],
-    "baseClueFact": "The rapper also known as Slim Shady.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "easy",
     "category": "rapper",
     "era": "Modern"
@@ -3455,13 +3455,13 @@
       "snoop dogg"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American rapper from California.",
       "He became famous through Dr. Dre's productions.",
       "He is known for a relaxed delivery and laid-back persona.",
-      "His name includes an animal often associated with loyalty.",
-      "First name: Snoop. Last name starts with 'D'."
+      "His name includes an animal often associated with loyalty."
     ],
-    "baseClueFact": "The laid-back West Coast rapper.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "rapper",
     "era": "Modern"
@@ -3480,13 +3480,13 @@
       "tupac shakur"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "An American rapper and actor famous in the 1990s.",
-      "He is also known as 2Pac.",
+      "He is also known as this figure.",
       "His songs include California Love and Changes.",
-      "He died after a shooting in Las Vegas in 1996.",
-      "First name: Tupac. Last name starts with 'S'."
+      "He died after a shooting in Las Vegas in 1996."
     ],
-    "baseClueFact": "The legendary 1990s rapper also known as 2Pac.",
+    "baseClueFact": "A globally recognized music figure from 20th Century.",
     "difficulty": "medium",
     "category": "rapper",
     "era": "20th Century"
@@ -3501,13 +3501,13 @@
       "drake"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Canadian rapper and singer.",
       "He first became known as an actor on Degrassi.",
       "His hits include Hotline Bling and God's Plan.",
-      "He is one of the most streamed artists in the world.",
-      "Name: Drake."
+      "He is one of the most streamed artists in the world."
     ],
-    "baseClueFact": "The Canadian rapper behind Hotline Bling.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "rapper",
     "era": "Modern"
@@ -3526,13 +3526,13 @@
       "weeknd"
     ],
     "hints": [
-      "A Canadian singer whose real name is Abel Tesfaye.",
+      "Built fame in the age of global mass media.",
+      "A Canadian singer whose real name is this figure.",
       "He is known for dark pop and R&B sounds.",
       "His hit Blinding Lights became globally huge.",
-      "His stage name begins with The.",
-      "First name: The. Last name starts with 'W'."
+      "His stage name begins with The."
     ],
-    "baseClueFact": "The Canadian singer known for Blinding Lights.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3547,13 +3547,13 @@
       "billie eilish"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer who became famous as a teenager.",
       "She often works with her brother Finneas.",
       "Her breakout hit was Bad Guy.",
-      "She is known for whispery vocals and distinctive fashion.",
-      "First name: Billie. Last name starts with 'E'."
+      "She is known for whispery vocals and distinctive fashion."
     ],
-    "baseClueFact": "The pop star known for Bad Guy.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3568,13 +3568,13 @@
       "ariana grande"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer and former Nickelodeon actress.",
       "She is known for a high vocal range.",
       "Her signature look often includes a high ponytail.",
-      "Her hits include Thank U, Next and 7 Rings.",
-      "First name: Ariana. Last name starts with 'G'."
+      "Her hits include Thank U, Next and 7 Rings."
     ],
-    "baseClueFact": "The pop singer known for high vocals and ponytail.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3589,13 +3589,13 @@
       "justin bieber"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Canadian singer who became famous as a teenager.",
       "He was discovered through YouTube videos.",
       "His early hit was Baby.",
-      "He later released songs like Sorry and Peaches.",
-      "First name: Justin. Last name starts with 'B'."
+      "He later released songs like Sorry and Peaches."
     ],
-    "baseClueFact": "The Canadian pop star discovered on YouTube.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3610,13 +3610,13 @@
       "ed sheeran"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British singer-songwriter known for using a loop pedal.",
       "His hits include Shape of You and Perfect.",
       "He often performs with just a guitar.",
-      "He has red hair.",
-      "First name: Ed. Last name starts with 'S'."
+      "He has red hair."
     ],
-    "baseClueFact": "The British singer-songwriter behind Shape of You.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3635,13 +3635,13 @@
       "jennifer lopez"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer, dancer, and actress.",
-      "She is also known as J.Lo.",
+      "She is also known as this figure.",
       "She starred in Selena and Hustlers.",
-      "She performed at the Super Bowl halftime show with Shakira.",
-      "First name: Jennifer. Last name starts with 'L'."
+      "She performed at the Super Bowl halftime show with Shakira."
     ],
-    "baseClueFact": "The singer, dancer, and actress known as J.Lo.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3656,13 +3656,13 @@
       "katy perry"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American pop singer known for colorful costumes.",
       "Her hits include Firework and Roar.",
       "She sang I Kissed a Girl.",
-      "She has been a judge on American Idol.",
-      "First name: Katy. Last name starts with 'P'."
+      "She has been a judge on American Idol."
     ],
-    "baseClueFact": "The pop singer known for Firework and Roar.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3677,13 +3677,13 @@
       "bruno mars"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer and performer.",
       "His hits include Uptown Funk and Just the Way You Are.",
       "He is known for retro funk and dance-heavy shows.",
-      "His stage surname is a planet.",
-      "First name: Bruno. Last name starts with 'M'."
+      "His stage surname is a planet."
     ],
-    "baseClueFact": "The pop and funk performer known for Uptown Funk.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3698,13 +3698,13 @@
       "dua lipa"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British-Albanian pop singer.",
       "Her hits include New Rules and Levitating.",
       "She is known for dance-pop songs.",
-      "Her first name means love in Albanian.",
-      "First name: Dua. Last name starts with 'L'."
+      "Her first name means love in Albanian."
     ],
-    "baseClueFact": "The British-Albanian pop singer behind Levitating.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "hard",
     "category": "singer",
     "era": "Modern"
@@ -3719,13 +3719,13 @@
       "miley cyrus"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American singer and actress.",
       "She became famous as Hannah Montana.",
       "Her songs include Wrecking Ball and Flowers.",
-      "She is the daughter of Billy Ray Cyrus.",
-      "First name: Miley. Last name starts with 'C'."
+      "She is the daughter of Billy Ray Cyrus."
     ],
-    "baseClueFact": "The singer and actress who played Hannah Montana.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3740,13 +3740,13 @@
       "hannah montana"
     ],
     "hints": [
+      "Became widely known through television.",
       "A fictional teenage pop star from Disney Channel.",
       "She lives a double life.",
       "Miley Cyrus played her.",
-      "Her show was called by her stage name.",
-      "First name: Hannah. Last name starts with 'M'."
+      "Her show was called by her stage name."
     ],
-    "baseClueFact": "The Disney Channel pop-star alter ego.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "hard",
     "category": "fictional character",
     "era": "Television"
@@ -3761,13 +3761,13 @@
       "harry styles"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British singer and actor.",
       "He was a member of One Direction.",
       "His solo hits include Watermelon Sugar and As It Was.",
-      "He is known for fashion-forward style.",
-      "First name: Harry. Last name starts with 'S'."
+      "He is known for fashion-forward style."
     ],
-    "baseClueFact": "The British singer who was in One Direction.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "singer",
     "era": "Modern"
@@ -3784,13 +3784,13 @@
       "bts"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A South Korean pop group known worldwide.",
       "Their fans are called ARMY.",
       "Their hits include Dynamite and Butter.",
-      "Their name is three letters.",
-      "Name: BTS."
+      "Their name is three letters."
     ],
-    "baseClueFact": "The globally famous South Korean boy band.",
+    "baseClueFact": "A globally recognized music figure from modern pop culture.",
     "difficulty": "medium",
     "category": "music group",
     "era": "Modern"
@@ -3805,13 +3805,13 @@
       "tom cruise"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor famous for action films.",
       "He plays Ethan Hunt in Mission: Impossible.",
       "He is known for doing many of his own stunts.",
-      "He also starred in Top Gun.",
-      "First name: Tom. Last name starts with 'C'."
+      "He also starred in Top Gun."
     ],
-    "baseClueFact": "The Hollywood actor known for Mission: Impossible.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "easy",
     "category": "actor",
     "era": "Modern"
@@ -3826,13 +3826,13 @@
       "brad pitt"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American film star and producer.",
       "He starred in Fight Club, Troy, and Ocean's Eleven.",
       "He won an Oscar for Once Upon a Time in Hollywood.",
-      "He was married to Angelina Jolie.",
-      "First name: Brad. Last name starts with 'P'."
+      "He was married to Angelina Jolie."
     ],
-    "baseClueFact": "The Hollywood actor known for Fight Club and Troy.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3847,13 +3847,13 @@
       "angelina jolie"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actress and humanitarian.",
       "She played Lara Croft in Tomb Raider.",
       "She won an Oscar for Girl, Interrupted.",
-      "She was married to Brad Pitt.",
-      "First name: Angelina. Last name starts with 'J'."
+      "She was married to Brad Pitt."
     ],
-    "baseClueFact": "The actress known for Tomb Raider and humanitarian work.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3870,13 +3870,13 @@
       "leonardo dicaprio"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor who became a global star with Titanic.",
       "He starred in The Wolf of Wall Street and Inception.",
       "He won an Oscar for The Revenant.",
-      "His first name is the same as da Vinci's.",
-      "First name: Leonardo. Last name starts with 'D'."
+      "His first name is the same as da Vinci's."
     ],
-    "baseClueFact": "The actor famous for Titanic and The Revenant.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "easy",
     "category": "actor",
     "era": "Modern"
@@ -3891,13 +3891,13 @@
       "johnny depp"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor known for unusual characters.",
       "He played Captain Jack Sparrow.",
       "He worked often with Tim Burton.",
-      "He played Edward Scissorhands and Willy Wonka.",
-      "First name: Johnny. Last name starts with 'D'."
+      "He played Edward Scissorhands and Willy Wonka."
     ],
-    "baseClueFact": "The actor known for Captain Jack Sparrow.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3914,13 +3914,13 @@
       "dwayne johnson"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor and former professional wrestler.",
       "He was famous in WWE.",
-      "His nickname is The Rock.",
-      "He starred in Jumanji and Fast & Furious films.",
-      "First name: Dwayne. Last name starts with 'J'."
+      "His nickname is this figure.",
+      "He starred in Jumanji and Fast & Furious films."
     ],
-    "baseClueFact": "The actor and former wrestler known as The Rock.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3935,13 +3935,13 @@
       "will smith"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor and rapper.",
       "He starred in The Fresh Prince of Bel-Air.",
       "He played Agent J in Men in Black.",
-      "He won an Oscar for King Richard.",
-      "First name: Will. Last name starts with 'S'."
+      "He won an Oscar for King Richard."
     ],
-    "baseClueFact": "The actor and rapper from Men in Black and Fresh Prince.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3956,13 +3956,13 @@
       "morgan freeman"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor with one of cinema's most recognizable voices.",
       "He starred in The Shawshank Redemption.",
       "He played God in Bruce Almighty.",
-      "He is often used as a narrator.",
-      "First name: Morgan. Last name starts with 'F'."
+      "He is often used as a narrator."
     ],
-    "baseClueFact": "The actor famous for his deep voice.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -3977,13 +3977,13 @@
       "marilyn monroe"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "An American actress and model from old Hollywood.",
       "She was famous for blonde hair and glamorous image.",
       "She starred in Some Like It Hot.",
-      "One famous image shows her white dress blowing upward.",
-      "First name: Marilyn. Last name starts with 'M'."
+      "One famous image shows her white dress blowing upward."
     ],
-    "baseClueFact": "The classic Hollywood icon with the white dress image.",
+    "baseClueFact": "A globally recognized screen performer from 20th Century.",
     "difficulty": "medium",
     "category": "actor",
     "era": "20th Century"
@@ -4000,13 +4000,13 @@
       "charlie chaplin"
     ],
     "hints": [
+      "Rose to fame before the internet era made celebrity instant.",
       "A British comic actor from the silent film era.",
       "He created the character The Tramp.",
       "He wore a bowler hat and carried a cane.",
-      "He had a tiny mustache and exaggerated walk.",
-      "First name: Charlie. Last name starts with 'C'."
+      "He had a tiny mustache and exaggerated walk."
     ],
-    "baseClueFact": "The silent-film comedy icon with a cane and bowler hat.",
+    "baseClueFact": "A globally recognized screen performer from 20th Century.",
     "difficulty": "hard",
     "category": "actor",
     "era": "20th Century"
@@ -4025,13 +4025,13 @@
       "mr bean"
     ],
     "hints": [
+      "Became widely known through television.",
       "A British comedy character who rarely speaks.",
-      "He is played by Rowan Atkinson.",
+      "He is played by this figure.",
       "He often causes chaos through awkward behavior.",
-      "He drives a small green Mini.",
-      "First name: Mr. Last name starts with 'B'."
+      "He drives a small green Mini."
     ],
-    "baseClueFact": "The mostly silent comedy character played by Rowan Atkinson.",
+    "baseClueFact": "A well-known fictional character from Television.",
     "difficulty": "easy",
     "category": "fictional character",
     "era": "Television"
@@ -4048,13 +4048,13 @@
       "oprah winfrey"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American television host and media executive.",
       "She hosted one of the most successful talk shows in history.",
       "She is often referred to by her first name only.",
-      "She is associated with book clubs and powerful interviews.",
-      "First name: Oprah. Last name starts with 'W'."
+      "She is associated with book clubs and powerful interviews."
     ],
-    "baseClueFact": "The famous TV host and media mogul.",
+    "baseClueFact": "A well-known fictional character from modern pop culture.",
     "difficulty": "medium",
     "category": "TV personality",
     "era": "Modern"
@@ -4069,13 +4069,13 @@
       "kim kardashian"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American reality TV personality and businesswoman.",
       "She became famous through Keeping Up with the Kardashians.",
       "She founded SKIMS.",
-      "Her family name is extremely famous in celebrity culture.",
-      "First name: Kim. Last name starts with 'K'."
+      "Her family name is extremely famous in celebrity culture."
     ],
-    "baseClueFact": "The reality TV star and businesswoman.",
+    "baseClueFact": "A well-known fictional character from modern pop culture.",
     "difficulty": "medium",
     "category": "celebrity",
     "era": "Modern"
@@ -4092,13 +4092,13 @@
       "arnold schwarzenegger"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An Austrian-American bodybuilder, actor, and politician.",
       "He won Mr. Olympia multiple times.",
       "He played the Terminator.",
-      "He served as governor of California.",
-      "First name: Arnold. Last name starts with 'S'."
+      "He served as governor of California."
     ],
-    "baseClueFact": "The actor, bodybuilder, and former governor famous for Terminator.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4115,13 +4115,13 @@
       "sylvester stallone"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor and filmmaker.",
       "He created and played Rocky Balboa.",
       "He also played John Rambo.",
-      "He is associated with action films and boxing.",
-      "First name: Sylvester. Last name starts with 'S'."
+      "He is associated with action films and boxing."
     ],
-    "baseClueFact": "The actor known for Rocky and Rambo.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4136,13 +4136,13 @@
       "keanu reeves"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Canadian actor known for a calm public image.",
       "He played Neo in The Matrix.",
       "He also plays John Wick.",
-      "He is strongly associated with black suits and action roles.",
-      "First name: Keanu. Last name starts with 'R'."
+      "He is strongly associated with black suits and action roles."
     ],
-    "baseClueFact": "The actor known for The Matrix and John Wick.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "easy",
     "category": "actor",
     "era": "Modern"
@@ -4157,13 +4157,13 @@
       "jim carrey"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Canadian-American actor famous for physical comedy.",
       "He starred in The Mask, Ace Ventura, and Dumb and Dumber.",
       "He is known for elastic facial expressions.",
-      "He also starred in The Truman Show.",
-      "First name: Jim. Last name starts with 'C'."
+      "He also starred in The Truman Show."
     ],
-    "baseClueFact": "The comic actor known for The Mask and Ace Ventura.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4178,13 +4178,13 @@
       "robin williams"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American comedian and actor famous for improvisation.",
       "He voiced the Genie in Aladdin.",
       "He starred in Mrs. Doubtfire and Good Will Hunting.",
-      "He had a fast and energetic comic style.",
-      "First name: Robin. Last name starts with 'W'."
+      "He had a fast and energetic comic style."
     ],
-    "baseClueFact": "The beloved comic actor who voiced the Genie.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4199,13 +4199,13 @@
       "harrison ford"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actor famous for adventure and sci-fi roles.",
       "He played Han Solo in Star Wars.",
       "He played Indiana Jones.",
-      "He also starred in Blade Runner.",
-      "First name: Harrison. Last name starts with 'F'."
+      "He also starred in Blade Runner."
     ],
-    "baseClueFact": "The actor known for Han Solo and Indiana Jones.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4220,13 +4220,13 @@
       "meryl streep"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actress widely considered one of the greatest.",
       "She starred in The Devil Wears Prada.",
       "She has received many Academy Award nominations.",
-      "She played Margaret Thatcher in The Iron Lady.",
-      "First name: Meryl. Last name starts with 'S'."
+      "She played Margaret Thatcher in The Iron Lady."
     ],
-    "baseClueFact": "The actress known for many Oscar nominations.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "hard",
     "category": "actor",
     "era": "Modern"
@@ -4241,13 +4241,13 @@
       "julia roberts"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actress with a famous smile.",
       "She starred in Pretty Woman.",
       "She won an Oscar for Erin Brockovich.",
-      "She became one of the biggest stars of the 1990s.",
-      "First name: Julia. Last name starts with 'R'."
+      "She became one of the biggest stars of the 1990s."
     ],
-    "baseClueFact": "The actress known for Pretty Woman.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "hard",
     "category": "actor",
     "era": "Modern"
@@ -4262,13 +4262,13 @@
       "jennifer aniston"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American actress famous for a sitcom role.",
       "She played Rachel Green.",
       "Her hairstyle in the 1990s became very famous.",
-      "The show was Friends.",
-      "First name: Jennifer. Last name starts with 'A'."
+      "The show was Friends."
     ],
-    "baseClueFact": "The actress known for playing Rachel in Friends.",
+    "baseClueFact": "A globally recognized screen performer from modern pop culture.",
     "difficulty": "medium",
     "category": "actor",
     "era": "Modern"
@@ -4287,13 +4287,13 @@
       "lady diana"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British royal figure loved around the world.",
       "She married Prince Charles.",
       "She was the mother of Princes William and Harry.",
-      "She was often called the People's Princess.",
-      "First name: Lady. Last name starts with 'D'."
+      "She was often called the People's Princess."
     ],
-    "baseClueFact": "The People's Princess.",
+    "baseClueFact": "A widely known royal figure from modern pop culture.",
     "difficulty": "hard",
     "category": "royal",
     "era": "Modern"
@@ -4310,13 +4310,13 @@
       "queen elizabeth ii"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A British monarch who reigned for more than 70 years.",
       "She became queen in 1952.",
       "She was the mother of King Charles III.",
-      "She is often shown with pearls, hats, and corgis.",
-      "First name: Queen. Last name starts with 'I'."
+      "She is often shown with pearls, hats, and corgis."
     ],
-    "baseClueFact": "The long-reigning Queen of the United Kingdom.",
+    "baseClueFact": "A widely known royal figure from modern pop culture.",
     "difficulty": "easy",
     "category": "royal",
     "era": "Modern"
@@ -4333,13 +4333,13 @@
       "donald trump"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American businessman, TV personality, and politician.",
       "He hosted The Apprentice.",
       "He served as President of the United States.",
-      "His surname became one of the most recognizable in global politics.",
-      "First name: Donald. Last name starts with 'T'."
+      "His surname became one of the most recognizable in global politics."
     ],
-    "baseClueFact": "The businessman, TV personality, and American president.",
+    "baseClueFact": "A widely known political figure from modern pop culture.",
     "difficulty": "easy",
     "category": "politician",
     "era": "Modern"
@@ -4356,13 +4356,13 @@
       "barack obama"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "An American politician who became globally famous in 2008.",
       "He served as President of the United States.",
       "He was the first Black person elected to that office.",
-      "His campaign slogan included 'Yes We Can'.",
-      "First name: Barack. Last name starts with 'O'."
+      "His campaign slogan included 'Yes We Can'."
     ],
-    "baseClueFact": "The first Black president of the United States.",
+    "baseClueFact": "A widely known political figure from modern pop culture.",
     "difficulty": "easy",
     "category": "politician",
     "era": "Modern"
@@ -4379,13 +4379,13 @@
       "vladimir putin"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Russian politician and former intelligence officer.",
       "He has served as president and prime minister of Russia.",
       "He is one of the most internationally recognized modern political figures.",
-      "His surname begins with P and often appears in world news.",
-      "First name: Vladimir. Last name starts with 'P'."
+      "His surname begins with P and often appears in world news."
     ],
-    "baseClueFact": "A long-serving Russian leader.",
+    "baseClueFact": "A widely known political figure from modern pop culture.",
     "difficulty": "medium",
     "category": "politician",
     "era": "Modern"
@@ -4404,13 +4404,13 @@
       "volodymyr zelenskyy"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Ukrainian politician and former actor-comedian.",
       "He starred in Servant of the People.",
       "He became president of Ukraine.",
-      "He became globally known during Russia's full-scale invasion of Ukraine.",
-      "First name: Volodymyr. Last name starts with 'Z'."
+      "He became globally known during Russia's full-scale invasion of Ukraine."
     ],
-    "baseClueFact": "The Ukrainian president and former comedian.",
+    "baseClueFact": "A widely known political figure from modern pop culture.",
     "difficulty": "hard",
     "category": "politician",
     "era": "Modern"
@@ -4427,13 +4427,13 @@
       "pope francis"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A religious leader from Argentina.",
       "He became pope in 2013.",
       "He was the first pope from the Americas.",
-      "He chose the name Francis.",
-      "First name: Pope. Last name starts with 'F'."
+      "He chose the name this figure."
     ],
-    "baseClueFact": "A globally known pope from Argentina.",
+    "baseClueFact": "A globally known religious figure from modern pop culture.",
     "difficulty": "hard",
     "category": "religious figure",
     "era": "Modern"
@@ -4452,13 +4452,13 @@
       "jesus christ"
     ],
     "hints": [
+      "Has been recognized across many centuries.",
       "A religious figure known throughout the world.",
-      "Christians believe he is the Son of God.",
+      "this figureians believe he is the Son of God.",
       "His life is described in the New Testament.",
-      "He is associated with Christmas and Easter.",
-      "First name: Jesus. Last name starts with 'C'."
+      "He is associated with this figuremas and Easter."
     ],
-    "baseClueFact": "The central figure of Christianity.",
+    "baseClueFact": "A globally known religious figure from Ancient.",
     "difficulty": "easy",
     "category": "religious figure",
     "era": "Ancient"
@@ -4473,13 +4473,13 @@
       "mona lisa"
     ],
     "hints": [
+      "Is tied to one of the most studied artworks in history.",
       "A famous painted woman with a mysterious smile.",
       "She appears in a portrait by Leonardo da Vinci.",
       "The painting is kept in the Louvre.",
-      "The artwork's title is also her name.",
-      "First name: Mona. Last name starts with 'L'."
+      "The artwork's title is also her name."
     ],
-    "baseClueFact": "The woman in Leonardo da Vinci's most famous painting.",
+    "baseClueFact": "A famous figure from a work of art.",
     "difficulty": "hard",
     "category": "artwork figure",
     "era": "Renaissance"
@@ -4498,13 +4498,13 @@
       "cristiano ronaldo"
     ],
     "hints": [
+      "Built fame in the age of global mass media.",
       "A Portuguese footballer famous around the world.",
       "He played for Manchester United, Real Madrid, Juventus, and Portugal.",
       "He is associated with the number 7.",
-      "His nickname is CR7.",
-      "First name: Cristiano. Last name starts with 'R'."
+      "His nickname is this figure."
     ],
-    "baseClueFact": "The Portuguese football superstar known as CR7.",
+    "baseClueFact": "A globally recognized sports figure from modern pop culture.",
     "difficulty": "easy",
     "category": "athlete",
     "era": "Modern"

--- a/src/games/famous-figures/hints.ts
+++ b/src/games/famous-figures/hints.ts
@@ -1,29 +1,16 @@
 /**
  * Hint ladder utilities for Famous Figures.
  *
- * Hint ladder (0-based index):
- *   0  →  dataset hints[0]  — big content clue
- *   1  →  dataset hints[1]  — another big content clue
- *   2  →  generated          — "First name starts with 'X'"
- *   3  →  generated          — "Last name starts with 'Y'" (mononym fallback)
- *   4  →  generated          — "First name: Marie. Last name starts with 'C'."
- *                               Reveals the full first name and last-name initial
- *                               so players can narrow down their final guess.
+ * Dataset hints are curated from broad to specific for all five reveal steps.
+ * Older or incomplete rows can still fall back to generated name clues.
  */
 import type { FigureRow } from './model';
 
-// ─── Suffix stripping ─────────────────────────────────────────────────────────
-
-/**
- * Common generational/honorific suffixes that should not be treated as the
- * last name (e.g. "Martin Luther King Jr" → last = "King").
- */
 const KNOWN_SUFFIXES = new Set(['jr', 'sr', 'ii', 'iii', 'iv', 'v', 'vi']);
 
 /**
  * Parses a canonical name into first / last components.
- * Handles mononyms (e.g. "Cleopatra"), regnal names (e.g. "Louis XIV"),
- * and names with generational suffixes (e.g. "Martin Luther King Jr").
+ * Handles mononyms, regnal names, and names with generational suffixes.
  */
 function parseNameParts(canonicalName: string): {
   first: string;
@@ -32,7 +19,6 @@ function parseNameParts(canonicalName: string): {
 } {
   const raw = canonicalName.trim().split(/\s+/);
 
-  // Drop a trailing suffix so we don't mistake "Jr" / "III" for the last name.
   const lastToken = raw[raw.length - 1] ?? '';
   const parts =
     raw.length > 1 && KNOWN_SUFFIXES.has(lastToken.toLowerCase().replace(/\.$/, ''))
@@ -45,21 +31,18 @@ function parseNameParts(canonicalName: string): {
   return { first: parts[0], last: parts[parts.length - 1], isMononym: false };
 }
 
-// ─── Public API ───────────────────────────────────────────────────────────────
-
 /**
  * Returns the display text for the hint at `hintIndex` (0-based).
- *
- * Indices 0 and 1 return the dataset hints directly.
- * Indices 2–4 are generated from the figure's canonical name.
  */
 export function getHintText(figure: FigureRow, hintIndex: number): string {
   if (hintIndex < 0 || hintIndex > 4) {
-    throw new RangeError(`getHintText: hintIndex must be 0–4, got ${hintIndex}`);
+    throw new RangeError(`getHintText: hintIndex must be 0-4, got ${hintIndex}`);
   }
 
-  if (hintIndex === 0) return figure.hints[0];
-  if (hintIndex === 1) return figure.hints[1];
+  const datasetHint = figure.hints[hintIndex];
+  if (typeof datasetHint === 'string' && datasetHint.trim().length > 0) {
+    return datasetHint;
+  }
 
   const { first, last, isMononym } = parseNameParts(figure.canonicalName);
   const firstInitial = (first[0] ?? '?').toUpperCase();
@@ -78,11 +61,7 @@ export function getHintText(figure: FigureRow, hintIndex: number): string {
     return `Last name starts with '${lastInitial}'`;
   }
 
-  // hintIndex === 4  (Hint 5)
-  // Reveal the full first name and the last-name initial so players can narrow
-  // down the answer from prior clues.
   if (isMononym) {
-    // Single-name figures: reveal the full name directly.
     return `Name: ${first}`;
   }
   const lastInitial = (last[0] ?? '?').toUpperCase();

--- a/tests/unit/famous-figures/data.test.ts
+++ b/tests/unit/famous-figures/data.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { FAMOUS_FIGURES } from '../../../src/features/famousFigures/famousFiguresSlice';
 import { normalizeForMatching } from '../../../src/games/famous-figures/fuzzy';
+import { getHintText } from '../../../src/games/famous-figures/hints';
 
 describe('Famous Figures replacement data bank', () => {
   it('contains the 200 popular figure replacement entries', () => {
@@ -22,5 +23,27 @@ describe('Famous Figures replacement data bank', () => {
     expect(FAMOUS_FIGURES.some((figure) => figure.difficulty === 'easy')).toBe(true);
     expect(FAMOUS_FIGURES.some((figure) => figure.difficulty === 'medium')).toBe(true);
     expect(FAMOUS_FIGURES.some((figure) => figure.difficulty === 'hard')).toBe(true);
+  });
+
+  it('keeps obvious answers out of the opening clue and early hints', () => {
+    const protectedEntries = ['Jerry Mouse', 'Zelda'];
+
+    for (const name of protectedEntries) {
+      const figure = FAMOUS_FIGURES.find((entry) => entry.canonicalName === name);
+      expect(figure).toBeDefined();
+      expect(`${figure?.baseClueFact} ${figure?.hints[0]} ${figure?.hints[1]}`.toLowerCase()).not.toContain(
+        normalizeForMatching(name).split(' ')[0],
+      );
+    }
+  });
+
+  it('uses curated late hints instead of generated name reveals', () => {
+    const jerry = FAMOUS_FIGURES.find((figure) => figure.canonicalName === 'Jerry Mouse');
+    const zelda = FAMOUS_FIGURES.find((figure) => figure.canonicalName === 'Zelda');
+
+    expect(jerry).toBeDefined();
+    expect(zelda).toBeDefined();
+    expect(jerry ? getHintText(jerry, 4) : '').toBe('Rival name: Tom.');
+    expect(zelda ? getHintText(zelda, 4) : '').toBe('The franchise title includes her name.');
   });
 });

--- a/tests/unit/famous-figures/hints.test.ts
+++ b/tests/unit/famous-figures/hints.test.ts
@@ -1,20 +1,12 @@
 /**
  * Unit tests for the Famous Figures hint ladder.
  *
- * Hint mapping (0-based index):
- *   0 → dataset hints[0]
- *   1 → dataset hints[1]
- *   2 → generated "First name starts with 'X'" (or mononym variant)
- *   3 → generated "Last name starts with 'Y'" (or mononym fallback)
- *   4 → generated "First name: <FirstName>. Last name starts with '<Initial>'."
- *        Reveals the full first name and last-name initial; for mononyms
- *        reveals the full single name.
+ * Runtime prefers all five curated dataset hints. Generated name clues are
+ * retained only as a fallback for older or incomplete rows.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { getHintText } from '../../../src/games/famous-figures/hints';
 import type { FigureRow } from '../../../src/games/famous-figures/model';
-
-// ─── Helper: minimal FigureRow factory ───────────────────────────────────────
 
 function makeFigure(overrides: Partial<FigureRow> & { canonicalName: string }): FigureRow {
   return {
@@ -36,92 +28,7 @@ function makeFigure(overrides: Partial<FigureRow> & { canonicalName: string }): 
   };
 }
 
-// ─── Tests ────────────────────────────────────────────────────────────────────
-
-describe('getHintText — standard two-part name', () => {
-  const figure = makeFigure({ canonicalName: 'Albert Einstein' });
-
-  it('hint 0 returns dataset hints[0]', () => {
-    expect(getHintText(figure, 0)).toBe('Dataset hint one');
-  });
-
-  it('hint 1 returns dataset hints[1]', () => {
-    expect(getHintText(figure, 1)).toBe('Dataset hint two');
-  });
-
-  it('hint 2 contains first name initial', () => {
-    const text = getHintText(figure, 2);
-    expect(text).toContain("'A'");
-    expect(text.toLowerCase()).toContain('first name');
-  });
-
-  it('hint 3 contains last name initial', () => {
-    const text = getHintText(figure, 3);
-    expect(text).toContain("'E'");
-    expect(text.toLowerCase()).toContain('last name');
-  });
-
-  it('hint 4 reveals full first name and last-name initial', () => {
-    const text = getHintText(figure, 4);
-    // Must reveal the full first name
-    expect(text).toContain('Albert');
-    // Must reveal the last-name initial
-    expect(text).toContain("'E'");
-    // Must use the required format
-    expect(text).toMatch(/^First name:/i);
-    expect(text).toContain("Last name starts with");
-    // Must NOT be the "Either X or Y" decoy format
-    expect(text).not.toMatch(/^Either/i);
-  });
-});
-
-describe('getHintText — mononym (single name)', () => {
-  const figure = makeFigure({ canonicalName: 'Cleopatra' });
-
-  it('hint 2 mentions the single initial without "First name"', () => {
-    const text = getHintText(figure, 2);
-    expect(text).toContain("'C'");
-    // Should NOT say "First name" for mononyms
-    expect(text.toLowerCase()).not.toContain('first name');
-  });
-
-  it('hint 3 returns a letter-count fallback for mononyms', () => {
-    const text = getHintText(figure, 3);
-    expect(text).toContain('9'); // "Cleopatra" has 9 letters
-  });
-
-  it('hint 4 reveals the full single name for mononyms', () => {
-    const text = getHintText(figure, 4);
-    expect(text).toContain('Cleopatra');
-    // Must use the required format and NOT be the old "Either X or Y" decoy format
-    expect(text).toMatch(/^Name:/i);
-    expect(text).not.toMatch(/^Either/i);
-  });
-});
-
-describe('getHintText — regnal / multi-word last name', () => {
-  const figure = makeFigure({ canonicalName: 'Napoleon Bonaparte' });
-
-  it('hint 2 shows N for Napoleon', () => {
-    const text = getHintText(figure, 2);
-    expect(text).toContain("'N'");
-  });
-
-  it('hint 3 shows B for Bonaparte', () => {
-    const text = getHintText(figure, 3);
-    expect(text).toContain("'B'");
-  });
-
-  it('hint 4 reveals full first name and last-name initial', () => {
-    const text = getHintText(figure, 4);
-    expect(text).toContain('Napoleon');
-    expect(text).toContain("'B'");
-    expect(text).toMatch(/^First name:/i);
-    expect(text).not.toMatch(/^Either/i);
-  });
-});
-
-describe('getHintText — dataset hints use custom content', () => {
+describe('getHintText - curated dataset hints', () => {
   const figure = makeFigure({
     canonicalName: 'Marie Curie',
     hints: [
@@ -133,56 +40,60 @@ describe('getHintText — dataset hints use custom content', () => {
     ],
   });
 
-  it('hint 0 returns the custom dataset hints[0]', () => {
+  it('returns every custom dataset hint in order', () => {
     expect(getHintText(figure, 0)).toBe('Custom content hint 1');
-  });
-
-  it('hint 1 returns the custom dataset hints[1]', () => {
     expect(getHintText(figure, 1)).toBe('Custom content hint 2');
-  });
-
-  it('hint 2 is generated (not from dataset)', () => {
-    const text = getHintText(figure, 2);
-    expect(text).not.toBe('Custom content hint 3');
-    expect(text).toContain("'M'");
-  });
-
-  it('hint 4 reveals full first name "Marie" and last-name initial "C"', () => {
-    const text = getHintText(figure, 4);
-    expect(text).toContain('Marie');
-    expect(text).toContain("'C'");
-    expect(text).toMatch(/^First name:/i);
+    expect(getHintText(figure, 2)).toBe('Custom content hint 3');
+    expect(getHintText(figure, 3)).toBe('Custom content hint 4');
+    expect(getHintText(figure, 4)).toBe('Custom content hint 5');
   });
 });
 
-describe('getHintText — suffix stripping', () => {
-  it('ignores trailing "Jr" when choosing last name initial', () => {
-    const figure = makeFigure({ canonicalName: 'Martin Luther King Jr' });
-    // hint 3 should be "K" for King, not "J" for Jr
-    expect(getHintText(figure, 3)).toContain("'K'");
+describe('getHintText - generated fallback for incomplete rows', () => {
+  const makeLegacyFigure = (canonicalName: string) =>
+    makeFigure({
+      canonicalName,
+      hints: ['Dataset hint one', 'Dataset hint two', '', '', ''],
+    });
+
+  it('falls back to generated initials for a two-part name', () => {
+    const figure = makeLegacyFigure('Albert Einstein');
+
+    expect(getHintText(figure, 0)).toBe('Dataset hint one');
+    expect(getHintText(figure, 1)).toBe('Dataset hint two');
+    expect(getHintText(figure, 2)).toContain("'A'");
+    expect(getHintText(figure, 2).toLowerCase()).toContain('first name');
+    expect(getHintText(figure, 3)).toContain("'E'");
+    expect(getHintText(figure, 3).toLowerCase()).toContain('last name');
+
+    const finalHint = getHintText(figure, 4);
+    expect(finalHint).toContain('Albert');
+    expect(finalHint).toContain("'E'");
+    expect(finalHint).toMatch(/^First name:/i);
   });
 
-  it('ignores trailing "Sr" when choosing last name initial', () => {
-    const figure = makeFigure({ canonicalName: 'Robert Downey Sr' });
-    expect(getHintText(figure, 3)).toContain("'D'");
+  it('falls back to mononym initial, length, and name reveal', () => {
+    const figure = makeLegacyFigure('Cleopatra');
+
+    expect(getHintText(figure, 2)).toContain("'C'");
+    expect(getHintText(figure, 2).toLowerCase()).not.toContain('first name');
+    expect(getHintText(figure, 3)).toContain('9');
+    expect(getHintText(figure, 4)).toBe('Name: Cleopatra');
   });
 
-  it('ignores trailing Roman numeral suffix (III) when choosing last name', () => {
-    const figure = makeFigure({ canonicalName: 'Henry Ford III' });
-    expect(getHintText(figure, 3)).toContain("'F'");
-  });
+  it('ignores common suffixes when generating fallback last-name clues', () => {
+    expect(getHintText(makeLegacyFigure('Martin Luther King Jr'), 3)).toContain("'K'");
+    expect(getHintText(makeLegacyFigure('Robert Downey Sr'), 3)).toContain("'D'");
+    expect(getHintText(makeLegacyFigure('Henry Ford III'), 3)).toContain("'F'");
 
-  it('hint 4 reveals full first name and respects suffix stripping (last initial from King, not Jr)', () => {
-    const figure = makeFigure({ canonicalName: 'Martin Luther King Jr' });
-    const text = getHintText(figure, 4);
-    expect(text).toContain('Martin');
-    expect(text).toContain("'K'");
-    expect(text).toMatch(/^First name:/i);
-    expect(text).not.toMatch(/^Either/i);
+    const finalHint = getHintText(makeLegacyFigure('Martin Luther King Jr'), 4);
+    expect(finalHint).toContain('Martin');
+    expect(finalHint).toContain("'K'");
+    expect(finalHint).toMatch(/^First name:/i);
   });
 });
 
-describe('getHintText — out-of-range index', () => {
+describe('getHintText - out-of-range index', () => {
   const figure = makeFigure({ canonicalName: 'Albert Einstein' });
 
   it('throws RangeError for index 5', () => {


### PR DESCRIPTION
## Summary

This PR makes the Famous Figures minigame harder and more interesting by replacing giveaway opening clues with a gradual five-hint ladder.

- Rewrites the 200-entry Famous Figures bank so opening clues and early hints avoid obvious answer reveals.
- Updates `getHintText` to use all five curated dataset hints at runtime, with generated name clues kept only as fallback for incomplete legacy rows.
- Updates Famous Figures docs and tests to reflect the new hint contract.

## Why

The previous `jsn` replacement pool often revealed the answer immediately, for example `The mouse from Tom and Jerry` or `The princess from The Legend of Zelda`. This undermined the scoring model because players could solve many entries from the base clue or first hint.

## Validation

- `npm ci` completed successfully.
- `npm run test:famous-figures` passed: 7 files, 89 tests.
- `npm test` was also run, but unrelated suites fail in this environment, mostly because broader tests expect `localStorage` to be available. Famous Figures tests remained green.