### PR TITLE
[codex] add morning shock day-start twist

### DIFF
--- a/src/components/DayStartShockPopup/DayStartShockPopup.css
+++ b/src/components/DayStartShockPopup/DayStartShockPopup.css
@@ -1,0 +1,220 @@
+.day-start-shock {
+  position: fixed;
+  inset: 0;
+  z-index: 9800;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  pointer-events: auto;
+}
+
+.day-start-shock__backdrop {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at top, rgba(255, 209, 134, 0.28), transparent 38%),
+    radial-gradient(circle at 50% 12%, rgba(255, 68, 68, 0.22), transparent 20%),
+    linear-gradient(180deg, rgba(8, 6, 16, 0.82), rgba(3, 5, 12, 0.94));
+  backdrop-filter: blur(12px) saturate(135%);
+}
+
+.day-start-shock__backdrop::before,
+.day-start-shock__backdrop::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.day-start-shock__backdrop::before {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 18%),
+    repeating-linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.03),
+      rgba(255, 255, 255, 0.03) 2px,
+      transparent 2px,
+      transparent 8px
+    );
+  mix-blend-mode: screen;
+  opacity: 0.42;
+}
+
+.day-start-shock__backdrop::after {
+  background: radial-gradient(circle at center, transparent 20%, rgba(0, 0, 0, 0.36) 100%);
+}
+
+.day-start-shock__card {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 28rem);
+  max-height: min(92vh, 44rem);
+  overflow: hidden;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 199, 124, 0.34);
+  background:
+    linear-gradient(180deg, rgba(28, 14, 17, 0.98), rgba(9, 10, 20, 0.98)),
+    radial-gradient(circle at top, rgba(255, 120, 78, 0.24), transparent 42%);
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.72),
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+    0 0 32px rgba(255, 90, 64, 0.16);
+  padding: 1.4rem 1.4rem 1.2rem;
+  text-align: center;
+  color: #fff7ef;
+}
+
+.day-start-shock__card::before {
+  content: '';
+  position: absolute;
+  inset: -30% 30% auto;
+  height: 12rem;
+  background: radial-gradient(circle, rgba(255, 186, 112, 0.35), transparent 66%);
+  filter: blur(4px);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.day-start-shock__card::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 140%;
+  height: 0.45rem;
+  transform: translateX(-50%);
+  background: linear-gradient(90deg, transparent, rgba(255, 190, 132, 0.95), transparent);
+  box-shadow: 0 0 26px rgba(255, 184, 121, 0.55);
+}
+
+.day-start-shock__flare {
+  position: absolute;
+  inset: auto -20% -10% -20%;
+  height: 38%;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 106, 77, 0.16), transparent 70%);
+  pointer-events: none;
+}
+
+.day-start-shock__eyebrow {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 0.8rem;
+  padding: 0.28rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 163, 95, 0.13);
+  border: 1px solid rgba(255, 197, 134, 0.25);
+  color: #ffd19b;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.day-start-shock__portrait {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  margin-bottom: 0.75rem;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.45));
+}
+
+.day-start-shock__portrait .pa {
+  transform: scale(1.3);
+  transform-origin: center;
+}
+
+.day-start-shock__title {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-wrap: balance;
+}
+
+.day-start-shock__subhead {
+  position: relative;
+  z-index: 1;
+  margin: 0.35rem auto 0.7rem;
+  max-width: 24rem;
+  color: rgba(255, 234, 214, 0.82);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.day-start-shock__reason {
+  position: relative;
+  z-index: 1;
+  margin: 0 auto 1rem;
+  max-width: 24rem;
+  color: #ffe8c6;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  font-weight: 700;
+  text-wrap: balance;
+}
+
+.day-start-shock__confirm {
+  position: relative;
+  z-index: 1;
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.92rem 1.2rem;
+  width: min(100%, 18rem);
+  background:
+    linear-gradient(180deg, #ffd78b, #ff9a4f);
+  color: #1a0911;
+  font-size: 0.95rem;
+  font-weight: 900;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow:
+    0 10px 24px rgba(255, 153, 79, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.day-start-shock__confirm:hover {
+  transform: translateY(-1px) scale(1.02);
+  filter: brightness(1.03);
+  box-shadow:
+    0 14px 28px rgba(255, 153, 79, 0.36),
+    0 0 0 1px rgba(255, 255, 255, 0.18) inset;
+}
+
+.day-start-shock__confirm:focus-visible {
+  outline: 3px solid rgba(255, 224, 171, 0.75);
+  outline-offset: 3px;
+}
+
+@keyframes day-start-shock-flicker {
+  0%, 100% { opacity: 0.92; }
+  45% { opacity: 1; }
+  50% { opacity: 0.82; }
+  55% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .day-start-shock__card {
+    animation: day-start-shock-flicker 5.8s linear infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .day-start-shock,
+  .day-start-shock__backdrop,
+  .day-start-shock__card,
+  .day-start-shock__confirm {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/components/DayStartShockPopup/DayStartShockPopup.tsx
+++ b/src/components/DayStartShockPopup/DayStartShockPopup.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import type { Player } from '../../types';
+import PlayerAvatar from '../ui/PlayerAvatar';
+import './DayStartShockPopup.css';
+
+interface DayStartShockPopupProps {
+  player: Player;
+  reason: string;
+  onConfirm: () => void;
+}
+
+/**
+ * DayStartShockPopup - a dramatic morning shock interstitial.
+ *
+ * Shows the selected housemate portrait centered at the top, followed by the
+ * broadcast reason and a single confirmation button that hands the game over
+ * to the standard eviction animation.
+ */
+export default function DayStartShockPopup({ player, reason, onConfirm }: DayStartShockPopupProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <div className="day-start-shock" role="presentation" data-testid="day-start-shock-popup">
+      <motion.div
+        className="day-start-shock__backdrop"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: prefersReducedMotion ? 0.12 : 0.28, ease: 'easeOut' }}
+      >
+        <motion.section
+          className="day-start-shock__card"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="day-start-shock-title"
+          aria-describedby="day-start-shock-reason"
+          initial={prefersReducedMotion ? { opacity: 0.96 } : { opacity: 0, scale: 0.92, y: 18 }}
+          animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, scale: 1, y: 0 }}
+          exit={prefersReducedMotion ? { opacity: 0.96 } : { opacity: 0, scale: 0.96, y: 10 }}
+          transition={{ duration: prefersReducedMotion ? 0.18 : 0.38, ease: [0.2, 0.9, 0.2, 1] }}
+        >
+          <div className="day-start-shock__flare" aria-hidden="true" />
+          <div className="day-start-shock__eyebrow">Morning shock</div>
+          <div className="day-start-shock__portrait">
+            <PlayerAvatar player={player} size="lg" />
+          </div>
+          <h2 className="day-start-shock__title" id="day-start-shock-title">
+            {player.name}
+          </h2>
+          <p className="day-start-shock__subhead">
+            A housemate is being removed before the day can continue.
+          </p>
+          <p className="day-start-shock__reason" id="day-start-shock-reason">
+            {reason}
+          </p>
+          <button className="day-start-shock__confirm" type="button" onClick={onConfirm}>
+            Trigger eviction sequence
+          </button>
+        </motion.section>
+      </motion.div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -92,6 +92,7 @@ const INCOMING_TEXT: Record<IncomingInteractionType, string[]> = {
 const INCOMING_BATCH_SIZE = 6;
 const FORCED_SHOCK_OPTIONS: Array<{ value: ForcedShockType; label: string }> = [
   { value: 'doubleEviction', label: 'Double Elimination' },
+  { value: 'dayStartShock', label: 'Morning Shock' },
   { value: 'battleBack', label: 'Back 2 the Game' },
   { value: 'vip', label: 'Double Trouble Safety' },
   { value: 'diamond', label: 'Halo Exchange Safety' },

--- a/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
@@ -47,4 +47,26 @@ describe('DebugPanel forced shock controls', () => {
 
     expect(store.getState().game.pendingForcedShock?.type).toBe('battleBack')
   })
+
+  it('includes Morning Shock in the force shock dropdown and queues it', async () => {
+    const user = userEvent.setup()
+    const store = makeStore()
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/game?debug=1&qa=1']}>
+          <DebugPanel />
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    const forceShockSelect = screen.getByRole('combobox', { name: 'Force Shock' })
+
+    expect(screen.getByRole('option', { name: 'Morning Shock' })).toBeDefined()
+
+    await user.selectOptions(forceShockSelect, 'dayStartShock')
+    await user.click(screen.getByRole('button', { name: 'Queue' }))
+
+    expect(store.getState().game.pendingForcedShock?.type).toBe('dayStartShock')
+  })
 })

--- a/src/features/twists/__tests__/dayStartShock.test.ts
+++ b/src/features/twists/__tests__/dayStartShock.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DAY_START_SHOCK_TEMPLATE_COUNT, buildDayStartShockSelection } from '../dayStartShock';
+import type { Player } from '../../../types';
+
+describe('day start shock selection', () => {
+  it('ships with 30 templates and selects an active housemate', () => {
+    const players: Player[] = [
+      { id: 'a', name: 'Alpha', avatar: '🧑', status: 'active' },
+      { id: 'b', name: 'Bravo', avatar: '👩', status: 'active' },
+      { id: 'c', name: 'Charlie', avatar: '🧑', status: 'evicted' },
+    ];
+    const rng = vi.fn(() => 0);
+    rng.mockReturnValueOnce(0);
+    rng.mockReturnValueOnce(0.5);
+
+    const selection = buildDayStartShockSelection(players, rng);
+
+    expect(DAY_START_SHOCK_TEMPLATE_COUNT).toBe(30);
+    expect(selection?.targetId).toBe('a');
+    expect(selection?.reason).toContain('Alpha');
+    expect(selection?.reason).not.toContain('{{name}}');
+    expect(selection?.templateId).toBeTruthy();
+    expect(rng).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/twists/dayStartShock.ts
+++ b/src/features/twists/dayStartShock.ts
@@ -1,0 +1,156 @@
+import type { Player } from '../../types';
+import { seededPick } from '../../store/rng';
+
+export interface DayStartShockSelection {
+  targetId: string;
+  reason: string;
+  templateId: string;
+}
+
+type ShockTemplate = {
+  id: string;
+  text: string;
+};
+
+const DAY_START_SHOCK_TEMPLATES: ShockTemplate[] = [
+  {
+    id: 'family-emergency',
+    text: '{{name}} received devastating family news and was pulled from the game immediately.',
+  },
+  {
+    id: 'medical-faint',
+    text: '{{name}} fainted in the kitchen before breakfast and was rushed to the hospital for evaluation.',
+  },
+  {
+    id: 'panic-attack',
+    text: '{{name}} suffered a panic attack after a tense overnight exchange and needed to leave the house.',
+  },
+  {
+    id: 'aggressive-argument',
+    text: 'Security stepped in after {{name}} got far too aggressive during an argument, and they were removed from the game.',
+  },
+  {
+    id: 'medical-issue',
+    text: '{{name}} woke up with a medical issue that the house cameras could not ignore, and producers sent them out for care.',
+  },
+  {
+    id: 'family-call',
+    text: '{{name}} got a call from home that left them shaken and unable to continue.',
+  },
+  {
+    id: 'medication-check',
+    text: '{{name}} could not clear a medication issue and had to be escorted out before the day began.',
+  },
+  {
+    id: 'dehydration',
+    text: '{{name}} was taken out for dehydration after a rough night and will not return to the house.',
+  },
+  {
+    id: 'doctor-order',
+    text: 'A doctor\'s evaluation forced {{name}} to leave the game before the morning briefing even started.',
+  },
+  {
+    id: 'crossed-line',
+    text: '{{name}} lost their cool during a confrontation, crossed the line, and was expelled from the house.',
+  },
+  {
+    id: 'heatwave',
+    text: '{{name}} collapsed during a brutal heatwave in the backyard and was rushed out by medics.',
+  },
+  {
+    id: 'emotional-breakdown',
+    text: '{{name}} had a full emotional breakdown after a message from home and decided to walk.',
+  },
+  {
+    id: 'rule-violation',
+    text: '{{name}} was removed after an off-camera rule violation that producers are refusing to discuss.',
+  },
+  {
+    id: 'hyperventilating',
+    text: '{{name}} got caught in a late-night spiral, began hyperventilating, and the medical team ended their run.',
+  },
+  {
+    id: 'diary-room-exit',
+    text: '{{name}} was called to the Diary Room, then straight to the car, after a family emergency landed like a bombshell.',
+  },
+  {
+    id: 'no-calm-down',
+    text: '{{name}} refused to calm down after a fight and security made the call to remove them.',
+  },
+  {
+    id: 'slip-check',
+    text: '{{name}} slipped on the slick kitchen floor and, after a quick check, was ruled out for the day.',
+  },
+  {
+    id: 'fever',
+    text: '{{name}} woke up with a nasty fever and the game could not risk keeping them in the house.',
+  },
+  {
+    id: 'tears',
+    text: '{{name}} spent the night in tears after a brutal conversation and asked to leave.',
+  },
+  {
+    id: 'stomach-bug',
+    text: '{{name}} got a serious stomach bug after the house buffet and was sent home on medical advice.',
+  },
+  {
+    id: 'missing-charger',
+    text: '{{name}} spiraled over a missing charger, and somehow the stress turned into an immediate exit.',
+  },
+  {
+    id: 'near-physical',
+    text: '{{name}} blew up in the living room, came dangerously close to a physical confrontation, and was expelled.',
+  },
+  {
+    id: 'loved-one-news',
+    text: '{{name}} received crushing news about a loved one and left the house immediately.',
+  },
+  {
+    id: 'sleep-debt',
+    text: '{{name}} could not recover from a sleepless, stress-fueled night and the doctors called time.',
+  },
+  {
+    id: 'slammed-doors',
+    text: '{{name}} was removed after a fight with the rules that ended with one too many slammed doors.',
+  },
+  {
+    id: 'allergy',
+    text: '{{name}} had to leave after a sudden allergic reaction made the morning impossible.',
+  },
+  {
+    id: 'coffee-meltdown',
+    text: '{{name}} broke down after realizing the house had run out of their favorite coffee, and that was the final straw.',
+  },
+  {
+    id: 'toaster-war',
+    text: '{{name}} declared war on the toaster, lost the argument, and was told to pack up before noon.',
+  },
+  {
+    id: 'pantry-paranoia',
+    text: '{{name}} became convinced the pantry was plotting against them, and the stress escalated into an exit.',
+  },
+  {
+    id: 'crushing-call',
+    text: '{{name}} tried to keep it together after a brutal call from home, but the house finally got to them.',
+  },
+];
+
+export const DAY_START_SHOCK_TEMPLATE_COUNT = DAY_START_SHOCK_TEMPLATES.length;
+
+function formatShockReason(template: ShockTemplate, name: string): string {
+  return template.text.replace(/\{\{name\}\}/g, name);
+}
+
+export function buildDayStartShockSelection(players: Player[], rng: () => number): DayStartShockSelection | null {
+  const activePlayers = players.filter((player) => player.status !== 'evicted' && player.status !== 'jury');
+  if (activePlayers.length === 0) return null;
+
+  const target = seededPick(rng, activePlayers);
+  const template = seededPick(rng, DAY_START_SHOCK_TEMPLATES);
+
+  return {
+    targetId: target.id,
+    templateId: template.id,
+    reason: formatShockReason(template, target.name),
+  };
+}

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -10,6 +10,7 @@ import {
   finalizeFinal4Eviction,
   finalizeFinal3Eviction,
   finalizePendingEviction,
+  confirmDayStartShock,
   setEvictionOverlay,
   selectAlivePlayers,
   selectF3Part3PredictedWinnerId,
@@ -29,6 +30,8 @@ import {
   dismissBattleBack,
   tryActivateBattleBack,
   tryActivatePendingForcedBattleBack,
+  tryActivateDayStartShock,
+  tryActivatePendingForcedDayStartShock,
   tryActivateSecretMission,
   openBattleBackCompetition,
   tryActivateDoubleEviction,
@@ -78,6 +81,7 @@ import { isPlacementRankingGame } from '../../minigames/registry'
 import { computeScores } from '../../minigames/scoring'
 import FloatingActionBar from '../../components/FloatingActionBar/FloatingActionBar'
 import SpotlightEvictionOverlay from '../../components/Eviction/SpotlightEvictionOverlay'
+import DayStartShockPopup from '../../components/DayStartShockPopup/DayStartShockPopup'
 import CeremonyOverlay from '../../components/CeremonyOverlay/CeremonyOverlay'
 import type { CeremonyTile } from '../../components/CeremonyOverlay/CeremonyOverlay'
 import SpotlightAnimation from '../../components/SpotlightAnimation/spotlight-animation'
@@ -815,13 +819,37 @@ export default function GameScreen() {
   // Fire tryActivateSecretMission once per day when the game enters week_start.
   // The thunk centralizes the daily chance table, testing override, and
   // one-per-season guard.
-  const secretMissionActivationWeekRef = useRef<number | null>(null)
+  const weekStartActivationWeekRef = useRef<number | null>(null)
+  const weekStartActivationResolvedRef = useRef(false)
   useEffect(() => {
     if (game.phase !== 'week_start') return
-    if (secretMissionActivationWeekRef.current === game.week) return
-    secretMissionActivationWeekRef.current = game.week
-    dispatch(tryActivateSecretMission())
-  }, [game.phase, game.week, dispatch])
+    if (game.pendingEviction || game.dayStartShock) return
+    if (weekStartActivationWeekRef.current !== game.week) {
+      weekStartActivationWeekRef.current = game.week
+      weekStartActivationResolvedRef.current = false
+    }
+    if (weekStartActivationResolvedRef.current) return
+
+    if (dispatch(tryActivatePendingForcedDayStartShock())) {
+      weekStartActivationResolvedRef.current = true
+      return
+    }
+    if (dispatch(tryActivateDayStartShock())) {
+      weekStartActivationResolvedRef.current = true
+      return
+    }
+    if (dispatch(tryActivateSecretMission())) {
+      weekStartActivationResolvedRef.current = true
+    }
+  }, [
+    game.dayStartShock,
+    game.pendingEviction,
+    game.pendingForcedShock?.earliestWeek,
+    game.pendingForcedShock?.type,
+    game.phase,
+    game.week,
+    dispatch,
+  ])
 
   // ── Democracia activation on loh_comp_announcement entry ─────────────────
   // Fire tryActivatePendingForcedDemocracia (debug) or tryActivateDemocracia
@@ -2256,6 +2284,16 @@ export default function GameScreen() {
       }, POST_EVICTION_VOTE_BREAKDOWN_PROMPT_DELAY_MS)
     }
   }, [dispatch, game.pendingEviction, game.phase, setFinal4Stage])
+
+  const handleDayStartShockConfirm = useCallback(() => {
+    dispatch(confirmDayStartShock())
+  }, [dispatch])
+
+  const dayStartShock = game.dayStartShock
+  const dayStartShockPlayer = useMemo(() => {
+    if (!dayStartShock) return null
+    return game.players.find((player) => player.id === dayStartShock.targetId) ?? null
+  }, [dayStartShock, game.players])
 
 
   const battleBack = game.battleBack
@@ -3783,6 +3821,16 @@ export default function GameScreen() {
             onDone={handleEvictionSplashDone}
             layoutId={`avatar-tile-${pendingEvictionPlayer.id}`}
             devSkip={import.meta.env.DEV || import.meta.env.CI === 'true'}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {dayStartShock && dayStartShockPlayer && (
+          <DayStartShockPopup
+            key={`${dayStartShock.templateId}-${dayStartShock.triggeredWeek}-${dayStartShock.source}`}
+            player={dayStartShockPlayer}
+            reason={dayStartShock.reason}
+            onConfirm={handleDayStartShockConfirm}
           />
         )}
       </AnimatePresence>

--- a/src/screens/SettingsAdmin/SettingsAdmin.tsx
+++ b/src/screens/SettingsAdmin/SettingsAdmin.tsx
@@ -487,6 +487,29 @@ export default function SettingsAdmin() {
             )}
 
             {settings.sim.enableTwists && (
+              <div className="settings-row settings-row--col">
+                <label className="settings-row__label">
+                  Morning Shock Chance — {settings.sim.dayStartShockChance ?? 1}%
+                </label>
+                <input
+                  type="range"
+                  className="settings-slider"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={settings.sim.dayStartShockChance ?? 1}
+                  onChange={(e) =>
+                    dispatch(setSim({ dayStartShockChance: Number(e.target.value) }))
+                  }
+                  aria-label="Morning Shock chance percentage"
+                />
+                <p className="settings-helper-text">
+                  Chance that a Day 3+ morning shock removes an active housemate before the LOH comp starts. Only fires when more than 4 housemates are still alive.
+                </p>
+              </div>
+            )}
+
+            {settings.sim.enableTwists && (
               <>
                 <div className="settings-row">
                   <label className="settings-row__label">Public's Favorite (Public Vote)</label>

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, createSelector, type PayloadAction } from '@reduxjs/toolki
 import type { RootState, AppDispatch } from './store';
 import type {
   DemocraciaResultDisplay,
+  DayStartShockState,
   GameState,
   Player,
   Phase,
@@ -71,6 +72,7 @@ import {
   buildDoubleEvictionTieResolutionMessage,
   calculateRequiredDoubleEvictionSlots,
 } from '../features/twists/doubleEvictionTieUtils';
+import { buildDayStartShockSelection } from '../features/twists/dayStartShock';
 import { LIVE_VOTE_PITCHES_EVENT_KEY, LIVE_VOTE_PITCHES_TEXT } from '../constants/tvEvents';
 
 // ─── Canonical phase order ────────────────────────────────────────────────────
@@ -95,6 +97,8 @@ const PHASE_ORDER: Phase[] = [
 ];
 
 const IMMUNITY_REPLACEMENT_SEED_MODIFIER = 0x51c4f1d3;
+const DAY_START_SHOCK_MIN_WEEK = 3;
+const DAY_START_SHOCK_RNG_SALT = 0x7c2f5d19;
 const AI_USER_THREAT_WEIGHT = 6;
 const AI_LOH_REVENGE_THREAT_WEIGHT = 6;
 const AI_LOH_BASE_THREAT_WEIGHT = 2;
@@ -118,7 +122,8 @@ function getForcedShockActivationWeek(
     || state.doubleEviction?.weekActive === true
     || state.specialVeto?.activeType != null
     || state.democracia?.active === true;
-  return phaseWindowPassed || currentWeekBlocked ? state.week + 1 : state.week;
+  const earliestWeek = phaseWindowPassed || currentWeekBlocked ? state.week + 1 : state.week;
+  return safePhase === 'week_start' ? Math.max(DAY_START_SHOCK_MIN_WEEK, earliestWeek) : earliestWeek;
 }
 
 function formatForcedShockLabel(type: ForcedShockType): string {
@@ -137,6 +142,8 @@ function formatForcedShockLabel(type: ForcedShockType): string {
       return 'Force Majeure';
     case 'democracia':
       return 'Democracia';
+    case 'dayStartShock':
+      return 'Morning Shock';
     default:
       return type;
   }
@@ -172,6 +179,8 @@ function getForcedShockSafePhase(type: ForcedShockType): Phase {
       return 'eviction_results';
     case 'democracia':
       return 'loh_comp_announcement';
+    case 'dayStartShock':
+      return 'week_start';
     default:
       return 'pos_results';
   }
@@ -370,6 +379,7 @@ export function createInitialGameState(): GameState {
       awaitingVipSecondSaveTarget: false,
     },
     pendingForcedShock: null,
+    dayStartShock: null,
     democracia: {
       usedThisSeason: false,
       active: false,
@@ -2141,6 +2151,7 @@ const gameSlice = createSlice({
       evictee.status = evictedStatus(state);
       state.nomineeIds = state.nomineeIds.filter((id) => id !== evicteeId);
       state.pendingEviction = null;
+      state.dayStartShock = null;
 
       pushEvent(state, msg, 'game');
 
@@ -2486,6 +2497,29 @@ const gameSlice = createSlice({
     /** Clear a queued debug shock after it has been successfully consumed. */
     consumeForcedShock(state) {
       state.pendingForcedShock = null;
+    },
+
+    /**
+     * Activate the day-start shock popup.
+     * The popup stays visible until the player confirms the elimination.
+     */
+    activateDayStartShock(state, action: PayloadAction<DayStartShockState>) {
+      state.dayStartShock = action.payload;
+      state.twistActivatedThisWeek = true;
+    },
+
+    /**
+     * Confirm the day-start shock and hand the chosen housemate off to the
+     * standard eviction splash.
+     */
+    confirmDayStartShock(state) {
+      if (!state.dayStartShock) return;
+      const { targetId, reason } = state.dayStartShock;
+      state.pendingEviction = {
+        evicteeId: targetId,
+        evictionMessage: reason,
+      };
+      state.dayStartShock = null;
     },
 
     /**
@@ -3010,6 +3044,7 @@ const gameSlice = createSlice({
       state.voteResults = null;
       state.evictionSplashId = null;
       state.pendingEviction = null;
+      state.dayStartShock = null;
       pushEvent(state, `[DEBUG] Blocking flags cleared — Continue button restored. 🔧`, 'game');
     },
     /**
@@ -3111,6 +3146,7 @@ const gameSlice = createSlice({
         state.awaitingTieBreak ||
         state.awaitingFinal3Eviction ||
         state.awaitingFinal3Plea ||
+        state.dayStartShock != null ||
         state.specialVeto?.awaitingHolderReplacement ||
         state.specialVeto?.awaitingCoupReplacement1 ||
         state.specialVeto?.awaitingCoupReplacement2 ||
@@ -5119,6 +5155,8 @@ export const {
   queueForcedShock,
   clearForcedShock,
   consumeForcedShock,
+  activateDayStartShock,
+  confirmDayStartShock,
   submitDiamondReplacement,
   submitCoupReplacement,
   submitVipSecondUseDecision,
@@ -5425,6 +5463,11 @@ function resolveDebugBlockers(
 
   if (game.pendingEviction) {
     dispatch(finalizePendingEviction(game.pendingEviction.evicteeId));
+    return true;
+  }
+
+  if (game.dayStartShock) {
+    dispatch(confirmDayStartShock());
     return true;
   }
 
@@ -5898,6 +5941,100 @@ export const tryActivateSecretMission =
   };
 
 /**
+ * Attempt to trigger the random day-start shock on the current day.
+ *
+ * Eligibility:
+ *  - `settings.sim.enableTwists` must be true
+ *  - current phase must be `week_start`
+ *  - the season must be at least Day 3
+ *  - at least 5 housemates must still be alive
+ *  - no other twist may already be active this week
+ *  - no queued debug shock may be waiting to consume the window
+ *
+ * If the roll succeeds, the popup is activated and the user must confirm the
+ * eviction before the standard eviction animation can begin.
+ */
+export const tryActivateDayStartShock =
+  () =>
+  (dispatch: AppDispatch, getState: () => RootState): boolean => {
+    const { game, settings } = getState();
+
+    if (!settings.sim.enableTwists) return false;
+    if (game.phase !== 'week_start') return false;
+    if (game.dayStartShock) return false;
+    if (game.pendingForcedShock) return false;
+    if (game.twistActivatedThisWeek) return false;
+    if (game.week < DAY_START_SHOCK_MIN_WEEK) return false;
+
+    const activePlayers = game.players.filter(
+      (player) => player.status !== 'evicted' && player.status !== 'jury',
+    );
+    if (activePlayers.length <= 4) return false;
+
+    const chance = Math.max(0, Math.min(100, settings.sim.dayStartShockChance ?? 1));
+    if (chance <= 0) return false;
+
+    const rng = mulberry32((game.seed ^ DAY_START_SHOCK_RNG_SALT) >>> 0);
+    if (rng() * 100 >= chance) return false;
+
+    const selection = buildDayStartShockSelection(game.players, rng);
+    if (!selection) return false;
+
+    dispatch(
+      activateDayStartShock({
+        ...selection,
+        triggeredWeek: game.week,
+        source: 'random',
+      }),
+    );
+    return true;
+  };
+
+/**
+ * Attempt to trigger a queued debug day-start shock.
+ *
+ * Bypasses the probability roll, but still respects the day 1 / day 2 and
+ * final-4 guardrails so the debug queue mirrors the live ruleset.
+ */
+export const tryActivatePendingForcedDayStartShock =
+  () =>
+  (dispatch: AppDispatch, getState: () => RootState): boolean => {
+    const { game } = getState();
+    const pending = game.pendingForcedShock;
+
+    if (!pending || pending.type !== 'dayStartShock') return false;
+    if (game.phase !== 'week_start') return false;
+    if (game.week < pending.earliestWeek) return false;
+    if (game.dayStartShock) return false;
+    if (game.twistActivatedThisWeek) return false;
+
+    const activePlayers = game.players.filter(
+      (player) => player.status !== 'evicted' && player.status !== 'jury',
+    );
+    if (activePlayers.length <= 4) {
+      dispatch(clearForcedShock());
+      return false;
+    }
+
+    const rng = mulberry32((game.seed ^ (DAY_START_SHOCK_RNG_SALT ^ 0x1f1f1f1f)) >>> 0);
+    const selection = buildDayStartShockSelection(game.players, rng);
+    if (!selection) {
+      dispatch(clearForcedShock());
+      return false;
+    }
+
+    dispatch(
+      activateDayStartShock({
+        ...selection,
+        triggeredWeek: game.week,
+        source: 'debug',
+      }),
+    );
+    dispatch(consumeForcedShock());
+    return true;
+  };
+
+/**
  * Attempt to activate the Battle Back / Jury Return twist after an eviction.
  *
  * Eligibility:
@@ -6115,7 +6252,13 @@ export const tryActivatePendingForcedSpecialVeto =
     const { game } = getState();
     const pending = game.pendingForcedShock;
 
-    if (!pending || pending.type === 'doubleEviction' || pending.type === 'battleBack' || pending.type === 'democracia') return false;
+    if (
+      !pending ||
+      pending.type === 'doubleEviction' ||
+      pending.type === 'battleBack' ||
+      pending.type === 'democracia' ||
+      pending.type === 'dayStartShock'
+    ) return false;
     if (game.phase !== 'pos_results') return false;
     if (game.week < pending.earliestWeek) return false;
     if (game.doubleEviction?.weekActive) return false;

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -44,6 +44,8 @@ export interface SettingsState {
     specialSafetyChance: number;
     /** Probability (0–100) that a Double Eviction activates on each eligible week (after 5 evictions, above final 5). */
     doubleEvictionChance: number;
+    /** Probability (0–100) that a random day-start shock eliminates an active housemate before the LOH flow begins. */
+    dayStartShockChance: number;
     /** When true, show the "Public's Favorite Player" vote after the finale winner reveal. */
     enableFavoritePlayer: boolean;
     /** Cash prize (USD) awarded to the Public's Favorite Player winner. */
@@ -131,6 +133,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
     battleBackChance: 85,
     specialSafetyChance: 75,
     doubleEvictionChance: 35,
+    dayStartShockChance: 1,
     enableFavoritePlayer: true,
     favoritePlayerAwardAmount: 25000,
     // DEBUG/TESTING ONLY — null means default per-day chances are used.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -383,7 +383,7 @@ export interface SpecialVetoState {
   awaitingVipSecondSaveTarget: boolean;
 }
 
-export type ForcedShockType = 'doubleEviction' | 'battleBack' | SpecialVetoType | 'democracia';
+export type ForcedShockType = 'doubleEviction' | 'battleBack' | SpecialVetoType | 'democracia' | 'dayStartShock';
 
 export interface ForcedShockState {
   /** Shock that should be triggered from the debug menu at the next safe chance. */
@@ -392,6 +392,24 @@ export interface ForcedShockState {
   requestedWeek: number;
   /** Earliest week when the shock is allowed to begin. */
   earliestWeek: number;
+}
+
+/**
+ * State for the day-start elimination shock popup.
+ * When set, the game is waiting for the user to confirm the eviction before
+ * the standard eviction animation can take over.
+ */
+export interface DayStartShockState {
+  /** ID of the active housemate who will be eliminated. */
+  targetId: string;
+  /** Dramatic broadcast-style reason shown in the popup. */
+  reason: string;
+  /** Template identifier used to generate the reason. */
+  templateId: string;
+  /** Week when the shock was activated. */
+  triggeredWeek: number;
+  /** Whether the shock was triggered by the random roll or the debug queue. */
+  source: 'random' | 'debug';
 }
 
 // ─── Public's Favorite voting twist ──────────────────────────────────────────
@@ -721,6 +739,12 @@ export interface GameState {
    * Append-only; used for post-season display and debugging.
    */
   history?: GameHistoryEvent[];
+  /**
+   * Day-start elimination shock state.
+   * When set, the popup is visible and advance() is blocked until the player
+   * confirms the eviction.
+   */
+  dayStartShock?: DayStartShockState | null;
   /**
    * When set, the VoteResultsPopup is shown with the vote tally before
    * advancing. Maps nominee ID → number of votes received.


### PR DESCRIPTION
## What changed
- Adds a 1% default morning shock event that can be adjusted from 0-100% in Advanced Settings.
- Limits activation to active housemates only, after Day 2, with more than four housemates still alive, and before the LOH comp starts.
- Adds a pool of 30 dramatic TV-style exit reasons for the shock event.
- Introduces a dedicated popup with the selected housemate avatar centered at the top, the reason text below, and a confirm flow into the existing eviction animation.
- Adds a Debug Panel option to queue the morning shock for testing.

## Validation
- `npm run typecheck`
- Targeted Vitest coverage for the new debug menu selector and shock template selection