### PR TITLE
Add aftermath flow to the final winner modal

### DIFF
--- a/src/screens/GameOver/GameOver.css
+++ b/src/screens/GameOver/GameOver.css
@@ -1,10 +1,16 @@
 .gameover-shell {
-  min-height: 100vh;
+  --gameover-bottom-clearance: calc(var(--nav-bar-height, 60px) + 36px);
+  min-height: 100dvh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(ellipse at 50% 40%, #0d1230 0%, #05080f 70%);
-  padding: 20px;
+  background: radial-gradient(ellipse at 50% 28%, #162043 0%, #080b14 68%);
+  padding:
+    calc(20px + var(--safe-top))
+    calc(16px + var(--safe-right))
+    calc(var(--gameover-bottom-clearance) + var(--safe-bottom))
+    calc(16px + var(--safe-left));
   color: var(--color-text);
   font-family: inherit;
   position: relative;
@@ -16,25 +22,44 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 70% 50% at 50% 0%, color-mix(in srgb, var(--color-gold-secondary) 8%, transparent) 0%, transparent 65%),
-    radial-gradient(ellipse 50% 40% at 80% 80%, color-mix(in srgb, var(--color-accent) 6%, transparent) 0%, transparent 60%);
+    radial-gradient(ellipse 72% 50% at 50% 0%, color-mix(in srgb, var(--color-gold-secondary) 12%, transparent) 0%, transparent 68%),
+    radial-gradient(ellipse 48% 36% at 82% 82%, color-mix(in srgb, #df4153 16%, transparent) 0%, transparent 58%);
   pointer-events: none;
 }
 
+.gameover-brand,
 .gameover-card {
+  position: relative;
+  z-index: 1;
+}
+
+.gameover-brand {
+  display: flex;
+  justify-content: center;
   width: 100%;
-  max-width: 520px;
+  margin-bottom: 10px;
+}
+
+.gameover-brand__logo {
+  width: min(190px, 48vw);
+  max-width: 100%;
+  object-fit: contain;
+  filter:
+    drop-shadow(0 14px 28px rgba(0, 0, 0, 0.42))
+    drop-shadow(0 0 22px rgba(245, 158, 11, 0.14));
+}
+
+.gameover-card {
+  width: min(100%, 540px);
   background: linear-gradient(160deg, #141b2e 0%, #0f1422 100%);
   border: 1px solid color-mix(in srgb, var(--color-gold-secondary) 25%, transparent);
   border-radius: 20px;
-  padding: 28px 24px 24px;
+  padding: 24px 20px 20px;
   text-align: center;
   box-shadow:
     0 0 0 1px var(--color-line),
     0 20px 80px rgba(0, 0, 0, 0.7),
     0 0 40px color-mix(in srgb, var(--color-gold-secondary) 10%, transparent);
-  position: relative;
-  z-index: 1;
   animation: gameover-entrance 0.5s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -45,11 +70,11 @@
 
 .gameover-title {
   margin: 0 0 6px;
-  font-size: 1.4rem;
+  font-size: 1.35rem;
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--color-gold-primary); /* fallback for browsers/selection that don't support gradient text */
+  color: var(--color-gold-primary);
   background: linear-gradient(135deg, var(--color-gold-primary) 0%, var(--color-gold-secondary) 50%, var(--color-gold-deep) 100%);
   -webkit-background-clip: text;
   background-clip: text;
@@ -57,7 +82,7 @@
 }
 
 .gameover-sub {
-  margin: 0 0 18px;
+  margin: 0 0 16px;
   color: var(--color-text-muted);
   font-size: 0.82rem;
 }
@@ -73,10 +98,12 @@
 }
 
 .gameover-winner::before {
-  content: '🏆';
+  content: 'TROPHY';
   position: absolute;
-  font-size: 5rem;
-  opacity: 0.06;
+  font-size: 3.5rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  opacity: 0.05;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -94,10 +121,10 @@
 }
 
 .gameover-winner__name {
-  font-size: 1.6rem;
+  font-size: 1.55rem;
   font-weight: 900;
   margin-top: 0;
-  color: var(--color-text); /* fallback for browsers/selection that don't support gradient text */
+  color: var(--color-text);
   letter-spacing: 0.02em;
   animation: gameover-shimmer 2.5s ease-in-out infinite;
   background: linear-gradient(90deg, var(--color-text) 30%, var(--color-gold-primary) 50%, var(--color-text) 70%);
@@ -138,32 +165,38 @@
 }
 
 .gameover-actions {
-  margin-top: 20px;
-  display: flex;
-  gap: 10px;
-  justify-content: center;
-  flex-wrap: wrap;
+  margin-top: 18px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
 }
 
 .gameover-btn {
-  padding: 11px 20px;
+  min-height: 44px;
+  padding: 10px 10px;
   border-radius: 12px;
-  font-size: 0.9rem;
+  font-size: 0.79rem;
   font-weight: 800;
   cursor: pointer;
   border: none;
-  transition: opacity 0.15s, transform 0.1s, box-shadow 0.15s;
+  transition: opacity 0.15s, transform 0.1s, box-shadow 0.15s, background 0.15s;
   letter-spacing: 0.02em;
   transform: translateY(0);
+  font-family: inherit;
 }
 
-.gameover-btn:hover {
-  opacity: 0.88;
+.gameover-btn:hover:not(:disabled) {
+  opacity: 0.92;
   transform: translateY(-2px);
 }
 
-.gameover-btn:active {
+.gameover-btn:active:not(:disabled) {
   transform: scale(0.97);
+}
+
+.gameover-btn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
 }
 
 .gameover-btn--primary {
@@ -178,7 +211,11 @@
   color: var(--color-text-muted);
 }
 
-/* ── Rotating scoreboard carousel ─────────────────────────────────────────── */
+.gameover-btn--accent {
+  background: linear-gradient(135deg, #e04b5d 0%, #f59e0b 100%);
+  color: #fff8ed;
+  box-shadow: 0 6px 22px rgba(224, 75, 93, 0.28);
+}
 
 .gameover-carousel {
   position: relative;
@@ -232,8 +269,6 @@
   background: var(--color-gold-secondary);
 }
 
-/* ── Scoreboard list ─────────────────────────────────────────────────────── */
-
 .gameover-scoreboard {
   list-style: none;
   margin: 0;
@@ -272,3 +307,326 @@
   font-size: 0.78rem;
 }
 
+.gameover-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding:
+    calc(18px + var(--safe-top))
+    calc(14px + var(--safe-right))
+    calc(18px + var(--safe-bottom))
+    calc(14px + var(--safe-left));
+}
+
+.gameover-overlay__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 5, 10, 0.76);
+  backdrop-filter: blur(10px);
+}
+
+.gameover-prompt,
+.gameover-aftermath {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 560px);
+  max-height: min(100%, 760px);
+  overflow: auto;
+  border-radius: 20px;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+}
+
+.gameover-prompt {
+  padding: 24px 20px;
+  background: linear-gradient(180deg, #171e33 0%, #0f1525 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.gameover-prompt__eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-gold-secondary);
+}
+
+.gameover-prompt__title {
+  margin: 0 0 10px;
+  font-size: 1.3rem;
+  line-height: 1.12;
+}
+
+.gameover-prompt__body {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.gameover-prompt__actions,
+.gameover-aftermath__actions {
+  display: grid;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.gameover-prompt__actions {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gameover-aftermath {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0)),
+    radial-gradient(circle at top, rgba(255, 239, 201, 0.75), rgba(245, 230, 206, 0.16) 32%, transparent 56%),
+    linear-gradient(180deg, #371216 0%, #1a1012 18%, #efe3cb 18.1%, #e7d7be 100%);
+  color: #17120e;
+  padding: 14px;
+  border: 1px solid rgba(255, 247, 233, 0.68);
+}
+
+.gameover-aftermath--excellent {
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(245, 158, 11, 0.18);
+}
+
+.gameover-aftermath--good {
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(34, 197, 94, 0.16);
+}
+
+.gameover-aftermath--neutral {
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(100, 116, 139, 0.16);
+}
+
+.gameover-aftermath--bad {
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(239, 68, 68, 0.16);
+}
+
+.gameover-aftermath--tragic {
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(127, 29, 29, 0.26);
+}
+
+.gameover-aftermath__topbar,
+.gameover-aftermath__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gameover-aftermath__topbar {
+  margin-bottom: 12px;
+}
+
+.gameover-aftermath__edition,
+.gameover-aftermath__tone {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+}
+
+.gameover-aftermath__edition {
+  background: #420c12;
+  color: #fff2df;
+}
+
+.gameover-aftermath__tone {
+  color: #1a1206;
+  background: #f4c56b;
+}
+
+.gameover-aftermath__tone--good {
+  background: #9fdaa3;
+}
+
+.gameover-aftermath__tone--neutral {
+  background: #ced4dd;
+}
+
+.gameover-aftermath__tone--bad {
+  background: #f7b0a8;
+}
+
+.gameover-aftermath__tone--tragic {
+  background: #d08b8b;
+}
+
+.gameover-aftermath__meta {
+  margin-bottom: 12px;
+}
+
+.gameover-aftermath__player {
+  margin: 0;
+  font-size: 1.22rem;
+  font-weight: 900;
+  letter-spacing: 0.01em;
+}
+
+.gameover-aftermath__placement,
+.gameover-aftermath__progress,
+.gameover-aftermath__kicker,
+.gameover-aftermath__caption {
+  margin: 0;
+}
+
+.gameover-aftermath__placement,
+.gameover-aftermath__progress,
+.gameover-aftermath__caption {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(23, 18, 14, 0.68);
+}
+
+.gameover-aftermath__paper {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, #f8f1e1 0%, #eadac0 100%);
+  border-radius: 16px;
+  border: 1px solid rgba(53, 32, 11, 0.16);
+  padding: 16px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    0 18px 30px rgba(66, 12, 18, 0.12);
+}
+
+.gameover-aftermath__lead {
+  padding-bottom: 12px;
+  border-bottom: 2px solid rgba(53, 32, 11, 0.16);
+}
+
+.gameover-aftermath__kicker {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #7e1f2b;
+}
+
+.gameover-aftermath__headline {
+  margin: 6px 0 8px;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.55rem, 4.8vw, 2.15rem);
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+}
+
+.gameover-aftermath__subheadline {
+  margin: 0;
+  font-size: 0.97rem;
+  line-height: 1.42;
+  color: rgba(23, 18, 14, 0.86);
+}
+
+.gameover-aftermath__story-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.96fr) minmax(0, 1.04fr);
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.gameover-aftermath__photo-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.gameover-aftermath__photo {
+  width: 100%;
+  min-height: 280px;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid rgba(53, 32, 11, 0.18);
+  background:
+    linear-gradient(135deg, rgba(59, 18, 23, 0.18), rgba(245, 158, 11, 0.12)),
+    #d7ccba;
+}
+
+.gameover-aftermath__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.gameover-aftermath__bullets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.gameover-aftermath__bullets li {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(117, 31, 43, 0.08);
+  border: 1px solid rgba(117, 31, 43, 0.08);
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.gameover-aftermath__body {
+  margin: 0;
+  padding-top: 2px;
+  font-size: 0.94rem;
+  line-height: 1.52;
+  color: rgba(23, 18, 14, 0.88);
+}
+
+.gameover-aftermath__actions {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 460px) {
+  .gameover-card {
+    padding: 20px 16px 16px;
+  }
+
+  .gameover-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gameover-actions .gameover-btn--accent {
+    grid-column: 1 / -1;
+  }
+
+  .gameover-prompt__actions,
+  .gameover-aftermath__actions {
+    grid-template-columns: 1fr;
+  }
+
+  .gameover-aftermath__story-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gameover-aftermath__photo {
+    min-height: 220px;
+  }
+}
+
+@media (max-width: 360px) {
+  .gameover-shell {
+    padding:
+      calc(14px + var(--safe-top))
+      calc(12px + var(--safe-right))
+      calc(14px + var(--safe-bottom))
+      calc(12px + var(--safe-left));
+  }
+
+  .gameover-brand__logo {
+    width: min(150px, 52vw);
+  }
+
+  .gameover-btn {
+    font-size: 0.76rem;
+  }
+}

--- a/src/screens/GameOver/GameOver.tsx
+++ b/src/screens/GameOver/GameOver.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import RecapImage from '../../components/SeasonRecapCinematic/RecapImage';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { resetGame, archiveSeason } from '../../store/gameSlice';
 import { selectActiveProfileId, selectIsGuest } from '../../store/profilesSlice';
@@ -10,11 +11,13 @@ import { computeLeaderboardScore, computeSeasonLeaderboard } from '../../scoring
 import { computeAllTimeLeaderboard } from '../../scoring/computeAllTime';
 import { DEFAULT_WEIGHTS } from '../../scoring/weights';
 import { SoundManager } from '../../services/sound/SoundManager';
+import { buildAftermathStories } from './aftermath';
 import './GameOver.css';
 
 const CAROUSEL_INTERVAL_MS = 5000;
+const LOGO_SRC = `${import.meta.env.BASE_URL}assets/kolequant.png`;
 
-/** Build PlayerSeasonSummary array from current player state — pure (no Date.now). */
+/** Build PlayerSeasonSummary array from current player state - pure (no Date.now). */
 function buildSummaries(players: Player[], favoriteWinnerId: string | null, week: number): PlayerSeasonSummary[] {
   return players.map((p) => {
     // Only players with status 'jury' are actual jury members.
@@ -57,7 +60,7 @@ function buildSummaries(players: Player[], favoriteWinnerId: string | null, week
   });
 }
 
-/** Build a SeasonArchive from pre-computed summaries — called only from event handlers. */
+/** Build a SeasonArchive from pre-computed summaries - called only from event handlers. */
 function buildArchive(season: number, summaries: PlayerSeasonSummary[]): SeasonArchive {
   return {
     seasonIndex: season,
@@ -66,6 +69,8 @@ function buildArchive(season: number, summaries: PlayerSeasonSummary[]): SeasonA
     playerSummaries: summaries,
   };
 }
+
+type GameOverPanel = 'results' | 'adPrompt' | 'aftermath';
 
 export default function GameOver() {
   const dispatch = useAppDispatch();
@@ -82,15 +87,19 @@ export default function GameOver() {
   const archivedRef = useRef(false);
 
   const [carouselSlide, setCarouselSlide] = useState(0);
+  const [panel, setPanel] = useState<GameOverPanel>('results');
+  const [storyIndex, setStoryIndex] = useState(0);
 
   const winner = players.find((p) => p.isWinner) ?? players.find((p) => p.finalRank === 1);
   const runnerUp = players.find((p) => p.finalRank === 2);
 
-  // Compute per-player summaries (pure — no impure calls)
+  // Compute per-player summaries (pure - no impure calls)
   const summaries = buildSummaries(players, favoriteWinnerId, week);
 
   const seasonLeaderboard = computeSeasonLeaderboard(summaries, DEFAULT_WEIGHTS).slice(0, 5);
   const allTimeLeaderboard = computeAllTimeLeaderboard(seasonArchives, DEFAULT_WEIGHTS).slice(0, 5);
+  const aftermathStories = useMemo(() => buildAftermathStories(players, season), [players, season]);
+  const activeStory = aftermathStories[storyIndex] ?? aftermathStories[0];
 
   // Auto-advance carousel
   useEffect(() => {
@@ -130,13 +139,44 @@ export default function GameOver() {
     navigate('/');
   }
 
+  function openAftermathPrompt() {
+    setPanel('adPrompt');
+  }
+
+  function closeOverlay() {
+    setPanel('results');
+    setStoryIndex(0);
+  }
+
+  function watchAd() {
+    SoundManager.unlockFromGesture();
+    setStoryIndex(0);
+    setPanel('aftermath');
+  }
+
+  function showPreviousStory() {
+    setStoryIndex((current) => Math.max(current - 1, 0));
+  }
+
+  function showNextStory() {
+    if (storyIndex >= aftermathStories.length - 1) {
+      closeOverlay();
+      return;
+    }
+    setStoryIndex((current) => Math.min(current + 1, aftermathStories.length - 1));
+  }
+
   return (
     <div className="gameover-shell">
+      <div className="gameover-brand" aria-hidden="true">
+        <img className="gameover-brand__logo" src={LOGO_SRC} alt="" />
+      </div>
+
       <div className="gameover-card">
         <h1 className="gameover-title">Season Complete</h1>
-        <p className="gameover-sub">Thanks for playing — here are the results</p>
+        <p className="gameover-sub">Thanks for playing - here are the results</p>
 
-        {/* ── Carousel ── */}
+        {/* -- Carousel -- */}
         <div className="gameover-carousel" aria-live="polite">
           {/* Slide 0: Winner / Runner-up */}
           <div
@@ -159,7 +199,7 @@ export default function GameOver() {
           <div
             className={`gameover-carousel__slide${carouselSlide === 1 ? ' gameover-carousel__slide--active' : ''}`}
           >
-            <p className="gameover-carousel__heading">Season Top 5 🏆</p>
+            <p className="gameover-carousel__heading">Season Top 5</p>
             <ul className="gameover-scoreboard">
               {seasonLeaderboard.map((entry, i) => (
                 <li key={entry.playerId} className="gameover-scoreboard__row">
@@ -175,7 +215,7 @@ export default function GameOver() {
           <div
             className={`gameover-carousel__slide${carouselSlide === 2 ? ' gameover-carousel__slide--active' : ''}`}
           >
-            <p className="gameover-carousel__heading">All-Time Top 5 🌟</p>
+            <p className="gameover-carousel__heading">All-Time Top 5</p>
             <ul className="gameover-scoreboard">
               {allTimeLeaderboard.map((entry, i) => (
                 <li key={entry.playerId} className="gameover-scoreboard__row">
@@ -188,7 +228,7 @@ export default function GameOver() {
           </div>
         </div>
 
-        {/* ── Carousel dots ── */}
+        {/* -- Carousel dots -- */}
         <div className="gameover-carousel__dots">
           {[0, 1, 2].map((i) => (
             <button
@@ -196,19 +236,113 @@ export default function GameOver() {
               className={`gameover-carousel__dot${carouselSlide === i ? ' gameover-carousel__dot--active' : ''}`}
               onClick={() => setCarouselSlide(i)}
               aria-label={`Show slide ${i + 1}`}
+              type="button"
             />
           ))}
         </div>
 
         <div className="gameover-actions">
-          <button className="gameover-btn gameover-btn--primary" onClick={startNewSeason}>
-            Start New Season
+          <button className="gameover-btn gameover-btn--primary" onClick={startNewSeason} type="button">
+            New Season
           </button>
-          <button className="gameover-btn gameover-btn--ghost" onClick={exitToHome}>
-            Exit to Home
+          <button className="gameover-btn gameover-btn--ghost" onClick={exitToHome} type="button">
+            Home
+          </button>
+          <button className="gameover-btn gameover-btn--accent" onClick={openAftermathPrompt} type="button">
+            Aftermath
           </button>
         </div>
       </div>
+
+      {panel !== 'results' && (
+        <div className="gameover-overlay" role="dialog" aria-modal="true">
+          <div className="gameover-overlay__scrim" onClick={panel === 'adPrompt' ? closeOverlay : undefined} />
+
+          {panel === 'adPrompt' && (
+            <div className="gameover-prompt">
+              <p className="gameover-prompt__eyebrow">Aftermath Special</p>
+              <h2 className="gameover-prompt__title">Watch a quick ad to unlock the gossip reel.</h2>
+              <p className="gameover-prompt__body">
+                See what happened to the housemates after the finale. For testing, tapping Watch Ad simulates a completed ad.
+              </p>
+              <div className="gameover-prompt__actions">
+                <button className="gameover-btn gameover-btn--primary" onClick={watchAd} type="button">
+                  Watch Ad
+                </button>
+                <button className="gameover-btn gameover-btn--ghost" onClick={closeOverlay} type="button">
+                  Back
+                </button>
+              </div>
+            </div>
+          )}
+
+          {panel === 'aftermath' && activeStory && (
+            <div className={`gameover-aftermath gameover-aftermath--${activeStory.tone}`}>
+              <div className="gameover-aftermath__topbar">
+                <span className="gameover-aftermath__edition">Late Edition</span>
+                <span className={`gameover-aftermath__tone gameover-aftermath__tone--${activeStory.tone}`}>
+                  {activeStory.toneLabel}
+                </span>
+              </div>
+
+              <div className="gameover-aftermath__meta">
+                <div>
+                  <p className="gameover-aftermath__player">{activeStory.playerName}</p>
+                  <p className="gameover-aftermath__placement">{activeStory.placementLabel}</p>
+                </div>
+                <p className="gameover-aftermath__progress">
+                  {storyIndex + 1} / {aftermathStories.length}
+                </p>
+              </div>
+
+              <div className="gameover-aftermath__paper">
+                <div className="gameover-aftermath__lead">
+                  <p className="gameover-aftermath__kicker">What happened next</p>
+                  <h2 className="gameover-aftermath__headline">{activeStory.headline}</h2>
+                  <p className="gameover-aftermath__subheadline">{activeStory.subheadline}</p>
+                </div>
+
+                <div className="gameover-aftermath__story-grid">
+                  <div className="gameover-aftermath__photo-panel">
+                    <RecapImage
+                      className="gameover-aftermath__photo"
+                      sources={activeStory.imageSources}
+                      alt={activeStory.playerName}
+                    />
+                    <p className="gameover-aftermath__caption">Exclusive post-show sighting.</p>
+                  </div>
+
+                  <div className="gameover-aftermath__copy">
+                    <ul className="gameover-aftermath__bullets">
+                      {activeStory.bulletPoints.map((bullet) => (
+                        <li key={bullet}>{bullet}</li>
+                      ))}
+                    </ul>
+                    <p className="gameover-aftermath__body">{activeStory.body}</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="gameover-aftermath__actions">
+                <button className="gameover-btn gameover-btn--ghost" onClick={closeOverlay} type="button">
+                  Results
+                </button>
+                <button
+                  className="gameover-btn gameover-btn--ghost"
+                  onClick={showPreviousStory}
+                  disabled={storyIndex === 0}
+                  type="button"
+                >
+                  Previous
+                </button>
+                <button className="gameover-btn gameover-btn--primary" onClick={showNextStory} type="button">
+                  {storyIndex === aftermathStories.length - 1 ? 'Done' : 'Next'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/screens/GameOver/aftermath.ts
+++ b/src/screens/GameOver/aftermath.ts
@@ -1,0 +1,332 @@
+import { resolveRecapTabloidSources } from '../../components/SeasonRecapCinematic/seasonRecapData';
+import type { Player } from '../../types';
+
+export type AftermathTone = 'excellent' | 'good' | 'neutral' | 'bad' | 'tragic';
+
+export interface AftermathStory {
+  playerId: string;
+  playerName: string;
+  placementLabel: string;
+  tone: AftermathTone;
+  toneLabel: string;
+  headline: string;
+  subheadline: string;
+  body: string;
+  bulletPoints: string[];
+  imageSources: string[];
+}
+
+interface TabloidPhotoEntry {
+  id: string;
+  matchToken: string;
+  extension: string;
+  source: string;
+}
+
+interface AftermathScenarioTemplate {
+  tone: AftermathTone;
+  toneLabel: string;
+  headline: (firstName: string) => string;
+  subheadline: (firstName: string) => string;
+  body: (firstName: string) => string;
+  bulletPoints: (firstName: string) => [string, string];
+}
+
+const TABLOID_PHOTO_MODULES = import.meta.glob('../../../public/assets/tabloid_photos/*.{png,jpg,jpeg,jxl,webp,avif}', {
+  eager: true,
+  import: 'default',
+}) as Record<string, string>;
+
+const AFTERMATH_SCENARIOS: Record<AftermathTone, AftermathScenarioTemplate[]> = {
+  excellent: [
+    {
+      tone: 'excellent',
+      toneLabel: 'Excellent',
+      headline: (firstName) => `${firstName} Cashes In Fast`,
+      subheadline: (firstName) => `${firstName} turns finale buzz into a luxury comeback tour and does not look back.`,
+      body: (firstName) =>
+        `${firstName} books a glossy streaming special, launches a suspiciously expensive lifestyle line, and keeps saying the cameras finally captured the "real me."`,
+      bulletPoints: (firstName) => [
+        `${firstName} signs a six-figure brand deal after one dramatic breakfast interview.`,
+        'Fans call it the cleanest post-show glow-up of the season.',
+      ],
+    },
+    {
+      tone: 'excellent',
+      toneLabel: 'Excellent',
+      headline: (firstName) => `${firstName} Becomes Prime-Time Gold`,
+      subheadline: (firstName) => `${firstName} lands every red carpet invite before the confetti is even swept up.`,
+      body: (firstName) =>
+        `${firstName} pivots from house drama to celebrity darling status, smiling through flashbulbs while rivals insist they "always knew this would happen."`,
+      bulletPoints: (firstName) => [
+        `${firstName} gets spotted leaving a TV studio with a mystery executive.`,
+        'A tabloid poll names them the season’s biggest winner off-camera too.',
+      ],
+    },
+  ],
+  good: [
+    {
+      tone: 'good',
+      toneLabel: 'Good',
+      headline: (firstName) => `${firstName} Finds the Sweet Spot`,
+      subheadline: (firstName) => `${firstName} stays booked, liked, and just messy enough to stay interesting.`,
+      body: (firstName) =>
+        `${firstName} settles into the influencer circuit, stacks a few tasteful sponsorships, and keeps reunion gossip alive with perfectly timed vague posts.`,
+      bulletPoints: (firstName) => [
+        `${firstName} starts a recap podcast with a shocking number of listeners.`,
+        'The comment section mostly agrees this is solid damage control.',
+      ],
+    },
+    {
+      tone: 'good',
+      toneLabel: 'Good',
+      headline: (firstName) => `${firstName} Leaves With Momentum`,
+      subheadline: (firstName) => `${firstName} turns public curiosity into a surprisingly polished second act.`,
+      body: (firstName) =>
+        `${firstName} keeps the fame at a manageable simmer, showing up at enough events to stay relevant without becoming everyone’s full-time group chat topic.`,
+      bulletPoints: (firstName) => [
+        `${firstName} quietly books a hosting gig no one saw coming.`,
+        'Even the haters admit the rollout looks annoyingly competent.',
+      ],
+    },
+  ],
+  neutral: [
+    {
+      tone: 'neutral',
+      toneLabel: 'Neutral',
+      headline: (firstName) => `${firstName} Chooses Peace and Wi-Fi`,
+      subheadline: (firstName) => `${firstName} skips the circus, posts twice, then vanishes into suspicious tranquility.`,
+      body: (firstName) =>
+        `${firstName} returns to ordinary life with a calm smile, one oddly cryptic live stream, and a strict refusal to explain the finale group chat leak.`,
+      bulletPoints: (firstName) => [
+        `${firstName} says they are "focusing on real life for now."`,
+        'The internet cannot decide whether this is maturity or a soft launch.',
+      ],
+    },
+    {
+      tone: 'neutral',
+      toneLabel: 'Neutral',
+      headline: (firstName) => `${firstName} Keeps It Mysterious`,
+      subheadline: (firstName) => `${firstName} neither flames out nor cashes in, which somehow becomes its own headline.`,
+      body: (firstName) =>
+        `${firstName} drifts into that strange post-show middle ground where every public sighting feels important even though absolutely nothing dramatic is confirmed.`,
+      bulletPoints: (firstName) => [
+        `${firstName} is seen twice at the same cafe and once at a very normal supermarket.`,
+        'A fake engagement rumor survives for forty-eight glorious hours.',
+      ],
+    },
+  ],
+  bad: [
+    {
+      tone: 'bad',
+      toneLabel: 'Bad',
+      headline: (firstName) => `${firstName} Cannot Stop Posting`,
+      subheadline: (firstName) => `${firstName} picks three avoidable feuds and somehow loses all of them by lunch.`,
+      body: (firstName) =>
+        `${firstName} treats every rumor like a personal challenge, fires off late-night responses, and accidentally turns a tiny misunderstanding into a multi-week mess.`,
+      bulletPoints: (firstName) => [
+        `${firstName} uploads an apology note, deletes it, then blames "team confusion."`,
+        'A reunion seating chart becomes a full scandal for no good reason.',
+      ],
+    },
+    {
+      tone: 'bad',
+      toneLabel: 'Bad',
+      headline: (firstName) => `${firstName} Hits a Rough Patch`,
+      subheadline: (firstName) => `${firstName} exits the house and walks straight into a publicity pothole.`,
+      body: (firstName) =>
+        `${firstName} fumbles an easy victory lap, overexplains old alliances in every interview, and ends up more memed than celebrated by the end of the month.`,
+      bulletPoints: (firstName) => [
+        `${firstName} gets ratioed by fans after trying to "clear things up."`,
+        'One leaked voice note keeps reappearing like an unpaid bill.',
+      ],
+    },
+  ],
+  tragic: [
+    {
+      tone: 'tragic',
+      toneLabel: 'Tragic',
+      headline: (firstName) => `${firstName}'s Comeback Implodes`,
+      subheadline: (firstName) => `${firstName} announces a dramatic rebrand that collapses before the merch even ships.`,
+      body: (firstName) =>
+        `${firstName} aims for icon status, but the whole operation spirals into a chaotic cautionary tale involving a doomed launch party and one very hostile entertainment blogger.`,
+      bulletPoints: (firstName) => [
+        `${firstName}'s victory brunch ends with three ex-allies live-posting subtweets.`,
+        'Even the gossip channels describe the fallout as "cinematic."',
+      ],
+    },
+    {
+      tone: 'tragic',
+      toneLabel: 'Tragic',
+      headline: (firstName) => `${firstName} Suffers a Public Meltdown Arc`,
+      subheadline: (firstName) => `${firstName} goes for a grand post-show reinvention and trips over every possible rake.`,
+      body: (firstName) =>
+        `${firstName} books a tell-all, leaks their own teaser, starts a feud with a stylist, and somehow ends the week apologizing to a morning show audience.`,
+      bulletPoints: (firstName) => [
+        `${firstName} gets dropped from an appearance after a very messy comment spiral.`,
+        'The tabloids celebrate the chaos with ruthless front pages for days.',
+      ],
+    },
+  ],
+};
+
+function normalizeToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function firstName(player: Player | undefined): string {
+  return player?.name.split(' ')[0] ?? 'Housemate';
+}
+
+function extensionPriority(extension: string): number {
+  switch (extension.toLowerCase()) {
+    case 'webp':
+      return 0;
+    case 'jxl':
+      return 1;
+    case 'png':
+      return 2;
+    case 'jpg':
+    case 'jpeg':
+      return 3;
+    case 'avif':
+      return 4;
+    default:
+      return 5;
+  }
+}
+
+function listTabloidPhotos(): TabloidPhotoEntry[] {
+  return Object.entries(TABLOID_PHOTO_MODULES)
+    .map(([path, source]) => {
+      const filename = path.split('/').pop() ?? path;
+      const extension = filename.split('.').pop() ?? '';
+      const basename = filename.replace(/\.[^.]+$/, '');
+      const matchBase = basename.replace(/_tabloid\d*$/i, '');
+      return {
+        id: basename,
+        matchToken: normalizeToken(matchBase),
+        extension,
+        source,
+      };
+    })
+    .sort((left, right) => {
+      if (left.matchToken !== right.matchToken) {
+        return left.matchToken.localeCompare(right.matchToken);
+      }
+      const extensionDifference = extensionPriority(left.extension) - extensionPriority(right.extension);
+      if (extensionDifference !== 0) {
+        return extensionDifference;
+      }
+      return left.id.localeCompare(right.id);
+    });
+}
+
+function uniqueSources(sources: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  return sources.filter((source): source is string => {
+    if (!source || seen.has(source)) return false;
+    seen.add(source);
+    return true;
+  });
+}
+
+function pickTabloidPhoto(
+  player: Player | undefined,
+  photos: TabloidPhotoEntry[],
+  usedPhotoIds: Set<string>,
+): string | null {
+  if (photos.length === 0) return null;
+
+  const desiredTokens = uniqueSources([player?.name, firstName(player)]).map(normalizeToken);
+  const matched = photos.find(
+    (photo) => !usedPhotoIds.has(photo.id) && desiredTokens.includes(photo.matchToken),
+  );
+  if (matched) {
+    usedPhotoIds.add(matched.id);
+    return matched.source;
+  }
+
+  const unusedFallback = photos.find((photo) => !usedPhotoIds.has(photo.id));
+  if (unusedFallback) {
+    usedPhotoIds.add(unusedFallback.id);
+    return unusedFallback.source;
+  }
+
+  return photos[0]?.source ?? null;
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function getPlacementValue(player: Player): number {
+  if (typeof player.finalRank === 'number') return player.finalRank;
+  if (typeof player.seasonPlacement === 'number') return player.seasonPlacement;
+  if (player.isWinner) return 1;
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function getPlacementLabel(player: Player): string {
+  const placement = getPlacementValue(player);
+  if (placement === 1) return 'Winner';
+  if (placement === 2) return 'Runner-up';
+  if (placement === 3) return 'Third place';
+  if (placement !== Number.MAX_SAFE_INTEGER) return `Placed #${placement}`;
+  if (player.status === 'jury') return 'Juror';
+  if (player.status === 'evicted') return 'Evicted';
+  return 'Housemate';
+}
+
+function sortPlayers(players: Player[]): Player[] {
+  return [...players].sort((left, right) => {
+    const placementDifference = getPlacementValue(left) - getPlacementValue(right);
+    if (placementDifference !== 0) return placementDifference;
+    return left.name.localeCompare(right.name);
+  });
+}
+
+function selectScenario(player: Player, season: number): AftermathScenarioTemplate {
+  const toneOrder: AftermathTone[] = ['excellent', 'good', 'neutral', 'bad', 'tragic'];
+  const tone = toneOrder[hashString(`${season}:${player.id}:tone`) % toneOrder.length];
+  const templates = AFTERMATH_SCENARIOS[tone];
+  return templates[hashString(`${season}:${player.id}:scenario`) % templates.length];
+}
+
+export function buildAftermathStories(players: Player[], season: number): AftermathStory[] {
+  const sortedPlayers = sortPlayers(players);
+  const safePlayers = sortedPlayers.length > 0
+    ? sortedPlayers
+    : [{
+        id: 'house',
+        name: 'The House',
+        avatar: '',
+        status: 'evicted' as const,
+      }];
+  const tabloidPhotos = listTabloidPhotos();
+  const usedPhotoIds = new Set<string>();
+
+  return safePlayers.map((player) => {
+    const scenario = selectScenario(player, season);
+    const matchedPhoto = pickTabloidPhoto(player, tabloidPhotos, usedPhotoIds);
+    const name = firstName(player);
+
+    return {
+      playerId: player.id,
+      playerName: player.name,
+      placementLabel: getPlacementLabel(player),
+      tone: scenario.tone,
+      toneLabel: scenario.toneLabel,
+      headline: scenario.headline(name),
+      subheadline: scenario.subheadline(name),
+      body: scenario.body(name),
+      bulletPoints: scenario.bulletPoints(name),
+      imageSources: resolveRecapTabloidSources(player, matchedPhoto),
+    };
+  });
+}

--- a/tests/gameOver.screen.test.tsx
+++ b/tests/gameOver.screen.test.tsx
@@ -75,7 +75,7 @@ describe('GameOver screen', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /exit to home/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^home$/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Home route')).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe('GameOver screen', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /start new season/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^new season$/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Home route')).toBeInTheDocument();
@@ -159,7 +159,7 @@ describe('GameOver screen', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /exit to home/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^home$/i }));
     await waitFor(() => expect(screen.getByText('Home')).toBeInTheDocument());
 
     const archives = store.getState().game.seasonArchives ?? [];
@@ -225,7 +225,7 @@ describe('GameOver screen', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /exit to home/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^home$/i }));
     await waitFor(() => expect(screen.getByText('Home')).toBeInTheDocument());
 
     const archives = store.getState().game.seasonArchives ?? [];
@@ -237,5 +237,51 @@ describe('GameOver screen', () => {
       (s) => s.isEvicted,
     );
     expect(evictedSummary?.survivedDoubleEviction).toBeUndefined();
+  });
+
+  it('opens the aftermath ad prompt and enters the aftermath sequence after the fake ad', async () => {
+    const store = makeStore({
+      week: 9,
+      phase: 'jury',
+      seasonFinale: {
+        phase: 'seasonComplete',
+        winnerId: 'user',
+        interviewIndex: 0,
+        goodbyeIndex: 0,
+        isChatOpen: false,
+        isLightsOffAnimating: false,
+        publicFavoriteEnabled: false,
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/gameover']}>
+          <Routes>
+            <Route path="/" element={<div>Home route</div>} />
+            <Route path="/gameover" element={<GameOver />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^aftermath$/i }));
+
+    expect(screen.getByText('Aftermath Special')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^watch ad$/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
+    await waitFor(() => {
+      expect(screen.queryByText('Aftermath Special')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^aftermath$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^watch ad$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Late Edition')).toBeInTheDocument();
+      expect(screen.getByText(/What happened next/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^results$/i })).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #1028

## Root cause / feature entry point
The final winner modal in `src/screens/GameOver/GameOver.tsx` only exposed restart and home exits, so there was no post-finale discovery flow for "what happened next" content.

## Implementation strategy
- Added the KoleQuant logo above the final results card using the existing project asset.
- Renamed the existing actions to `New Season` and `Home`.
- Compactened the mobile action layout so the results modal stays phone-friendly, including the smallest tested viewport.
- Added a third `Aftermath` action that opens a rewarded-ad style prompt.
- Kept the ad flow fake for now: `Watch Ad` immediately simulates success and advances to the aftermath sequence, while `Back` returns to the results modal.
- Implemented a tabloid-style aftermath sequence with compact headlines, subheads, bullet blurbs, and image-driven story cards.
- Reused existing recap image plumbing and safe fallbacks so missing tabloid assets or sparse player data do not crash the flow.

## Files changed
- `src/screens/GameOver/GameOver.tsx`
- `src/screens/GameOver/GameOver.css`
- `src/screens/GameOver/aftermath.ts`
- `tests/gameOver.screen.test.tsx`

## How the fake ad flow works
Pressing `Aftermath` opens a modal prompt that offers `Watch Ad` or `Back`.
Pressing `Watch Ad` does not call any SDK yet; it simply simulates a successful reward and opens the aftermath sequence.
Pressing `Back` closes the prompt and returns to the original final winner modal.

## How aftermath scenarios are selected
Each houseguest gets one aftermath story built from a small scenario bank with `excellent`, `good`, `neutral`, `bad`, and `tragic` tones.
Selection is deterministic per `season` and `player.id`, so each player gets a stable pseudo-random scenario within that season without reshuffling on rerender.
Tabloid imagery is matched from `public/assets/tabloid_photos` when available, with recap-image fallbacks when an exact tabloid photo is missing.

## Testing done
- `npx vitest run tests/gameOver.screen.test.tsx`
- `npm run build`
- Manual mobile verification against the local app preview at `390x844` and `320x640`
- Verified the final winner modal renders correctly
- Verified `New Season` and `Home` behavior still pass via screen tests
- Verified `Aftermath` opens the ad prompt
- Verified `Watch Ad` advances into the aftermath sequence
- Verified no horizontal overflow in the results modal or aftermath overlay on the tested phone-sized viewports
- Verified no browser page errors during the flow

## Remaining limitations
- The ad flow is intentionally simulated and does not integrate a real rewarded ad SDK yet.
- Headless local-browser QA still reports existing audio/network console warnings from the broader app environment, but this change did not introduce new page/runtime exceptions in the Game Over flow.