### PR TITLE
[codex] Fix tutorial spotlight centering (#1016)

### DIFF
--- a/src/components/FloatingActionBar/ConfessionalSpotlightOverlay.tsx
+++ b/src/components/FloatingActionBar/ConfessionalSpotlightOverlay.tsx
@@ -29,6 +29,28 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
+function areSpotlightRectsEqual(previousRect: SpotlightRect | null, nextRect: SpotlightRect | null) {
+  return (
+    previousRect?.left === nextRect?.left &&
+    previousRect?.top === nextRect?.top &&
+    previousRect?.width === nextRect?.width &&
+    previousRect?.height === nextRect?.height
+  );
+}
+
+function measureSpotlightRect(element: HTMLElement): SpotlightRect {
+  const rect = element.getBoundingClientRect();
+  const viewportOffsetLeft = window.visualViewport?.offsetLeft ?? 0;
+  const viewportOffsetTop = window.visualViewport?.offsetTop ?? 0;
+
+  return {
+    left: rect.left + viewportOffsetLeft,
+    top: rect.top + viewportOffsetTop,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
 export default function ConfessionalSpotlightOverlay({
   active,
   targetRef,
@@ -40,30 +62,24 @@ export default function ConfessionalSpotlightOverlay({
   useLayoutEffect(() => {
     if (!active) return;
 
+    let animationFrameId = 0;
+
     const updateTargetRect = () => {
       const element = targetRef.current;
       if (!element) {
-        setTargetRect(null);
+        setTargetRect((previousRect) => (previousRect === null ? previousRect : null));
         return;
       }
-      const rect = element.getBoundingClientRect();
+
+      const rect = measureSpotlightRect(element);
       setTargetRect((previousRect) => {
-        if (
-          previousRect &&
-          previousRect.left === rect.left &&
-          previousRect.top === rect.top &&
-          previousRect.width === rect.width &&
-          previousRect.height === rect.height
-        ) {
+        if (areSpotlightRectsEqual(previousRect, rect)) {
           return previousRect;
         }
-        return {
-          left: rect.left,
-          top: rect.top,
-          width: rect.width,
-          height: rect.height,
-        };
+        return rect;
       });
+
+      animationFrameId = window.requestAnimationFrame(updateTargetRect);
     };
 
     updateTargetRect();
@@ -81,6 +97,7 @@ export default function ConfessionalSpotlightOverlay({
       resizeObserver?.observe(observedElement);
     }
     return () => {
+      window.cancelAnimationFrame(animationFrameId);
       window.removeEventListener('resize', updateTargetRect);
       window.removeEventListener('orientationchange', updateTargetRect);
       window.removeEventListener('scroll', updateTargetRect, true);

--- a/src/components/FloatingActionBar/__tests__/ConfessionalSpotlightOverlay.test.tsx
+++ b/src/components/FloatingActionBar/__tests__/ConfessionalSpotlightOverlay.test.tsx
@@ -36,6 +36,8 @@ describe('ConfessionalSpotlightOverlay', () => {
       configurable: true,
       value: {
         addEventListener: vi.fn(),
+        offsetLeft: 0,
+        offsetTop: 0,
         removeEventListener: vi.fn(),
       },
     });
@@ -129,6 +131,87 @@ describe('ConfessionalSpotlightOverlay', () => {
       expect(updatedOverlayLayer.style.getPropertyValue('--confessional-spotlight-x')).toBe('192px');
       expect(updatedOverlayLayer.style.getPropertyValue('--confessional-spotlight-y')).toBe('332px');
     });
+  });
+
+  it('tracks target movement across animation frames without waiting for resize events', async () => {
+    const target = document.createElement('button');
+    const targetRef = createRef<HTMLElement>();
+    targetRef.current = target;
+
+    let rect = {
+      left: 24,
+      top: 40,
+      width: 20,
+      height: 20,
+      right: 44,
+      bottom: 60,
+    };
+    target.getBoundingClientRect = () => rect as DOMRect;
+
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    render(<ConfessionalSpotlightOverlay active targetRef={targetRef} onComplete={() => {}} />);
+
+    rect = {
+      left: 164,
+      top: 210,
+      width: 20,
+      height: 20,
+      right: 184,
+      bottom: 230,
+    };
+
+    await act(async () => {
+      const nextFrame = animationFrames.shift();
+      nextFrame?.(16);
+    });
+
+    await waitFor(() => {
+      const overlayLayer = screen
+        .getByTestId('confessional-spotlight')
+        .querySelector('.confessional-spotlight__overlay') as HTMLElement;
+      expect(overlayLayer.style.getPropertyValue('--confessional-spotlight-x')).toBe('174px');
+      expect(overlayLayer.style.getPropertyValue('--confessional-spotlight-y')).toBe('220px');
+    });
+  });
+
+  it('accounts for visual viewport offsets when positioning the fixed overlay', () => {
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: {
+        addEventListener: vi.fn(),
+        offsetLeft: 14,
+        offsetTop: 28,
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    const target = document.createElement('button');
+    const targetRef = createRef<HTMLElement>();
+    targetRef.current = target;
+    target.getBoundingClientRect = () =>
+      ({
+        left: 60,
+        top: 80,
+        width: 24,
+        height: 24,
+        right: 84,
+        bottom: 104,
+      }) as DOMRect;
+
+    render(<ConfessionalSpotlightOverlay active targetRef={targetRef} onComplete={() => {}} />);
+
+    const overlayLayer = screen
+      .getByTestId('confessional-spotlight')
+      .querySelector('.confessional-spotlight__overlay') as HTMLElement;
+
+    expect(overlayLayer.style.getPropertyValue('--confessional-spotlight-x')).toBe('86px');
+    expect(overlayLayer.style.getPropertyValue('--confessional-spotlight-y')).toBe('120px');
   });
 
   it('waits for the doubled spotlight duration before completing', () => {


### PR DESCRIPTION
## Summary
Fixes the reusable tutorial spotlight so its circle stays centered on the live target element instead of drifting when the target animates or when the visual viewport is offset.

## Root cause
The spotlight overlay measured its target once and then only refreshed on resize, scroll, orientation changes, or ResizeObserver callbacks. That missed movement caused by transforms or parent/container animation, so the fixed overlay could keep drawing around a stale center. It also used raw `getBoundingClientRect()` coordinates without accounting for `visualViewport` offsets, which can shift fixed overlays on some mobile layouts.

## Files changed
- `src/components/FloatingActionBar/ConfessionalSpotlightOverlay.tsx`
- `src/components/FloatingActionBar/__tests__/ConfessionalSpotlightOverlay.test.tsx`

## Testing done
- `npm test -- src/components/FloatingActionBar/__tests__/ConfessionalSpotlightOverlay.test.tsx`
- `npm run typecheck`

## Screens/components verified
- Confessional tutorial spotlight on the `GameControlDock` confessional icon
- TV announcement tutorial spotlight on the `TvAnnouncementOverlay` info button

## Notes
The change is intentionally scoped to spotlight measurement/rendering only. No tutorial copy, colors, animation timing, or unrelated behavior was changed.