### PR TITLE
[codex] Fix Democracia faux-TV results fit

### DIFF
--- a/src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.css
+++ b/src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.css
@@ -1,63 +1,75 @@
 .democracia-results {
   position: absolute;
   inset: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.875rem;
-  padding: 1rem;
   background:
     radial-gradient(circle at 50% 42%, rgba(251, 191, 36, 0.24), transparent 48%),
     linear-gradient(180deg, rgba(17, 24, 39, 0.96), rgba(10, 14, 24, 0.98));
   color: #fff7ed;
   text-align: center;
   z-index: 21;
+  overflow: hidden;
+}
+
+.democracia-results__safe-area {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding:
+    calc(clamp(0.55rem, 2.8vh, 1rem) + env(safe-area-inset-top, 0px))
+    calc(clamp(0.65rem, 2vw, 1rem) + env(safe-area-inset-right, 0px))
+    calc(clamp(0.55rem, 2.2vh, 0.9rem) + env(safe-area-inset-bottom, 0px))
+    calc(clamp(0.65rem, 2vw, 1rem) + env(safe-area-inset-left, 0px));
+  overflow: hidden;
+}
+
+.democracia-results__content {
+  width: min(100%, 32rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(0.45rem, 2vh, 0.875rem);
+  transform-origin: center center;
+  will-change: transform;
 }
 
 .democracia-results__badge {
   align-self: center;
-  padding: 0.3rem 0.75rem;
+  padding: 0.28rem 0.72rem;
   border-radius: 999px;
   background: rgba(239, 68, 68, 0.88);
   color: #fff;
-  font-size: 0.72rem;
+  font-size: clamp(0.62rem, 1.8vw, 0.72rem);
   font-weight: 800;
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
 .democracia-results__body {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: clamp(0.45rem, 1.6vh, 0.625rem);
   align-items: center;
-}
-
-.democracia-results__title {
-  margin: 0;
-  font-size: clamp(1.2rem, 4vw, 1.8rem);
-  font-weight: 900;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
 }
 
 .democracia-results__subtitle {
   margin: 0;
-  max-width: 32rem;
+  max-width: 28rem;
   color: rgba(255, 247, 237, 0.82);
-  font-size: 0.95rem;
-  line-height: 1.4;
+  font-size: clamp(0.8rem, 2.6vw, 0.95rem);
+  line-height: 1.35;
 }
 
 .democracia-results__participants {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-  width: min(100%, 32rem);
+  gap: clamp(0.5rem, 1.8vw, 0.75rem);
+  width: min(100%, 30rem);
 }
 
 .democracia-results__participants--solo {
-  grid-template-columns: minmax(0, 13rem);
+  grid-template-columns: minmax(0, 11.5rem);
   justify-content: center;
 }
 
@@ -69,21 +81,27 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.75rem 0.5rem;
+  min-width: 0;
+  gap: clamp(0.35rem, 1.2vh, 0.4rem);
+  padding: clamp(0.55rem, 2vh, 0.75rem) clamp(0.45rem, 1.8vw, 0.5rem);
   border: 1px solid rgba(251, 191, 36, 0.28);
   border-radius: 1rem;
   background: rgba(17, 24, 39, 0.5);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
+.democracia-results__participant .pa--lg {
+  width: clamp(3.2rem, 9vw, 4rem);
+  height: clamp(3.2rem, 9vw, 4rem);
+}
+
 .democracia-results__participant-name {
-  font-size: 0.92rem;
+  font-size: clamp(0.82rem, 2.2vw, 0.92rem);
   font-weight: 700;
 }
 
 .democracia-results__participant-count {
   color: #fcd34d;
-  font-size: 0.82rem;
+  font-size: clamp(0.74rem, 2vw, 0.82rem);
   font-weight: 700;
 }

--- a/src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.tsx
+++ b/src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from 'react';
 import type { Player } from '../../../types';
 import PlayerAvatar from '../../PlayerAvatar/PlayerAvatar';
 import './DemocraciaResultsReveal.css';
@@ -27,10 +27,67 @@ export default function DemocraciaResultsReveal({
   onDone,
   countdownMs = DEFAULT_COUNTDOWN_MS,
 }: DemocraciaResultsRevealProps) {
+  const safeAreaRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [contentScale, setContentScale] = useState(1);
+
   useEffect(() => {
     const timeoutId = window.setTimeout(() => onDone(), countdownMs);
     return () => window.clearTimeout(timeoutId);
   }, [countdownMs, onDone]);
+
+  useLayoutEffect(() => {
+    const safeArea = safeAreaRef.current;
+    const content = contentRef.current;
+
+    if (!safeArea || !content) return;
+
+    let frameId = 0;
+
+    const recalculateScale = () => {
+      const availableWidth = safeArea.clientWidth;
+      const availableHeight = safeArea.clientHeight;
+      const contentWidth = content.scrollWidth;
+      const contentHeight = content.scrollHeight;
+
+      if (availableWidth <= 0 || availableHeight <= 0 || contentWidth <= 0 || contentHeight <= 0) {
+        setContentScale(1);
+        return;
+      }
+
+      const nextScale = Number(
+        Math.min(1, availableWidth / contentWidth, availableHeight / contentHeight).toFixed(4),
+      );
+
+      setContentScale((currentScale) => (
+        Math.abs(currentScale - nextScale) < 0.01 ? currentScale : nextScale
+      ));
+    };
+
+    const scheduleRecalculation = () => {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(recalculateScale);
+    };
+
+    scheduleRecalculation();
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        scheduleRecalculation();
+      });
+      resizeObserver.observe(safeArea);
+      resizeObserver.observe(content);
+    }
+
+    window.addEventListener('resize', scheduleRecalculation);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleRecalculation);
+    };
+  }, [mode, participants, subtitle, title]);
 
   const badgeLabel =
     mode === 'winner'
@@ -39,31 +96,39 @@ export default function DemocraciaResultsReveal({
         ? 'Tie'
         : 'Revote';
 
+  const contentStyle: CSSProperties = {
+    transform: `scale(${contentScale})`,
+  };
+
   return (
     <section className="democracia-results" aria-label="Democracia results">
-      <div className="democracia-results__badge">{badgeLabel}</div>
-      <div className="democracia-results__body">
-        <h2 className="democracia-results__title">{title}</h2>
-        <p className="democracia-results__subtitle">{subtitle}</p>
-        {participants.length > 0 && (
-          <div
-            className={[
-              'democracia-results__participants',
-              participants.length === 1 ? 'democracia-results__participants--solo' : '',
-              participants.length === 2 ? 'democracia-results__participants--pair' : '',
-            ].filter(Boolean).join(' ')}
-          >
-            {participants.map(({ player, voteCount }) => (
-              <article className="democracia-results__participant" key={player.id}>
-                <PlayerAvatar player={player} size="lg" showEvictedStyle={false} />
-                <span className="democracia-results__participant-name">{player.name}</span>
-                <span className="democracia-results__participant-count">
-                  {voteCount} vote{voteCount === 1 ? '' : 's'}
-                </span>
-              </article>
-            ))}
+      <div className="democracia-results__safe-area" ref={safeAreaRef}>
+        <div className="democracia-results__content" ref={contentRef} style={contentStyle}>
+          <div className="democracia-results__badge">{badgeLabel}</div>
+          <div className="democracia-results__body">
+            <h2 className="visually-hidden">{title}</h2>
+            <p className="democracia-results__subtitle">{subtitle}</p>
+            {participants.length > 0 && (
+              <div
+                className={[
+                  'democracia-results__participants',
+                  participants.length === 1 ? 'democracia-results__participants--solo' : '',
+                  participants.length === 2 ? 'democracia-results__participants--pair' : '',
+                ].filter(Boolean).join(' ')}
+              >
+                {participants.map(({ player, voteCount }) => (
+                  <article className="democracia-results__participant" key={player.id}>
+                    <PlayerAvatar player={player} size="lg" showEvictedStyle={false} />
+                    <span className="democracia-results__participant-name">{player.name}</span>
+                    <span className="democracia-results__participant-count">
+                      {voteCount} vote{voteCount === 1 ? '' : 's'}
+                    </span>
+                  </article>
+                ))}
+              </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
     </section>
   );

--- a/src/components/ui/DemocraciaResultsReveal/__tests__/DemocraciaResultsReveal.test.tsx
+++ b/src/components/ui/DemocraciaResultsReveal/__tests__/DemocraciaResultsReveal.test.tsx
@@ -1,0 +1,168 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DemocraciaResultsReveal from '../DemocraciaResultsReveal';
+import type { Player } from '../../../../types';
+
+type LayoutScenario = {
+  safeAreaWidth: number;
+  safeAreaHeight: number;
+  contentWidth: number;
+  contentHeight: number;
+};
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+const originalScrollWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
+const originalScrollHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollHeight');
+
+let layoutScenario: LayoutScenario;
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function makePlayer(id: string, name: string): Player {
+  return {
+    id,
+    name,
+    avatar: '🧑',
+    isUser: false,
+    status: 'active' as const,
+  };
+}
+
+describe('DemocraciaResultsReveal', () => {
+  beforeEach(() => {
+    layoutScenario = {
+      safeAreaWidth: 220,
+      safeAreaHeight: 180,
+      contentWidth: 320,
+      contentHeight: 360,
+    };
+
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        if (this.classList?.contains('democracia-results__safe-area')) {
+          return layoutScenario.safeAreaWidth;
+        }
+
+        return originalClientWidth?.get?.call(this) ?? 0;
+      },
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        if (this.classList?.contains('democracia-results__safe-area')) {
+          return layoutScenario.safeAreaHeight;
+        }
+
+        return originalClientHeight?.get?.call(this) ?? 0;
+      },
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get() {
+        if (this.classList?.contains('democracia-results__content')) {
+          return layoutScenario.contentWidth;
+        }
+
+        return originalScrollWidth?.get?.call(this) ?? 0;
+      },
+    });
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        if (this.classList?.contains('democracia-results__content')) {
+          return layoutScenario.contentHeight;
+        }
+
+        return originalScrollHeight?.get?.call(this) ?? 0;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    });
+
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    }
+
+    if (originalClientHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+    }
+
+    if (originalScrollWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
+    }
+
+    if (originalScrollHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+    }
+  });
+
+  it('scales the content to stay inside the faux-tv viewport bounds', async () => {
+    const { container } = render(
+      <DemocraciaResultsReveal
+        mode="tie"
+        title="TIED VOTE"
+        subtitle="Ash and Remy are tied at 3 votes."
+        participants={[
+          { player: makePlayer('p1', 'Ash'), voteCount: 3 },
+          { player: makePlayer('p2', 'Remy'), voteCount: 3 },
+        ]}
+        onDone={vi.fn()}
+        countdownMs={100000}
+      />,
+    );
+
+    const content = container.querySelector('.democracia-results__content');
+
+    await waitFor(() => {
+      expect(content).toHaveStyle({ transform: 'scale(0.5)' });
+    });
+  });
+
+  it('keeps the content at full scale when the viewport has enough room', async () => {
+    layoutScenario = {
+      safeAreaWidth: 480,
+      safeAreaHeight: 420,
+      contentWidth: 320,
+      contentHeight: 260,
+    };
+
+    const { container } = render(
+      <DemocraciaResultsReveal
+        mode="winner"
+        title="DEMOCRACIA WINNER"
+        subtitle="Remy wins the vote with 10 votes."
+        participants={[
+          { player: makePlayer('p2', 'Remy'), voteCount: 10 },
+        ]}
+        onDone={vi.fn()}
+        countdownMs={100000}
+      />,
+    );
+
+    const content = container.querySelector('.democracia-results__content');
+
+    await waitFor(() => {
+      expect(content).toHaveStyle({ transform: 'scale(1)' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1014 by making the Democracia faux-TV results layout fit inside the visible TV viewport without cropping.

## Root cause
The Democracia results overlay assumed it always had enough vertical room inside the faux-TV viewport. Its centered content stack used fixed-ish spacing plus a duplicated large heading under the red status pill, so winner/tie result cards could overflow the clipped TV viewport on shorter or narrower screens.

## What changed
- Added a viewport-fit wrapper in `src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.tsx` that measures the available faux-TV content area and scales the results content to fit when space is constrained.
- Updated `src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.css` to use safer responsive padding, tighter participant sizing, and safe-area-aware bounds within the faux-TV viewport.
- Removed the redundant visible title line under the red pill and kept the title accessible only to screen readers to conserve vertical space.
- Added focused coverage in `src/components/ui/DemocraciaResultsReveal/__tests__/DemocraciaResultsReveal.test.tsx` for the auto-fit scaling behavior.

## Files changed
- `src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.tsx`
- `src/components/ui/DemocraciaResultsReveal/DemocraciaResultsReveal.css`
- `src/components/ui/DemocraciaResultsReveal/__tests__/DemocraciaResultsReveal.test.tsx`

## Testing done
- `npm run typecheck`
- `npm run test -- src/components/ui/DemocraciaResultsReveal/__tests__/DemocraciaResultsReveal.test.tsx src/components/ui/__tests__/TvZone.announcement.test.tsx`

## Screen sizes and states verified
- `1280x720` desktop: Democracia winner and tied-vote faux-TV states
- `390x844` phone portrait: Democracia winner and tied-vote faux-TV states
- `844x390` phone landscape: Democracia winner and tied-vote faux-TV states