### PR TITLE
[codex] lock gameplay shell scrolling

### DIFF
--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -19,3 +19,8 @@
   /* Push content above bottom safe area */
   padding-bottom: var(--safe-bottom);
 }
+
+.app-shell__main--screen-owned-scroll {
+  overflow: hidden;
+  overscroll-behavior: none;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import NavBar from './NavBar';
 import DebugPanel from '../DebugPanel/DebugPanel';
 import FinalFaceoff from '../FinalFaceoff/FinalFaceoff';
@@ -30,6 +30,7 @@ const THEME_PRESETS = ['midnight', 'neon', 'sunset', 'ocean'];
  * The nav bar automatically picks it up from its own LINKS array.
  */
 export default function AppShell() {
+  const { pathname } = useLocation();
   const phase = useAppSelector((s) => s.game.phase);
   const seasonFinale = useAppSelector((s) => s.game.seasonFinale);
   const finale = useAppSelector(selectFinale);
@@ -83,9 +84,13 @@ export default function AppShell() {
     document.body.classList.toggle('no-animations', !settings.gameUX.animations);
   }, [settings.gameUX.animations]);
 
+  const screenOwnsScroll =
+    pathname.startsWith('/game') ||
+    pathname.startsWith('/diary-room');
+
   return (
     <div className="app-shell">
-      <main className="app-shell__main">
+      <main className={`app-shell__main${screenOwnsScroll ? ' app-shell__main--screen-owned-scroll' : ''}`}>
         <Outlet />
       </main>
       <NavBar />

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -2,8 +2,12 @@
 .game-screen {
   display: flex;
   flex-direction: column;
+  min-height: 100%;
+  height: 100%;
   gap: 6px;
   padding: 12px 12px calc(var(--nav-bar-height) + 10px + var(--safe-bottom));
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .game-screen--compact-roster-balance {


### PR DESCRIPTION
## What changed
- teaches `AppShell` to disable outer-page scrolling on gameplay-owned screens
- keeps `/game` and `/diary-room` layouts responsible for their own scroll behavior instead of letting the shell drag content under native iPhone chrome
- locks the main game screen to the available app-shell height so accidental page pull does not shift the HUD into the status area

## Validation
- `npm run build`

## Notes
- This PR is intentionally limited to gameplay/confessional scroll ownership and does not change IntroHub centering or background loading.