### PR TITLE
[codex] fix double elimination eviction reveal

### DIFF
--- a/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.tsx
+++ b/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.tsx
@@ -51,6 +51,8 @@ export interface AnimatedVoteResultsModalProps {
   nominees: VoteTally[];
   /** Pre-determined evictee; pass null to let the component detect ties. */
   evictee?: Player | null;
+  /** Optional list of evictee IDs for multi-eviction reveals such as double elimination. */
+  evicteeIds?: string[];
   onTiebreakerRequired?: (tiedNomineeIds: string[]) => void;
   publicTiebreak?: PublicEvictionTiebreakDisplay | null;
   onPublicTiebreakResolved?: (evicteeIds: string[]) => void;
@@ -128,6 +130,7 @@ function buildVoteSequence(tallies: VoteTally[]): string[] {
 export default function AnimatedVoteResultsModal({
   nominees,
   evictee: evicteeProp = null,
+  evicteeIds,
   onTiebreakerRequired,
   publicTiebreak = null,
   onPublicTiebreakResolved,
@@ -181,6 +184,11 @@ export default function AnimatedVoteResultsModal({
 
   const allRevealed = totalVotes === 0 || revealStep >= voteSequence.length;
   const isTied = tiedIds.length > 1;
+  const resolvedEvicteeIds = useMemo(() => {
+    if (evicteeIds && evicteeIds.length > 0) return new Set(evicteeIds);
+    return resolvedEvictee ? new Set([resolvedEvictee.id]) : new Set<string>();
+  }, [evicteeIds, resolvedEvictee]);
+  const showResolvedEvictees = variant === 'tv' ? allRevealed : outcomeVisible;
   const maxShownVotes = useMemo(
     () => Math.max(0, ...nominees.map((t) => displayedCounts[t.nominee.id] ?? 0)),
     [displayedCounts, nominees],
@@ -269,7 +277,7 @@ export default function AnimatedVoteResultsModal({
             <div className="avrm__tallies avrm__tallies--tv">
               {nominees.map((t, index) => {
                 const shown = displayedCounts[t.nominee.id] ?? 0;
-                const isEvictee = resolvedEvictee?.id === t.nominee.id;
+                const isEvictee = resolvedEvicteeIds.has(t.nominee.id);
                 const isPulsing = lastRevealedId === t.nominee.id;
                 const isLeading = outcomeVisible
                   ? isEvictee
@@ -287,7 +295,7 @@ export default function AnimatedVoteResultsModal({
                         'avrm__tally--visible',
                         'avrm__tally--tv',
                         nominees.length > 2 ? 'avrm__tally--tv-triple' : '',
-                        isEvictee && outcomeVisible ? 'avrm__tally--evictee' : '',
+                        isEvictee && showResolvedEvictees ? 'avrm__tally--evictee' : '',
                         isLeading ? 'avrm__tally--leading' : '',
                         isPulsing ? 'avrm__tally--pulse' : '',
                       ]
@@ -316,7 +324,7 @@ export default function AnimatedVoteResultsModal({
           <div className="avrm__tallies">
             {nominees.map((t) => {
               const shown = displayedCounts[t.nominee.id] ?? 0;
-              const isEvictee = resolvedEvictee?.id === t.nominee.id;
+              const isEvictee = resolvedEvicteeIds.has(t.nominee.id);
               const isPulsing = lastRevealedId === t.nominee.id;
               return (
                 <div
@@ -324,7 +332,7 @@ export default function AnimatedVoteResultsModal({
                   className={[
                     'avrm__tally',
                     'avrm__tally--visible',
-                    isEvictee && outcomeVisible ? 'avrm__tally--evictee' : '',
+                    isEvictee && showResolvedEvictees ? 'avrm__tally--evictee' : '',
                     isPulsing ? 'avrm__tally--pulse' : '',
                   ]
                     .filter(Boolean)

--- a/src/components/AnimatedVoteResultsModal/__tests__/AnimatedVoteResultsModal.test.tsx
+++ b/src/components/AnimatedVoteResultsModal/__tests__/AnimatedVoteResultsModal.test.tsx
@@ -221,4 +221,28 @@ describe('AnimatedVoteResultsModal public tie-break reveal', () => {
     expect(container.querySelector('.avrm__tv-duel-divider')).toBeNull();
     expect(container.querySelector('.avrm__commentary--tv')).toBeNull();
   });
+
+  it('highlights both evictees in the TV variant during a double elimination', async () => {
+    const { container } = render(
+      <AnimatedVoteResultsModal
+        nominees={[
+          { nominee: makePlayer('p1', 'Nominee 1'), voteCount: 0 },
+          { nominee: makePlayer('p2', 'Nominee 2'), voteCount: 0 },
+          { nominee: makePlayer('p3', 'Nominee 3'), voteCount: 0 },
+        ]}
+        evictee={makePlayer('p1', 'Nominee 1')}
+        evicteeIds={['p1', 'p2']}
+        onDone={vi.fn()}
+        revealIntervalMs={1}
+        postRevealDelayMs={1}
+        variant="tv"
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5);
+    });
+
+    expect(container.querySelectorAll('.avrm__tally--evictee')).toHaveLength(2);
+  });
 });

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -210,6 +210,7 @@ type TvZonePublicSaveReveal = {
 type TvZoneVoteResultsReveal = {
   nominees: VoteTally[];
   evictee?: Player | null;
+  evicteeIds?: string[];
   onTiebreakerRequired?: (tiedNomineeIds: string[]) => void;
   publicTiebreak?: PublicEvictionTiebreakDisplay | null;
   onPublicTiebreakResolved?: (evicteeIds: string[]) => void;
@@ -839,6 +840,7 @@ export default function TvZone(props: TvZoneProps) {
               <AnimatedVoteResultsModal
                 nominees={props.voteResultsReveal.nominees}
                 evictee={props.voteResultsReveal.evictee}
+                evicteeIds={props.voteResultsReveal.evicteeIds}
                 onTiebreakerRequired={props.voteResultsReveal.onTiebreakerRequired}
                 publicTiebreak={props.voteResultsReveal.publicTiebreak}
                 onPublicTiebreakResolved={props.voteResultsReveal.onPublicTiebreakResolved}

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -1721,6 +1721,14 @@ export default function GameScreen() {
         .filter((p) => game.voteResults && p.id in game.voteResults)
         .map((p) => ({ nominee: p, voteCount: game.voteResults![p.id] ?? 0 }))
     : []
+  const voteResultsEvicteeIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (game.pendingEviction?.evicteeId) ids.add(game.pendingEviction.evicteeId)
+    if (game.doubleEviction?.pendingSecondEviction?.evicteeId) {
+      ids.add(game.doubleEviction.pendingSecondEviction.evicteeId)
+    }
+    return [...ids]
+  }, [game.doubleEviction?.pendingSecondEviction?.evicteeId, game.pendingEviction?.evicteeId])
   // After dismissing vote results: show the eviction splash if one is pending,
   // otherwise advance the game phase directly.
   // When a tie-break is still pending (awaitingTieBreak), do not advance — the
@@ -2226,6 +2234,7 @@ export default function GameScreen() {
   const handleEvictionSplashDone = useCallback(() => {
     const evicteeId = game.pendingEviction?.evicteeId
     if (!evicteeId) return
+    const hasQueuedSecondEviction = Boolean(game.doubleEviction?.pendingSecondEviction)
     // Clear the overlay flag so AvatarTile returns to normal after the cinematic.
     dispatch(setEvictionOverlay(null))
     // Capture the phase before dispatch since finalizePendingEviction may change it.
@@ -2234,6 +2243,9 @@ export default function GameScreen() {
     if (isFinal4) {
       // Final-4: advance the local stage machine; no battle back check needed.
       setFinal4Stage('done')
+    } else if (hasQueuedSecondEviction) {
+      // Keep the second double-eviction cinematic in the same flow so it gets
+      // its own overlay mount and eviction stinger before the week advances.
     } else {
       const activated =
         dispatch(tryActivatePendingForcedBattleBack()) ||
@@ -2923,6 +2935,7 @@ export default function GameScreen() {
           voteResultsReveal={{
             nominees: voteResultsTallies,
             evictee: voteResultsEvictee,
+            evicteeIds: voteResultsEvicteeIds,
             onTiebreakerRequired: handleTiebreakerRequired,
             publicTiebreak: publicEvictionTiebreak,
             onPublicTiebreakResolved: handlePublicEvictionTiebreakResolved,

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -2267,7 +2267,7 @@ export default function GameScreen() {
         setShowVoteBreakdownPrompt(true)
       }, POST_EVICTION_VOTE_BREAKDOWN_PROMPT_DELAY_MS)
     }
-  }, [dispatch, game.pendingEviction, game.phase, setFinal4Stage])
+  }, [dispatch, game.doubleEviction?.pendingSecondEviction, game.pendingEviction, game.phase, setFinal4Stage])
 
 
   const battleBack = game.battleBack

--- a/tests/unit/sound/soundMiddleware.test.ts
+++ b/tests/unit/sound/soundMiddleware.test.ts
@@ -149,6 +149,18 @@ describe('soundMiddleware eviction and finale SFX', () => {
     expect(releaseBgmMock).not.toHaveBeenCalled();
   });
 
+  it('replays the eviction stinger for a second eviction after the first overlay clears', () => {
+    const { store } = makeTestStore();
+
+    store.dispatch({ type: 'game/setEvictionOverlay', payload: 'player-1' });
+    store.dispatch({ type: 'game/setEvictionOverlay', payload: null });
+    store.dispatch({ type: 'game/setEvictionOverlay', payload: 'player-2' });
+
+    expect(playMock).toHaveBeenCalledTimes(2);
+    expect(playMock).toHaveBeenNthCalledWith(1, 'player:evicted');
+    expect(playMock).toHaveBeenNthCalledWith(2, 'player:evicted');
+  });
+
   it('suppresses eviction SFX for a Battle Back return overlay', () => {
     const { store } = makeTestStore();
     store.dispatch({


### PR DESCRIPTION
## Root cause
The faux-TV vote-results reveal only accepted a single evictee, so during double elimination it styled only the top vote-getter as eliminated even when a second queued eviction existed. Separately, the game advanced through the normal post-eviction path immediately after the first double-elimination cinematic, which could interrupt the second cinematic's clean overlay cycle.

## What changed
- Passed both queued double-elimination evictee IDs into the TV vote-results reveal so both eliminated avatars get the red eliminated styling.
- Made the TV vote-results component understand multi-eviction outcomes while preserving the existing single-eviction behavior.
- Kept the second double-elimination cinematic in the same flow before advancing the week so it gets its own full eviction overlay/stinger cycle.
- Added focused regressions for the double-elimination TV styling and back-to-back eviction stingers.

## Files changed
- `src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.tsx`
- `src/components/AnimatedVoteResultsModal/__tests__/AnimatedVoteResultsModal.test.tsx`
- `src/components/ui/TvZone.tsx`
- `src/screens/GameScreen/GameScreen.tsx`
- `tests/unit/sound/soundMiddleware.test.ts`

## Testing done
- `npm test -- src/components/AnimatedVoteResultsModal/__tests__/AnimatedVoteResultsModal.test.tsx tests/unit/sound/soundMiddleware.test.ts`
