### PR TITLE
[codex] restore iphone tv layout

### DIFF
--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -6,14 +6,16 @@
   padding: 12px 12px calc(var(--nav-bar-height) + 10px + var(--safe-bottom));
 }
 
-.game-screen--compact-roster-balance {
-  box-sizing: border-box;
-  min-height: calc(100dvh - 84px);
-}
+@media (min-width: 640px) and (min-height: 760px) {
+  .game-screen--compact-small-balance {
+    box-sizing: border-box;
+    min-height: calc(100dvh - 84px);
+  }
 
-.game-screen--compact-roster-balance > .tv-zone {
-  flex: 1 1 auto;
-  min-height: 0;
+  .game-screen--compact-small-balance > .tv-zone {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
 }
 
 /* Gameplay background shell */

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -2817,8 +2817,9 @@ export default function GameScreen() {
     spectatorF3Active ||
     spectatorLegacyActive
 
-  const expandsTvForCompactRoster = settings.gameUX.compactRoster
-  const compactRosterLogRows = expandsTvForCompactRoster ? 6 : 2
+  const expandsTvForCompactSmall =
+    settings.gameUX.compactRoster && settings.gameUX.compactRosterLayout === 'small'
+  const compactSmallLogRows = expandsTvForCompactSmall ? 6 : 2
 
   // ── Viewport fallback message for blank-TV states ────────────────────────
   // Provides a meaningful holding message during states where no fresh TV event
@@ -2865,7 +2866,7 @@ export default function GameScreen() {
   return (
     <LayoutGroup id="game-layout">
     <div
-      className={`game-screen game-screen-shell${expandsTvForCompactRoster ? ' game-screen--compact-roster-balance' : ''}`}
+      className={`game-screen game-screen-shell${expandsTvForCompactSmall ? ' game-screen--compact-small-balance' : ''}`}
     >
       {showPublicSaveReveal && publicSaveWinnerId ? (
         <TvZone
@@ -2889,7 +2890,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={compactSmallLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showDemocraciaResults && democraciaResultDisplay ? (
@@ -2915,7 +2916,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={compactSmallLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showVoteResults ? (
@@ -2942,7 +2943,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={compactSmallLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : (
@@ -2970,7 +2971,7 @@ export default function GameScreen() {
                   ? handlePublicSaveResultDismiss
                   : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={compactSmallLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       )}

--- a/tests/integration/gameScreen.compactRosterLayout.test.tsx
+++ b/tests/integration/gameScreen.compactRosterLayout.test.tsx
@@ -45,18 +45,18 @@ function renderGameScreen(store: ReturnType<typeof makeStore>) {
 }
 
 describe('GameScreen compact roster balancing', () => {
-  it('expands the tv stack for compact slider mode and requests a taller log feed', () => {
+  it('expands the tv stack only for compact small mode and requests a taller log feed', () => {
     const store = makeStore()
 
-    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'small' }))
 
     const { container } = renderGameScreen(store)
 
-    expect(container.firstElementChild).toHaveClass('game-screen--compact-roster-balance')
+    expect(container.firstElementChild).toHaveClass('game-screen--compact-small-balance')
     expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '6')
   })
 
-  it('keeps the roster balance active on narrow viewports so the TV log stays visible', () => {
+  it('keeps phone slider mode on the original tv sizing and default log rows', () => {
     const store = makeStore()
 
     store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
@@ -65,7 +65,7 @@ describe('GameScreen compact roster balancing', () => {
 
     const { container } = renderGameScreen(store)
 
-    expect(container.firstElementChild).toHaveClass('game-screen--compact-roster-balance')
-    expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '6')
+    expect(container.firstElementChild).not.toHaveClass('game-screen--compact-small-balance')
+    expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '2')
   })
 })


### PR DESCRIPTION
## What changed
- limited the TV/roster rebalance back to the original compact-small layout on larger screens only
- removed that rebalance from compact slider mode on phones so iPhone keeps the original faux TV proportions
- restored the default 2-row TV log behavior for phone slider mode instead of forcing the expanded compact-roster balance
- updated the integration coverage so phone compact slider mode must keep the original TV sizing while compact-small still gets the taller layout

## Why this changed
The iPhone regression came from a later change that applied a compact-roster TV rebalance to every compact roster mode. That pulled phone layouts into a behavior that was only meant for the older compact-small larger-screen case, which shrank the faux TV area and pushed the visible log/feed behavior away from the original layout.

## User impact
- iPhone should match the original reference layout again more closely
- the faux TV area should no longer be reduced by the compact roster rebalance on phone slider mode
- the TV log area stays in the normal phone layout path instead of the altered compact-roster balance path
- desktop and larger compact-small layouts keep their intended balancing behavior

## Validation
- `npx vitest run tests/integration/gameScreen.compactRosterLayout.test.tsx src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx src/components/ui/__tests__/TvZone.screenStyle.test.tsx src/components/TVLog/__tests__/TVLog.test.tsx`
- `npm run typecheck`