### PR TITLE
[codex] restore iPhone roster layout

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -93,10 +93,12 @@ export default function HouseguestGrid({
 
   useEffect(() => {
     function setAvailableHeight() {
-      const viewportHeight = window.innerHeight
+      const visualViewport = window.visualViewport
+      const viewportHeight = visualViewport?.height ?? window.innerHeight
+      const viewportTop = visualViewport?.offsetTop ?? 0
       let listTop = 0
       let footerH = DEFAULT_FOOTER_HEIGHT
-      let bottomBoundary = viewportHeight - footerH
+      let bottomBoundary = viewportTop + viewportHeight - footerH
 
       const footerEl = document.querySelector(footerSelector)
       const overlayEl = overlaySelector ? document.querySelector(overlaySelector) : null
@@ -134,7 +136,13 @@ export default function HouseguestGrid({
 
     setAvailableHeight()
     window.addEventListener('resize', setAvailableHeight)
-    return () => window.removeEventListener('resize', setAvailableHeight)
+    window.visualViewport?.addEventListener('resize', setAvailableHeight)
+    window.visualViewport?.addEventListener('scroll', setAvailableHeight)
+    return () => {
+      window.removeEventListener('resize', setAvailableHeight)
+      window.visualViewport?.removeEventListener('resize', setAvailableHeight)
+      window.visualViewport?.removeEventListener('scroll', setAvailableHeight)
+    }
   }, [headerSelector, footerSelector, overlaySelector])
 
   const gridSizeClass = gridSize === 16 ? styles.hgGrid16 : gridSize === 12 ? styles.hgGrid12 : ''

--- a/src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx
+++ b/src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx
@@ -87,6 +87,59 @@ describe('HouseguestGrid', () => {
     expect(within(list).getAllByRole('listitem')).toHaveLength(16)
   })
 
+  it('tracks the visual viewport when mobile browser chrome changes the available height', () => {
+    vi.stubGlobal('innerHeight', 900)
+    vi.stubGlobal('visualViewport', {
+      height: 620,
+      offsetTop: 0,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+
+    const headerEl = document.createElement('div')
+    headerEl.className = 'test-tv-zone'
+    document.body.appendChild(headerEl)
+
+    const dockEl = document.createElement('div')
+    dockEl.className = 'test-dock'
+    document.body.appendChild(dockEl)
+
+    const footerEl = document.createElement('nav')
+    footerEl.className = 'test-nav'
+    document.body.appendChild(footerEl)
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      if (this.classList.contains('test-tv-zone')) return rect({ top: 12, height: 308 })
+      if (this.classList.contains('test-dock')) return rect({ top: 560, height: 76 })
+      if (this.classList.contains('test-nav')) return rect({ top: 830, height: 78 })
+      if (this.getAttribute('aria-labelledby') === 'houseguests-heading') {
+        return rect({ top: 338, height: 260 })
+      }
+      if (this.getAttribute('role') === 'list') {
+        return rect({ top: 372, height: 226 })
+      }
+      return rect({})
+    })
+
+    const houseguests: Houseguest[] = Array.from({ length: 16 }, (_, index) => ({
+      id: `p${index + 1}`,
+      name: `Player ${index + 1}`,
+    }))
+
+    const { container } = render(
+      <HouseguestGrid
+        houseguests={houseguests}
+        gridSize={16}
+        occupancyLabel="16/16"
+        headerSelector=".test-tv-zone"
+        footerSelector=".test-nav"
+        overlaySelector=".test-dock"
+      />,
+    )
+
+    expect((container.firstElementChild as HTMLElement | null)?.style.getPropertyValue('--grid-available-height')).toBe('220px')
+  })
+
   it('renders the compact slider layout when requested', () => {
     const houseguests: Houseguest[] = Array.from({ length: 6 }, (_, index) => ({
       id: `p${index + 1}`,

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -449,8 +449,8 @@
   }
 
   .tv-zone__viewport {
-    min-height: 144px;
-    padding: 18px 14px;
+    min-height: 120px;
+    padding: 16px 14px;
   }
   .tv-zone__now {
     font-size: 0.82rem;

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -6,14 +6,16 @@
   padding: 12px 12px calc(var(--nav-bar-height) + 10px + var(--safe-bottom));
 }
 
-.game-screen--compact-roster-balance {
-  box-sizing: border-box;
-  min-height: calc(100dvh - 84px);
-}
+@media (min-width: 640px) and (min-height: 760px) {
+  .game-screen--compact-roster-balance {
+    box-sizing: border-box;
+    min-height: calc(100dvh - 84px);
+  }
 
-.game-screen--compact-roster-balance > .tv-zone {
-  flex: 1 1 auto;
-  min-height: 0;
+  .game-screen--compact-roster-balance > .tv-zone {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
 }
 
 /* Gameplay background shell */

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -176,6 +176,15 @@ const PUBLIC_MODE_STORE_PROMPT =
   'If you want to activate public mode, go to the store in the home hub.'
 const SOCIAL_MODULE_UNAVAILABLE_ANNOUNCEMENT_MS = 3000
 
+function canExpandCompactRosterViewport(): boolean {
+  if (typeof window === 'undefined') return false
+  const isLargeByDimensions = window.innerWidth >= 640 && window.innerHeight >= 760
+  if (typeof window.matchMedia !== 'function') {
+    return isLargeByDimensions
+  }
+  return window.matchMedia('(min-width: 640px) and (min-height: 760px)').matches || isLargeByDimensions
+}
+
 type PendingPublicSaveResult = {
   savedId: string
   supportPercent?: number
@@ -2817,7 +2826,8 @@ export default function GameScreen() {
     spectatorF3Active ||
     spectatorLegacyActive
 
-  const expandsTvForCompactRoster = settings.gameUX.compactRoster
+  const expandsTvForCompactRoster =
+    settings.gameUX.compactRoster && canExpandCompactRosterViewport()
   const compactRosterLogRows = expandsTvForCompactRoster ? 6 : 2
 
   // ── Viewport fallback message for blank-TV states ────────────────────────

--- a/tests/integration/gameScreen.compactRosterLayout.test.tsx
+++ b/tests/integration/gameScreen.compactRosterLayout.test.tsx
@@ -55,4 +55,17 @@ describe('GameScreen compact roster balancing', () => {
     expect(container.firstElementChild).toHaveClass('game-screen--compact-roster-balance')
     expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '6')
   })
+
+  it('keeps the roster balance off on narrow viewports', () => {
+    const store = makeStore()
+
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
+    vi.stubGlobal('innerWidth', 390)
+    vi.stubGlobal('innerHeight', 844)
+
+    const { container } = renderGameScreen(store)
+
+    expect(container.firstElementChild).not.toHaveClass('game-screen--compact-roster-balance')
+    expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '2')
+  })
 })


### PR DESCRIPTION
## What changed
- Restored the compact roster TV expansion to desktop-sized viewports only.
- Returned the mobile TV viewport to its original smaller height so the main log and full roster fit on iPhone.
- Switched the roster height measurement to use `visualViewport` when available, which is safer on iOS Safari.

## Why
The earlier compact-roster balance fix made the TV block too tall on iPhone. That pushed the log off-screen and left the bottom roster row clipped. The target layout is the original full-size roster with the smaller TV area and visible log strip.

## Validation
- `npm run typecheck`
- `npx vitest run tests/integration/gameScreen.compactRosterLayout.test.tsx src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx`
- `npx eslint src/screens/GameScreen/GameScreen.tsx src/components/HouseguestGrid/HouseguestGrid.tsx src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx tests/integration/gameScreen.compactRosterLayout.test.tsx`