### PR TITLE
Fix native iOS background skin loading

### DIFF
--- a/public/assets/skins/skins.json
+++ b/public/assets/skins/skins.json
@@ -1,13 +1,13 @@
 {
-  "sunrise": "sunrise-background.jpg",
-  "day": "daily-background.jpg",
-  "sunset": "sunset-background.jpg",
-  "night": "bg-night.jpg",
-  "rain": "rainy-background.jpg",
-  "snow": "blizzard-background.png",
-  "snowday": "snowday-background.png",
-  "thunderstorm": "thunderstorm-background.png",
-  "xmasDay": "xmas-day-background.png",
-  "xmasEve": "xmas-eve-background.png",
-  "xmasNight": "xmasy-night-background.png"
+  "sunrise": "bg-sunrise.png",
+  "day": "bg-day.png",
+  "sunset": "bg-sunset.png",
+  "night": "bg-night.png",
+  "rain": "bg-rain.png",
+  "snow": "bg-snow.png",
+  "snowday": "bg-snowday.png",
+  "thunderstorm": "bg-thunderstorm.png",
+  "xmasDay": "bg-xmas-day.png",
+  "xmasEve": "bg-xmas-eve.png",
+  "xmasNight": "bg-xmas-night.png"
 }

--- a/scripts/fetch-skins.sh
+++ b/scripts/fetch-skins.sh
@@ -8,27 +8,34 @@
 # Usage:
 #   bash scripts/fetch-skins.sh
 #
-# Requirements: curl (or wget as fallback)
+# Requirements: curl (or wget as fallback), Node.js (for reading the shared registry)
 
 set -euo pipefail
 
 REPO_RAW="https://raw.githubusercontent.com/georgi-cole/bbmobile/main"
 DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/public/assets/skins"
 
-# Canonical list of skin files from the legacy repo
-SKIN_FILES=(
-  "bg-sunrise.png"
-  "bg-day.png"
-  "bg-sunset.png"
-  "bg-night.png"
-  "bg-rain.png"
-  "bg-snow.png"
-  "bg-snowday.png"
-  "bg-thunderstorm.png"
-  "bg-xmas-day.png"
-  "bg-xmas-eve.png"
-  "bg-xmas-night.png"
-  "daily-background.png"
+# Read the canonical file list from the shared registry so the download list
+# stays in sync with the runtime resolver and manifest generator.
+mapfile -t SKIN_FILES < <(
+  node <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const registryPath = path.resolve(process.cwd(), 'src/data/skinRegistry.json');
+const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+const seen = new Set();
+
+for (const key of Object.keys(registry)) {
+  const entry = registry[key] || {};
+  const candidates = [entry.canonicalFile, ...(entry.aliases ?? [])];
+  for (const file of candidates) {
+    if (typeof file === 'string' && file.length > 0 && !seen.has(file)) {
+      seen.add(file);
+      console.log(file);
+    }
+  }
+}
+NODE
 )
 
 mkdir -p "$DEST_DIR"

--- a/scripts/fetch-skins.sh
+++ b/scripts/fetch-skins.sh
@@ -12,8 +12,9 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_RAW="https://raw.githubusercontent.com/georgi-cole/bbmobile/main"
-DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/public/assets/skins"
+DEST_DIR="${REPO_ROOT}/public/assets/skins"
 SKIN_FILES=()
 
 # Read the canonical file list from the shared registry so the download list
@@ -21,10 +22,10 @@ SKIN_FILES=()
 while IFS= read -r file; do
   [[ -n "$file" ]] && SKIN_FILES+=("$file")
 done < <(
-  node <<'NODE'
+  REPO_ROOT="$REPO_ROOT" node <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
-const registryPath = path.resolve(process.cwd(), 'src/data/skinRegistry.json');
+const registryPath = path.resolve(process.env.REPO_ROOT, 'src/data/skinRegistry.json');
 const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
 const seen = new Set();
 

--- a/scripts/fetch-skins.sh
+++ b/scripts/fetch-skins.sh
@@ -14,10 +14,13 @@ set -euo pipefail
 
 REPO_RAW="https://raw.githubusercontent.com/georgi-cole/bbmobile/main"
 DEST_DIR="$(cd "$(dirname "$0")/.." && pwd)/public/assets/skins"
+SKIN_FILES=()
 
 # Read the canonical file list from the shared registry so the download list
 # stays in sync with the runtime resolver and manifest generator.
-mapfile -t SKIN_FILES < <(
+while IFS= read -r file; do
+  [[ -n "$file" ]] && SKIN_FILES+=("$file")
+done < <(
   node <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/generate-skins-manifest.mjs
+++ b/scripts/generate-skins-manifest.mjs
@@ -2,8 +2,8 @@
 /**
  * generate-skins-manifest.mjs
  *
- * Scans public/assets/skins/ for image files and heuristically maps them to
- * the canonical theme keys used by backgroundTheme.ts.  Writes the result to
+ * Scans public/assets/skins/ for image files and maps them to the canonical
+ * theme keys declared in src/data/skinRegistry.json. Writes the result to
  * public/assets/skins/skins.json (pretty-printed).
  *
  * Usage:
@@ -19,56 +19,8 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SKINS_DIR = path.resolve(__dirname, '..', 'public', 'assets', 'skins');
+const REGISTRY_PATH = path.resolve(__dirname, '..', 'src', 'data', 'skinRegistry.json');
 const MANIFEST_PATH = path.join(SKINS_DIR, 'skins.json');
-
-/** Canonical theme keys (must match ThemeKey in backgroundTheme.ts). */
-const THEME_KEYS = [
-  'sunrise',
-  'day',
-  'sunset',
-  'night',
-  'rain',
-  'snow',
-  'snowday',
-  'thunderstorm',
-  'xmasDay',
-  'xmasEve',
-  'xmasNight',
-];
-
-/**
- * Substrings to look for in a filename (lower-cased) to identify each key.
- * Earlier entries in the array = more canonical match; used for sort priority.
- * NOTE: Keep in sync with the CANDIDATES map in src/utils/backgroundTheme.ts
- * so the generator can detect all filenames used by the runtime prober.
- */
-const KEY_HINTS = {
-  sunrise:      ['sunrise'],
-  day:          ['day', 'daily', 'autumn', 'leaves'], // checked after xmasDay/snowday to avoid conflicts
-  sunset:       ['sunset'],
-  night:        ['night'],       // checked in DETECTION_PRIORITY before 'snow'; covers night-snow-background
-  rain:         ['rain'],
-  snowday:      ['snowday'],     // must come before 'snow'
-  snow:         ['snow', 'blizzard'],
-  thunderstorm: ['thunder', 'storm'],
-  xmasDay:      ['xmas-day', 'xmasday', 'santa-day', 'santaday', 'christmas-day',
-                 'xmas-background'], // 'xmas-background' is not a substring of 'xmas-*-background' so it uniquely matches xmas-background.{ext}
-  xmasEve:      ['xmas-eve', 'xmaseve', 'christmas-eve'],
-  xmasNight:    ['xmas-night', 'xmasnight', 'xmasy-night', 'christmas-night'],
-};
-
-/**
- * Priority order for key detection — more-specific keys are checked first to
- * avoid partial-match ambiguity.  'night' is checked before 'snow' so that
- * 'night-snow-background.png' maps to night rather than snow.
- */
-const DETECTION_PRIORITY = [
-  'xmasDay', 'xmasEve', 'xmasNight',
-  'snowday', 'thunderstorm',
-  'sunrise', 'sunset',
-  'rain', 'night', 'snow',
-  'day',
-];
 
 /** Supported image extensions. */
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif']);
@@ -77,21 +29,13 @@ function isImageFile(filename) {
   return IMAGE_EXTENSIONS.has(path.extname(filename).toLowerCase());
 }
 
-/**
- * Returns the theme key and the index of the matching hint within that key's
- * hints array for a given filename.  Earlier hint index = more canonical name.
- * Returns null if no key matches.
- */
-function detectKeyWithHintIndex(filename) {
-  const lower = filename.toLowerCase();
-  for (const key of DETECTION_PRIORITY) {
-    const hints = KEY_HINTS[key] ?? [];
-    const hintIndex = hints.findIndex((h) => lower.includes(h));
-    if (hintIndex !== -1) {
-      return { key, hintIndex };
-    }
+function readRegistry() {
+  const raw = fs.readFileSync(REGISTRY_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`[generate-skins-manifest] registry is not an object: ${REGISTRY_PATH}`);
   }
-  return null;
+  return /** @type {Record<string, { canonicalFile?: string; aliases?: string[] }>} */ (parsed);
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -111,54 +55,59 @@ if (!skinsStats.isDirectory()) {
   process.exit(1);
 }
 
+let registry;
+try {
+  registry = readRegistry();
+} catch (err) {
+  console.error(`[generate-skins-manifest] ERROR: unable to read registry: ${REGISTRY_PATH}`);
+  console.error(`  ${String(err)}`);
+  process.exit(1);
+}
+
+const themeKeys = Object.keys(registry);
 const allFiles = fs.readdirSync(SKINS_DIR).filter((f) => isImageFile(f));
+const fileSet = new Set(allFiles);
+const manifest = {};
+const usedFiles = new Set();
 
 if (allFiles.length === 0) {
   console.warn('[generate-skins-manifest] WARNING: no image files found in', SKINS_DIR);
-  console.warn('  The manifest will be empty.  Run scripts/fetch-skins.sh to download assets.');
+  console.warn('  The manifest will be empty. Run scripts/fetch-skins.sh to download assets.');
 }
 
-// Build per-key candidate lists with hint-index metadata for sorting.
-/** @type {Record<string, Array<{file: string, hintIndex: number}>>} */
-const keyGroups = {};
-for (const file of allFiles) {
-  const match = detectKeyWithHintIndex(file);
-  if (!match) {
-    console.log(`  [skip] ${file}  (no matching theme key)`);
+for (const key of themeKeys) {
+  const entry = registry[key] ?? {};
+  const candidates = [entry.canonicalFile, ...(entry.aliases ?? [])].filter(Boolean);
+  const hit = candidates.find((file) => fileSet.has(file));
+
+  if (!hit) {
+    console.warn(`[generate-skins-manifest] WARNING: no file found for ${key}; candidates: ${candidates.join(', ')}`);
     continue;
   }
-  if (!keyGroups[match.key]) keyGroups[match.key] = [];
-  keyGroups[match.key].push({ file, hintIndex: match.hintIndex });
-}
 
-// Sort each group and emit manifest entries.
-// Sort order: earlier hint index (more canonical) > no spaces/parens > alphabetical.
-const manifest = {};
-for (const key of THEME_KEYS) {
-  const group = keyGroups[key];
-  if (!group || group.length === 0) continue;
+  manifest[key] = hit;
+  usedFiles.add(hit);
+  console.log(`  [map]  ${hit}  → ${key}`);
 
-  group.sort((a, b) => {
-    if (a.hintIndex !== b.hintIndex) return a.hintIndex - b.hintIndex;
-    const aComplex = /[\s()]/.test(a.file) ? 1 : 0;
-    const bComplex = /[\s()]/.test(b.file) ? 1 : 0;
-    if (aComplex !== bComplex) return aComplex - bComplex;
-    return a.file.localeCompare(b.file);
-  });
-
-  manifest[key] = group[0].file;
-  console.log(`  [map]  ${group[0].file}  → ${key}`);
-  for (let i = 1; i < group.length; i++) {
-    console.log(`  [dup]  ${group[i].file}  → ${key} (already mapped to ${group[0].file}; skipping)`);
+  for (const candidate of candidates) {
+    if (candidate !== hit && fileSet.has(candidate) && !usedFiles.has(candidate)) {
+      console.log(`  [alt]  ${candidate}  → ${key} (available but not canonical)`);
+    }
   }
 }
 
-// Report any theme keys that received no mapping
-const unmapped = THEME_KEYS.filter((k) => !manifest[k]);
-if (unmapped.length > 0) {
-  console.warn('\n[generate-skins-manifest] WARNING: no file found for keys:', unmapped.join(', '));
-  console.warn('  These keys will fall back to candidate probing at runtime.');
+// Report any image files that are not used by the registry.
+for (const file of allFiles) {
+  if (!usedFiles.has(file)) {
+    console.log(`  [skip] ${file}  (not referenced by skinRegistry.json)`);
+  }
 }
 
-fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+const unmapped = themeKeys.filter((k) => !manifest[k]);
+if (unmapped.length > 0) {
+  console.warn('\n[generate-skins-manifest] WARNING: no file found for keys:', unmapped.join(', '));
+  console.warn('  These keys will fall back to bundled asset resolution at runtime.');
+}
+
+fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 console.log(`\n[generate-skins-manifest] Wrote ${MANIFEST_PATH}`);

--- a/src/components/SeasonRecapCinematic/SeasonRecapCinematic.tsx
+++ b/src/components/SeasonRecapCinematic/SeasonRecapCinematic.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import type { Player } from '../../types';
 import type { PublicOpinionState } from '../../publicOpinion/types';
 import { resolveAvatarCandidates } from '../../utils/avatar';
+import { resolveSkinAssetPath } from '../../utils/skinAssets';
 import FullSizeCutoutImage from '../FullSizeCutoutImage/FullSizeCutoutImage';
 import EvictionLadder from './EvictionLadder';
 import { buildSeasonRecapData, deriveEvictionFallbackPlacement, type AwardCategory } from './seasonRecapData';
@@ -31,7 +32,8 @@ const LADDER_ARCHIVE_LIMIT = 6;
 const FINALISTS_RANK_OFFSET = 2;
 const DICEBEAR_HOST = 'api.dicebear.com';
 const URL_PARSE_BASE = 'https://bbmobilenew.local';
-const RECAP_SKINS_BASE = `${import.meta.env.BASE_URL}assets/skins/`;
+const RECAP_GIRLS_IMAGE = resolveSkinAssetPath('thegirls.webp');
+const RECAP_BOYS_IMAGE = resolveSkinAssetPath('the boys.webp');
 
 function isDicebearAvatar(candidate: string): boolean {
   try {
@@ -183,7 +185,7 @@ function HeadlineGirlsScene() {
   return (
     <FullscreenPhotoScene
       className="src-scene--headline-girls"
-      imageSrc={`${RECAP_SKINS_BASE}thegirls.webp`}
+      imageSrc={RECAP_GIRLS_IMAGE}
       imageAlt="The girls season photoshoot"
       eyebrow="Final photoshoot"
       title="The Girls"
@@ -196,7 +198,7 @@ function PhonePostBoysScene() {
   return (
     <FullscreenPhotoScene
       className="src-scene--phone-post-boys"
-      imageSrc={`${RECAP_SKINS_BASE}the boys.webp`}
+      imageSrc={RECAP_BOYS_IMAGE}
       imageAlt="The boys season photoshoot"
       eyebrow="Final photoshoot"
       title="The Boys"

--- a/src/data/skinRegistry.json
+++ b/src/data/skinRegistry.json
@@ -1,0 +1,57 @@
+{
+  "sunrise": {
+    "label": "Sunrise",
+    "canonicalFile": "bg-sunrise.png",
+    "aliases": ["sunrise-background.jpg", "sunrise-background.png"]
+  },
+  "day": {
+    "label": "Daytime",
+    "canonicalFile": "bg-day.png",
+    "aliases": ["daily-background.jpg", "daily-background.png", "autumn-leaves-background.png"]
+  },
+  "sunset": {
+    "label": "Sunset",
+    "canonicalFile": "bg-sunset.png",
+    "aliases": ["sunset-background.jpg", "sunset-background.png"]
+  },
+  "night": {
+    "label": "Night",
+    "canonicalFile": "bg-night.png",
+    "aliases": ["bg-night.jpg", "icy-night-background.jpg", "night-snow-background.png"]
+  },
+  "rain": {
+    "label": "Rainy",
+    "canonicalFile": "bg-rain.png",
+    "aliases": ["rainy-background.jpg", "rainy-background.png"]
+  },
+  "snow": {
+    "label": "Snow",
+    "canonicalFile": "bg-snow.png",
+    "aliases": ["blizzard-background.png"]
+  },
+  "snowday": {
+    "label": "Snowy Day",
+    "canonicalFile": "bg-snowday.png",
+    "aliases": ["snowday-background.png"]
+  },
+  "thunderstorm": {
+    "label": "Thunderstorm",
+    "canonicalFile": "bg-thunderstorm.png",
+    "aliases": ["thunderstorm-background.png"]
+  },
+  "xmasDay": {
+    "label": "Christmas Day",
+    "canonicalFile": "bg-xmas-day.png",
+    "aliases": ["xmas-day-background.png", "discrete-santa-day-background.png", "xmas-background.jpg"]
+  },
+  "xmasEve": {
+    "label": "Christmas Eve",
+    "canonicalFile": "bg-xmas-eve.png",
+    "aliases": ["xmas-eve-background.png"]
+  },
+  "xmasNight": {
+    "label": "Christmas Night",
+    "canonicalFile": "bg-xmas-night.png",
+    "aliases": ["xmasy-night-background.png"]
+  }
+}

--- a/src/hooks/useBackgroundTheme.ts
+++ b/src/hooks/useBackgroundTheme.ts
@@ -12,6 +12,7 @@
 import { useState, useEffect } from 'react';
 import { resolveTheme } from '../utils/backgroundTheme';
 import type { ResolvedTheme, ThemeKey } from '../utils/backgroundTheme';
+import { getBinaryFallbackKey, resolveSkinAsset } from '../utils/skinAssets';
 import { preloadImage } from '../utils/preload';
 
 interface BackgroundState {
@@ -38,36 +39,67 @@ export default function useBackgroundTheme(
   useEffect(() => {
     let cancelled = false;
 
-    resolveTheme().then((resolved: ResolvedTheme) => {
-      if (cancelled) return;
-
-      setState({
-        url: resolved.url,
-        key: resolved.key,
-        reason: resolved.reason,
-      });
-      console.info(
-        '[useBackgroundTheme] background applied:',
-        resolved.key,
-        resolved.url,
-        `(${resolved.reason})`,
-        `[${resolved.assetSource}:${resolved.assetFile}]`,
-      );
-
-      if (attachToRoot) {
-        document.documentElement.style.setProperty(
-          '--intro-bg-image',
-          `url("${resolved.url}")`,
-        );
-      }
-
-      // Preload the background image in parallel so it's in cache when used,
-      // but do not gate state updates on this completing.
-      preloadImage(resolved.url).then(() => {
+    resolveTheme()
+      .then((resolved: ResolvedTheme) => {
         if (cancelled) return;
-        // Optional: could add debug logging here if desired.
+
+        setState({
+          url: resolved.url,
+          key: resolved.key,
+          reason: resolved.reason,
+        });
+        console.info(
+          '[useBackgroundTheme] background applied:',
+          resolved.key,
+          resolved.url,
+          `(${resolved.reason})`,
+          `[${resolved.assetSource}:${resolved.assetFile}]`,
+        );
+
+        if (attachToRoot) {
+          document.documentElement.style.setProperty(
+            '--intro-bg-image',
+            `url("${resolved.url}")`,
+          );
+        }
+
+        // Preload the background image in parallel so it's in cache when used,
+        // but do not gate state updates on this completing.
+        preloadImage(resolved.url).then(() => {
+          if (cancelled) return;
+          // Optional: could add debug logging here if desired.
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+
+        const fallbackKey = getBinaryFallbackKey(new Date());
+        const fallbackAsset = resolveSkinAsset(fallbackKey);
+        const fallbackReason = `resolveTheme:error:${error instanceof Error ? error.message : String(error)}`;
+
+        console.warn('[useBackgroundTheme] resolver failed; using emergency fallback', {
+          error,
+          fallbackKey,
+          fallbackAsset,
+        });
+
+        setState({
+          url: fallbackAsset.url,
+          key: fallbackAsset.key,
+          reason: fallbackReason,
+        });
+
+        if (attachToRoot) {
+          document.documentElement.style.setProperty(
+            '--intro-bg-image',
+            `url("${fallbackAsset.url}")`,
+          );
+        }
+
+        preloadImage(fallbackAsset.url).catch(() => {
+          // If even the emergency fallback fails, the background layer still has a URL.
+        });
       });
-    });
 
     return () => {
       cancelled = true;

--- a/src/hooks/useBackgroundTheme.ts
+++ b/src/hooks/useBackgroundTheme.ts
@@ -41,27 +41,29 @@ export default function useBackgroundTheme(
     resolveTheme().then((resolved: ResolvedTheme) => {
       if (cancelled) return;
 
-      // Normalize URL to work on GitHub Pages where BASE_URL may be '/bbmobilenew/'.
-      // Avoid double-prefixing if backgroundTheme already includes the base.
-      const base = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
-      const normalized = (base && resolved.url.startsWith('/') && !resolved.url.startsWith(`${base}/`))
-        ? `${base}${resolved.url}`
-        : resolved.url;
-
-      // Apply the background immediately so consumers don't wait on image preload.
-      setState({ url: normalized, key: resolved.key, reason: resolved.reason });
-      console.info('[useBackgroundTheme] background applied:', resolved.key, normalized, `(${resolved.reason})`);
+      setState({
+        url: resolved.url,
+        key: resolved.key,
+        reason: resolved.reason,
+      });
+      console.info(
+        '[useBackgroundTheme] background applied:',
+        resolved.key,
+        resolved.url,
+        `(${resolved.reason})`,
+        `[${resolved.assetSource}:${resolved.assetFile}]`,
+      );
 
       if (attachToRoot) {
         document.documentElement.style.setProperty(
           '--intro-bg-image',
-          `url("${normalized}")`,
+          `url("${resolved.url}")`,
         );
       }
 
       // Preload the background image in parallel so it's in cache when used,
       // but do not gate state updates on this completing.
-      preloadImage(normalized).then(() => {
+      preloadImage(resolved.url).then(() => {
         if (cancelled) return;
         // Optional: could add debug logging here if desired.
       });

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,0 +1,4 @@
+declare module '*.json' {
+  const value: any;
+  export default value;
+}

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,4 +1,4 @@
 declare module '*.json' {
-  const value: any;
+  const value: unknown;
   export default value;
 }

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -159,6 +159,7 @@ export async function resolveTheme(
   const now = new Date();
   const platform = getPlatformLabel();
   const permissionStatus = await getGeolocationPermissionStatus();
+  const permissionDenied = permissionStatus === 'denied';
   const timeKey = timeOfDayKey(now);
   const binaryFallbackKey = getBinaryFallbackKey(now);
 
@@ -173,7 +174,7 @@ export async function resolveTheme(
   if (isHolidayWindow(now)) {
     selectedKey = holidayKey(now);
     reason = 'holiday';
-  } else if (!forceNoGeo && typeof navigator !== 'undefined' && navigator.geolocation && permissionStatus !== 'denied') {
+  } else if (!forceNoGeo && typeof navigator !== 'undefined' && navigator.geolocation && !permissionDenied) {
     // 2. Geolocation + weather
     try {
       const position = await getPosition(geolocationTimeoutMs);
@@ -197,13 +198,13 @@ export async function resolveTheme(
     } catch (err) {
       locationError = err instanceof Error ? err.message : String(err);
       selectedKey = binaryFallbackKey;
-      reason = permissionStatus === 'denied' ? 'fallback:permission-denied' : 'fallback:location';
+      reason = permissionDenied ? 'fallback:permission-denied' : 'fallback:location';
     }
   } else {
     // No usable location signal: fall back to a guaranteed day/night asset.
     locationError = forceNoGeo
       ? 'forceNoGeo'
-      : permissionStatus === 'denied'
+      : permissionDenied
         ? 'permission denied'
         : 'geolocation unavailable';
     selectedKey = binaryFallbackKey;

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -2,7 +2,6 @@ import {
   getBinaryFallbackKey,
   getGeolocationPermissionStatus,
   getPlatformLabel,
-  getSkinCandidates,
   resolveSkinAsset,
   SKIN_REGISTRY,
   type SkinAssetSource,

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -4,6 +4,7 @@ import {
   getPlatformLabel,
   resolveSkinAsset,
   SKIN_REGISTRY,
+  type GeolocationPermissionStatus,
   type SkinAssetSource,
   type ThemeKey,
   type PlatformLabel,
@@ -81,7 +82,7 @@ export interface ResolvedTheme {
   assetFile: string;
   assetSource: SkinAssetSource;
   platform: PlatformLabel;
-  permissionStatus: PermissionState | 'unsupported' | 'unknown';
+  permissionStatus: GeolocationPermissionStatus;
 }
 
 export interface ResolveOptions {

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -184,10 +184,14 @@ export async function resolveTheme(
       if (weatherKey) {
         selectedKey = weatherKey;
         reason = `weather:${weatherCode}`;
-      } else {
-        // Clear/overcast: use the local time bucket.
+      } else if (weatherCode === 0 || weatherCode === 1 || weatherCode === 2 || weatherCode === 3) {
+        // Clear/overcast: use the local time bucket so sunrise/sunset remain visible.
         selectedKey = timeKey;
         reason = `weather:${weatherCode}:timeofday`;
+      } else {
+        // Unrecognized weather codes fall back to a guaranteed day/night asset.
+        selectedKey = binaryFallbackKey;
+        reason = `weather:${weatherCode}:fallback`;
       }
     } catch (err) {
       locationError = err instanceof Error ? err.message : String(err);

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -1,3 +1,15 @@
+import {
+  getBinaryFallbackKey,
+  getGeolocationPermissionStatus,
+  getPlatformLabel,
+  getSkinCandidates,
+  resolveSkinAsset,
+  SKIN_REGISTRY,
+  type SkinAssetSource,
+  type ThemeKey,
+  type PlatformLabel,
+} from './skinAssets';
+
 /**
  * backgroundTheme.ts
  *
@@ -6,77 +18,32 @@
  *   2. Geolocation + Open-Meteo current weather (no API key required)
  *   3. Time-of-day fallback
  *
- * Asset resolution order for each chosen theme key:
- *   a. Fetch public/assets/skins/skins.json manifest → use mapped filename if
- *      the file exists (HEAD check).
- *   b. Probe candidate filename lists with HEAD requests; pick first hit.
- *   c. Fall back to DEFAULT_FILE.
+ * The skin lookup itself is handled by src/utils/skinAssets.ts, which provides
+ * a shared native-safe registry and a bundled asset URL resolver.
  */
 
-const VITE_BASE: string = import.meta.env.BASE_URL ?? '/';
-export const ASSETS_BASE = `${VITE_BASE.replace(/\/$/, '')}/assets/skins/`;
-
-/** Ultimate fallback filename when no candidate can be found. */
-const DEFAULT_FILE = 'daily-background.png';
+const base = import.meta.env.BASE_URL ?? '/';
+const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+export const ASSETS_BASE = `${normalizedBase}assets/skins/`;
 
 export interface BackgroundEntry {
   file: string;
   label: string;
 }
 
-export type ThemeKey =
-  | 'sunrise'
-  | 'day'
-  | 'sunset'
-  | 'night'
-  | 'rain'
-  | 'snow'
-  | 'snowday'
-  | 'thunderstorm'
-  | 'xmasDay'
-  | 'xmasEve'
-  | 'xmasNight';
+export const BACKGROUNDS: Record<ThemeKey, BackgroundEntry> = Object.fromEntries(
+  Object.entries(SKIN_REGISTRY).map(([key, entry]) => [
+    key,
+    { file: entry.canonicalFile, label: entry.label },
+  ]),
+) as Record<ThemeKey, BackgroundEntry>;
 
-export const BACKGROUNDS: Record<ThemeKey, BackgroundEntry> = {
-  sunrise:      { file: 'bg-sunrise.png',      label: 'Sunrise'      },
-  day:          { file: 'bg-day.png',           label: 'Daytime'      },
-  sunset:       { file: 'bg-sunset.png',        label: 'Sunset'       },
-  night:        { file: 'bg-night.png',         label: 'Night'        },
-  rain:         { file: 'bg-rain.png',          label: 'Rainy'        },
-  snow:         { file: 'bg-snow.png',          label: 'Snow'         },
-  snowday:      { file: 'bg-snowday.png',       label: 'Snowy Day'    },
-  thunderstorm: { file: 'bg-thunderstorm.png',  label: 'Thunderstorm' },
-  xmasDay:      { file: 'bg-xmas-day.png',      label: 'Christmas Day'   },
-  xmasEve:      { file: 'bg-xmas-eve.png',      label: 'Christmas Eve'   },
-  xmasNight:    { file: 'bg-xmas-night.png',    label: 'Christmas Night' },
-};
-
-/**
- * Candidate filenames to probe (HEAD) when no manifest is available.
- * Listed in priority order; first existing file wins.
- * NOTE: Keep in sync with the filenames emitted by scripts/generate-skins-manifest.mjs
- * so that the fallback probing covers any files the manifest generator would detect.
- */
-export const CANDIDATES: Record<ThemeKey, string[]> = {
-  sunrise:      ['bg-sunrise.png',      'sunrise-background.png'                              ],
-  day:          ['bg-day.png',          'daily-background.png',    'autumn-leaves-background.png'],
-  sunset:       ['bg-sunset.png',       'sunset-background.png'                               ],
-  night:        ['bg-night.png',        'icy-night-background.jpg', 'night-snow-background.png'],
-  rain:         ['bg-rain.png',         'rainy-background.png'                                ],
-  snow:         ['bg-snow.png',         'blizzard-background.png'                             ],
-  snowday:      ['bg-snowday.png',      'snowday-background.png'                              ],
-  thunderstorm: ['bg-thunderstorm.png', 'thunderstorm-background.png'                         ],
-  xmasDay:      ['bg-xmas-day.png',     'xmas-day-background.png', 'discrete-santa-day-background.png', 'xmas-background.jpg'],
-  xmasEve:      ['bg-xmas-eve.png',     'xmas-eve-background.png'                            ],
-  xmasNight:    ['bg-xmas-night.png',   'xmasy-night-background.png'                         ],
-};
-
-/** Shape of the optional skins.json manifest (key → filename). */
-export type SkinsManifest = Partial<Record<ThemeKey, string>>;
-
-/** Module-level manifest cache to avoid redundant network fetches. */
-const MANIFEST_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-let _manifestCache: { data: SkinsManifest | null; fetchedAt: number } | null = null;
+export const CANDIDATES: Record<ThemeKey, string[]> = Object.fromEntries(
+  Object.entries(SKIN_REGISTRY).map(([key, entry]) => [
+    key,
+    [entry.canonicalFile, ...(entry.aliases ?? [])],
+  ]),
+) as Record<ThemeKey, string[]>;
 
 /**
  * Maps Open-Meteo WMO weathercode to a theme key.
@@ -85,10 +52,10 @@ let _manifestCache: { data: SkinsManifest | null; fetchedAt: number } | null = n
 export function mapWeatherCodeToTheme(weathercode: number): ThemeKey | null {
   if (weathercode === 0 || weathercode === 1) return null; // clear — fall through to time-of-day
   if (weathercode === 2 || weathercode === 3) return null; // partly/overcast — time-of-day
-  if (weathercode >= 51 && weathercode <= 67) return 'rain';        // drizzle / rain
-  if (weathercode >= 71 && weathercode <= 77) return 'snow';        // snow
-  if (weathercode >= 80 && weathercode <= 82) return 'rain';        // showers
-  if (weathercode >= 85 && weathercode <= 86) return 'snowday';     // snow showers
+  if (weathercode >= 51 && weathercode <= 67) return 'rain'; // drizzle / rain
+  if (weathercode >= 71 && weathercode <= 77) return 'snow'; // snow
+  if (weathercode >= 80 && weathercode <= 82) return 'rain'; // showers
+  if (weathercode >= 85 && weathercode <= 86) return 'snowday'; // snow showers
   if (weathercode >= 95 && weathercode <= 99) return 'thunderstorm'; // thunderstorm
   return null;
 }
@@ -102,8 +69,8 @@ export function mapWeatherCodeToTheme(weathercode: number): ThemeKey | null {
  */
 export function timeOfDayKey(date: Date): ThemeKey {
   const hour = date.getHours();
-  if (hour >= 5 && hour <= 7)   return 'sunrise';
-  if (hour >= 8 && hour <= 17)  return 'day';
+  if (hour >= 5 && hour <= 7) return 'sunrise';
+  if (hour >= 8 && hour <= 17) return 'day';
   if (hour >= 18 && hour <= 20) return 'sunset';
   return 'night';
 }
@@ -112,101 +79,15 @@ export interface ResolvedTheme {
   key: ThemeKey;
   url: string;
   reason: string;
+  assetFile: string;
+  assetSource: SkinAssetSource;
+  platform: PlatformLabel;
+  permissionStatus: PermissionState | 'unsupported' | 'unknown';
 }
 
 export interface ResolveOptions {
   geolocationTimeoutMs?: number;
   forceNoGeo?: boolean;
-}
-
-/** Returns true if the given URL responds with HTTP 2xx (file exists). */
-export async function existsHead(url: string): Promise<boolean> {
-  try {
-    const res = await fetch(url, { method: 'HEAD' });
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Attempts to fetch and parse `skins.json` from ASSETS_BASE.
- * Results are cached for MANIFEST_CACHE_TTL_MS to avoid repeated network requests.
- * Returns the manifest mapping or null on any failure.
- */
-export async function fetchManifest(): Promise<SkinsManifest | null> {
-  const now = Date.now();
-  if (_manifestCache && now - _manifestCache.fetchedAt < MANIFEST_CACHE_TTL_MS) {
-    return _manifestCache.data;
-  }
-  try {
-    const res = await fetch(`${ASSETS_BASE}skins.json`);
-    const data: SkinsManifest | null = res.ok ? (await res.json()) as SkinsManifest : null;
-    _manifestCache = { data, fetchedAt: now };
-    return data;
-  } catch {
-    _manifestCache = { data: null, fetchedAt: now };
-    return null;
-  }
-}
-
-/**
- * Resolves the asset URL for a key using a manifest entry.
- * Returns the URL if the manifest contains a filename for the key and that
- * file responds to a HEAD request; otherwise returns null.
- */
-export async function resolveAssetForKeyWithManifest(
-  key: ThemeKey,
-  manifest: SkinsManifest,
-): Promise<string | null> {
-  const filename = manifest[key];
-  if (!filename) return null;
-  // Reject filenames containing path separators or null bytes — a bare filename
-  // with no separators cannot cause path traversal regardless of encoding.
-  if (filename.includes('/') || filename.includes('\\') || filename.includes('\0')) {
-    console.warn('[backgroundTheme] manifest entry for', key, 'contains unsafe path; ignoring');
-    return null;
-  }
-  const url = `${ASSETS_BASE}${filename}`;
-  const ok = await existsHead(url);
-  if (ok) {
-    console.debug('[backgroundTheme] manifest hit for', key, '→', filename);
-    return url;
-  }
-  console.debug('[backgroundTheme] manifest entry for', key, '(', filename, ') returned 404; will probe');
-  return null;
-}
-
-/**
- * Resolves the asset URL for a key by probing CANDIDATES with HEAD requests.
- * All candidates are probed concurrently; the first hit in priority order wins.
- * Returns the first URL that exists, or the default fallback URL.
- */
-export async function resolveAssetForKeyByProbing(key: ThemeKey): Promise<string> {
-  const candidates = CANDIDATES[key] ?? [];
-  const urls = candidates.map((f) => `${ASSETS_BASE}${f}`);
-  const results = await Promise.all(urls.map((url) => existsHead(url)));
-  const hitIndex = results.indexOf(true);
-  if (hitIndex !== -1) {
-    const url = urls[hitIndex];
-    console.debug('[backgroundTheme] probe hit for', key, '→', candidates[hitIndex]);
-    return url;
-  }
-  const fallback = `${ASSETS_BASE}${DEFAULT_FILE}`;
-  console.debug('[backgroundTheme] no probe hit for', key, '; using default', DEFAULT_FILE);
-  return fallback;
-}
-
-/**
- * Resolves the final asset URL for a theme key.
- * Tries the manifest first, then probing, then the default.
- */
-async function resolveAssetUrl(key: ThemeKey, manifest: SkinsManifest | null): Promise<string> {
-  if (manifest) {
-    const url = await resolveAssetForKeyWithManifest(key, manifest);
-    if (url) return url;
-  }
-  return resolveAssetForKeyByProbing(key);
 }
 
 /** Wraps navigator.geolocation.getCurrentPosition in a Promise with timeout. */
@@ -239,19 +120,25 @@ async function fetchWeatherCode(lat: number, lon: number): Promise<number> {
 /** Returns true when the current date falls in the Dec 20 – Jan 1 holiday window. */
 function isHolidayWindow(date: Date): boolean {
   const month = date.getMonth() + 1; // 1-based
-  const day   = date.getDate();
+  const day = date.getDate();
   return (month === 12 && day >= 20) || (month === 1 && day === 1);
 }
 
 /** Picks the holiday sub-theme (Eve vs Day vs Night) within the window. */
 function holidayKey(date: Date): ThemeKey {
   const month = date.getMonth() + 1;
-  const day   = date.getDate();
-  const hour  = date.getHours();
+  const day = date.getDate();
+  const hour = date.getHours();
 
-  if (month === 12 && day === 24) return hour >= 18 ? 'xmasEve'   : 'xmasDay';
+  if (month === 12 && day === 24) return hour >= 18 ? 'xmasEve' : 'xmasDay';
   if (month === 12 && day === 25) return hour >= 18 ? 'xmasNight' : 'xmasDay';
   return hour >= 18 ? 'xmasNight' : 'xmasDay';
+}
+
+function logBackgroundResolution(details: Record<string, unknown>): void {
+  if (import.meta.env.DEV) {
+    console.info('[backgroundTheme] resolution', details);
+  }
 }
 
 /**
@@ -262,60 +149,92 @@ function holidayKey(date: Date): ThemeKey {
  *   2. Geolocation → Open-Meteo weather code → theme key
  *   3. Time-of-day fallback
  *
- * For each resolved theme key the asset URL is determined by:
- *   a. skins.json manifest (if present and the file exists)
- *   b. Probing CANDIDATES with HEAD requests
- *   c. DEFAULT_FILE fallback
+ * The selected theme key is resolved against the shared skin registry and,
+ * if needed, falls back to the binary day/night background for the current
+ * local time so the app never renders with an empty background.
  */
 export async function resolveTheme(
   { geolocationTimeoutMs = 7000, forceNoGeo = false }: ResolveOptions = {},
 ): Promise<ResolvedTheme> {
   const now = new Date();
+  const platform = getPlatformLabel();
+  const permissionStatus = await getGeolocationPermissionStatus();
+  const timeKey = timeOfDayKey(now);
+  const binaryFallbackKey = getBinaryFallbackKey(now);
 
-  // Fetch manifest once; failures are silently ignored
-  const manifest = await fetchManifest();
-  if (manifest) {
-    console.debug('[backgroundTheme] skins.json manifest loaded');
-  } else {
-    console.debug('[backgroundTheme] skins.json not available; will probe candidates');
-  }
+  let selectedKey: ThemeKey;
+  let reason: string;
+  let coordinates: { latitude: number; longitude: number } | null = null;
+  let locationError: string | null = null;
+  let weatherCode: number | null = null;
+  let weatherKey: ThemeKey | null = null;
 
   // 1. Holiday override
   if (isHolidayWindow(now)) {
-    const key = holidayKey(now);
-    const url = await resolveAssetUrl(key, manifest);
-    console.info('[backgroundTheme] Holiday override →', key, url);
-    return { key, url, reason: 'holiday' };
-  }
-
-  // 2. Geolocation + weather
-  if (!forceNoGeo && typeof navigator !== 'undefined') {
+    selectedKey = holidayKey(now);
+    reason = 'holiday';
+  } else if (!forceNoGeo && typeof navigator !== 'undefined' && navigator.geolocation && permissionStatus !== 'denied') {
+    // 2. Geolocation + weather
     try {
       const position = await getPosition(geolocationTimeoutMs);
       const { latitude, longitude } = position.coords;
-      console.debug('[backgroundTheme] Got position', latitude, longitude);
-      const code = await fetchWeatherCode(latitude, longitude);
-      console.debug('[backgroundTheme] weathercode', code);
-      const weatherKey = mapWeatherCodeToTheme(code);
+      coordinates = { latitude, longitude };
+      weatherCode = await fetchWeatherCode(latitude, longitude);
+      weatherKey = mapWeatherCodeToTheme(weatherCode);
+
       if (weatherKey) {
-        const url = await resolveAssetUrl(weatherKey, manifest);
-        console.info('[backgroundTheme] Weather theme →', weatherKey, `(code ${code})`, url);
-        return { key: weatherKey, url, reason: `weather:${code}` };
+        selectedKey = weatherKey;
+        reason = `weather:${weatherCode}`;
+      } else {
+        // Clear/overcast: use the local time bucket.
+        selectedKey = timeKey;
+        reason = `weather:${weatherCode}:timeofday`;
       }
-      // Clear/overcast — fall through to time-of-day but note the source
-      const todKey = timeOfDayKey(now);
-      const url = await resolveAssetUrl(todKey, manifest);
-      console.info('[backgroundTheme] Clear/overcast; time-of-day →', todKey, url);
-      return { key: todKey, url, reason: `weather:${code}:timeofday` };
     } catch (err) {
-      // Geo or network failure — fall through to time-of-day
-      console.debug('[backgroundTheme] geo/weather unavailable:', err);
+      locationError = err instanceof Error ? err.message : String(err);
+      selectedKey = binaryFallbackKey;
+      reason = permissionStatus === 'denied' ? 'fallback:permission-denied' : 'fallback:location';
     }
+  } else {
+    // No usable location signal: fall back to a guaranteed day/night asset.
+    locationError = forceNoGeo
+      ? 'forceNoGeo'
+      : permissionStatus === 'denied'
+        ? 'permission denied'
+        : 'geolocation unavailable';
+    selectedKey = binaryFallbackKey;
+    reason = 'fallback:location';
   }
 
-  // 3. Time-of-day fallback
-  const key = timeOfDayKey(now);
-  const url = await resolveAssetUrl(key, manifest);
-  console.info('[backgroundTheme] Time-of-day fallback →', key, url);
-  return { key, url, reason: 'timeofday' };
+  const resolvedAsset = resolveSkinAsset(selectedKey, binaryFallbackKey);
+  const resolvedReason = resolvedAsset.key === selectedKey ? reason : `${reason}:asset-fallback:${resolvedAsset.key}`;
+
+  logBackgroundResolution({
+    platform,
+    permissionStatus,
+    coordinates,
+    locationError,
+    weatherCode,
+    weatherKey,
+    timeKey,
+    binaryFallbackKey,
+    selectedKey,
+    resolvedKey: resolvedAsset.key,
+    selectedAssetFile: resolvedAsset.file,
+    selectedAssetSource: resolvedAsset.source,
+    selectedAssetUrl: resolvedAsset.url,
+    reason: resolvedReason,
+  });
+
+  return {
+    key: resolvedAsset.key,
+    url: resolvedAsset.url,
+    reason: resolvedReason,
+    assetFile: resolvedAsset.file,
+    assetSource: resolvedAsset.source,
+    platform,
+    permissionStatus,
+  };
 }
+
+export type { ThemeKey } from './skinAssets';

--- a/src/utils/skinAssets.ts
+++ b/src/utils/skinAssets.ts
@@ -74,14 +74,14 @@ function resolveSkinAssetWithoutFallback(key: ThemeKey): SkinAssetResolution | n
   const candidates = unique([entry.canonicalFile, ...(entry.aliases ?? [])]);
 
   for (const file of candidates) {
-    const url = resolveSkinAssetPath(file);
+    const url = SKIN_URL_BY_FILENAME.get(file) ?? null;
     if (url) {
       return {
         key,
         label: entry.label,
         file,
         url,
-        source: SKIN_URL_BY_FILENAME.has(file) ? 'bundled' : 'public',
+        source: 'bundled',
         candidates,
       };
     }
@@ -116,8 +116,8 @@ export function resolveSkinAsset(key: ThemeKey, fallbackKey?: ThemeKey): SkinAss
     key: fallbackKey ?? key,
     label: entry.label,
     file,
-    url: buildPublicSkinUrl(file),
-    source: 'public',
+    url: resolveSkinAssetPath(file),
+    source: SKIN_URL_BY_FILENAME.has(file) ? 'bundled' : 'public',
     candidates,
   };
 }

--- a/src/utils/skinAssets.ts
+++ b/src/utils/skinAssets.ts
@@ -1,0 +1,150 @@
+import { Capacitor } from '@capacitor/core';
+import skinRegistry from '../data/skinRegistry.json';
+
+export type ThemeKey =
+  | 'sunrise'
+  | 'day'
+  | 'sunset'
+  | 'night'
+  | 'rain'
+  | 'snow'
+  | 'snowday'
+  | 'thunderstorm'
+  | 'xmasDay'
+  | 'xmasEve'
+  | 'xmasNight';
+
+export type PlatformLabel = 'web' | 'ios' | 'android';
+export type SkinAssetSource = 'bundled' | 'public';
+
+export interface SkinRegistryEntry {
+  label: string;
+  canonicalFile: string;
+  aliases?: string[];
+}
+
+export type SkinRegistry = Record<ThemeKey, SkinRegistryEntry>;
+
+export interface SkinAssetResolution {
+  key: ThemeKey;
+  label: string;
+  file: string;
+  url: string;
+  source: SkinAssetSource;
+  candidates: string[];
+}
+
+export const SKIN_REGISTRY = skinRegistry as SkinRegistry;
+
+const SKIN_ASSET_MODULES = import.meta.glob(
+  '../../public/assets/skins/*.{png,jpg,jpeg,webp,avif,gif,svg,wp2}',
+  {
+    eager: true,
+    import: 'default',
+  },
+) as Record<string, string>;
+
+const SKIN_URL_BY_FILENAME = new Map<string, string>(
+  Object.entries(SKIN_ASSET_MODULES).map(([assetPath, url]) => [
+    assetPath.split('/').pop() ?? assetPath,
+    url,
+  ]),
+);
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}
+
+function getRegistryEntry(key: ThemeKey): SkinRegistryEntry {
+  return SKIN_REGISTRY[key];
+}
+
+function buildPublicSkinUrl(filename: string): string {
+  const base = import.meta.env.BASE_URL ?? '/';
+  const prefix = base.endsWith('/') ? base : `${base}/`;
+  return `${prefix}assets/skins/${filename}`;
+}
+
+function resolveBundledSkinUrl(filename: string): string | null {
+  return SKIN_URL_BY_FILENAME.get(filename) ?? null;
+}
+
+function resolveSkinAssetWithoutFallback(key: ThemeKey): SkinAssetResolution | null {
+  const entry = getRegistryEntry(key);
+  const candidates = unique([entry.canonicalFile, ...(entry.aliases ?? [])]);
+
+  for (const file of candidates) {
+    const url = resolveBundledSkinUrl(file);
+    if (url) {
+      return {
+        key,
+        label: entry.label,
+        file,
+        url,
+        source: 'bundled',
+        candidates,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function getSkinCandidates(key: ThemeKey): string[] {
+  const entry = getRegistryEntry(key);
+  return unique([entry.canonicalFile, ...(entry.aliases ?? [])]);
+}
+
+export function resolveSkinAsset(key: ThemeKey, fallbackKey?: ThemeKey): SkinAssetResolution {
+  const primary = resolveSkinAssetWithoutFallback(key);
+  if (primary) {
+    return primary;
+  }
+
+  if (fallbackKey && fallbackKey !== key) {
+    const fallback = resolveSkinAssetWithoutFallback(fallbackKey);
+    if (fallback) {
+      return fallback;
+    }
+  }
+
+  const entry = getRegistryEntry(fallbackKey ?? key);
+  const candidates = unique([entry.canonicalFile, ...(entry.aliases ?? [])]);
+  const file = candidates[0] ?? `${fallbackKey ?? key}.png`;
+
+  return {
+    key: fallbackKey ?? key,
+    label: entry.label,
+    file,
+    url: buildPublicSkinUrl(file),
+    source: 'public',
+    candidates,
+  };
+}
+
+export function getPlatformLabel(): PlatformLabel {
+  if (Capacitor.isNativePlatform()) {
+    const platform = Capacitor.getPlatform();
+    return platform === 'ios' || platform === 'android' ? platform : 'web';
+  }
+
+  return 'web';
+}
+
+export async function getGeolocationPermissionStatus(): Promise<PermissionState | 'unsupported' | 'unknown'> {
+  if (typeof navigator === 'undefined' || !navigator.permissions?.query) {
+    return 'unsupported';
+  }
+
+  try {
+    const status = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
+    return status.state;
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function getBinaryFallbackKey(date: Date): Extract<ThemeKey, 'day' | 'night'> {
+  const hour = date.getHours();
+  return hour >= 6 && hour < 18 ? 'day' : 'night';
+}

--- a/src/utils/skinAssets.ts
+++ b/src/utils/skinAssets.ts
@@ -16,6 +16,7 @@ export type ThemeKey =
 
 export type PlatformLabel = 'web' | 'ios' | 'android';
 export type SkinAssetSource = 'bundled' | 'public';
+export type GeolocationPermissionStatus = PermissionState | 'denied' | 'unsupported' | 'unknown';
 
 export interface SkinRegistryEntry {
   label: string;
@@ -131,14 +132,14 @@ export function getPlatformLabel(): PlatformLabel {
   return 'web';
 }
 
-export async function getGeolocationPermissionStatus(): Promise<PermissionState | 'unsupported' | 'unknown'> {
+export async function getGeolocationPermissionStatus(): Promise<GeolocationPermissionStatus> {
   if (typeof navigator === 'undefined' || !navigator.permissions?.query) {
     return 'unsupported';
   }
 
   try {
     const status = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
-    return status.state;
+    return status.state as GeolocationPermissionStatus;
   } catch {
     return 'unknown';
   }

--- a/src/utils/skinAssets.ts
+++ b/src/utils/skinAssets.ts
@@ -65,8 +65,8 @@ function buildPublicSkinUrl(filename: string): string {
   return `${prefix}assets/skins/${filename}`;
 }
 
-function resolveBundledSkinUrl(filename: string): string | null {
-  return SKIN_URL_BY_FILENAME.get(filename) ?? null;
+export function resolveSkinAssetPath(filename: string): string {
+  return SKIN_URL_BY_FILENAME.get(filename) ?? buildPublicSkinUrl(filename);
 }
 
 function resolveSkinAssetWithoutFallback(key: ThemeKey): SkinAssetResolution | null {
@@ -74,14 +74,14 @@ function resolveSkinAssetWithoutFallback(key: ThemeKey): SkinAssetResolution | n
   const candidates = unique([entry.canonicalFile, ...(entry.aliases ?? [])]);
 
   for (const file of candidates) {
-    const url = resolveBundledSkinUrl(file);
+    const url = resolveSkinAssetPath(file);
     if (url) {
       return {
         key,
         label: entry.label,
         file,
         url,
-        source: 'bundled',
+        source: SKIN_URL_BY_FILENAME.has(file) ? 'bundled' : 'public',
         candidates,
       };
     }


### PR DESCRIPTION
## Summary
- Add a shared skin registry and native-safe resolver for dynamic backgrounds
- Keep weather/time backgrounds working on web while bundling assets for Capacitor iOS/Android
- Align skin scripts and manifest generation to the same canonical filenames
- Add safe day/night fallback logging and emergency fallback behavior

## Notes
- Browser behavior should remain unchanged
- Native shells should now resolve backgrounds from bundled assets instead of browser-only public paths

## Verification
- Simulator verification still needs to be completed on a Mac/Xcode host
