### PR TITLE
[codex] recenter IntroHub button stack

### DIFF
--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -5,12 +5,15 @@
   position: relative;
   min-height: 100vh;
   min-height: 100dvh;
+  min-height: calc(100% + var(--app-safe-area-top, 0px) + var(--safe-bottom, 0px));
   overflow: hidden;
   background: transparent;
   display: flex;
   align-items: center;    /* vertically center */
   justify-content: center;/* horizontally center */
   padding: 0;
+  margin-top: calc(-1 * var(--app-safe-area-top, 0px));
+  margin-bottom: calc(-1 * var(--safe-bottom, 0px));
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## What changed
- reclaims the full visual viewport for the IntroHub shell so the shared app safe-area padding does not visually push the central button stack downward
- preserves the existing centered layout while keeping the global safe-area system intact

## Validation
- `npm run build`

## Notes
- This PR only fixes IntroHub vertical centering and does not touch background asset loading.