### PR TITLE
[codex] compact main game layout on narrow phones

### DIFF
--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -2817,8 +2817,30 @@ export default function GameScreen() {
     spectatorF3Active ||
     spectatorLegacyActive
 
-  const expandsTvForCompactRoster = settings.gameUX.compactRoster
-  const compactRosterLogRows = expandsTvForCompactRoster ? 6 : 2
+  const [isCompactMobileViewport, setIsCompactMobileViewport] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return (window.visualViewport?.width ?? window.innerWidth) <= 480
+  })
+
+  useEffect(() => {
+    function updateCompactMobileViewport() {
+      const viewportWidth = window.visualViewport?.width ?? window.innerWidth
+      setIsCompactMobileViewport(viewportWidth <= 480)
+    }
+
+    updateCompactMobileViewport()
+    window.addEventListener('resize', updateCompactMobileViewport)
+    window.visualViewport?.addEventListener('resize', updateCompactMobileViewport)
+
+    return () => {
+      window.removeEventListener('resize', updateCompactMobileViewport)
+      window.visualViewport?.removeEventListener('resize', updateCompactMobileViewport)
+    }
+  }, [])
+
+  const usesCompactRosterBalance = settings.gameUX.compactRoster || isCompactMobileViewport
+  const compactRosterLayout = settings.gameUX.compactRoster ? settings.gameUX.compactRosterLayout : 'small'
+  const compactRosterLogRows = settings.gameUX.compactRoster ? 6 : isCompactMobileViewport ? 3 : 2
 
   // ── Viewport fallback message for blank-TV states ────────────────────────
   // Provides a meaningful holding message during states where no fresh TV event
@@ -2865,7 +2887,7 @@ export default function GameScreen() {
   return (
     <LayoutGroup id="game-layout">
     <div
-      className={`game-screen game-screen-shell${expandsTvForCompactRoster ? ' game-screen--compact-roster-balance' : ''}`}
+      className={`game-screen game-screen-shell${usesCompactRosterBalance ? ' game-screen--compact-roster-balance' : ''}`}
     >
       {showPublicSaveReveal && publicSaveWinnerId ? (
         <TvZone
@@ -4111,8 +4133,8 @@ export default function GameScreen() {
         headerSelector=".tv-zone"
         footerSelector=".nav-bar"
         overlaySelector=".game-control-dock"
-        compact={settings.gameUX.compactRoster}
-        compactLayout={settings.gameUX.compactRosterLayout}
+          compact={usesCompactRosterBalance}
+          compactLayout={compactRosterLayout}
         occupancyLabel={`${alivePlayers.length}/${game.players.length}`}
       />
       {previewPlayer && <HouseguestInfoDialog player={previewPlayer} onClose={() => setPreviewPlayer(null)} />}


### PR DESCRIPTION
## What changed
- auto-enables the compact roster balance on narrow mobile viewports so the main game screen keeps the TV log visible on iPhone-sized screens
- gives the main TV log a little more room on narrow phones instead of collapsing it into the tiny two-row strip that hid the section entirely
- keeps the desktop/web layout unchanged

## Validation
- `npm run build`

## Notes
- This is a follow-up to merged PR `#999` and only covers the narrow-phone layout tuning.
- No unrelated gameplay, asset, audio, or IntroHub changes are included.