### PR TITLE
[codex] gate intro hub until all assets are loaded

### DIFF
--- a/src/components/HubLoadingOverlay/HubLoadingOverlay.css
+++ b/src/components/HubLoadingOverlay/HubLoadingOverlay.css
@@ -1,0 +1,93 @@
+/* HubLoadingOverlay - shown while the intro hub is still assembling assets. */
+
+.hub-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background:
+    radial-gradient(circle at top, rgba(123, 92, 255, 0.18), transparent 42%),
+    linear-gradient(180deg, rgba(4, 8, 18, 0.94) 0%, rgba(5, 8, 15, 0.98) 100%);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: hub-loading-overlay-in 180ms ease both;
+}
+
+@keyframes hub-loading-overlay-in {
+  from {
+    opacity: 0;
+    transform: scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.hub-loading-overlay__card {
+  width: min(360px, 88vw);
+  display: grid;
+  gap: 10px;
+  padding: 24px 22px 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(176, 198, 255, 0.16);
+  background: linear-gradient(180deg, rgba(18, 24, 38, 0.94) 0%, rgba(9, 12, 20, 0.96) 100%);
+  box-shadow:
+    0 24px 48px rgba(0, 0, 0, 0.42),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.hub-loading-overlay__eyebrow {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.hub-loading-overlay__title {
+  margin: 0;
+  color: #fff;
+  font-size: 1.25rem;
+  font-weight: 800;
+  line-height: 1.15;
+}
+
+.hub-loading-overlay__copy {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.hub-loading-overlay__bar-track {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.hub-loading-overlay__bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7b5cff 0%, #6fb7ff 100%);
+  transition: width 140ms linear;
+}
+
+.hub-loading-overlay__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}

--- a/src/components/HubLoadingOverlay/HubLoadingOverlay.tsx
+++ b/src/components/HubLoadingOverlay/HubLoadingOverlay.tsx
@@ -1,0 +1,39 @@
+import './HubLoadingOverlay.css';
+
+interface HubLoadingOverlayProps {
+  progress: number;
+  status: string;
+}
+
+export default function HubLoadingOverlay({ progress, status }: HubLoadingOverlayProps) {
+  const clampedProgress = Math.max(0, Math.min(progress, 100));
+
+  return (
+    <div
+      className="hub-loading-overlay"
+      role="status"
+      aria-live="polite"
+      aria-label={`${status} ${clampedProgress}%`}
+    >
+      <div className="hub-loading-overlay__card">
+        <p className="hub-loading-overlay__eyebrow">Kolequant</p>
+        <h2 className="hub-loading-overlay__title">{status}</h2>
+        <p className="hub-loading-overlay__copy">
+          Backgrounds, button art, and utility chips are being prepared.
+        </p>
+
+        <div className="hub-loading-overlay__bar-track" aria-hidden="true">
+          <div
+            className="hub-loading-overlay__bar-fill"
+            style={{ width: `${clampedProgress}%` }}
+          />
+        </div>
+
+        <div className="hub-loading-overlay__meta" aria-hidden="true">
+          <span>Preparing screen</span>
+          <span>{clampedProgress}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useHomeHubAssets.ts
+++ b/src/hooks/useHomeHubAssets.ts
@@ -26,15 +26,12 @@ export default function useHomeHubAssets(effectiveBgUrl: string | null): HomeHub
 
   const assetUrls = useMemo(() => getHomeHubAssetUrls(effectiveBgUrl), [effectiveBgUrl]);
   const [imagesLoaded, setImagesLoaded] = useState(0);
-  const [imagesReady, setImagesReady] = useState(assetUrls.length === 0);
+  const [imagesReady, setImagesReady] = useState(() => assetUrls.length === 0);
   const [fontsReady, setFontsReady] = useState(() => !hasFontFaceSet());
   const [runtimeReady, setRuntimeReady] = useState(() => hasIntroHubChips());
 
   useEffect(() => {
     let cancelled = false;
-
-    setImagesLoaded(0);
-    setImagesReady(assetUrls.length === 0);
 
     if (assetUrls.length === 0) {
       return () => {
@@ -74,12 +71,10 @@ export default function useHomeHubAssets(effectiveBgUrl: string | null): HomeHub
 
   useEffect(() => {
     if (!hasFontFaceSet()) {
-      setFontsReady(true);
       return;
     }
 
     let cancelled = false;
-    setFontsReady(false);
 
     document.fonts.ready
       .then(() => {
@@ -108,20 +103,21 @@ export default function useHomeHubAssets(effectiveBgUrl: string | null): HomeHub
       return;
     }
 
+    let cancelled = false;
     const syncRuntime = () => {
-      if (container.querySelector('.hub-chip')) {
+      if (!cancelled && container.querySelector('.hub-chip')) {
         setRuntimeReady(true);
       }
     };
 
-    syncRuntime();
-    if (hasIntroHubChips()) {
-      return;
-    }
+    Promise.resolve().then(syncRuntime);
 
     const observer = new MutationObserver(syncRuntime);
     observer.observe(container, { childList: true, subtree: true });
-    return () => observer.disconnect();
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
   }, [runtimeReady]);
 
   const totalSteps = assetUrls.length + 2;

--- a/src/hooks/useHomeHubAssets.ts
+++ b/src/hooks/useHomeHubAssets.ts
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useState } from 'react';
+import useLoadIntroHub from './useLoadIntroHub';
+import { preloadImage } from '../utils/preload';
+import { getHomeHubAssetUrls } from '../screens/HomeHub/homeHubAssets';
+
+interface HomeHubAssetsState {
+  ready: boolean;
+  progress: number;
+  status: string;
+}
+
+function hasIntroHubChips(): boolean {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  return document.querySelector('#intro-hub .hub-chip') != null;
+}
+
+function hasFontFaceSet(): boolean {
+  return typeof document !== 'undefined' && 'fonts' in document && !!document.fonts;
+}
+
+export default function useHomeHubAssets(effectiveBgUrl: string | null): HomeHubAssetsState {
+  useLoadIntroHub();
+
+  const assetUrls = useMemo(() => getHomeHubAssetUrls(effectiveBgUrl), [effectiveBgUrl]);
+  const [imagesLoaded, setImagesLoaded] = useState(0);
+  const [imagesReady, setImagesReady] = useState(assetUrls.length === 0);
+  const [fontsReady, setFontsReady] = useState(() => !hasFontFaceSet());
+  const [runtimeReady, setRuntimeReady] = useState(() => hasIntroHubChips());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setImagesLoaded(0);
+    setImagesReady(assetUrls.length === 0);
+
+    if (assetUrls.length === 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const loadImages = async () => {
+      const [first, ...rest] = assetUrls;
+
+      await preloadImage(first);
+      if (cancelled) return;
+      setImagesLoaded((count) => count + 1);
+
+      if (rest.length > 0) {
+        await Promise.all(
+          rest.map((url) =>
+            preloadImage(url).then(() => {
+              if (cancelled) return;
+              setImagesLoaded((count) => count + 1);
+            }),
+          ),
+        );
+      }
+
+      if (!cancelled) {
+        setImagesReady(true);
+      }
+    };
+
+    void loadImages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assetUrls]);
+
+  useEffect(() => {
+    if (!hasFontFaceSet()) {
+      setFontsReady(true);
+      return;
+    }
+
+    let cancelled = false;
+    setFontsReady(false);
+
+    document.fonts.ready
+      .then(() => {
+        if (!cancelled) {
+          setFontsReady(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFontsReady(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (runtimeReady || typeof document === 'undefined') {
+      return;
+    }
+
+    const container = document.getElementById('intro-hub');
+    if (!container) {
+      return;
+    }
+
+    const syncRuntime = () => {
+      if (container.querySelector('.hub-chip')) {
+        setRuntimeReady(true);
+      }
+    };
+
+    syncRuntime();
+    if (hasIntroHubChips()) {
+      return;
+    }
+
+    const observer = new MutationObserver(syncRuntime);
+    observer.observe(container, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [runtimeReady]);
+
+  const totalSteps = assetUrls.length + 2;
+  const completedSteps = imagesLoaded + (fontsReady ? 1 : 0) + (runtimeReady ? 1 : 0);
+  const progress = totalSteps > 0 ? Math.min(100, Math.round((completedSteps / totalSteps) * 100)) : 100;
+  const ready = imagesReady && fontsReady && runtimeReady;
+  const status = ready
+    ? 'Intro hub ready'
+    : !runtimeReady && imagesReady && fontsReady
+    ? 'Finalizing intro hub...'
+    : 'Loading intro hub...';
+
+  return { ready, progress, status };
+}

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
@@ -17,13 +17,13 @@ import {
 } from '../../store/saveStatePersistence';
 import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
 import useBackgroundTheme from '../../hooks/useBackgroundTheme';
-import useLoadIntroHub from '../../hooks/useLoadIntroHub';
 import KolequantSplash from '../../components/KolequantSplash/KolequantSplash';
+import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOverlay';
 import AssetPreloaderOverlay from '../../components/AssetPreloaderOverlay/AssetPreloaderOverlay';
 import PermissionPrompts from '../../components/PermissionPrompts/PermissionPrompts';
 import { SoundManager } from '../../services/sound/SoundManager';
-import { preloadImage } from '../../utils/preload';
 import GameButton, { type GameButtonVariant } from '../../components/GameButton/GameButton';
+import useHomeHubAssets from '../../hooks/useHomeHubAssets';
 import {
   hasSeenHomeHubSplashForGame,
   markHomeHubSplashSeenForGame,
@@ -43,10 +43,11 @@ import './HomeHub.css';
  *
  * Load ordering:
  *   1. KolequantSplash shown — logo only, no dialogs, hub preloads in background.
- *   2. Splash fades out after ~1.2s animation completes automatically.
- *   3. IMPORTANT — background loaded first: hub background is preloaded during
- *      the splash so buttons never appear over an empty background.
- *   4. After splash exits, PermissionPrompts appear over the hub (location only).
+ *   2. Hub assets preload during the splash: background, buttons, fonts, and
+ *      the intro-hub runtime are all loaded before the screen is revealed.
+ *   3. If the splash finishes first, a loading overlay stays up until the full
+ *      hub bundle is ready so the UI never appears half-built.
+ *   4. After the hub is ready, PermissionPrompts appear over the hub (location only).
  *   5. When Play is pressed AssetPreloaderOverlay runs then navigates to /game.
  */
 const HUB_BUTTONS = [
@@ -90,20 +91,15 @@ export default function HomeHub() {
   // Remote background takes priority over weather/time-of-day background.
   const effectiveBgUrl = remoteBgUrl ?? bgUrl;
   const [splashDone, setSplashDone] = useState(() => hasSeenHomeHubSplashForGame(gameId));
-  // Track whether the hub background has loaded so buttons are never shown
-  // on an empty background (background-first ordering).
-  const [loadedBgUrl, setLoadedBgUrl] = useState<string | null>(null);
-  const bgLoaded = effectiveBgUrl != null && loadedBgUrl === effectiveBgUrl;
   // Seed preloading from transient route state so "Start New Season" can
   // reuse the existing Play → preloader → /game flow without setting state in
   // an effect on mount.
   const [preloading, setPreloading] = useState(autoStartGame);
-  const preloadedBgUrlRef = useRef<string | null>(null);
   // Resume-season prompt state for the Play flow.
   const [showResumePrompt, setShowResumePrompt] = useState(false);
 
-  // Load the intro hub overlay assets only while HomeHub is mounted.
-  useLoadIntroHub();
+  const { ready: homeHubReady, progress: homeHubLoadProgress, status: homeHubLoadStatus } =
+    useHomeHubAssets(effectiveBgUrl);
 
   useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
@@ -127,24 +123,6 @@ export default function HomeHub() {
     // doesn't auto-start another season from the same history entry.
     navigate('/', { replace: true });
   }, [autoStartGame, navigate]);
-
-  // Preload background as soon as its URL resolves, so it is ready before
-  // the splash dismisses and buttons become visible.
-  useEffect(() => {
-    if (!effectiveBgUrl || preloadedBgUrlRef.current === effectiveBgUrl) return;
-
-    let cancelled = false;
-    preloadedBgUrlRef.current = effectiveBgUrl;
-
-    preloadImage(effectiveBgUrl).then(() => {
-      if (cancelled || preloadedBgUrlRef.current !== effectiveBgUrl) return;
-      setLoadedBgUrl(effectiveBgUrl);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [effectiveBgUrl]);
 
   const handlePlay = () => {
     // Unlock audio in the gesture context.  We intentionally do NOT follow up
@@ -217,8 +195,13 @@ export default function HomeHub() {
 
       {/* Permission prompts shown after splash exits, over the hub.
           Sound prompt disabled — audio is unlocked when the player explicitly starts the game. */}
-      {splashDone && (
+      {splashDone && homeHubReady && (
         <PermissionPrompts showSoundPrompt={false} />
+      )}
+
+      {/* Hub loading overlay — shown if the splash finishes before all hub assets are ready. */}
+      {splashDone && !homeHubReady && (
+        <HubLoadingOverlay progress={homeHubLoadProgress} status={homeHubLoadStatus} />
       )}
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
@@ -253,15 +236,14 @@ export default function HomeHub() {
             />
           )}
 
-          {/* Foreground content — buttons hidden until background has loaded
-              to avoid showing the UI over an empty/transparent background. */}
+          {/* Foreground content — hidden until the full hub asset bundle is ready. */}
           <div className="homehub-content home-hub">
             {/* Hero / icon area (no branding text — logo is shown in the splash) */}
             <div className="home-hub__hero" aria-hidden="true" />
 
-            {/* Button stack: only rendered once background is ready AND splash has dismissed,
-                to prevent accidental clicks through the pointer-events: none splash overlay. */}
-            {splashDone && bgLoaded && (
+            {/* Button stack: only rendered once the splash has dismissed and the
+                full hub bundle is ready. */}
+            {splashDone && homeHubReady && (
               <nav className="home-hub__buttons" aria-label="Main menu">
                 {HUB_BUTTONS.map(({ to, label, icon, variant }) => (
                   <GameButton

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
 import { hydrateFinale } from '../../store/finaleSlice';
@@ -58,6 +58,57 @@ const HUB_BUTTONS = [
   { to: '/credits',      label: 'Credits',     icon: '🎬', variant: 'secondary_small'  },
 ] as const satisfies ReadonlyArray<{ to: string; label: string; icon: string; variant: GameButtonVariant }>;
 
+interface HomeHubAssetLayerProps {
+  splashDone: boolean;
+  effectiveBgUrl: string | null;
+  onPlay: () => void;
+  onNavigate: NavigateFunction;
+}
+
+function HomeHubAssetLayer({
+  splashDone,
+  effectiveBgUrl,
+  onPlay,
+  onNavigate,
+}: HomeHubAssetLayerProps) {
+  const { ready: homeHubReady, progress: homeHubLoadProgress, status: homeHubLoadStatus } =
+    useHomeHubAssets(effectiveBgUrl);
+
+  return (
+    <>
+      {splashDone && homeHubReady && (
+        <PermissionPrompts showSoundPrompt={false} />
+      )}
+
+      {splashDone && !homeHubReady && (
+        <HubLoadingOverlay progress={homeHubLoadProgress} status={homeHubLoadStatus} />
+      )}
+
+      {/* Foreground content — hidden until the full hub asset bundle is ready. */}
+      <div className="homehub-content home-hub">
+        {/* Hero / icon area (no branding text — logo is shown in the splash) */}
+        <div className="home-hub__hero" aria-hidden="true" />
+
+        {/* Button stack: only rendered once the splash has dismissed and the
+            full hub bundle is ready. */}
+        {splashDone && homeHubReady && (
+          <nav className="home-hub__buttons" aria-label="Main menu">
+            {HUB_BUTTONS.map(({ to, label, icon, variant }) => (
+              <GameButton
+                key={to}
+                label={label}
+                icon={icon}
+                variant={variant}
+                onClick={to === '/game' ? onPlay : () => onNavigate(to)}
+              />
+            ))}
+          </nav>
+        )}
+      </div>
+    </>
+  );
+}
+
 export default function HomeHub() {
   const location = useLocation();
   const autoStartGame = (location.state as { autoStartGame?: boolean } | null)?.autoStartGame === true;
@@ -97,9 +148,6 @@ export default function HomeHub() {
   const [preloading, setPreloading] = useState(autoStartGame);
   // Resume-season prompt state for the Play flow.
   const [showResumePrompt, setShowResumePrompt] = useState(false);
-
-  const { ready: homeHubReady, progress: homeHubLoadProgress, status: homeHubLoadStatus } =
-    useHomeHubAssets(effectiveBgUrl);
 
   useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
@@ -193,17 +241,6 @@ export default function HomeHub() {
         <KolequantSplash onFinish={handleSplashFinish} />
       )}
 
-      {/* Permission prompts shown after splash exits, over the hub.
-          Sound prompt disabled — audio is unlocked when the player explicitly starts the game. */}
-      {splashDone && homeHubReady && (
-        <PermissionPrompts showSoundPrompt={false} />
-      )}
-
-      {/* Hub loading overlay — shown if the splash finishes before all hub assets are ready. */}
-      {splashDone && !homeHubReady && (
-        <HubLoadingOverlay progress={homeHubLoadProgress} status={homeHubLoadStatus} />
-      )}
-
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
       {preloading && <AssetPreloaderOverlay />}
 
@@ -236,27 +273,14 @@ export default function HomeHub() {
             />
           )}
 
-          {/* Foreground content — hidden until the full hub asset bundle is ready. */}
-          <div className="homehub-content home-hub">
-            {/* Hero / icon area (no branding text — logo is shown in the splash) */}
-            <div className="home-hub__hero" aria-hidden="true" />
+          <HomeHubAssetLayer
+            key={effectiveBgUrl ?? 'default'}
+            splashDone={splashDone}
+            effectiveBgUrl={effectiveBgUrl}
+            onPlay={handlePlay}
+            onNavigate={navigate}
+          />
 
-            {/* Button stack: only rendered once the splash has dismissed and the
-                full hub bundle is ready. */}
-            {splashDone && homeHubReady && (
-              <nav className="home-hub__buttons" aria-label="Main menu">
-                {HUB_BUTTONS.map(({ to, label, icon, variant }) => (
-                  <GameButton
-                    key={to}
-                    label={label}
-                    icon={icon}
-                    variant={variant}
-                    onClick={to === '/game' ? handlePlay : () => navigate(to)}
-                  />
-                ))}
-              </nav>
-            )}
-          </div>
           {/* Intro hub overlay — chips rendered only while HomeHub is mounted */}
           <div id="intro-hub" />
         </div>

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -223,6 +223,35 @@ describe('HomeHub', () => {
     });
   });
 
+  it('shows the hub loading overlay until the full hub bundle is ready', async () => {
+    const pendingResolvers: Array<() => void> = [];
+    preloadImageMock.mockImplementation(() => new Promise<void>((resolve) => {
+      pendingResolvers.push(resolve);
+    }));
+
+    const view = renderHomeHub();
+
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
+
+    expect(screen.getByRole('status', { name: /Loading intro hub\.\.\./ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play' })).toBeNull();
+
+    while (pendingResolvers.length > 0) {
+      pendingResolvers.splice(0).forEach((resolve) => resolve());
+      await Promise.resolve();
+    }
+    view.rerender(
+      <MemoryRouter>
+        <HomeHub />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+    });
+  });
+
   it('auto-starts the game preloader when returning from Game Over with autoStartGame state', async () => {
     renderHomeHub({ pathname: '/', state: { autoStartGame: true } });
 

--- a/src/screens/HomeHub/homeHubAssets.ts
+++ b/src/screens/HomeHub/homeHubAssets.ts
@@ -1,0 +1,59 @@
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+const BUTTON_VARIANTS = [
+  'primary_large',
+  'secondary_medium',
+  'secondary_wide',
+  'secondary_small',
+] as const;
+
+const BUTTON_STATES = ['normal', 'hover', 'pressed', 'disabled'] as const;
+
+const INTRO_HUB_SHELL_STATES = ['normal', 'hover', 'pressed', 'disabled'] as const;
+
+const INTRO_HUB_ICONS = [
+  'housemates',
+  'music',
+  'sound',
+  'settings',
+  'share',
+  'feedback',
+  'news',
+  'achievements',
+  'social',
+  'shop',
+] as const;
+
+function assetUrl(path: string): string {
+  return `${BASE}${path}`;
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+export function getHomeHubAssetUrls(effectiveBgUrl: string | null): string[] {
+  const urls: string[] = [];
+
+  if (effectiveBgUrl) {
+    urls.push(effectiveBgUrl);
+  }
+
+  BUTTON_VARIANTS.forEach((variant) => {
+    BUTTON_STATES.forEach((state) => {
+      urls.push(assetUrl(`/assets/buttons/${variant}_${state}.svg`));
+    });
+  });
+
+  INTRO_HUB_SHELL_STATES.forEach((state) => {
+    urls.push(assetUrl(`/assets/side_utilities_button/side_utility_shell_${state}.svg`));
+  });
+
+  urls.push(assetUrl('/assets/side_utilities_button/badge_alert_red.svg'));
+
+  INTRO_HUB_ICONS.forEach((icon) => {
+    urls.push(assetUrl(`/assets/side_utilities_button/${icon}_v2.svg`));
+  });
+
+  return unique(urls);
+}


### PR DESCRIPTION
## What changed
- Added a full asset-readiness gate for the intro hub so it stays behind a loading overlay until the background, button art, utility chips, and fonts are ready.
- Introduced a dedicated `HubLoadingOverlay` with progress feedback so the user never sees the screen half-painted.
- Updated the HomeHub tests to cover the loading gate and the remote background preload flow.

## Why
The intro hub could render its text/buttons before all of its visual assets had finished loading, which caused partial paints and a jarring first impression on slower connections.

## Validation
- `npm test -- src/screens/HomeHub/__tests__/HomeHub.test.tsx`
- `npm run typecheck`