### PR TITLE
[codex] expose advanced settings in QA debug mode

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
   advance,
@@ -156,6 +156,7 @@ export default function DebugPanel() {
   const isE2E = (window as { __E2E__?: boolean }).__E2E__ === true;
   const isDebug = isE2E || isDebugAccessGranted(searchParams, window.location.hostname);
 
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const game = useAppSelector((s) => s.game);
   const incomingLogs = useAppSelector(selectIncomingInteractionLogs);
@@ -601,6 +602,20 @@ export default function DebugPanel() {
                   onClick={() => dispatch(resetGame())}
                 >
                   Reset Season
+                </button>
+              </div>
+
+              <div className="dbg-row">
+                <button
+                  className="dbg-btn dbg-btn--wide"
+                  onClick={() =>
+                    navigate({
+                      pathname: '/settingsatiste',
+                      search: searchParams.toString() ? `?${searchParams.toString()}` : '',
+                    })
+                  }
+                >
+                  Open Advanced Settings
                 </button>
               </div>
             </section>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -28,10 +28,11 @@ import Rules                from './screens/Rules/Rules';
 import PublicMeter          from './screens/PublicMeter/PublicMeter';
 import Settings             from './screens/Settings/Settings';
 import NotFound             from './screens/NotFound/NotFound';
+import { canAccessSpecialSettings } from './utils/debugMode';
 import { lazy, Suspense }   from 'react';
 
-// Dev-only admin/debug screens stay out of production bundles entirely.
-const SettingsAdmin = import.meta.env.DEV
+// Admin/debug screens stay hidden unless the current session has QA debug access.
+const SettingsAdmin = import.meta.env.DEV || canAccessSpecialSettings()
   ? lazy(() => import('./screens/SettingsAdmin/SettingsAdmin'))
   : null;
 const GameDebug = import.meta.env.DEV

--- a/src/utils/__tests__/debugMode.test.ts
+++ b/src/utils/__tests__/debugMode.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { detectDebugMode, isDebugAccessGranted } from '../debugMode';
+import { canAccessSpecialSettings, detectDebugMode, isDebugAccessGranted } from '../debugMode';
 
 describe('debugMode gating', () => {
   afterEach(() => {
@@ -44,6 +44,26 @@ describe('debugMode gating', () => {
         hash: '#/game?debug=1&qa=1',
       } as unknown as Location),
     ).toBe(true);
+  });
+
+  it('opens the advanced settings route with the same qa debug hash flags', () => {
+    expect(
+      canAccessSpecialSettings({
+        hostname: 'georgi-cole.github.io',
+        search: '',
+        hash: '#/game?debug=1&qa=1',
+      } as unknown as Location),
+    ).toBe(true);
+  });
+
+  it('keeps advanced settings locked on production without qa', () => {
+    expect(
+      canAccessSpecialSettings({
+        hostname: 'georgi-cole.github.io',
+        search: '',
+        hash: '#/game?debug=1',
+      } as unknown as Location),
+    ).toBe(false);
   });
 
   it('treats localhost as an allowed debug host', () => {

--- a/src/utils/debugMode.ts
+++ b/src/utils/debugMode.ts
@@ -12,12 +12,34 @@ function isLocalDebugHost(hostname: string): boolean {
   return LOCAL_DEBUG_HOSTS.has(hostname);
 }
 
+function hasDebugQaAccess(locationLike: DebugLocationLike): boolean {
+  const debugRequested =
+    readQueryParam(locationLike.search, 'debug') === '1' ||
+    readQueryParam(locationLike.hash, 'debug') === '1';
+
+  if (!debugRequested) return false;
+
+  return (
+    isLocalDebugHost(locationLike.hostname) ||
+    readQueryParam(locationLike.search, 'qa') === '1' ||
+    readQueryParam(locationLike.hash, 'qa') === '1'
+  );
+}
+
 export function isDebugAccessGranted(
   searchParams: URLSearchParams,
   hostname: string,
 ): boolean {
   if (searchParams.get('debug') !== '1') return false;
   return isLocalDebugHost(hostname) || searchParams.get('qa') === '1';
+}
+
+export function canAccessSpecialSettings(locationLike?: DebugLocationLike): boolean {
+  if (typeof window === 'undefined') return false;
+  if ((window as { __E2E__?: boolean }).__E2E__ === true) return true;
+
+  const resolvedLocation = locationLike ?? window.location;
+  return hasDebugQaAccess(resolvedLocation);
 }
 
 /**
@@ -37,16 +59,5 @@ export function detectDebugMode(
   if ((window as { __E2E__?: boolean }).__E2E__ === true) return true;
 
   const resolvedLocation = locationLike ?? window.location;
-
-  const debugRequested =
-    readQueryParam(resolvedLocation.search, 'debug') === '1' ||
-    readQueryParam(resolvedLocation.hash, 'debug') === '1';
-
-  if (!debugRequested) return false;
-
-  return (
-    isLocalDebugHost(resolvedLocation.hostname) ||
-    readQueryParam(resolvedLocation.search, 'qa') === '1' ||
-    readQueryParam(resolvedLocation.hash, 'qa') === '1'
-  );
+  return hasDebugQaAccess(resolvedLocation);
 }


### PR DESCRIPTION
## What changed
- Exposed `settingsatiste` outside DEV builds when the session has the same `debug=1&qa=1` access used by the existing debug panel.
- Added a debug-panel shortcut to open Advanced Settings directly from the game.
- Added tests covering the special-settings access rule.

## Why
- The advanced settings screen was still dev-only, so it was not reachable on GitHub Pages or Capacitor even when QA/debug mode was enabled.
- This makes the route accessible in the same controlled debug context as the rest of the QA tools.

## Impact
- Normal players still do not see the advanced settings route.
- QA/debug sessions on production hosts can now reach `#/settingsatiste?debug=1&qa=1`.

## Validation
- `npm run build`
- `npm run lint`