### PR TITLE
[codex] restore original mobile tv sizing

### DIFF
--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -449,8 +449,8 @@
   }
 
   .tv-zone__viewport {
-    min-height: 144px;
-    padding: 18px 14px;
+    min-height: 120px;
+    padding: 16px 14px;
   }
   .tv-zone__now {
     font-size: 0.82rem;

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -7,12 +7,12 @@
 }
 
 @media (min-width: 640px) and (min-height: 760px) {
-  .game-screen--compact-small-balance {
+  .game-screen--compact-roster-balance {
     box-sizing: border-box;
     min-height: calc(100dvh - 84px);
   }
 
-  .game-screen--compact-small-balance > .tv-zone {
+  .game-screen--compact-roster-balance > .tv-zone {
     flex: 1 1 auto;
     min-height: 0;
   }

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -176,6 +176,15 @@ const PUBLIC_MODE_STORE_PROMPT =
   'If you want to activate public mode, go to the store in the home hub.'
 const SOCIAL_MODULE_UNAVAILABLE_ANNOUNCEMENT_MS = 3000
 
+function canExpandCompactRosterViewport(): boolean {
+  if (typeof window === 'undefined') return false
+  const isLargeByDimensions = window.innerWidth >= 640 && window.innerHeight >= 760
+  if (typeof window.matchMedia !== 'function') {
+    return isLargeByDimensions
+  }
+  return window.matchMedia('(min-width: 640px) and (min-height: 760px)').matches || isLargeByDimensions
+}
+
 type PendingPublicSaveResult = {
   savedId: string
   supportPercent?: number
@@ -2817,9 +2826,9 @@ export default function GameScreen() {
     spectatorF3Active ||
     spectatorLegacyActive
 
-  const expandsTvForCompactSmall =
-    settings.gameUX.compactRoster && settings.gameUX.compactRosterLayout === 'small'
-  const compactSmallLogRows = expandsTvForCompactSmall ? 6 : 2
+  const expandsTvForCompactRoster =
+    settings.gameUX.compactRoster && canExpandCompactRosterViewport()
+  const compactRosterLogRows = expandsTvForCompactRoster ? 6 : 2
 
   // ── Viewport fallback message for blank-TV states ────────────────────────
   // Provides a meaningful holding message during states where no fresh TV event
@@ -2866,7 +2875,7 @@ export default function GameScreen() {
   return (
     <LayoutGroup id="game-layout">
     <div
-      className={`game-screen game-screen-shell${expandsTvForCompactSmall ? ' game-screen--compact-small-balance' : ''}`}
+      className={`game-screen game-screen-shell${expandsTvForCompactRoster ? ' game-screen--compact-roster-balance' : ''}`}
     >
       {showPublicSaveReveal && publicSaveWinnerId ? (
         <TvZone
@@ -2890,7 +2899,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactSmallLogRows}
+          mainLogMaxVisible={compactRosterLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showDemocraciaResults && democraciaResultDisplay ? (
@@ -2916,7 +2925,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactSmallLogRows}
+          mainLogMaxVisible={compactRosterLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showVoteResults ? (
@@ -2943,7 +2952,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactSmallLogRows}
+          mainLogMaxVisible={compactRosterLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : (
@@ -2971,7 +2980,7 @@ export default function GameScreen() {
                   ? handlePublicSaveResultDismiss
                   : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactSmallLogRows}
+          mainLogMaxVisible={compactRosterLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       )}

--- a/tests/integration/gameScreen.compactRosterLayout.test.tsx
+++ b/tests/integration/gameScreen.compactRosterLayout.test.tsx
@@ -45,18 +45,18 @@ function renderGameScreen(store: ReturnType<typeof makeStore>) {
 }
 
 describe('GameScreen compact roster balancing', () => {
-  it('expands the tv stack only for compact small mode and requests a taller log feed', () => {
+  it('expands the tv stack on large compact roster layouts and requests a taller log feed', () => {
     const store = makeStore()
 
-    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'small' }))
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
 
     const { container } = renderGameScreen(store)
 
-    expect(container.firstElementChild).toHaveClass('game-screen--compact-small-balance')
+    expect(container.firstElementChild).toHaveClass('game-screen--compact-roster-balance')
     expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '6')
   })
 
-  it('keeps phone slider mode on the original tv sizing and default log rows', () => {
+  it('keeps narrow phone viewports on the original sizing without the large-screen balance', () => {
     const store = makeStore()
 
     store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
@@ -65,7 +65,7 @@ describe('GameScreen compact roster balancing', () => {
 
     const { container } = renderGameScreen(store)
 
-    expect(container.firstElementChild).not.toHaveClass('game-screen--compact-small-balance')
+    expect(container.firstElementChild).not.toHaveClass('game-screen--compact-roster-balance')
     expect(screen.getByTestId('tv-zone')).toHaveAttribute('data-log-rows', '2')
   })
 })


### PR DESCRIPTION
## What changed
- restored the earlier mobile TV viewport size and padding from two days ago
- returned the compact-roster balance to the old large-screen-only rule
- removed the extra phone-specific stretch experiments
- kept the roster/log sizing test aligned with the original narrow-phone behavior

## Why this changed
The iPhone layout was still being treated like the newer mobile balance path, which made the faux TV area feel cropped and removed space from the TV/log region. The earlier layout from two days ago keeps the TV viewport and roster balance split the way it was originally intended.

## User impact
- iPhone should regain the earlier faux TV proportions
- the TV log strip should return to the older visible layout path
- the roster grid should stop being forced through the newer phone-specific balance behavior

## Validation
- `npx vitest run tests/integration/gameScreen.compactRosterLayout.test.tsx src/components/HouseguestGrid/__tests__/HouseguestGrid.test.tsx src/components/ui/__tests__/TvZone.screenStyle.test.tsx src/components/TVLog/__tests__/TVLog.test.tsx`
- `npm run typecheck`