### PR TITLE
[codex] extend safe-area shell for minigames and confessional

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -2,6 +2,20 @@
 .minigame-host {
   position: fixed;
   inset: 0;
+  --minigame-safe-top: var(--app-safe-area-top);
+  --minigame-safe-right: var(--safe-right);
+  --minigame-safe-bottom: var(--safe-bottom);
+  --minigame-safe-left: var(--safe-left);
+  --minigame-safe-padding-top: calc(var(--minigame-safe-top) + clamp(10px, 2.8vw, 18px));
+  --minigame-safe-padding-right: calc(var(--minigame-safe-right) + clamp(10px, 2.6vw, 18px));
+  --minigame-safe-padding-bottom: calc(var(--minigame-safe-bottom) + clamp(10px, 2.6vw, 18px));
+  --minigame-safe-padding-left: calc(var(--minigame-safe-left) + clamp(10px, 2.6vw, 18px));
+  --safe-top: var(--minigame-safe-top);
+  --safe-right: var(--minigame-safe-right);
+  --safe-bottom: var(--minigame-safe-bottom);
+  --safe-left: var(--minigame-safe-left);
+  --floating-corner-top-base: 14px;
+  --floating-corner-top-safe-padding: 12px;
   background: #0d0d1a;
   display: flex;
   flex-direction: column;
@@ -12,12 +26,20 @@
   overflow: hidden;
 }
 
-/* ─── Ready countdown ────────────────────────────────────────────────────── */
 .minigame-host-ready {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 16px;
+  width: 100%;
+  max-width: 32rem;
+  max-height: 100dvh;
+  padding:
+    var(--minigame-safe-padding-top)
+    var(--minigame-safe-padding-right)
+    var(--minigame-safe-padding-bottom)
+    var(--minigame-safe-padding-left);
+  box-sizing: border-box;
   animation: fadeIn 0.3s ease;
 }
 
@@ -49,25 +71,190 @@
   animation: pop 0.3s ease;
 }
 
-/* ─── Playing ────────────────────────────────────────────────────────────── */
-/* The playing area takes the full screen and clips any overflowing game content */
 .minigame-host-playing {
   position: absolute;
   inset: 0;
   overflow: hidden;
 }
 
-/* ─── Results overlay ────────────────────────────────────────────────────── */
-/* Results fills most of the viewport so it never appears pinned to the top */
+.minigame-host-playing > .pp,
+.minigame-host-playing > .qtr,
+.minigame-host-playing > .qtr-canvas,
+.minigame-host-playing > .td,
+.minigame-host-playing > .bbl,
+.minigame-host-playing > .tbg,
+.minigame-host-playing > .snake-root {
+  box-sizing: border-box;
+}
+
+.minigame-host-playing > .pp {
+  padding:
+    var(--minigame-safe-padding-top)
+    var(--minigame-safe-padding-right)
+    var(--minigame-safe-padding-bottom)
+    var(--minigame-safe-padding-left);
+}
+
+.minigame-host-playing > .pp .pp__card {
+  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+}
+
+.minigame-host-playing > .qtr {
+  padding:
+    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-safe-right))
+    calc(16px + var(--minigame-safe-bottom))
+    calc(16px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .qtr-canvas {
+  padding:
+    calc(12px + var(--minigame-safe-top))
+    calc(12px + var(--minigame-safe-right))
+    calc(12px + var(--minigame-safe-bottom))
+    calc(12px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .qtr-canvas .qtr-canvas__card {
+  max-height: min(
+    760px,
+    calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom) - 24px)
+  );
+}
+
+.minigame-host-playing > .td {
+  padding:
+    calc(12px + var(--minigame-safe-top))
+    calc(12px + var(--minigame-safe-right))
+    calc(12px + var(--minigame-safe-bottom))
+    calc(12px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .bbl {
+  padding:
+    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-safe-right))
+    calc(16px + var(--minigame-safe-bottom))
+    calc(16px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .bbl .bbl__card {
+  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+}
+
+.minigame-host-playing > .tbg {
+  padding:
+    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-safe-right))
+    calc(16px + var(--minigame-safe-bottom))
+    calc(16px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .tbg .tbg__card {
+  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+}
+
+.minigame-host-playing > .snake-root {
+  padding:
+    var(--minigame-safe-padding-top)
+    var(--minigame-safe-padding-right)
+    var(--minigame-safe-padding-bottom)
+    var(--minigame-safe-padding-left);
+}
+
+.minigame-host-playing > .snake-root .snake-phone {
+  height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+}
+
+.minigame-host-playing > .cm {
+  padding:
+    calc(12px + var(--minigame-safe-top))
+    calc(8px + var(--minigame-safe-right))
+    calc(20px + var(--minigame-safe-bottom))
+    calc(8px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .tilt-labyrinth-host {
+  padding:
+    calc(8px + var(--minigame-safe-top))
+    calc(8px + var(--minigame-safe-right))
+    calc(16px + var(--minigame-safe-bottom))
+    calc(8px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .mc-host {
+  padding:
+    calc(14px + var(--minigame-safe-top))
+    calc(10px + var(--minigame-safe-right))
+    calc(24px + var(--minigame-safe-bottom))
+    calc(10px + var(--minigame-safe-left));
+}
+
+.minigame-host-playing > .ta-root {
+  padding-top: calc(12px + var(--minigame-safe-top));
+  padding-right: calc(16px + var(--minigame-safe-right));
+  padding-bottom: calc(12px + var(--minigame-safe-bottom));
+  padding-left: calc(16px + var(--minigame-safe-left));
+  box-sizing: border-box;
+}
+
+.minigame-host-playing > .minesweeps {
+  padding:
+    calc(1rem + var(--minigame-safe-top))
+    calc(1rem + var(--minigame-safe-right))
+    calc(1rem + var(--minigame-safe-bottom))
+    calc(1rem + var(--minigame-safe-left));
+  box-sizing: border-box;
+}
+
+.minigame-host-playing > .grid-of-luck {
+  padding:
+    calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-top))
+    calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-right))
+    calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-bottom))
+    calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-left));
+  box-sizing: border-box;
+}
+
+.minigame-host-playing > .number-trivia {
+  padding:
+    calc(var(--minigame-safe-top) + 72px)
+    max(16px, calc(var(--minigame-safe-right) + 16px))
+    calc(var(--minigame-safe-bottom) + 24px)
+    max(16px, calc(var(--minigame-safe-left) + 16px));
+}
+
+.minigame-host-playing > .capitalization {
+  padding:
+    calc(var(--minigame-safe-top) + 72px)
+    max(16px, calc(var(--minigame-safe-right) + 16px))
+    calc(var(--minigame-safe-bottom) + 24px)
+    max(16px, calc(var(--minigame-safe-left) + 16px));
+}
+
+.minigame-host-playing > .chain-of-greed .chain-of-greed__shell {
+  padding:
+    calc(var(--minigame-safe-top) + 0.6rem)
+    calc(var(--minigame-safe-right) + 0.85rem)
+    calc(var(--minigame-safe-bottom) + 0.4rem)
+    calc(var(--minigame-safe-left) + 0.85rem);
+}
+
 .minigame-host-results {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  padding: 24px 24px 32px;
   width: 100%;
   max-width: 460px;
-  max-height: 90dvh;
+  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  padding:
+    var(--minigame-safe-padding-top)
+    max(24px, var(--minigame-safe-padding-right))
+    max(32px, var(--minigame-safe-padding-bottom))
+    max(24px, var(--minigame-safe-padding-left));
+  box-sizing: border-box;
   animation: fadeIn 0.3s ease;
 }
 
@@ -83,7 +270,6 @@
   color: #ccc;
 }
 
-/* ─── Leaderboard (shown when participants are passed) ───────────────────── */
 .minigame-host-results-winner {
   margin: 0;
   font-size: 1rem;
@@ -217,18 +403,15 @@
 
 @keyframes pulse {
   0%, 100% { transform: scale(1); }
-  50%       { transform: scale(1.08); }
+  50% { transform: scale(1.08); }
 }
 
 @keyframes pop {
-  0%   { transform: scale(0.5); opacity: 0; }
-  70%  { transform: scale(1.1); opacity: 1; }
+  0% { transform: scale(0.5); opacity: 0; }
+  70% { transform: scale(1.1); opacity: 1; }
   100% { transform: scale(1); opacity: 1; }
 }
 
-
-
-/* ─── Close button (top-right of playing phase) ─────────────────────────────── */
 .minigame-host-close-btn {
   --floating-corner-top-base: 12px;
   --floating-corner-right-base: 14px;
@@ -236,8 +419,6 @@
   position: absolute;
   top: var(--floating-corner-top-offset);
   right: var(--floating-corner-right-offset);
-  /* Must stay above full-viewport minigame roots (e.g. Bullseye Blitz uses a
-     fixed overlay at z-index 200) so the exit button is always reachable. */
   z-index: 9600;
   width: 36px;
   height: 36px;

--- a/src/components/MinigameRules/MinigameRules.css
+++ b/src/components/MinigameRules/MinigameRules.css
@@ -7,7 +7,12 @@
   align-items: center;
   justify-content: center;
   z-index: 200;
-  padding: 16px;
+  padding:
+    var(--minigame-safe-padding-top, 16px)
+    max(16px, var(--minigame-safe-padding-right, 16px))
+    max(16px, var(--minigame-safe-padding-bottom, 16px))
+    max(16px, var(--minigame-safe-padding-left, 16px));
+  box-sizing: border-box;
 }
 
 .minigame-rules-modal {
@@ -20,8 +25,9 @@
   padding: 24px;
   color: #eee;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
-  max-height: 85vh;
+  max-height: calc(100dvh - var(--minigame-safe-padding-top, 16px) - var(--minigame-safe-padding-bottom, 16px));
   overflow-y: auto;
+  box-sizing: border-box;
 }
 
 .minigame-rules-title {
@@ -118,8 +124,8 @@
 
 .minigame-rules-btn-dismiss {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 12px;
+  right: 12px;
   background: transparent;
   color: #888;
   border: none;

--- a/src/screens/DiaryRoom/DiaryRoom.css
+++ b/src/screens/DiaryRoom/DiaryRoom.css
@@ -3,7 +3,8 @@
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  padding-bottom: 24px;
+  height: 100%;
+  overflow: hidden;
 }
 
 .diary-room__shell {
@@ -11,6 +12,8 @@
   flex: 1;
   flex-direction: column;
   min-height: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .diary-room__shell--masked {
@@ -24,6 +27,8 @@
   gap: 12px;
   padding: 16px 16px 10px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  background: var(--color-bg);
+  flex-shrink: 0;
 }
 
 .diary-room__back {
@@ -340,7 +345,12 @@
 /* ── Body ────────────────────────────────────────────────────────────────── */
 .diary-room__body {
   flex: 1;
-  padding: 16px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
+  padding: 16px 16px calc(16px + var(--safe-bottom));
+  box-sizing: border-box;
 }
 
 .diary-room__locked {
@@ -478,6 +488,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-height: 100%;
 }
 
 .diary-room__mini-game-card {


### PR DESCRIPTION
## What changed
- added a shared minigame safe-area contract in `MinigameHost.css`
- applied that contract to the host close button, ready screen, rules modal, and results screen
- added centralized safe-area handling for fullscreen minigame shells that bypass the shared host layout
- fixed the Diary Room / confessional layout so the header stays separate from the scrollable content area

## Why it changed
Dynamic Island / status-bar overlap was still happening inside minigames and in long confessional/chat flows because several screens were rendering against the raw viewport or letting the scroll container push content under the top chrome.

## Impact
- minigame headers, turn indicators, and close buttons now sit below the iOS safe area more consistently
- fullscreen minigames that render their own root shell no longer ignore the shared safe-area layout
- long confessional logs and mission checklists scroll under the confessional header instead of through it

## Root cause
The app had safe-area variables globally, but minigames were split across multiple layout families. Some relied on `MinigameHost`, some rendered their own fullscreen shell, and the confessional screen used a page-level scroll layout instead of a fixed shell plus internal scrolling body.

## Validation
- `npm run build`
- `npm run build:mobile`

## Manual QA to focus on
- Crystal Path
- Pressure Plank
- QuickTapRace canvas
- NumberTrivia / Capitalization / GridOfLuck
- Diary Room with a long checklist and long Big Eye chat log