### PR TITLE
[codex] keep minigame results reachable on iPhone

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -248,6 +248,7 @@
   gap: 12px;
   width: 100%;
   max-width: 460px;
+  height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
   max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
   padding:
     var(--minigame-safe-padding-top)
@@ -255,6 +256,7 @@
     max(32px, var(--minigame-safe-padding-bottom))
     max(24px, var(--minigame-safe-padding-left));
   box-sizing: border-box;
+  overflow: hidden;
   animation: fadeIn 0.3s ease;
 }
 
@@ -263,11 +265,14 @@
   font-weight: 700;
   color: #e94560;
   margin: 0;
+  flex-shrink: 0;
 }
 
 .minigame-host-results-score {
   font-size: 1.1rem;
   color: #ccc;
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .minigame-host-results-winner {
@@ -276,6 +281,7 @@
   font-weight: 800;
   color: #fff;
   text-align: center;
+  flex-shrink: 0;
 }
 
 .minigame-host-leaderboard {
@@ -289,6 +295,30 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+}
+
+.minigame-host-results-actions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: auto;
+  flex-shrink: 0;
+}
+
+.minigame-host-results-retry {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.minigame-host-results-retry-copy {
+  margin: 0;
+  color: #ccc;
+  font-size: 0.92rem;
+  line-height: 1.45;
+  text-align: center;
 }
 
 .minigame-host-leaderboard-entry {
@@ -348,7 +378,6 @@
 }
 
 .minigame-host-results-btn {
-  margin-top: 8px;
   width: 100%;
   padding: 14px 32px;
   background: #e94560;

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -719,34 +719,36 @@ export default function MinigameHost({
             </p>
           )}
 
-          {activeCompetitionRetry && (
-            <div className="minigame-host-results-retry" role="group" aria-label="Competition retry">
-              <p className="minigame-host-results-retry-copy">
-                Finished last? Watch a short ad to retry before the result is locked in.
-              </p>
-              <button
-                className="minigame-host-results-btn minigame-host-results-btn--retry"
-                onClick={() => activeCompetitionRetry.onWatch(handleRetryRestart)}
-                disabled={activeCompetitionRetry.pending}
-                autoFocus
-              >
-                {activeCompetitionRetry.pending ? 'Opening Ad…' : 'Watch Ad to Retry'}
-              </button>
-            </div>
-          )}
+          <div className="minigame-host-results-actions">
+            {activeCompetitionRetry && (
+              <div className="minigame-host-results-retry" role="group" aria-label="Competition retry">
+                <p className="minigame-host-results-retry-copy">
+                  Finished last? Watch a short ad to retry before the result is locked in.
+                </p>
+                <button
+                  className="minigame-host-results-btn minigame-host-results-btn--retry"
+                  onClick={() => activeCompetitionRetry.onWatch(handleRetryRestart)}
+                  disabled={activeCompetitionRetry.pending}
+                  autoFocus
+                >
+                  {activeCompetitionRetry.pending ? 'Opening Ad…' : 'Watch Ad to Retry'}
+                </button>
+              </div>
+            )}
 
-          <button
-            className="minigame-host-results-btn"
-            onClick={() => {
-              if (showCompetitionRetry) {
-                competitionRetry?.onContinueWithoutRetry?.();
-              }
-              handleContinue();
-            }}
-            {...(!showCompetitionRetry ? { autoFocus: true } : {})}
-          >
-            {showCompetitionRetry ? 'No Thanks — Continue ▶' : 'Continue ▶'}
-          </button>
+            <button
+              className="minigame-host-results-btn"
+              onClick={() => {
+                if (showCompetitionRetry) {
+                  competitionRetry?.onContinueWithoutRetry?.();
+                }
+                handleContinue();
+              }}
+              {...(!showCompetitionRetry ? { autoFocus: true } : {})}
+            >
+              {showCompetitionRetry ? 'No Thanks — Continue ▶' : 'Continue ▶'}
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## What changed
- includes the shared minigame safe-area groundwork needed to keep gameplay content below the iPhone camera/status area
- keeps the minigame results panel within the visible viewport instead of letting the leaderboard push the bottom actions off-screen
- groups the retry copy and continue CTA into a dedicated bottom actions region so the game can always progress

## Validation
- `npm run build`
- `npx vitest run src/components/MinigameHost/__tests__/MinigameHost.test.tsx`

## Notes
- This stays focused on the minigame/results reachability issue and does not touch IntroHub visuals or asset loading.