### PR TITLE
[codex] standardize shared button styles

### DIFF
--- a/src/components/ConfirmExitModal/ConfirmExitModal.css
+++ b/src/components/ConfirmExitModal/ConfirmExitModal.css
@@ -32,23 +32,9 @@
   display: flex;
   gap: 10px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .confirm-modal__btn {
-  padding: 8px 14px;
-  border-radius: 10px;
-  font-weight: 700;
-  border: none;
-  cursor: pointer;
-}
-
-.confirm-modal__btn--primary {
-  background: linear-gradient(135deg,#7b5cff,#6fb7ff);
-  color: white;
-}
-
-.confirm-modal__btn--ghost {
-  background: transparent;
-  color: rgba(255,255,255,0.9);
-  border: 1px solid rgba(255,255,255,0.06);
+  min-width: 112px;
 }

--- a/src/components/ConfirmExitModal/ConfirmExitModal.tsx
+++ b/src/components/ConfirmExitModal/ConfirmExitModal.tsx
@@ -62,11 +62,11 @@ export default function ConfirmExitModal({
         {description && <p id={descId} className="confirm-modal__desc">{description}</p>}
         <div className="confirm-modal__actions">
           {showCancel && (
-            <button type="button" className="confirm-modal__btn confirm-modal__btn--ghost" onClick={onCancel}>
+            <button type="button" className="confirm-modal__btn game-button game-button--ghost" onClick={onCancel}>
               {cancelLabel}
             </button>
           )}
-          <button type="button" className="confirm-modal__btn confirm-modal__btn--primary" onClick={onConfirm}>
+          <button type="button" className="confirm-modal__btn game-button game-button--primary" onClick={onConfirm}>
             {confirmLabel}
           </button>
         </div>

--- a/src/components/GameBottomNav/GameBottomNav.css
+++ b/src/components/GameBottomNav/GameBottomNav.css
@@ -58,7 +58,7 @@
   justify-content: center;
   width: 100%;
   min-width: 0;
-  min-height: 42px;
+  min-height: 44px;
   gap: 2px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.05));
   border: 1px solid rgba(255, 255, 255, 0.055);
@@ -108,7 +108,7 @@
 .game-bottom-nav__label {
   position: relative;
   z-index: 1;
-  font-size: 0.52rem;
+  font-size: 0.58rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.24px;

--- a/src/components/TopUtilityButton/TopUtilityButton.css
+++ b/src/components/TopUtilityButton/TopUtilityButton.css
@@ -13,9 +13,9 @@
   transition: transform 150ms ease, opacity 150ms ease;
   -webkit-user-select: none;
   user-select: none;
-  /* Sized to be secondary/small — matches existing audio button footprint */
-  width: 30px;
-  height: 30px;
+  /* Enlarge to a reliable touch target while keeping the shell compact. */
+  width: 44px;
+  height: 44px;
   flex-shrink: 0;
 }
 
@@ -50,8 +50,8 @@
 .top-utility-btn__glyph {
   position: relative;
   z-index: 1;
-  width: 52%;
-  height: 52%;
+  width: 56%;
+  height: 56%;
   object-fit: contain;
   pointer-events: none;
   user-select: none;

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,117 @@ button, a {
   -webkit-tap-highlight-color: transparent;
 }
 
+/* Shared native button system for menus, dialogs, and HUD actions.
+   Keep the visual language neon and glassy, but make the sizing/padding
+   consistent across repeated UI patterns. */
+.game-button {
+  --game-button-bg: linear-gradient(180deg, rgba(25, 33, 53, 0.96), rgba(15, 20, 33, 0.98));
+  --game-button-border: rgba(255, 255, 255, 0.12);
+  --game-button-shadow: 0 10px 24px rgba(2, 6, 16, 0.22);
+  --game-button-text: var(--color-text);
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 44px;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--game-button-border);
+  border-radius: 14px;
+  background: var(--game-button-bg);
+  color: var(--game-button-text);
+  font: inherit;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-appearance: none;
+  appearance: none;
+  touch-action: manipulation;
+  box-shadow: var(--game-button-shadow);
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease,
+    background 150ms ease,
+    border-color 150ms ease,
+    opacity 150ms ease,
+    filter 150ms ease;
+}
+
+.game-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  filter: brightness(1.02);
+}
+
+.game-button:active:not(:disabled) {
+  transform: translateY(0) scale(0.985);
+}
+
+.game-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.game-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.78);
+  outline-offset: 2px;
+}
+
+.game-button--primary {
+  --game-button-bg: linear-gradient(135deg, rgba(92, 100, 255, 0.96), rgba(136, 84, 255, 0.96));
+  --game-button-border: rgba(255, 255, 255, 0.15);
+  --game-button-shadow:
+    0 12px 28px rgba(56, 70, 255, 0.24),
+    0 0 22px rgba(139, 92, 246, 0.12);
+}
+
+.game-button--secondary {
+  --game-button-bg: linear-gradient(180deg, rgba(22, 31, 49, 0.96), rgba(14, 19, 31, 0.98));
+}
+
+.game-button--menu {
+  min-height: 40px;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.game-button--ghost {
+  --game-button-bg: rgba(255, 255, 255, 0.04);
+  --game-button-border: rgba(255, 255, 255, 0.1);
+  --game-button-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.game-button--icon {
+  width: 44px;
+  min-width: 44px;
+  padding: 0;
+  border-radius: 14px;
+}
+
+.game-button--close {
+  width: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.game-button--back {
+  padding-inline: 0.95rem 1.05rem;
+}
+
+.game-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
 /* ── Shared placeholder screen layout ────────────────────────────────────── */
 .placeholder-screen {
   display: flex;

--- a/src/screens/Leaderboard/Leaderboard.css
+++ b/src/screens/Leaderboard/Leaderboard.css
@@ -1,16 +1,7 @@
 /* Leaderboard */
 .leaderboard-screen__back {
   align-self: flex-start;
-  padding: 8px 14px;
   margin-bottom: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text);
-  font: inherit;
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
 }
 
 .leaderboard-screen__tabs {
@@ -21,19 +12,11 @@
 }
 
 .leaderboard-screen__tab {
-  padding: 7px 18px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.05);
   color: var(--color-text-muted);
-  font-size: 0.82rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
 }
 
 .leaderboard-screen__tab--active {
-  background: var(--color-accent);
+  background: linear-gradient(135deg, rgba(92, 100, 255, 0.96), rgba(136, 84, 255, 0.96));
   color: var(--color-text);
   border-color: transparent;
 }

--- a/src/screens/Leaderboard/Leaderboard.tsx
+++ b/src/screens/Leaderboard/Leaderboard.tsx
@@ -72,31 +72,35 @@ export default function Leaderboard() {
   return (
     <div className="placeholder-screen leaderboard-screen">
       <button
-        className="leaderboard-screen__back"
+        className="leaderboard-screen__back game-button game-button--ghost game-button--back"
         type="button"
         aria-label="Go back"
         onClick={() => navigate(-1)}
       >
-        ← Back
+        <span aria-hidden="true">←</span>
+        <span>Back</span>
       </button>
 
       <h1 className="placeholder-screen__title">🏆 Leaderboard</h1>
 
       <div className="leaderboard-screen__tabs">
         <button
-          className={`leaderboard-screen__tab${tab === 'season' ? ' leaderboard-screen__tab--active' : ''}`}
+          type="button"
+          className={`leaderboard-screen__tab game-button game-button--menu game-button--ghost${tab === 'season' ? ' leaderboard-screen__tab--active' : ''}`}
           onClick={() => setTab('season')}
         >
           This Season
         </button>
         <button
-          className={`leaderboard-screen__tab${tab === 'alltime' ? ' leaderboard-screen__tab--active' : ''}`}
+          type="button"
+          className={`leaderboard-screen__tab game-button game-button--menu game-button--ghost${tab === 'alltime' ? ' leaderboard-screen__tab--active' : ''}`}
           onClick={() => setTab('alltime')}
         >
           All-Time
         </button>
         <button
-          className={`leaderboard-screen__tab${tab === 'pastWinners' ? ' leaderboard-screen__tab--active' : ''}`}
+          type="button"
+          className={`leaderboard-screen__tab game-button game-button--menu game-button--ghost${tab === 'pastWinners' ? ' leaderboard-screen__tab--active' : ''}`}
           onClick={() => setTab('pastWinners')}
         >
           Past Winners
@@ -115,6 +119,7 @@ export default function Leaderboard() {
                 className={`leaderboard-screen__row${isUser ? ' leaderboard-screen__row--you' : ''}`}
               >
                 <button
+                  type="button"
                   className="leaderboard-screen__row-main"
                   onClick={() => toggleExpand(entry.playerId)}
                   aria-expanded={isExpanded}
@@ -163,6 +168,7 @@ export default function Leaderboard() {
                 className={`leaderboard-screen__row${isUser ? ' leaderboard-screen__row--you' : ''}`}
               >
                 <button
+                  type="button"
                   className="leaderboard-screen__row-main"
                   onClick={() => toggleExpand(`at-${entry.playerId}`)}
                   aria-expanded={isExpanded}

--- a/src/screens/NotFound/NotFound.css
+++ b/src/screens/NotFound/NotFound.css
@@ -44,26 +44,5 @@
 }
 
 .not-found__btn {
-  padding: 0.6rem 1.2rem;
-  border: 1px solid var(--color-accent, #6366f1);
-  border-radius: 8px;
-  background: transparent;
-  color: inherit;
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.not-found__btn:hover {
-  background: var(--color-accent, #6366f1);
-  color: #fff;
-}
-
-.not-found__btn--primary {
-  background: var(--color-accent, #6366f1);
-  color: #fff;
-}
-
-.not-found__btn--primary:hover {
-  opacity: 0.85;
+  min-width: 132px;
 }

--- a/src/screens/NotFound/NotFound.tsx
+++ b/src/screens/NotFound/NotFound.tsx
@@ -13,10 +13,10 @@ export default function NotFound() {
         <code>{pathname}</code>
       </p>
       <div className="not-found__actions">
-        <button className="not-found__btn not-found__btn--primary" onClick={() => navigate('/')}>
+        <button type="button" className="not-found__btn game-button game-button--primary" onClick={() => navigate('/')}>
           🏠 Go Home
         </button>
-        <button className="not-found__btn" onClick={() => navigate(-1)}>
+        <button type="button" className="not-found__btn game-button game-button--secondary" onClick={() => navigate(-1)}>
           ← Back
         </button>
       </div>

--- a/src/screens/Profile/Profile.css
+++ b/src/screens/Profile/Profile.css
@@ -60,13 +60,6 @@
 }
 
 .profile-screen__icon-btn {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 0.8rem;
-  cursor: pointer;
-  color: rgba(255, 255, 255, 0.8);
   white-space: nowrap;
 }
 
@@ -196,13 +189,6 @@
 /* Switch profile button */
 .profile-screen__switch-btn {
   width: 100%;
-  padding: 12px;
-  border-radius: 10px;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.88rem;
-  cursor: pointer;
-  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
 }
 

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -155,7 +155,7 @@ export default function Profile() {
         </div>
         <button
           type="button"
-          className="profile-screen__switch-btn"
+          className="profile-screen__switch-btn game-button game-button--secondary"
           onClick={() => navigate('/profile-picker')}
         >
           👥 Select Profile
@@ -173,7 +173,7 @@ export default function Profile() {
         </p>
         <button
           type="button"
-          className="profile-screen__switch-btn"
+          className="profile-screen__switch-btn game-button game-button--secondary"
           onClick={() => navigate('/profile-picker')}
           style={{ marginBottom: 12 }}
         >
@@ -206,7 +206,7 @@ export default function Profile() {
         <div className="profile-screen__header-btns">
           <button
             type="button"
-            className="profile-screen__icon-btn"
+            className="profile-screen__icon-btn game-button game-button--menu game-button--ghost"
             onClick={() => navigate('/profile-edit')}
             aria-label="Edit profile"
           >
@@ -214,7 +214,7 @@ export default function Profile() {
           </button>
           <button
             type="button"
-            className="profile-screen__icon-btn"
+            className="profile-screen__icon-btn game-button game-button--menu game-button--ghost"
             onClick={() => navigate('/profile-picker')}
             aria-label="Switch profile"
           >


### PR DESCRIPTION
## What changed
- Added a shared native button styling layer in `src/index.css` for common menu, primary, secondary, ghost, back, close, and icon buttons.
- Updated the shared confirmation modal, leaderboard navigation, profile action buttons, and not-found controls to use the common button system.
- Tightened mobile touch targets for the top utility buttons and bottom navigation items.

## Button groups audited
- Primary action buttons
- Secondary action buttons
- Menu/tab buttons
- Icon buttons
- Back buttons
- Confirm/cancel dialog buttons
- Bottom navigation buttons

## Intentionally left unchanged
- Bespoke game menu buttons driven by `GameButton`
- HUD fabric buttons in `GameControlDock`
- Minigame-specific gameplay buttons and controls

## Validation
- `npm run lint`
- `npm run build`

## Notes
- No gameplay, routing, background, audio, safe-area, or asset-path changes were included.