### PR TITLE
[codex] tighten minigame top safe area

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -10,6 +10,8 @@
   --minigame-safe-padding-right: calc(var(--minigame-safe-right) + clamp(10px, 2.6vw, 18px));
   --minigame-safe-padding-bottom: calc(var(--minigame-safe-bottom) + clamp(10px, 2.6vw, 18px));
   --minigame-safe-padding-left: calc(var(--minigame-safe-left) + clamp(10px, 2.6vw, 18px));
+  --minigame-stage-top-gap: clamp(56px, 12vh, 92px);
+  --minigame-stage-top-padding: calc(var(--minigame-safe-top) + var(--minigame-stage-top-gap));
   --safe-top: var(--minigame-safe-top);
   --safe-right: var(--minigame-safe-right);
   --safe-bottom: var(--minigame-safe-bottom);
@@ -35,7 +37,7 @@
   max-width: 32rem;
   max-height: 100dvh;
   padding:
-    var(--minigame-safe-padding-top)
+    var(--minigame-stage-top-padding)
     var(--minigame-safe-padding-right)
     var(--minigame-safe-padding-bottom)
     var(--minigame-safe-padding-left);
@@ -89,19 +91,19 @@
 
 .minigame-host-playing > .pp {
   padding:
-    var(--minigame-safe-padding-top)
+    var(--minigame-stage-top-padding)
     var(--minigame-safe-padding-right)
     var(--minigame-safe-padding-bottom)
     var(--minigame-safe-padding-left);
 }
 
 .minigame-host-playing > .pp .pp__card {
-  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .qtr {
   padding:
-    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-stage-top-padding))
     calc(16px + var(--minigame-safe-right))
     calc(16px + var(--minigame-safe-bottom))
     calc(16px + var(--minigame-safe-left));
@@ -109,7 +111,7 @@
 
 .minigame-host-playing > .qtr-canvas {
   padding:
-    calc(12px + var(--minigame-safe-top))
+    calc(12px + var(--minigame-stage-top-padding))
     calc(12px + var(--minigame-safe-right))
     calc(12px + var(--minigame-safe-bottom))
     calc(12px + var(--minigame-safe-left));
@@ -118,13 +120,13 @@
 .minigame-host-playing > .qtr-canvas .qtr-canvas__card {
   max-height: min(
     760px,
-    calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom) - 24px)
+    calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom) - 24px)
   );
 }
 
 .minigame-host-playing > .td {
   padding:
-    calc(12px + var(--minigame-safe-top))
+    calc(12px + var(--minigame-stage-top-padding))
     calc(12px + var(--minigame-safe-right))
     calc(12px + var(--minigame-safe-bottom))
     calc(12px + var(--minigame-safe-left));
@@ -132,44 +134,44 @@
 
 .minigame-host-playing > .bbl {
   padding:
-    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-stage-top-padding))
     calc(16px + var(--minigame-safe-right))
     calc(16px + var(--minigame-safe-bottom))
     calc(16px + var(--minigame-safe-left));
 }
 
 .minigame-host-playing > .bbl .bbl__card {
-  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .tbg {
   padding:
-    calc(16px + var(--minigame-safe-top))
+    calc(16px + var(--minigame-stage-top-padding))
     calc(16px + var(--minigame-safe-right))
     calc(16px + var(--minigame-safe-bottom))
     calc(16px + var(--minigame-safe-left));
 }
 
 .minigame-host-playing > .tbg .tbg__card {
-  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .snake-root {
   padding:
-    var(--minigame-safe-padding-top)
+    var(--minigame-stage-top-padding)
     var(--minigame-safe-padding-right)
     var(--minigame-safe-padding-bottom)
     var(--minigame-safe-padding-left);
 }
 
 .minigame-host-playing > .snake-root .snake-phone {
-  height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
-  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .cm {
   padding:
-    calc(12px + var(--minigame-safe-top))
+    calc(12px + var(--minigame-stage-top-padding))
     calc(8px + var(--minigame-safe-right))
     calc(20px + var(--minigame-safe-bottom))
     calc(8px + var(--minigame-safe-left));
@@ -177,7 +179,7 @@
 
 .minigame-host-playing > .tilt-labyrinth-host {
   padding:
-    calc(8px + var(--minigame-safe-top))
+    calc(8px + var(--minigame-stage-top-padding))
     calc(8px + var(--minigame-safe-right))
     calc(16px + var(--minigame-safe-bottom))
     calc(8px + var(--minigame-safe-left));
@@ -185,14 +187,14 @@
 
 .minigame-host-playing > .mc-host {
   padding:
-    calc(14px + var(--minigame-safe-top))
+    calc(14px + var(--minigame-stage-top-padding))
     calc(10px + var(--minigame-safe-right))
     calc(24px + var(--minigame-safe-bottom))
     calc(10px + var(--minigame-safe-left));
 }
 
 .minigame-host-playing > .ta-root {
-  padding-top: calc(12px + var(--minigame-safe-top));
+  padding-top: calc(12px + var(--minigame-stage-top-padding));
   padding-right: calc(16px + var(--minigame-safe-right));
   padding-bottom: calc(12px + var(--minigame-safe-bottom));
   padding-left: calc(16px + var(--minigame-safe-left));
@@ -201,7 +203,7 @@
 
 .minigame-host-playing > .minesweeps {
   padding:
-    calc(1rem + var(--minigame-safe-top))
+    calc(1rem + var(--minigame-stage-top-padding))
     calc(1rem + var(--minigame-safe-right))
     calc(1rem + var(--minigame-safe-bottom))
     calc(1rem + var(--minigame-safe-left));
@@ -210,7 +212,7 @@
 
 .minigame-host-playing > .grid-of-luck {
   padding:
-    calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-top))
+    calc(clamp(16px, 3vw, 28px) + var(--minigame-stage-top-padding))
     calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-right))
     calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-bottom))
     calc(clamp(16px, 3vw, 28px) + var(--minigame-safe-left));
@@ -219,7 +221,7 @@
 
 .minigame-host-playing > .number-trivia {
   padding:
-    calc(var(--minigame-safe-top) + 72px)
+    calc(var(--minigame-stage-top-padding) + 72px)
     max(16px, calc(var(--minigame-safe-right) + 16px))
     calc(var(--minigame-safe-bottom) + 24px)
     max(16px, calc(var(--minigame-safe-left) + 16px));
@@ -227,7 +229,7 @@
 
 .minigame-host-playing > .capitalization {
   padding:
-    calc(var(--minigame-safe-top) + 72px)
+    calc(var(--minigame-stage-top-padding) + 72px)
     max(16px, calc(var(--minigame-safe-right) + 16px))
     calc(var(--minigame-safe-bottom) + 24px)
     max(16px, calc(var(--minigame-safe-left) + 16px));
@@ -235,7 +237,7 @@
 
 .minigame-host-playing > .chain-of-greed .chain-of-greed__shell {
   padding:
-    calc(var(--minigame-safe-top) + 0.6rem)
+    calc(var(--minigame-stage-top-padding) + 0.6rem)
     calc(var(--minigame-safe-right) + 0.85rem)
     calc(var(--minigame-safe-bottom) + 0.4rem)
     calc(var(--minigame-safe-left) + 0.85rem);
@@ -244,14 +246,14 @@
 .minigame-host-results {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 12px;
   width: 100%;
   max-width: 460px;
-  height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
-  max-height: calc(100dvh - var(--minigame-safe-padding-top) - var(--minigame-safe-padding-bottom));
+  height: 100dvh;
+  max-height: 100dvh;
   padding:
-    var(--minigame-safe-padding-top)
+    var(--minigame-stage-top-padding)
     max(24px, var(--minigame-safe-padding-right))
     max(32px, var(--minigame-safe-padding-bottom))
     max(24px, var(--minigame-safe-padding-left));

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -31,12 +31,14 @@ describe('safe-area layout styles', () => {
       readFileSync(resolve(process.cwd(), 'src/components/MinigameHost/MinigameHost.css'), 'utf8'),
     );
 
-    expect(globalCss).toContain('--safe-area-inset-top: env(safe-area-inset-top, 0px);');
-    expect(globalCss).toContain('--safe-area-inset-left: env(safe-area-inset-left, 0px);');
-    expect(globalCss).toContain('--safe-area-inset-right: env(safe-area-inset-right, 0px);');
+    expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);');
+    expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
+    expect(globalCss).toContain('--safe-left: env(safe-area-inset-left, 0px);');
+    expect(globalCss).toContain('--safe-right: env(safe-area-inset-right, 0px);');
+    expect(globalCss).toContain('--safe-area-inset-top: var(--safe-top);');
     expect(globalCss).toContain('--app-safe-area-top-fallback: 0px;');
     expect(globalCss).toContain(
-      '--app-safe-area-top: max(var(--app-safe-area-top-fallback), var(--safe-area-inset-top));',
+      '--app-safe-area-top: max(var(--app-safe-area-top-fallback), var(--safe-top));',
     );
     expect(globalCss).toContain(
       '--app-safe-area-top-extra: max(0px, calc(var(--app-safe-area-top) - 16px));',
@@ -63,16 +65,16 @@ describe('safe-area layout styles', () => {
       '--floating-corner-top-offset: max( var(--floating-corner-top-base), calc(var(--app-safe-area-top) + var(--floating-corner-top-safe-padding)) );',
     );
     expect(globalCss).toContain(
-      '--floating-corner-left-offset: max( var(--floating-corner-left-base), calc(var(--safe-area-inset-left) + var(--floating-corner-left-safe-padding)) );',
+      '--floating-corner-left-offset: max( var(--floating-corner-left-base), calc(var(--safe-left) + var(--floating-corner-left-safe-padding)) );',
     );
     expect(globalCss).toContain(
-      '--floating-corner-right-offset: max( var(--floating-corner-right-base), calc(var(--safe-area-inset-right) + var(--floating-corner-right-safe-padding)) );',
+      '--floating-corner-right-offset: max( var(--floating-corner-right-base), calc(var(--safe-right) + var(--floating-corner-right-safe-padding)) );',
     );
     expect(globalCss).toContain('html.is-capacitor,');
     expect(globalCss).toContain('html.is-chrome-android {');
     expect(globalCss).toContain('--app-safe-area-top-fallback: 16px;');
     expect(appShellCss).toContain('padding-top: var(--app-safe-area-top);');
-    expect(appShellCss).toContain('padding-bottom: var(--safe-area-inset-bottom);');
+    expect(appShellCss).toContain('padding-bottom: var(--safe-bottom);');
     expect(juryRevealCss).toContain('--floating-corner-top-base: 12px;');
     expect(juryRevealCss).toContain('top: var(--floating-corner-top-offset);');
     expect(juryRevealCss).toContain('right: var(--floating-corner-right-offset);');
@@ -82,6 +84,8 @@ describe('safe-area layout styles', () => {
     expect(evictionCss).toContain('left: var(--floating-corner-left-offset);');
     expect(minigameHostCss).toContain('--floating-corner-top-base: 12px;');
     expect(minigameHostCss).toContain('--floating-corner-right-base: 14px;');
+    expect(minigameHostCss).toContain('--minigame-stage-top-gap: clamp(56px, 12vh, 92px);');
+    expect(minigameHostCss).toContain('--minigame-stage-top-padding: calc(var(--minigame-safe-top) + var(--minigame-stage-top-gap));');
     expect(minigameHostCss).toContain('top: var(--floating-corner-top-offset);');
     expect(minigameHostCss).toContain('right: var(--floating-corner-right-offset);');
   });


### PR DESCRIPTION
## What changed
- Added one shared top-stage inset in `MinigameHost` so gameplay and results screens start below the iPhone status/camera area.
- Applied that inset consistently across the ready screen, playing state, and results state.
- Updated the layout regression test to lock the shared safe-area contract in place.

## Why
- Some minigames and result screens could drift upward into the iPhone service row.
- This makes the host enforce one global top boundary instead of letting each screen decide its own offset.

## Impact
- Minigames stay visually framed below the phone chrome for the entire game flow.
- Results screens follow the same rule, so the experience stays consistent from start to finish.
- Reduces the chance of future overlap regressions when new games are added.

## Checks
- `npm run typecheck`
- `npx vitest run tests/unit/layout/safeArea.styles.test.ts`