### PR TITLE
[codex] Capitalization minigame and mobile flow

### DIFF
--- a/src/ai/competition/minigameAiRegistry.ts
+++ b/src/ai/competition/minigameAiRegistry.ts
@@ -348,6 +348,18 @@ export const minigameAiRegistry: Record<string, MinigameAiModel> = {
     volatility: VOLATILITY_TRIVIA,
     weights: WEIGHTS_MENTAL,
   },
+  capitalization: {
+    key: 'capitalization',
+    category: 'mental',
+    scoreDirection: 'higher-is-better',
+    volatility: VOLATILITY_TRIVIA,
+    weights: WEIGHTS_MENTAL_PRECISION,
+    minScore: 45,
+    maxScore: 95,
+    notes:
+      'Capitalization uses this 45-95 skill band as the AI knowledge baseline; ' +
+      'the React component converts it into per-question accuracy, speed, and attempts.',
+  },
   tetris: {
     key: 'tetris',
     category: 'precision',

--- a/src/components/Capitalization/Capitalization.css
+++ b/src/components/Capitalization/Capitalization.css
@@ -1,0 +1,603 @@
+.capitalization {
+  position: absolute;
+  inset: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + 72px)
+    max(16px, env(safe-area-inset-right, 0px))
+    calc(env(safe-area-inset-bottom, 0px) + 24px)
+    max(16px, env(safe-area-inset-left, 0px));
+  background:
+    linear-gradient(135deg, rgba(91, 214, 138, 0.12), transparent 34%),
+    linear-gradient(160deg, #0c1214 0%, #141d1a 48%, #21191c 100%);
+  color: #eef6f0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.capitalization__shell {
+  width: min(100%, 1120px);
+  min-height: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.capitalization__header,
+.capitalization__globe-panel,
+.capitalization__question-panel,
+.capitalization__mini-board,
+.capitalization__scoreboard {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(22, 30, 33, 0.94);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.3);
+}
+
+.capitalization__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px;
+}
+
+.capitalization__eyebrow {
+  margin: 0 0 6px;
+  color: #5bd68a;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.capitalization__title,
+.capitalization__country-name,
+.capitalization__scoreboard h3,
+.capitalization__mini-board h3 {
+  margin: 0;
+}
+
+.capitalization__title {
+  font-size: 2.7rem;
+  line-height: 1.04;
+}
+
+.capitalization__meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.capitalization__meta span,
+.capitalization__location,
+.capitalization__stats div {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.capitalization__meta span {
+  padding: 8px 10px;
+  color: #b8c5bf;
+  font-size: 0.85rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.capitalization__arena {
+  display: grid;
+  grid-template-columns: minmax(380px, 1fr) minmax(340px, 420px);
+  gap: 16px;
+  min-height: 520px;
+}
+
+.capitalization__globe-panel {
+  position: relative;
+  min-height: 520px;
+  overflow: hidden;
+  background: #091113;
+}
+
+.capitalization__globe {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.capitalization__globe-caption {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  max-width: calc(100% - 32px);
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(8, 13, 14, 0.74);
+  color: #f6f4e8;
+  font-weight: 800;
+}
+
+.capitalization__question-panel {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.capitalization__country-strip {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.capitalization__flag {
+  width: 78px;
+  height: 62px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 14px;
+  background: rgba(8, 13, 14, 0.72);
+  font-size: 2.35rem;
+}
+
+.capitalization__continent-label {
+  margin: 0 0 4px;
+  color: #9fb2ad;
+  font-weight: 800;
+}
+
+.capitalization__country-name {
+  font-size: 2rem;
+  line-height: 1.08;
+  overflow-wrap: anywhere;
+}
+
+.capitalization__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.capitalization__stats div {
+  padding: 12px;
+}
+
+.capitalization__stats span,
+.capitalization__location span,
+.capitalization__answer-form label {
+  display: block;
+  color: #9fb2ad;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.capitalization__stats strong,
+.capitalization__location strong {
+  display: block;
+  margin-top: 5px;
+  color: #f3c75f;
+  font-size: 1.22rem;
+}
+
+.capitalization__answer-form {
+  display: grid;
+  gap: 8px;
+}
+
+.capitalization__answer-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+}
+
+.capitalization__answer-row input {
+  min-width: 0;
+  min-height: 50px;
+  border: 2px solid rgba(91, 214, 138, 0.82);
+  border-radius: 14px;
+  background: rgba(8, 13, 14, 0.9);
+  color: #f6fbf8;
+  padding: 0 14px;
+  font: inherit;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.capitalization__answer-row input:disabled {
+  opacity: 0.55;
+}
+
+.capitalization__answer-row input:focus {
+  outline: none;
+  border-color: #66b8ff;
+  box-shadow: 0 0 0 3px rgba(102, 184, 255, 0.2);
+}
+
+.capitalization__answer-row button,
+.capitalization__answer-review button,
+.capitalization__footer button {
+  min-height: 50px;
+  border: 0;
+  border-radius: 14px;
+  padding: 0 18px;
+  background: #f3c75f;
+  color: #171206;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+}
+
+.capitalization__answer-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.capitalization__answer-row button[type='button'] {
+  background: rgba(255, 255, 255, 0.12);
+  color: #eef6f0;
+}
+
+.capitalization__error {
+  margin: 0;
+  color: #ffb29e;
+  font-weight: 700;
+}
+
+.capitalization__feedback {
+  min-height: 76px;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  background: rgba(8, 13, 14, 0.62);
+  color: #b8c5bf;
+  line-height: 1.45;
+}
+
+.capitalization__location {
+  margin-top: auto;
+  padding: 12px;
+}
+
+.capitalization__mini-board,
+.capitalization__scoreboard {
+  padding: 16px;
+}
+
+.capitalization__mini-board h3 {
+  font-size: 1rem;
+  color: #b8c5bf;
+}
+
+.capitalization__mini-board ol {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.capitalization__mini-board li {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.capitalization__mini-board li.is-eliminated {
+  opacity: 0.5;
+}
+
+.capitalization__mini-board span {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #5bd68a;
+  color: #08100b;
+  font-size: 0.78rem;
+  font-weight: 900;
+}
+
+.capitalization__mini-board strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.capitalization__mini-board em {
+  color: #f3c75f;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.capitalization__scoreboard {
+  display: grid;
+  gap: 14px;
+}
+
+.capitalization__scoreboard-copy p {
+  margin: 8px 0 0;
+  color: #b8c5bf;
+}
+
+.capitalization__scoreboard-copy h3 {
+  color: #f3c75f;
+  font-size: 2rem;
+}
+
+.capitalization__table-wrap {
+  overflow-x: auto;
+}
+
+.capitalization__table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.capitalization__table th,
+.capitalization__table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.capitalization__table th {
+  color: #9fb2ad;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.capitalization__row--leader {
+  background: rgba(91, 214, 138, 0.08);
+}
+
+.capitalization__row--human {
+  background: rgba(102, 184, 255, 0.08);
+}
+
+.capitalization__row--eliminated {
+  opacity: 0.55;
+}
+
+.capitalization__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  color: #b8c5bf;
+}
+
+.capitalization__arena--spinning {
+  grid-template-columns: 1fr;
+  min-height: min(520px, calc(100dvh - 190px));
+}
+
+.capitalization__arena--focused {
+  grid-template-columns: minmax(0, 640px);
+  justify-content: center;
+  min-height: 0;
+}
+
+.capitalization__arena--spinning .capitalization__globe-panel {
+  min-height: min(520px, calc(100dvh - 190px));
+}
+
+.capitalization__answer-review {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(91, 214, 138, 0.22);
+  border-radius: 14px;
+  background: rgba(91, 214, 138, 0.08);
+}
+
+.capitalization__answer-review h3 {
+  margin: 0;
+  color: #f3c75f;
+  font-size: 1.7rem;
+}
+
+.capitalization__standings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.capitalization__standing-card {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.capitalization__standing-card--leader {
+  background: rgba(91, 214, 138, 0.08);
+}
+
+.capitalization__standing-card--human {
+  border-color: rgba(102, 184, 255, 0.32);
+  background: rgba(102, 184, 255, 0.08);
+}
+
+.capitalization__standing-card--eliminated {
+  opacity: 0.55;
+}
+
+.capitalization__rank {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #5bd68a;
+  color: #08100b;
+  font-weight: 900;
+}
+
+.capitalization__standing-main,
+.capitalization__standing-score {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.capitalization__standing-main strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.capitalization__standing-main span,
+.capitalization__standing-score span {
+  color: #9fb2ad;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.capitalization__standing-score {
+  text-align: right;
+}
+
+.capitalization__standing-score strong {
+  color: #f3c75f;
+  font-size: 1.25rem;
+}
+
+.capitalization--answerReview .capitalization__stats,
+.capitalization--answerReview .capitalization__location {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .capitalization__arena {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .capitalization__globe-panel {
+    min-height: 420px;
+  }
+
+  .capitalization__mini-board ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .capitalization {
+    padding-top: calc(env(safe-area-inset-top, 0px) + 88px);
+  }
+
+  .capitalization__header {
+    flex-direction: column;
+  }
+
+  .capitalization__title {
+    font-size: 2.15rem;
+  }
+
+  .capitalization__meta {
+    justify-content: flex-start;
+  }
+
+  .capitalization__globe-panel {
+    min-height: 340px;
+  }
+
+  .capitalization__question-panel {
+    padding: 14px;
+  }
+
+  .capitalization__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .capitalization__answer-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .capitalization__answer-row input {
+    grid-column: 1 / -1;
+  }
+
+  .capitalization__mini-board ol {
+    grid-template-columns: 1fr;
+  }
+
+  .capitalization__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .capitalization__header {
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .capitalization__meta span {
+    padding: 6px 8px;
+    font-size: 0.78rem;
+  }
+
+  .capitalization--question .capitalization__stats,
+  .capitalization--question .capitalization__location {
+    display: none;
+  }
+
+  .capitalization__country-strip {
+    align-items: flex-start;
+  }
+
+  .capitalization__flag {
+    width: 58px;
+    height: 46px;
+    border-radius: 10px;
+    font-size: 1.8rem;
+  }
+
+  .capitalization__country-name {
+    font-size: 1.55rem;
+  }
+
+  .capitalization__feedback {
+    min-height: 0;
+    padding: 10px 12px;
+  }
+
+  .capitalization__answer-review {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .capitalization__standing-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .capitalization__standing-score {
+    grid-column: 2;
+    grid-row: 2;
+    text-align: left;
+  }
+}

--- a/src/components/Capitalization/Capitalization.tsx
+++ b/src/components/Capitalization/Capitalization.tsx
@@ -1,0 +1,853 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
+import type { GenericMinigameProps } from '../../minigames/reactComponents';
+import {
+  CAPITALIZATION_CONTINENT_STYLES,
+  CAPITALIZATION_LAND_SHAPES,
+  type CapitalizationContinent,
+} from './capitalizationData';
+import {
+  CAPITALIZATION_QUESTIONS_PER_CONTINENT,
+  CAPITALIZATION_TOTAL_CONTINENTS,
+  CAPITALIZATION_TOTAL_QUESTIONS,
+  applyCapitalizationPerformance,
+  buildCapitalizationQuestionSet,
+  buildCapitalizationRawResults,
+  createCapitalizationAiRng,
+  createCapitalizationStandings,
+  eliminateCapitalizationField,
+  formatCapitalizationTimeMs,
+  isCapitalAnswerAccepted,
+  rankCapitalizationStandings,
+  resolveCapitalizationRunSeed,
+  simulateCapitalizationAiPerformance,
+  type CapitalizationParticipant,
+  type CapitalizationQuestion,
+  type CapitalizationRoundPerformance,
+  type CapitalizationStanding,
+} from './capitalizationUtils';
+import './Capitalization.css';
+
+const SPIN_DURATION_MS = 2600;
+
+type CapitalizationPhase = 'spinning' | 'question' | 'answerReview' | 'scoreboard';
+
+interface CapitalizationScoreboard {
+  question: CapitalizationQuestion;
+  standings: CapitalizationStanding[];
+  eliminatedIds: string[];
+  final: boolean;
+}
+
+const FALLBACK_PARTICIPANTS: CapitalizationParticipant[] = [
+  { id: 'human', name: 'You', isHuman: true, precomputedScore: 0 },
+  { id: 'ai-atlas', name: 'Atlas Byte', isHuman: false, precomputedScore: 78 },
+  { id: 'ai-mira', name: 'Mira Meridian', isHuman: false, precomputedScore: 72 },
+  { id: 'ai-nova', name: 'Nova Nomad', isHuman: false, precomputedScore: 66 },
+  { id: 'ai-rio', name: 'Rio Riddle', isHuman: false, precomputedScore: 60 },
+  { id: 'ai-orbit', name: 'Orbit Oracle', isHuman: false, precomputedScore: 84 },
+  { id: 'ai-vega', name: 'Vega Vale', isHuman: false, precomputedScore: 56 },
+];
+
+function resolveParticipants(
+  participantIds?: string[],
+  participants?: GenericMinigameProps['participants'],
+): CapitalizationParticipant[] {
+  if (participants && participants.length > 0) {
+    return participants.map((participant) => ({
+      id: participant.id,
+      name: participant.name,
+      isHuman: participant.isHuman,
+      precomputedScore: participant.precomputedScore,
+    }));
+  }
+
+  if (participantIds && participantIds.length > 0) {
+    return participantIds.map((id, index) => ({
+      id,
+      name: index === 0 ? 'You' : `Player ${index + 1}`,
+      isHuman: index === 0,
+      precomputedScore: 52 + index * 6,
+    }));
+  }
+
+  return FALLBACK_PARTICIPANTS;
+}
+
+export default function Capitalization({
+  onFinish,
+  participantIds,
+  participants,
+  seed,
+}: GenericMinigameProps) {
+  const resolvedParticipants = useMemo(
+    () => resolveParticipants(participantIds, participants),
+    [participantIds, participants],
+  );
+  const [fallbackRunSeed] = useState(() => resolveCapitalizationRunSeed(undefined));
+  const runSeed = resolveCapitalizationRunSeed(seed, () => fallbackRunSeed);
+  const questionSet = useMemo(() => buildCapitalizationQuestionSet(runSeed), [runSeed]);
+  const humanId = useMemo(
+    () =>
+      resolvedParticipants.find((participant) => participant.isHuman)?.id ??
+      resolvedParticipants[0]?.id ??
+      'human',
+    [resolvedParticipants],
+  );
+
+  const [standings, setStandings] = useState<CapitalizationStanding[]>(() =>
+    createCapitalizationStandings(resolvedParticipants),
+  );
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [phase, setPhase] = useState<CapitalizationPhase>('spinning');
+  const [answerInput, setAnswerInput] = useState('');
+  const [attempts, setAttempts] = useState(0);
+  const [feedback, setFeedback] = useState('The globe is choosing the next continent.');
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [scoreboard, setScoreboard] = useState<CapitalizationScoreboard | null>(null);
+  const [nowMs, setNowMs] = useState(0);
+  const [questionStartedAtMs, setQuestionStartedAtMs] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const questionStartedAtRef = useRef(0);
+  const completionFiredRef = useRef(false);
+
+  const currentQuestion = questionSet.questions[questionIndex];
+  const currentContinentIndex = Math.floor(questionIndex / CAPITALIZATION_QUESTIONS_PER_CONTINENT) + 1;
+  const humanStanding = standings.find((standing) => standing.participantId === humanId) ?? null;
+  const rankedStandings = useMemo(() => rankCapitalizationStandings(standings), [standings]);
+  const activeCount = standings.filter((standing) => standing.eliminatedAfterQuestion === null).length;
+  const elapsedMs = phase === 'question' && questionStartedAtMs > 0
+    ? nowMs - questionStartedAtMs
+    : 0;
+
+  useEffect(() => {
+    if (phase !== 'spinning' || !currentQuestion) return;
+
+    const timer = window.setTimeout(() => {
+      questionStartedAtRef.current = Date.now();
+      setQuestionStartedAtMs(questionStartedAtRef.current);
+      setNowMs(questionStartedAtRef.current);
+      setPhase('question');
+      setFeedback(`Name the capital of ${currentQuestion.name}.`);
+      window.setTimeout(() => inputRef.current?.focus(), 0);
+    }, SPIN_DURATION_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [currentQuestion, phase]);
+
+  useEffect(() => {
+    if (phase !== 'question') return;
+    const timer = window.setInterval(() => setNowMs(Date.now()), 120);
+    return () => window.clearInterval(timer);
+  }, [phase]);
+
+  const finishCompetition = useCallback((finalStandings: CapitalizationStanding[]) => {
+    if (!onFinish || completionFiredRef.current) return;
+    completionFiredRef.current = true;
+
+    const ranked = rankCapitalizationStandings(finalStandings);
+    const winner = ranked[0];
+    const rawResults = buildCapitalizationRawResults(finalStandings);
+    const humanRawValue = rawResults[humanId] ?? winner?.cumulativeScore ?? 0;
+
+    onFinish(humanRawValue, undefined, {
+      authoritativeWinnerId: winner?.participantId ?? null,
+      rawValue: humanRawValue,
+      rawResults,
+    });
+  }, [humanId, onFinish]);
+
+  const resolveQuestion = useCallback((humanPerformance: CapitalizationRoundPerformance) => {
+    if (!currentQuestion || phase !== 'question') return;
+
+    const performanceByParticipantId: Record<string, CapitalizationRoundPerformance> = {
+      [humanId]: humanPerformance,
+    };
+    const activeIds = new Set(
+      standings
+        .filter((standing) => standing.eliminatedAfterQuestion === null)
+        .map((standing) => standing.participantId),
+    );
+
+    resolvedParticipants.forEach((participant) => {
+      if (participant.isHuman || !activeIds.has(participant.id)) return;
+      performanceByParticipantId[participant.id] = simulateCapitalizationAiPerformance(
+        {
+          participant,
+          question: currentQuestion,
+        },
+        createCapitalizationAiRng({
+          seed: runSeed,
+          participantId: participant.id,
+          questionNumber: currentQuestion.questionNumber,
+        }),
+      );
+    });
+
+    const scoredStandings = applyCapitalizationPerformance(
+      standings,
+      performanceByParticipantId,
+    );
+    const shouldEliminate =
+      currentQuestion.questionNumber % CAPITALIZATION_QUESTIONS_PER_CONTINENT === 0 &&
+      currentQuestion.questionNumber < CAPITALIZATION_TOTAL_QUESTIONS;
+    const { standings: nextStandings, eliminatedIds } = shouldEliminate
+      ? eliminateCapitalizationField(scoredStandings, currentQuestion.questionNumber)
+      : { standings: scoredStandings, eliminatedIds: [] };
+    const ranked = rankCapitalizationStandings(nextStandings);
+    const final = currentQuestion.questionNumber >= CAPITALIZATION_TOTAL_QUESTIONS;
+    const checkpoint =
+      final ||
+      currentQuestion.questionNumber % CAPITALIZATION_QUESTIONS_PER_CONTINENT === 0;
+
+    setStandings(nextStandings);
+    setScoreboard({
+      question: currentQuestion,
+      standings: ranked,
+      eliminatedIds,
+      final,
+    });
+    setFeedback(
+      humanPerformance.guessed
+        ? `Correct. ${currentQuestion.capital} is the capital of ${currentQuestion.name}.`
+        : `Skipped. ${currentQuestion.capital} is the capital of ${currentQuestion.name}.`,
+    );
+    setPhase(checkpoint ? 'scoreboard' : 'answerReview');
+  }, [
+    currentQuestion,
+    humanId,
+    phase,
+    resolvedParticipants,
+    runSeed,
+    standings,
+  ]);
+
+  const submitAnswer = useCallback(() => {
+    if (!currentQuestion || phase !== 'question') return;
+    const trimmed = answerInput.trim();
+    if (!trimmed) {
+      setInputError('Enter a capital or skip.');
+      return;
+    }
+
+    const nextAttempts = attempts + 1;
+    setAttempts(nextAttempts);
+    setInputError(null);
+
+    if (!isCapitalAnswerAccepted(trimmed, currentQuestion)) {
+      setFeedback(`No match for "${trimmed}". Try again or skip.`);
+      setAnswerInput('');
+      return;
+    }
+
+    resolveQuestion({
+      guessed: true,
+      attempts: nextAttempts,
+      timeMs: Date.now() - questionStartedAtRef.current,
+    });
+  }, [answerInput, attempts, currentQuestion, phase, resolveQuestion]);
+
+  const skipQuestion = useCallback(() => {
+    if (!currentQuestion || phase !== 'question') return;
+    resolveQuestion({
+      guessed: false,
+      skipped: true,
+      attempts: Math.max(1, attempts),
+      timeMs: Date.now() - questionStartedAtRef.current,
+    });
+  }, [attempts, currentQuestion, phase, resolveQuestion]);
+
+  const continueFromScoreboard = useCallback(() => {
+    if (!scoreboard) return;
+    if (scoreboard.final) {
+      finishCompetition(scoreboard.standings);
+      return;
+    }
+    const nextQuestion = questionSet.questions[questionIndex + 1];
+    setAnswerInput('');
+    setAttempts(0);
+    setInputError(null);
+    setScoreboard(null);
+    setQuestionStartedAtMs(0);
+    setFeedback(`The globe is landing on ${nextQuestion?.continent ?? 'the next continent'}.`);
+    setQuestionIndex((index) => index + 1);
+    setPhase('spinning');
+  }, [finishCompetition, questionIndex, questionSet.questions, scoreboard]);
+
+  const winner = scoreboard?.standings[0] ?? rankedStandings[0] ?? null;
+  const inputDisabled = phase !== 'question';
+  const showCheckpoint = phase === 'scoreboard' && scoreboard;
+  const showGlobe = phase === 'spinning';
+  const rootClassName = [
+    'capitalization',
+    `capitalization--${phase}`,
+  ].join(' ');
+
+  return (
+    <div className={rootClassName} data-testid="capitalization-root">
+      <div className="capitalization__shell">
+        <header className="capitalization__header">
+          <div>
+            <p className="capitalization__eyebrow">Capitalization</p>
+            <h2 className="capitalization__title">
+              {phase === 'spinning'
+                ? 'Globe spin'
+                : phase === 'scoreboard' && scoreboard?.final
+                  ? 'Final scoreboard'
+                  : phase === 'scoreboard'
+                    ? 'Checkpoint'
+                    : phase === 'answerReview'
+                      ? 'Answer revealed'
+                      : 'Name the capital'}
+            </h2>
+          </div>
+          <div className="capitalization__meta" aria-live="polite">
+            <span>Question {currentQuestion?.questionNumber ?? 0}/{CAPITALIZATION_TOTAL_QUESTIONS}</span>
+            <span>Continent {Math.min(currentContinentIndex, CAPITALIZATION_TOTAL_CONTINENTS)}/{CAPITALIZATION_TOTAL_CONTINENTS}</span>
+            <span>{activeCount} alive</span>
+          </div>
+        </header>
+
+        {showCheckpoint ? (
+          <Scoreboard
+            scoreboard={scoreboard}
+            winner={winner}
+            onContinue={continueFromScoreboard}
+          />
+        ) : (
+          <section
+            className={[
+              'capitalization__arena',
+              showGlobe ? 'capitalization__arena--spinning' : 'capitalization__arena--focused',
+            ].join(' ')}
+            aria-label="Capitalization game"
+          >
+            {showGlobe && (
+              <div className="capitalization__globe-panel">
+                <CapitalizationGlobe question={currentQuestion} phase={phase} />
+                <div className="capitalization__globe-caption" aria-live="polite">
+                  {`Finding ${currentQuestion?.continent ?? 'a continent'}`}
+                </div>
+              </div>
+            )}
+
+            {!showGlobe && (
+              <section className="capitalization__question-panel" aria-label="Capital question">
+                <div className="capitalization__country-strip">
+                  <span className="capitalization__flag" aria-label={currentQuestion ? `${currentQuestion.name} flag` : 'Flag'}>
+                    {currentQuestion?.flag ?? '?'}
+                  </span>
+                  <div>
+                    <p className="capitalization__continent-label">
+                      {currentQuestion?.continent ?? 'Awaiting continent'}
+                    </p>
+                    <h3 className="capitalization__country-name">
+                      {currentQuestion?.name ?? 'Country'}
+                    </h3>
+                  </div>
+                </div>
+
+                <div className="capitalization__stats" aria-label="Your round stats">
+                  <div>
+                    <span>Timer</span>
+                    <strong>{formatCapitalizationTimeMs(elapsedMs)}</strong>
+                  </div>
+                  <div>
+                    <span>Attempts</span>
+                    <strong>{attempts}</strong>
+                  </div>
+                  <div>
+                    <span>Your score</span>
+                    <strong>{humanStanding?.cumulativeScore ?? 0}</strong>
+                  </div>
+                </div>
+
+                {phase === 'question' && (
+                  <form
+                    className="capitalization__answer-form"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      submitAnswer();
+                    }}
+                  >
+                    <label htmlFor="capitalization-answer">Capital city</label>
+                    <div className="capitalization__answer-row">
+                      <input
+                        ref={inputRef}
+                        id="capitalization-answer"
+                        type="text"
+                        value={answerInput}
+                        disabled={inputDisabled}
+                        onChange={(event) => setAnswerInput(event.target.value)}
+                        aria-label="Capital city answer"
+                      />
+                      <button type="submit" disabled={inputDisabled}>
+                        Submit
+                      </button>
+                      <button type="button" disabled={inputDisabled} onClick={skipQuestion}>
+                        Skip
+                      </button>
+                    </div>
+                    {inputError && <p className="capitalization__error">{inputError}</p>}
+                  </form>
+                )}
+
+                <div className="capitalization__feedback" aria-live="polite">
+                  {feedback}
+                </div>
+
+                {phase === 'answerReview' && scoreboard && (
+                  <AnswerReview
+                    scoreboard={scoreboard}
+                    onContinue={continueFromScoreboard}
+                  />
+                )}
+
+                {currentQuestion && (
+                  <div className="capitalization__location">
+                    <span>Location</span>
+                    <strong>
+                      {Math.abs(currentQuestion.latitude).toFixed(1)} deg{currentQuestion.latitude >= 0 ? 'N' : 'S'}
+                      {' '}
+                      {Math.abs(currentQuestion.longitude).toFixed(1)} deg{currentQuestion.longitude >= 0 ? 'E' : 'W'}
+                    </strong>
+                  </div>
+                )}
+              </section>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AnswerReview({
+  scoreboard,
+  onContinue,
+}: {
+  scoreboard: CapitalizationScoreboard;
+  onContinue: () => void;
+}) {
+  return (
+    <section className="capitalization__answer-review" aria-label="Answer result">
+      <div>
+        <p className="capitalization__eyebrow">
+          Question {scoreboard.question.questionNumber} complete
+        </p>
+        <h3>{scoreboard.question.capital}</h3>
+      </div>
+      <button type="button" onClick={onContinue}>
+        Continue
+      </button>
+    </section>
+  );
+}
+
+function Scoreboard({
+  scoreboard,
+  winner,
+  onContinue,
+}: {
+  scoreboard: CapitalizationScoreboard;
+  winner: CapitalizationStanding | null;
+  onContinue: () => void;
+}) {
+  const eliminatedNames = scoreboard.eliminatedIds
+    .map(
+      (id) =>
+        scoreboard.standings.find((standing) => standing.participantId === id)
+          ?.participantName ?? id,
+    )
+    .join(', ');
+
+  return (
+    <section
+      className="capitalization__scoreboard"
+      aria-label={scoreboard.final ? 'Final standings' : 'Round standings'}
+    >
+      <div className="capitalization__scoreboard-copy">
+        <p className="capitalization__eyebrow">
+          {scoreboard.final ? 'Question 9 complete' : `Question ${scoreboard.question.questionNumber} complete`}
+        </p>
+        <h3>{scoreboard.question.capital}</h3>
+        <p>
+          {scoreboard.final
+            ? `${winner?.participantName ?? 'A player'} is ready to be crowned LOH.`
+            : eliminatedNames
+              ? `Eliminated before the next continent: ${eliminatedNames}.`
+              : 'No elimination before the next continent.'}
+        </p>
+      </div>
+
+      <ol className="capitalization__standings-list">
+        {scoreboard.standings.map((standing, index) => {
+          const eliminatedNow = scoreboard.eliminatedIds.includes(standing.participantId);
+          const eliminated = standing.eliminatedAfterQuestion !== null;
+          const status = scoreboard.final && index === 0
+            ? 'LOH'
+            : eliminatedNow
+              ? 'Eliminated'
+              : eliminated
+                ? `Out Q${standing.eliminatedAfterQuestion}`
+                : 'Alive';
+
+          return (
+            <li
+              key={standing.participantId}
+              className={[
+                'capitalization__standing-card',
+                standing.isHuman ? 'capitalization__standing-card--human' : '',
+                index === 0 ? 'capitalization__standing-card--leader' : '',
+                eliminated ? 'capitalization__standing-card--eliminated' : '',
+              ].filter(Boolean).join(' ')}
+            >
+              <span className="capitalization__rank">{index + 1}</span>
+              <div className="capitalization__standing-main">
+                <strong>{standing.isHuman ? 'You' : standing.participantName}</strong>
+                <span>
+                  {standing.correctAnswers}/{standing.questionsPlayed} correct - round {standing.lastQuestionScore} - {formatCapitalizationTimeMs(standing.lastQuestionTimeMs)}
+                </span>
+              </div>
+              <div className="capitalization__standing-score">
+                <strong>{standing.cumulativeScore}</strong>
+                <span>{status}</span>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="capitalization__footer">
+        <span>
+          {scoreboard.final
+            ? `${winner?.participantName ?? 'Winner'} leads the final board.`
+            : 'Next globe spin starts when you continue.'}
+        </span>
+        <button type="button" onClick={onContinue}>
+          {scoreboard.final ? 'Crown LOH' : 'Continue'}
+        </button>
+      </div>
+    </section>
+  );
+}
+function CapitalizationGlobe({
+  question,
+  phase,
+}: {
+  question?: CapitalizationQuestion;
+  phase: CapitalizationPhase;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const viewRef = useRef({ latitude: 8, longitude: 0 });
+  const spinRef = useRef<{
+    startedAt: number;
+    fromLatitude: number;
+    fromLongitude: number;
+    toLatitude: number;
+    toLongitude: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!question) return;
+    const center = CAPITALIZATION_CONTINENT_STYLES[question.continent].center;
+    spinRef.current = {
+      startedAt: performance.now(),
+      fromLatitude: viewRef.current.latitude,
+      fromLongitude: viewRef.current.longitude,
+      toLatitude: center.latitude,
+      toLongitude: center.longitude + 720 + (question.questionNumber % 2) * 180,
+    };
+  }, [question?.questionNumber, question]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let frame = 0;
+    const draw = (now: number) => {
+      renderGlobe(ctx, canvas, now, viewRef, spinRef, question, phase);
+      frame = requestAnimationFrame(draw);
+    };
+    frame = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(frame);
+  }, [phase, question]);
+
+  return <canvas ref={canvasRef} className="capitalization__globe" aria-hidden="true" />;
+}
+
+function renderGlobe(
+  ctx: CanvasRenderingContext2D,
+  canvas: HTMLCanvasElement,
+  now: number,
+  viewRef: MutableRefObject<{ latitude: number; longitude: number }>,
+  spinRef: MutableRefObject<{
+    startedAt: number;
+    fromLatitude: number;
+    fromLongitude: number;
+    toLatitude: number;
+    toLongitude: number;
+  } | null>,
+  question: CapitalizationQuestion | undefined,
+  phase: CapitalizationPhase,
+) {
+  const rect = canvas.getBoundingClientRect();
+  const scale = window.devicePixelRatio || 1;
+  const width = Math.max(320, Math.floor(rect.width * scale));
+  const height = Math.max(320, Math.floor(rect.height * scale));
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+
+  const view = viewRef.current;
+  const spin = spinRef.current;
+  if (spin) {
+    const progress = Math.min(1, (now - spin.startedAt) / SPIN_DURATION_MS);
+    const eased = easeOutCubic(progress);
+    view.latitude = lerp(spin.fromLatitude, spin.toLatitude, eased);
+    view.longitude = lerp(spin.fromLongitude, spin.toLongitude, eased);
+    if (progress >= 1) {
+      view.latitude = spin.toLatitude;
+      view.longitude = normalizeLongitude(spin.toLongitude);
+      spinRef.current = null;
+    }
+  } else if (phase === 'spinning') {
+    view.longitude = normalizeLongitude(view.longitude + 0.28);
+  }
+
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  const viewWidth = width / scale;
+  const viewHeight = height / scale;
+  const cx = viewWidth / 2;
+  const cy = viewHeight / 2;
+  const radius = Math.min(viewWidth, viewHeight) * 0.39;
+
+  ctx.clearRect(0, 0, viewWidth, viewHeight);
+  drawSpace(ctx, viewWidth, viewHeight);
+  drawSphere(ctx, cx, cy, radius);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.clip();
+  drawGrid(ctx, cx, cy, radius, view);
+  drawLand(ctx, cx, cy, radius, view, question?.continent);
+  if (question && phase !== 'spinning') {
+    drawMarker(ctx, cx, cy, radius, view, question.latitude, question.longitude);
+  }
+  ctx.restore();
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = 'rgba(255,255,255,0.32)';
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(cx - radius * 0.18, cy - radius * 0.16, radius * 0.92, 0, Math.PI * 2);
+  ctx.lineWidth = radius * 0.14;
+  ctx.strokeStyle = 'rgba(255,255,255,0.055)';
+  ctx.stroke();
+}
+
+function drawSpace(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  ctx.fillStyle = '#091113';
+  ctx.fillRect(0, 0, width, height);
+  ctx.fillStyle = 'rgba(255,255,255,0.38)';
+  for (let index = 0; index < 54; index += 1) {
+    const x = (index * 139 + 29) % width;
+    const y = (index * 83 + 47) % height;
+    const size = index % 5 === 0 ? 1.8 : 1;
+    ctx.globalAlpha = 0.28 + ((index * 7) % 10) / 22;
+    ctx.fillRect(x, y, size, size);
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawSphere(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number) {
+  const ocean = ctx.createRadialGradient(
+    cx - radius * 0.32,
+    cy - radius * 0.36,
+    radius * 0.2,
+    cx,
+    cy,
+    radius,
+  );
+  ocean.addColorStop(0, '#34a9db');
+  ocean.addColorStop(0.58, '#0b668f');
+  ocean.addColorStop(1, '#062b42');
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.fillStyle = ocean;
+  ctx.fill();
+}
+
+function drawGrid(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  view: { latitude: number; longitude: number },
+) {
+  ctx.lineWidth = 1;
+  ctx.strokeStyle = 'rgba(255,255,255,0.12)';
+  for (let latitude = -60; latitude <= 60; latitude += 30) {
+    drawProjectedLine(
+      ctx,
+      Array.from({ length: 73 }, (_, index) => ({
+        latitude,
+        longitude: -180 + index * 5,
+      })),
+      cx,
+      cy,
+      radius,
+      view,
+    );
+  }
+  for (let longitude = -180; longitude < 180; longitude += 30) {
+    drawProjectedLine(
+      ctx,
+      Array.from({ length: 37 }, (_, index) => ({
+        latitude: -90 + index * 5,
+        longitude,
+      })),
+      cx,
+      cy,
+      radius,
+      view,
+    );
+  }
+}
+
+function drawLand(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  view: { latitude: number; longitude: number },
+  highlightedContinent?: CapitalizationContinent,
+) {
+  CAPITALIZATION_LAND_SHAPES.forEach((shape) => {
+    const color = CAPITALIZATION_CONTINENT_STYLES[shape.continent].color;
+    const highlighted = highlightedContinent === shape.continent;
+    ctx.beginPath();
+    let hasVisible = false;
+    shape.points.forEach(([longitude, latitude]) => {
+      const projected = project(latitude, longitude, cx, cy, radius, view);
+      if (!projected.visible) return;
+      if (!hasVisible) ctx.moveTo(projected.x, projected.y);
+      else ctx.lineTo(projected.x, projected.y);
+      hasVisible = true;
+    });
+    if (!hasVisible) return;
+    ctx.closePath();
+    ctx.fillStyle = highlighted ? color : blendHex(color, 0.58);
+    ctx.globalAlpha = highlighted ? 0.92 : 0.62;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.lineWidth = highlighted ? 2.4 : 1;
+    ctx.strokeStyle = highlighted ? 'rgba(255,255,255,0.74)' : 'rgba(255,255,255,0.24)';
+    ctx.stroke();
+  });
+}
+
+function drawMarker(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  view: { latitude: number; longitude: number },
+  latitude: number,
+  longitude: number,
+) {
+  const projected = project(latitude, longitude, cx, cy, radius, view);
+  if (!projected.visible) return;
+  ctx.beginPath();
+  ctx.arc(projected.x, projected.y, 13, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(243,199,95,0.24)';
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(projected.x, projected.y, 6, 0, Math.PI * 2);
+  ctx.fillStyle = '#f3c75f';
+  ctx.fill();
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#1c1609';
+  ctx.stroke();
+}
+
+function drawProjectedLine(
+  ctx: CanvasRenderingContext2D,
+  points: Array<{ latitude: number; longitude: number }>,
+  cx: number,
+  cy: number,
+  radius: number,
+  view: { latitude: number; longitude: number },
+) {
+  let drawing = false;
+  ctx.beginPath();
+  points.forEach((point) => {
+    const projected = project(point.latitude, point.longitude, cx, cy, radius, view);
+    if (!projected.visible) {
+      drawing = false;
+      return;
+    }
+    if (!drawing) {
+      ctx.moveTo(projected.x, projected.y);
+      drawing = true;
+    } else {
+      ctx.lineTo(projected.x, projected.y);
+    }
+  });
+  ctx.stroke();
+}
+
+function project(
+  latitude: number,
+  longitude: number,
+  cx: number,
+  cy: number,
+  radius: number,
+  view: { latitude: number; longitude: number },
+) {
+  const latRad = toRad(latitude);
+  const lonRad = toRad(longitude - view.longitude);
+  const centerLatRad = toRad(view.latitude);
+  const cosLat = Math.cos(latRad);
+  const sinLat = Math.sin(latRad);
+  const cosCenter = Math.cos(centerLatRad);
+  const sinCenter = Math.sin(centerLatRad);
+  const x = cosLat * Math.sin(lonRad);
+  const y = sinLat * cosCenter - cosLat * Math.cos(lonRad) * sinCenter;
+  const z = sinLat * sinCenter + cosLat * Math.cos(lonRad) * cosCenter;
+
+  return {
+    x: cx + radius * x,
+    y: cy - radius * y,
+    visible: z > -0.05,
+  };
+}
+
+function blendHex(hex: string, amount: number): string {
+  const clean = hex.replace('#', '');
+  const red = Number.parseInt(clean.slice(0, 2), 16);
+  const green = Number.parseInt(clean.slice(2, 4), 16);
+  const blue = Number.parseInt(clean.slice(4, 6), 16);
+  return `rgb(${Math.round(red * amount)}, ${Math.round(green * amount)}, ${Math.round(blue * amount)})`;
+}
+
+function toRad(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function normalizeLongitude(longitude: number): number {
+  return ((((longitude + 180) % 360) + 360) % 360) - 180;
+}

--- a/src/components/Capitalization/capitalizationData.ts
+++ b/src/components/Capitalization/capitalizationData.ts
@@ -1,0 +1,242 @@
+export type CapitalizationContinent =
+  | 'Africa'
+  | 'Asia'
+  | 'Europe'
+  | 'North America'
+  | 'South America'
+  | 'Oceania';
+
+export interface CapitalizationCountry {
+  id: string;
+  name: string;
+  flag: string;
+  capital: string;
+  accepted: string[];
+  latitude: number;
+  longitude: number;
+  difficulty: 1 | 2 | 3 | 4 | 5;
+}
+
+export interface CapitalizationContinentStyle {
+  color: string;
+  center: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+export interface CapitalizationLandShape {
+  continent: CapitalizationContinent;
+  points: Array<[longitude: number, latitude: number]>;
+}
+
+function country(
+  id: string,
+  name: string,
+  flag: string,
+  capital: string,
+  latitude: number,
+  longitude: number,
+  difficulty: 1 | 2 | 3 | 4 | 5,
+  alternatives: string[] = [],
+): CapitalizationCountry {
+  return {
+    id,
+    name,
+    flag,
+    capital,
+    accepted: [capital, ...alternatives],
+    latitude,
+    longitude,
+    difficulty,
+  };
+}
+
+export const CAPITALIZATION_CONTINENTS: CapitalizationContinent[] = [
+  'Africa',
+  'Asia',
+  'Europe',
+  'North America',
+  'South America',
+  'Oceania',
+];
+
+export const CAPITALIZATION_CONTINENT_STYLES: Record<
+  CapitalizationContinent,
+  CapitalizationContinentStyle
+> = {
+  Africa: { color: '#5bd68a', center: { latitude: 2, longitude: 21 } },
+  Asia: { color: '#f3c75f', center: { latitude: 32, longitude: 91 } },
+  Europe: { color: '#66b8ff', center: { latitude: 51, longitude: 13 } },
+  'North America': { color: '#ff8b72', center: { latitude: 47, longitude: -101 } },
+  'South America': { color: '#c996ff', center: { latitude: -18, longitude: -61 } },
+  Oceania: { color: '#62d1c0', center: { latitude: -25, longitude: 136 } },
+};
+
+export const CAPITALIZATION_COUNTRIES_BY_CONTINENT: Record<
+  CapitalizationContinent,
+  CapitalizationCountry[]
+> = {
+  Africa: [
+    country('egypt', 'Egypt', '🇪🇬', 'Cairo', 26.8, 30.8, 1, ['Al Qahirah']),
+    country('kenya', 'Kenya', '🇰🇪', 'Nairobi', -0.1, 37.9, 2),
+    country('morocco', 'Morocco', '🇲🇦', 'Rabat', 31.8, -7.1, 2),
+    country('ghana', 'Ghana', '🇬🇭', 'Accra', 7.9, -1, 2),
+    country('tanzania', 'Tanzania', '🇹🇿', 'Dodoma', -6.4, 35, 3),
+    country('senegal', 'Senegal', '🇸🇳', 'Dakar', 14.5, -14.4, 3),
+    country('ethiopia', 'Ethiopia', '🇪🇹', 'Addis Ababa', 9.1, 40.5, 3),
+    country('rwanda', 'Rwanda', '🇷🇼', 'Kigali', -1.9, 29.9, 3),
+    country('tunisia', 'Tunisia', '🇹🇳', 'Tunis', 34, 9.5, 2),
+    country('nigeria', 'Nigeria', '🇳🇬', 'Abuja', 9.1, 8.7, 2),
+  ],
+  Asia: [
+    country('japan', 'Japan', '🇯🇵', 'Tokyo', 36.2, 138.3, 1),
+    country('south-korea', 'South Korea', '🇰🇷', 'Seoul', 36.4, 127.8, 1),
+    country('thailand', 'Thailand', '🇹🇭', 'Bangkok', 15.8, 101, 1),
+    country('vietnam', 'Vietnam', '🇻🇳', 'Hanoi', 16.2, 107.8, 2, ['Ha Noi']),
+    country('mongolia', 'Mongolia', '🇲🇳', 'Ulaanbaatar', 46.9, 103.8, 4, ['Ulan Bator']),
+    country('nepal', 'Nepal', '🇳🇵', 'Kathmandu', 28.4, 84.1, 3),
+    country('philippines', 'Philippines', '🇵🇭', 'Manila', 12.9, 121.8, 2),
+    country('malaysia', 'Malaysia', '🇲🇾', 'Kuala Lumpur', 4.2, 102, 2),
+    country('indonesia', 'Indonesia', '🇮🇩', 'Jakarta', -2.5, 118, 2),
+    country('jordan', 'Jordan', '🇯🇴', 'Amman', 31.2, 36.5, 3),
+  ],
+  Europe: [
+    country('france', 'France', '🇫🇷', 'Paris', 46.2, 2.2, 1),
+    country('germany', 'Germany', '🇩🇪', 'Berlin', 51.2, 10.5, 1),
+    country('italy', 'Italy', '🇮🇹', 'Rome', 42.9, 12.6, 1, ['Roma']),
+    country('spain', 'Spain', '🇪🇸', 'Madrid', 40.5, -3.7, 1),
+    country('portugal', 'Portugal', '🇵🇹', 'Lisbon', 39.4, -8.2, 2, ['Lisboa']),
+    country('greece', 'Greece', '🇬🇷', 'Athens', 39.1, 22.9, 1),
+    country('sweden', 'Sweden', '🇸🇪', 'Stockholm', 60.1, 18.6, 2),
+    country('poland', 'Poland', '🇵🇱', 'Warsaw', 52.1, 19.4, 2, ['Warszawa']),
+    country('norway', 'Norway', '🇳🇴', 'Oslo', 60.5, 8.5, 2),
+    country('ireland', 'Ireland', '🇮🇪', 'Dublin', 53.4, -8.2, 2),
+  ],
+  'North America': [
+    country('canada', 'Canada', '🇨🇦', 'Ottawa', 56.1, -106.3, 2),
+    country(
+      'united-states',
+      'United States',
+      '🇺🇸',
+      'Washington, D.C.',
+      39.8,
+      -98.6,
+      2,
+      ['Washington DC', 'Washington'],
+    ),
+    country('mexico', 'Mexico', '🇲🇽', 'Mexico City', 23.6, -102.6, 1, ['Ciudad de Mexico']),
+    country('guatemala', 'Guatemala', '🇬🇹', 'Guatemala City', 15.8, -90.2, 3),
+    country('cuba', 'Cuba', '🇨🇺', 'Havana', 21.5, -79.4, 2, ['La Habana']),
+    country('jamaica', 'Jamaica', '🇯🇲', 'Kingston', 18.1, -77.3, 3),
+    country('panama', 'Panama', '🇵🇦', 'Panama City', 8.5, -80.8, 2),
+    country('costa-rica', 'Costa Rica', '🇨🇷', 'San Jose', 9.7, -84.2, 3, ['San José']),
+    country('dominican-republic', 'Dominican Republic', '🇩🇴', 'Santo Domingo', 18.7, -70.2, 3),
+    country('bahamas', 'Bahamas', '🇧🇸', 'Nassau', 25, -77.4, 4),
+  ],
+  'South America': [
+    country('brazil', 'Brazil', '🇧🇷', 'Brasilia', -14.2, -51.9, 2, ['Brasília']),
+    country('argentina', 'Argentina', '🇦🇷', 'Buenos Aires', -38.4, -63.6, 1),
+    country('chile', 'Chile', '🇨🇱', 'Santiago', -35.7, -71.5, 1),
+    country('peru', 'Peru', '🇵🇪', 'Lima', -9.2, -75, 1),
+    country('colombia', 'Colombia', '🇨🇴', 'Bogota', 4.6, -74.1, 2, ['Bogotá']),
+    country('uruguay', 'Uruguay', '🇺🇾', 'Montevideo', -32.5, -55.8, 2),
+    country('paraguay', 'Paraguay', '🇵🇾', 'Asuncion', -23.4, -58.4, 3, ['Asunción']),
+    country('ecuador', 'Ecuador', '🇪🇨', 'Quito', -1.8, -78.2, 2),
+    country('venezuela', 'Venezuela', '🇻🇪', 'Caracas', 6.4, -66.6, 2),
+    country('guyana', 'Guyana', '🇬🇾', 'Georgetown', 4.9, -58.9, 4),
+  ],
+  Oceania: [
+    country('australia', 'Australia', '🇦🇺', 'Canberra', -25.3, 133.8, 1),
+    country('new-zealand', 'New Zealand', '🇳🇿', 'Wellington', -40.9, 174.9, 1),
+    country('fiji', 'Fiji', '🇫🇯', 'Suva', -17.7, 178.1, 3),
+    country('papua-new-guinea', 'Papua New Guinea', '🇵🇬', 'Port Moresby', -6.3, 143.9, 3),
+    country('samoa', 'Samoa', '🇼🇸', 'Apia', -13.8, -172.1, 4),
+    country('tonga', 'Tonga', '🇹🇴', "Nuku'alofa", -21.2, -175.2, 5, ['Nukualofa', 'Nuku alofa']),
+    country('vanuatu', 'Vanuatu', '🇻🇺', 'Port Vila', -15.4, 166.9, 4),
+    country('solomon-islands', 'Solomon Islands', '🇸🇧', 'Honiara', -9.6, 160.2, 4),
+    country('kiribati', 'Kiribati', '🇰🇮', 'South Tarawa', 1.9, -157.4, 5, ['Tarawa']),
+    country('tuvalu', 'Tuvalu', '🇹🇻', 'Funafuti', -7.1, 177.7, 5),
+  ],
+};
+
+export const CAPITALIZATION_LAND_SHAPES: CapitalizationLandShape[] = [
+  {
+    continent: 'Africa',
+    points: [
+      [-17, 35],
+      [5, 37],
+      [33, 31],
+      [51, 11],
+      [43, -12],
+      [31, -35],
+      [18, -35],
+      [8, -18],
+      [-9, -34],
+      [-16, -5],
+    ],
+  },
+  {
+    continent: 'Europe',
+    points: [
+      [-10, 36],
+      [0, 44],
+      [11, 48],
+      [25, 60],
+      [40, 55],
+      [43, 41],
+      [29, 36],
+      [15, 38],
+      [5, 36],
+    ],
+  },
+  {
+    continent: 'Asia',
+    points: [
+      [30, 10],
+      [45, 30],
+      [60, 50],
+      [95, 60],
+      [135, 50],
+      [150, 30],
+      [120, 5],
+      [105, -5],
+      [80, 5],
+      [65, 20],
+      [45, 12],
+    ],
+  },
+  {
+    continent: 'North America',
+    points: [
+      [-168, 15],
+      [-150, 60],
+      [-95, 72],
+      [-55, 52],
+      [-80, 25],
+      [-100, 15],
+      [-115, 25],
+      [-130, 24],
+    ],
+  },
+  {
+    continent: 'South America',
+    points: [
+      [-82, 12],
+      [-62, 8],
+      [-35, -10],
+      [-52, -55],
+      [-72, -45],
+      [-80, -10],
+    ],
+  },
+  {
+    continent: 'Oceania',
+    points: [
+      [112, -10],
+      [155, -10],
+      [160, -45],
+      [110, -45],
+    ],
+  },
+];

--- a/src/components/Capitalization/capitalizationUtils.ts
+++ b/src/components/Capitalization/capitalizationUtils.ts
@@ -1,0 +1,310 @@
+import { mulberry32 } from '../../store/rng';
+import { cryptoSeed } from '../../features/riskWheel/cryptoSpin';
+import {
+  CAPITALIZATION_CONTINENTS,
+  CAPITALIZATION_COUNTRIES_BY_CONTINENT,
+  type CapitalizationContinent,
+  type CapitalizationCountry,
+} from './capitalizationData';
+
+export const CAPITALIZATION_TOTAL_CONTINENTS = 3;
+export const CAPITALIZATION_QUESTIONS_PER_CONTINENT = 3;
+export const CAPITALIZATION_TOTAL_QUESTIONS =
+  CAPITALIZATION_TOTAL_CONTINENTS * CAPITALIZATION_QUESTIONS_PER_CONTINENT;
+export const CAPITALIZATION_ELIMINATION_RATE = 0.3;
+
+export interface CapitalizationQuestion extends CapitalizationCountry {
+  continent: CapitalizationContinent;
+  questionNumber: number;
+}
+
+export interface CapitalizationQuestionSet {
+  continents: CapitalizationContinent[];
+  questions: CapitalizationQuestion[];
+}
+
+export interface CapitalizationParticipant {
+  id: string;
+  name: string;
+  isHuman: boolean;
+  precomputedScore: number;
+}
+
+export interface CapitalizationRoundPerformance {
+  guessed: boolean;
+  attempts: number;
+  timeMs: number;
+  skipped?: boolean;
+}
+
+export interface CapitalizationStanding {
+  participantId: string;
+  participantName: string;
+  isHuman: boolean;
+  cumulativeScore: number;
+  correctAnswers: number;
+  questionsPlayed: number;
+  lastQuestionScore: number;
+  lastQuestionAttempts: number;
+  lastQuestionTimeMs: number;
+  lastQuestionGuessed: boolean;
+  eliminatedAfterQuestion: number | null;
+}
+
+export interface CapitalizationAiRngContext {
+  seed: number;
+  questionNumber: number;
+  participantId: string;
+}
+
+export interface CapitalizationAiPerformanceContext {
+  participant: CapitalizationParticipant;
+  question: CapitalizationQuestion;
+}
+
+export function resolveCapitalizationRunSeed(
+  seed: number | undefined,
+  makeSeed: () => number = cryptoSeed,
+): number {
+  return seed !== undefined && seed !== 0 ? seed : makeSeed();
+}
+
+export function buildCapitalizationQuestionSet(seed: number): CapitalizationQuestionSet {
+  const rng = mulberry32(seed >>> 0);
+  const continents = shuffleWithRng(CAPITALIZATION_CONTINENTS, rng).slice(
+    0,
+    CAPITALIZATION_TOTAL_CONTINENTS,
+  );
+  const questions = continents.flatMap((continent, continentIndex) =>
+    shuffleWithRng(CAPITALIZATION_COUNTRIES_BY_CONTINENT[continent], rng)
+      .slice(0, CAPITALIZATION_QUESTIONS_PER_CONTINENT)
+      .map((item, questionIndex) => ({
+        ...item,
+        continent,
+        questionNumber:
+          continentIndex * CAPITALIZATION_QUESTIONS_PER_CONTINENT + questionIndex + 1,
+      })),
+  );
+
+  return { continents, questions };
+}
+
+export function createCapitalizationStandings(
+  participants: CapitalizationParticipant[],
+): CapitalizationStanding[] {
+  return participants.map((participant) => ({
+    participantId: participant.id,
+    participantName: participant.name,
+    isHuman: participant.isHuman,
+    cumulativeScore: 0,
+    correctAnswers: 0,
+    questionsPlayed: 0,
+    lastQuestionScore: 0,
+    lastQuestionAttempts: 0,
+    lastQuestionTimeMs: 0,
+    lastQuestionGuessed: false,
+    eliminatedAfterQuestion: null,
+  }));
+}
+
+export function normalizeCapitalAnswer(value: string): string {
+  return value
+    .toLocaleLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\b(capital|city|the)\b/g, '')
+    .replace(/[^a-z0-9]/g, '');
+}
+
+export function isCapitalAnswerAccepted(
+  answer: string,
+  question: Pick<CapitalizationQuestion, 'accepted'>,
+): boolean {
+  const normalizedAnswer = normalizeCapitalAnswer(answer);
+  return question.accepted.some(
+    (acceptedAnswer) => normalizeCapitalAnswer(acceptedAnswer) === normalizedAnswer,
+  );
+}
+
+export function computeCapitalizationQuestionScore(
+  performance: CapitalizationRoundPerformance,
+): number {
+  const attempts = Math.max(1, performance.attempts);
+  if (!performance.guessed || performance.skipped) return 0;
+
+  const timePenalty = Math.min(620, Math.round((performance.timeMs / 1000) * 18));
+  const attemptPenalty = Math.max(0, attempts - 1) * 140;
+  const firstTryBonus = attempts === 1 ? 110 : 0;
+  return Math.max(90, 1000 + firstTryBonus - timePenalty - attemptPenalty);
+}
+
+export function createCapitalizationAiRng(context: CapitalizationAiRngContext): () => number {
+  const roundSeed = Math.imul(context.questionNumber >>> 0, 0x9e3779b9) >>> 0;
+  const participantSeed = hashStringU32(context.participantId);
+  return mulberry32(((context.seed >>> 0) ^ roundSeed ^ participantSeed) >>> 0);
+}
+
+export function simulateCapitalizationAiPerformance(
+  context: CapitalizationAiPerformanceContext,
+  rng: () => number,
+): CapitalizationRoundPerformance {
+  const skill = clamp(context.participant.precomputedScore / 100, 0.18, 0.96);
+  const difficultyPenalty = (context.question.difficulty - 1) * 0.075;
+  const lateMatchPressure = Math.max(0, context.question.questionNumber - 6) * 0.018;
+  const correctChance = clamp(0.34 + skill * 0.62 - difficultyPenalty - lateMatchPressure, 0.08, 0.97);
+  const guessed = rng() < correctChance;
+  const speedBias = 1 - skill;
+  const baseTimeMs = 2400 + rng() * 2800 + speedBias * 6200 + context.question.difficulty * 420;
+
+  if (guessed) {
+    let attempts = 1;
+    let extraAttemptChance = clamp(0.38 - skill * 0.28 + difficultyPenalty, 0.04, 0.54);
+    while (attempts < 4 && rng() < extraAttemptChance) {
+      attempts += 1;
+      extraAttemptChance *= 0.42;
+    }
+
+    return {
+      guessed: true,
+      attempts,
+      timeMs: Math.round(baseTimeMs + (attempts - 1) * (1100 + rng() * 900)),
+    };
+  }
+
+  const attempts = 1 + Math.floor(rng() * (context.question.difficulty >= 4 ? 4 : 3));
+  return {
+    guessed: false,
+    attempts,
+    skipped: rng() < 0.35,
+    timeMs: Math.round(baseTimeMs + attempts * (1200 + rng() * 1000)),
+  };
+}
+
+export function applyCapitalizationPerformance(
+  standings: CapitalizationStanding[],
+  performanceByParticipantId: Record<string, CapitalizationRoundPerformance>,
+): CapitalizationStanding[] {
+  return standings.map((standing) => {
+    const performance = performanceByParticipantId[standing.participantId];
+    if (!performance) return standing;
+    const score = computeCapitalizationQuestionScore(performance);
+    return {
+      ...standing,
+      cumulativeScore: standing.cumulativeScore + score,
+      correctAnswers: standing.correctAnswers + (performance.guessed ? 1 : 0),
+      questionsPlayed: standing.questionsPlayed + 1,
+      lastQuestionScore: score,
+      lastQuestionAttempts: Math.max(1, performance.attempts),
+      lastQuestionTimeMs: Math.max(0, performance.timeMs),
+      lastQuestionGuessed: performance.guessed,
+    };
+  });
+}
+
+export function getCapitalizationEliminationCount(activeAiCount: number): number {
+  if (activeAiCount <= 1) return 0;
+  return Math.min(
+    Math.ceil(activeAiCount * CAPITALIZATION_ELIMINATION_RATE),
+    activeAiCount - 1,
+  );
+}
+
+export function eliminateCapitalizationField(
+  standings: CapitalizationStanding[],
+  questionNumber: number,
+): {
+  standings: CapitalizationStanding[];
+  eliminatedIds: string[];
+} {
+  const activeAi = standings.filter(
+    (standing) => !standing.isHuman && standing.eliminatedAfterQuestion === null,
+  );
+  const eliminationCount = getCapitalizationEliminationCount(activeAi.length);
+  if (eliminationCount <= 0) return { standings, eliminatedIds: [] };
+
+  const eliminatedIds = activeAi
+    .slice()
+    .sort(compareCapitalizationStandingsForElimination)
+    .slice(0, eliminationCount)
+    .map((standing) => standing.participantId);
+  const eliminatedSet = new Set(eliminatedIds);
+
+  return {
+    eliminatedIds,
+    standings: standings.map((standing) =>
+      eliminatedSet.has(standing.participantId) && standing.eliminatedAfterQuestion === null
+        ? { ...standing, eliminatedAfterQuestion: questionNumber }
+        : standing,
+    ),
+  };
+}
+
+export function compareCapitalizationStandings(
+  a: CapitalizationStanding,
+  b: CapitalizationStanding,
+): number {
+  const aActive = a.eliminatedAfterQuestion === null;
+  const bActive = b.eliminatedAfterQuestion === null;
+  if (aActive !== bActive) return aActive ? -1 : 1;
+  if (b.cumulativeScore !== a.cumulativeScore) return b.cumulativeScore - a.cumulativeScore;
+  if (b.correctAnswers !== a.correctAnswers) return b.correctAnswers - a.correctAnswers;
+  if (a.lastQuestionTimeMs !== b.lastQuestionTimeMs) return a.lastQuestionTimeMs - b.lastQuestionTimeMs;
+  if (a.lastQuestionAttempts !== b.lastQuestionAttempts) {
+    return a.lastQuestionAttempts - b.lastQuestionAttempts;
+  }
+  return a.participantName.localeCompare(b.participantName);
+}
+
+export function rankCapitalizationStandings(
+  standings: CapitalizationStanding[],
+): CapitalizationStanding[] {
+  return standings.slice().sort(compareCapitalizationStandings);
+}
+
+export function buildCapitalizationRawResults(
+  standings: CapitalizationStanding[],
+): Record<string, number> {
+  return Object.fromEntries(
+    standings.map((standing) => [standing.participantId, standing.cumulativeScore]),
+  );
+}
+
+export function formatCapitalizationTimeMs(timeMs: number): string {
+  if (!Number.isFinite(timeMs) || timeMs <= 0) return '-';
+  return `${(timeMs / 1000).toFixed(1)}s`;
+}
+
+function compareCapitalizationStandingsForElimination(
+  a: CapitalizationStanding,
+  b: CapitalizationStanding,
+): number {
+  if (a.cumulativeScore !== b.cumulativeScore) return a.cumulativeScore - b.cumulativeScore;
+  if (a.correctAnswers !== b.correctAnswers) return a.correctAnswers - b.correctAnswers;
+  if (a.lastQuestionAttempts !== b.lastQuestionAttempts) {
+    return b.lastQuestionAttempts - a.lastQuestionAttempts;
+  }
+  if (a.lastQuestionTimeMs !== b.lastQuestionTimeMs) return b.lastQuestionTimeMs - a.lastQuestionTimeMs;
+  return a.participantName.localeCompare(b.participantName);
+}
+
+function shuffleWithRng<T>(items: readonly T[], rng: () => number): T[] {
+  const copy = [...items];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const other = Math.floor(rng() * (index + 1));
+    [copy[index], copy[other]] = [copy[other], copy[index]];
+  }
+  return copy;
+}
+
+function hashStringU32(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -589,6 +589,29 @@ export default function MinigameHost({
                 />
               );
             }
+            if (game.implementation === 'react' && game.reactComponentKey === 'Capitalization') {
+              // Capitalization should draw a fresh geography set for each hosted run.
+              // The challenge seed is stable for a pending challenge, so forwarding it
+              // makes repeated app/browser starts land on the same first country.
+              const CapitalizationComp = reactComponents.Capitalization;
+              return (
+                <CapitalizationComp
+                  autoStart={true}
+                  participantIds={participantIds}
+                  participants={participants}
+                  onFinish={(value: number, tiebreakerMs?: number, completion?: ReactMinigameCompletion) => {
+                    if (game.scoringAdapter === 'authoritative' || completion?.authoritativeWinnerId) {
+                      onDone(value, false, completion);
+                      return;
+                    }
+                    setFinalValue(value);
+                    setFinalTiebreakerMs(tiebreakerMs ?? null);
+                    setWasPartial(false);
+                    setPhase('results');
+                  }}
+                />
+              );
+            }
             if (game.implementation === 'react') {
               const key = game.reactComponentKey;
               if (!key) {

--- a/src/minigames/reactComponents.ts
+++ b/src/minigames/reactComponents.ts
@@ -45,6 +45,7 @@ import TimingBar from '../components/TimingBar/TimingBar';
 import Minesweeps from '../components/Minesweeps/Minesweeps';
 import HangmanChallengeComp from '../components/HangmanChallengeComp/HangmanChallengeComp';
 import NumberTrivia from '../components/NumberTrivia/NumberTrivia';
+import Capitalization from '../components/Capitalization/Capitalization';
 import CodeBreakerComp from '../components/CodeBreakerComp/CodeBreakerComp';
 import GridOfLuck from '../components/GridOfLuck/GridOfLuck';
 import ChainOfGreed from '../components/ChainOfGreed/ChainOfGreed';
@@ -102,6 +103,7 @@ const reactComponents: Record<string, ComponentType<GenericMinigameProps>> = {
   Minesweeps: Minesweeps as ComponentType<GenericMinigameProps>,
   HangmanChallenge: HangmanChallengeComp as ComponentType<GenericMinigameProps>,
   NumberTrivia: NumberTrivia as ComponentType<GenericMinigameProps>,
+  Capitalization: Capitalization as ComponentType<GenericMinigameProps>,
   CodeBreaker: CodeBreakerComp as ComponentType<GenericMinigameProps>,
   GridOfLuck: GridOfLuck as ComponentType<GenericMinigameProps>,
   ChainOfGreed: ChainOfGreed as ComponentType<GenericMinigameProps>,

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -790,6 +790,31 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     retired: false,
   },
 
+  capitalization: {
+    key: 'capitalization',
+    title: 'Capitalization',
+    description: 'A rotating-globe capital city tournament across three continents.',
+    instructions: [
+      'The globe spins and lands on one of three randomly selected continents.',
+      'Answer the capital city for three countries on that continent.',
+      'You have unlimited attempts, but faster first-try answers score much higher.',
+      'You may skip any country for zero points.',
+      'After questions 3 and 6, roughly 30% of the lowest-scoring AI players are eliminated.',
+      'Question 9 is the finale, and the highest surviving score is crowned LOH.',
+    ],
+    metricKind: 'points',
+    metricLabel: 'Score',
+    timeLimitMs: 0,
+    authoritative: true,
+    scoringAdapter: 'raw',
+    implementation: 'react',
+    reactComponentKey: 'Capitalization',
+    legacy: false,
+    weight: 1,
+    category: 'trivia',
+    retired: false,
+  },
+
   tetris: {
     key: 'tetris',
     title: 'Fit Me In',

--- a/tests/unit/capitalization/capitalization.component.test.tsx
+++ b/tests/unit/capitalization/capitalization.component.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Capitalization from '../../../src/components/Capitalization/Capitalization';
+
+const participants = [
+  { id: 'human', name: 'You', isHuman: true, precomputedScore: 0, previousPR: null },
+  { id: 'ai-1', name: 'Atlas', isHuman: false, precomputedScore: 82, previousPR: null },
+  { id: 'ai-2', name: 'Mira', isHuman: false, precomputedScore: 72, previousPR: null },
+  { id: 'ai-3', name: 'Nova', isHuman: false, precomputedScore: 64, previousPR: null },
+  { id: 'ai-4', name: 'Rio', isHuman: false, precomputedScore: 58, previousPR: null },
+];
+
+function mockCanvas() {
+  const ctx = {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    clip: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    stroke: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  };
+
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  );
+  vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: 0,
+    width: 720,
+    height: 520,
+    top: 0,
+    left: 0,
+    right: 720,
+    bottom: 520,
+    toJSON: () => ({}),
+  });
+  vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+}
+
+describe('Capitalization component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCanvas();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('plays through nine skipped questions and reports an authoritative winner', () => {
+    const onFinish = vi.fn();
+    render(<Capitalization seed={44} participants={participants} onFinish={onFinish} />);
+
+    expect(screen.getByText('Globe spin')).toBeInTheDocument();
+
+    for (let question = 1; question <= 9; question += 1) {
+      act(() => {
+        vi.advanceTimersByTime(2700);
+      });
+
+      expect(screen.getByLabelText('Capital city answer')).not.toBeDisabled();
+      fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      expect(screen.getByText(`Question ${question} complete`)).toBeInTheDocument();
+      expect(screen.queryByLabelText('Live standings')).not.toBeInTheDocument();
+
+      if (question === 3 || question === 6 || question === 9) {
+        expect(
+          screen.getByLabelText(question === 9 ? 'Final standings' : 'Round standings'),
+        ).toBeInTheDocument();
+      } else {
+        expect(screen.getByLabelText('Answer result')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Round standings')).not.toBeInTheDocument();
+      }
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: question === 9 ? 'Crown LOH' : 'Continue',
+        }),
+      );
+    }
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onFinish.mock.calls[0][2]).toMatchObject({
+      authoritativeWinnerId: expect.any(String),
+      rawResults: expect.any(Object),
+    });
+  });
+});

--- a/tests/unit/capitalization/capitalization.logic.test.ts
+++ b/tests/unit/capitalization/capitalization.logic.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { minigameAiRegistry } from '../../../src/ai/competition/minigameAiRegistry';
+import {
+  CAPITALIZATION_CONTINENTS,
+  CAPITALIZATION_COUNTRIES_BY_CONTINENT,
+} from '../../../src/components/Capitalization/capitalizationData';
+import {
+  CAPITALIZATION_QUESTIONS_PER_CONTINENT,
+  CAPITALIZATION_TOTAL_QUESTIONS,
+  buildCapitalizationQuestionSet,
+  computeCapitalizationQuestionScore,
+  createCapitalizationAiRng,
+  createCapitalizationStandings,
+  eliminateCapitalizationField,
+  isCapitalAnswerAccepted,
+  rankCapitalizationStandings,
+  resolveCapitalizationRunSeed,
+  simulateCapitalizationAiPerformance,
+} from '../../../src/components/Capitalization/capitalizationUtils';
+import { getGame } from '../../../src/minigames/registry';
+import reactComponents from '../../../src/minigames/reactComponents';
+
+describe('Capitalization question set', () => {
+  it('selects three non-Antarctica continents and nine total questions', () => {
+    const set = buildCapitalizationQuestionSet(12345);
+
+    expect(set.continents).toHaveLength(3);
+    expect(set.questions).toHaveLength(CAPITALIZATION_TOTAL_QUESTIONS);
+    expect(set.continents).not.toContain('Antarctica');
+    expect(new Set(set.continents).size).toBe(3);
+
+    for (let index = 0; index < set.continents.length; index += 1) {
+      const block = set.questions.slice(
+        index * CAPITALIZATION_QUESTIONS_PER_CONTINENT,
+        (index + 1) * CAPITALIZATION_QUESTIONS_PER_CONTINENT,
+      );
+      expect(block.every((question) => question.continent === set.continents[index])).toBe(true);
+    }
+  });
+
+  it('is deterministic for a given seed', () => {
+    expect(buildCapitalizationQuestionSet(77)).toEqual(buildCapitalizationQuestionSet(77));
+  });
+
+  it('uses fresh run seeds when no non-zero seed is provided', () => {
+    expect(resolveCapitalizationRunSeed(undefined, () => 1234)).toBe(1234);
+    expect(resolveCapitalizationRunSeed(0, () => 5678)).toBe(5678);
+    expect(resolveCapitalizationRunSeed(77, () => 9999)).toBe(77);
+  });
+});
+
+describe('Capitalization answer matching and scoring', () => {
+  it('accepts punctuation, accents, and common alternate forms', () => {
+    const unitedStates = CAPITALIZATION_COUNTRIES_BY_CONTINENT['North America']
+      .find((country) => country.id === 'united-states');
+    const brazil = CAPITALIZATION_COUNTRIES_BY_CONTINENT['South America']
+      .find((country) => country.id === 'brazil');
+
+    if (!unitedStates || !brazil) throw new Error('Fixture countries missing');
+
+    expect(isCapitalAnswerAccepted('Washington DC', unitedStates)).toBe(true);
+    expect(isCapitalAnswerAccepted('Washington, D.C.', unitedStates)).toBe(true);
+    expect(isCapitalAnswerAccepted('Brasília', brazil)).toBe(true);
+    expect(isCapitalAnswerAccepted('brasilia', brazil)).toBe(true);
+  });
+
+  it('rewards speed and first-try accuracy, while skips score zero', () => {
+    const fastFirstTry = computeCapitalizationQuestionScore({
+      guessed: true,
+      attempts: 1,
+      timeMs: 2_000,
+    });
+    const slowThirdTry = computeCapitalizationQuestionScore({
+      guessed: true,
+      attempts: 3,
+      timeMs: 18_000,
+    });
+    const skipped = computeCapitalizationQuestionScore({
+      guessed: false,
+      skipped: true,
+      attempts: 1,
+      timeMs: 4_000,
+    });
+
+    expect(fastFirstTry).toBeGreaterThan(slowThirdTry);
+    expect(slowThirdTry).toBeGreaterThan(0);
+    expect(skipped).toBe(0);
+  });
+});
+
+describe('Capitalization AI and eliminations', () => {
+  it('simulates deterministic AI performance per participant and question', () => {
+    const question = buildCapitalizationQuestionSet(91).questions[0];
+    const participant = {
+      id: 'ai-atlas',
+      name: 'Atlas Byte',
+      isHuman: false,
+      precomputedScore: 82,
+    };
+    const first = simulateCapitalizationAiPerformance(
+      { participant, question },
+      createCapitalizationAiRng({
+        seed: 91,
+        questionNumber: question.questionNumber,
+        participantId: participant.id,
+      }),
+    );
+    const second = simulateCapitalizationAiPerformance(
+      { participant, question },
+      createCapitalizationAiRng({
+        seed: 91,
+        questionNumber: question.questionNumber,
+        participantId: participant.id,
+      }),
+    );
+
+    expect(second).toEqual(first);
+  });
+
+  it('eliminates roughly thirty percent of the lowest-scoring AI players and preserves the human', () => {
+    const participants = [
+      { id: 'human', name: 'You', isHuman: true, precomputedScore: 0 },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        id: `ai-${index}`,
+        name: `AI ${index}`,
+        isHuman: false,
+        precomputedScore: 50,
+      })),
+    ];
+    const standings = createCapitalizationStandings(participants).map((standing) => ({
+      ...standing,
+      cumulativeScore: standing.isHuman ? 1 : Number(standing.participantId.replace('ai-', '')),
+    }));
+
+    const result = eliminateCapitalizationField(standings, 3);
+    const ranked = rankCapitalizationStandings(result.standings);
+
+    expect(result.eliminatedIds).toHaveLength(3);
+    expect(result.eliminatedIds).toEqual(['ai-0', 'ai-1', 'ai-2']);
+    expect(result.eliminatedIds).not.toContain('human');
+    expect(ranked[ranked.length - 1].eliminatedAfterQuestion).toBe(3);
+  });
+});
+
+describe('Capitalization registry wiring', () => {
+  it('registers the game as an active React trivia minigame', () => {
+    const entry = getGame('capitalization');
+
+    expect(entry).toBeDefined();
+    expect(entry?.retired).toBe(false);
+    expect(entry?.implementation).toBe('react');
+    expect(entry?.category).toBe('trivia');
+    expect(entry?.reactComponentKey).toBe('Capitalization');
+  });
+
+  it('is present in the generic React component and AI registries', () => {
+    expect(reactComponents.Capitalization).toBeDefined();
+    expect(minigameAiRegistry.capitalization).toMatchObject({
+      key: 'capitalization',
+      category: 'mental',
+      scoreDirection: 'higher-is-better',
+    });
+  });
+
+  it('keeps Oceania as the Australia/New Zealand/Oceania bucket', () => {
+    expect(CAPITALIZATION_CONTINENTS).toContain('Oceania');
+    expect(CAPITALIZATION_COUNTRIES_BY_CONTINENT.Oceania.map((country) => country.name))
+      .toEqual(expect.arrayContaining(['Australia', 'New Zealand']));
+  });
+});


### PR DESCRIPTION
## What changed
- Added the new `Capitalization` trivia minigame with globe spin, country flag prompts, unlimited attempts, AI competitors, and elimination checkpoints.
- Wired the game into the React minigame registry, AI registry, and host routing so it can run in competition flow.
- Reworked the UI for mobile: globe only during spin, compact answer-review state, and full standings only after questions 3, 6, and 9.
- Fixed the session seed behavior so hosted runs draw a fresh continent/country set instead of repeating the same first country every start.

## Why
- The game needed to match the existing minigame architecture and behave cleanly on small screens.
- The repeated Rwanda start was caused by the host forwarding a stable challenge seed into Capitalization.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/unit/capitalization`
- `npm run build`