### PR TITLE
Compact roster auto-detect and standard visibility

### DIFF
--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -110,6 +110,7 @@ import { resolvePublicSaveNominee } from '../../publicOpinion/PublicSaveService'
 import { updateApproval } from '../../publicOpinion/publicOpinionSlice'
 import type { PlayerPublicProfile } from '../../publicOpinion/types'
 import { selectSettings } from '../../store/settingsSlice'
+import { setGameUX } from '../../store/settingsSlice'
 import type { RootState } from '../../store/store'
 import { selectAdsState, clearLastCompLastPlace, recordAdShown } from '../../store/adsSlice'
 import { selectRemoteMainTvHeadline } from '../../remoteConfig/remoteConfigSlice'
@@ -150,6 +151,7 @@ import {
 } from '../../features/evictionVoteBreakdownStorage'
 import { selectActiveConfessionalDecision } from '../../store/confessionalDecisionSelectors'
 import './GameScreen.css'
+import { shouldPromptForCompactRoster } from './compactRosterPrompt'
 
 const LOH_BADGE_SRC = statusBadgeImageSrc('loh')
 const NOMINATION_BADGE_SRC = statusBadgeImageSrc('nominated')
@@ -167,6 +169,7 @@ const CONFESSIONAL_TV_PROMPT_MESSAGE =
 const PUBLIC_MODE_STORE_PROMPT =
   'If you want to activate public mode, go to the store in the home hub.'
 const SOCIAL_MODULE_UNAVAILABLE_ANNOUNCEMENT_MS = 3000
+const COMPACT_ROSTER_PROMPT_KEY = 'bbmobilenew_compact_roster_prompt_v1'
 
 type PendingPublicSaveResult = {
   savedId: string
@@ -308,6 +311,14 @@ export default function GameScreen() {
   const adsState = useAppSelector(selectAdsState)
   const remoteMainTvHeadline = useAppSelector(selectRemoteMainTvHeadline)
   const [previewPlayer, setPreviewPlayer] = useState<Player | null>(null)
+  const [showCompactRosterPrompt, setShowCompactRosterPrompt] = useState(false)
+  const [compactRosterPromptResolved, setCompactRosterPromptResolved] = useState(() => {
+    try {
+      return localStorage.getItem(COMPACT_ROSTER_PROMPT_KEY) != null
+    } catch {
+      return false
+    }
+  })
 
   // ── Ad prompt visibility state ─────────────────────────────────────────
   const [showEnergyRechargePrompt, setShowEnergyRechargePrompt] = useState(false)
@@ -344,6 +355,53 @@ export default function GameScreen() {
   const activeConfessionalDecisionKey = activeConfessionalDecision
     ? `${activeConfessionalDecision.type}:${activeConfessionalDecision.week}:${activeConfessionalDecision.phase}`
     : null
+
+  useEffect(() => {
+    if (settings.gameUX.compactRoster) {
+      setShowCompactRosterPrompt(false)
+      return
+    }
+
+    if (compactRosterPromptResolved) {
+      return
+    }
+
+    const evaluateCompactRosterNeed = () => {
+      const viewportWidth =
+        window.visualViewport?.width ?? window.innerWidth ?? document.documentElement.clientWidth
+      const viewportHeight =
+        window.visualViewport?.height ?? window.innerHeight ?? document.documentElement.clientHeight
+      const gameShell = document.querySelector('.game-screen-shell') as HTMLElement | null
+      return shouldPromptForCompactRoster({
+        viewportWidth,
+        viewportHeight,
+        gameShellScrollHeight: gameShell?.scrollHeight,
+      })
+    }
+
+    const syncPromptState = () => {
+      const shouldPrompt = evaluateCompactRosterNeed()
+      setShowCompactRosterPrompt(shouldPrompt)
+      if (shouldPrompt) {
+        setCompactRosterPromptResolved(true)
+        try {
+          localStorage.setItem(COMPACT_ROSTER_PROMPT_KEY, 'shown')
+        } catch {
+          // ignore storage failures
+        }
+      }
+    }
+
+    syncPromptState()
+    window.addEventListener('resize', syncPromptState)
+    window.visualViewport?.addEventListener('resize', syncPromptState)
+    window.visualViewport?.addEventListener('scroll', syncPromptState)
+    return () => {
+      window.removeEventListener('resize', syncPromptState)
+      window.visualViewport?.removeEventListener('resize', syncPromptState)
+      window.visualViewport?.removeEventListener('scroll', syncPromptState)
+    }
+  }, [compactRosterPromptResolved, settings.gameUX.compactRoster])
 
   useEffect(() => {
     return () => {
@@ -3975,6 +4033,38 @@ export default function GameScreen() {
             finalizeBattleBackOutcome(winnerId)
           }}
           pending={adPending}
+        />
+      )}
+
+      {showCompactRosterPrompt && !settings.gameUX.compactRoster && (
+        <AdPrompt
+          icon="📱"
+          title="Screen looks cramped"
+          description="This layout may be getting cropped or hard to read. Switch to Compact Roster with 2 rows of 8 avatars?"
+          watchLabel="Switch to Compact"
+          skipLabel="Keep Current"
+          onWatch={() => {
+            dispatch(setGameUX({
+              compactRoster: true,
+              compactRosterLayout: 'two-rows',
+            }))
+            setShowCompactRosterPrompt(false)
+            setCompactRosterPromptResolved(true)
+            try {
+              localStorage.setItem(COMPACT_ROSTER_PROMPT_KEY, 'accepted')
+            } catch {
+              // ignore storage failures
+            }
+          }}
+          onSkip={() => {
+            setShowCompactRosterPrompt(false)
+            setCompactRosterPromptResolved(true)
+            try {
+              localStorage.setItem(COMPACT_ROSTER_PROMPT_KEY, 'dismissed')
+            } catch {
+              // ignore storage failures
+            }
+          }}
         />
       )}
 

--- a/src/screens/GameScreen/__tests__/compactRosterPrompt.test.ts
+++ b/src/screens/GameScreen/__tests__/compactRosterPrompt.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { shouldPromptForCompactRoster } from '../compactRosterPrompt'
+
+describe('shouldPromptForCompactRoster', () => {
+  it('prompts when the viewport is too short', () => {
+    expect(
+      shouldPromptForCompactRoster({
+        viewportWidth: 1024,
+        viewportHeight: 600,
+      }),
+    ).toBe(true)
+  })
+
+  it('prompts when the viewport is too narrow', () => {
+    expect(
+      shouldPromptForCompactRoster({
+        viewportWidth: 360,
+        viewportHeight: 900,
+      }),
+    ).toBe(true)
+  })
+
+  it('prompts when the game shell overflows the viewport', () => {
+    expect(
+      shouldPromptForCompactRoster({
+        viewportWidth: 1024,
+        viewportHeight: 800,
+        gameShellScrollHeight: 840,
+      }),
+    ).toBe(true)
+  })
+
+  it('does not prompt for a roomy layout', () => {
+    expect(
+      shouldPromptForCompactRoster({
+        viewportWidth: 1280,
+        viewportHeight: 900,
+        gameShellScrollHeight: 880,
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/screens/GameScreen/compactRosterPrompt.ts
+++ b/src/screens/GameScreen/compactRosterPrompt.ts
@@ -1,0 +1,18 @@
+export const COMPACT_ROSTER_PROMPT_MIN_HEIGHT = 760
+export const COMPACT_ROSTER_PROMPT_MIN_WIDTH = 430
+
+export function shouldPromptForCompactRoster(options: {
+  viewportWidth: number
+  viewportHeight: number
+  gameShellScrollHeight?: number | null
+}): boolean {
+  const { viewportWidth, viewportHeight, gameShellScrollHeight } = options
+  const crowdedByViewport =
+    viewportHeight < COMPACT_ROSTER_PROMPT_MIN_HEIGHT ||
+    viewportWidth < COMPACT_ROSTER_PROMPT_MIN_WIDTH
+  const crowdedByOverflow =
+    typeof gameShellScrollHeight === 'number' &&
+    gameShellScrollHeight > viewportHeight + 24
+
+  return crowdedByViewport || crowdedByOverflow
+}

--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -8,6 +8,7 @@ import {
   setGameUX,
   type ThemePreset,
   type SettingsState,
+  type CompactRosterLayout,
 } from '../../store/settingsSlice';
 import './Settings.css';
 
@@ -44,9 +45,19 @@ type DropdownItem = {
 
 type SettingItem = ToggleItem | DropdownItem;
 
+type CompactRosterItem = {
+  type: 'compact-roster';
+  id: string;
+  label: string;
+  getEnabled: (s: SettingsState) => boolean;
+  getLayout: (s: SettingsState) => CompactRosterLayout;
+  onToggle: (dispatch: AppDispatch, val: boolean) => void;
+  onLayoutChange: (dispatch: AppDispatch, val: CompactRosterLayout) => void;
+};
+
 interface SettingSection {
   id: string;
-  items: SettingItem[];
+  items: Array<SettingItem | CompactRosterItem>;
 }
 
 // ── Sections config ────────────────────────────────────────────────────────────
@@ -129,6 +140,20 @@ const SECTIONS: SettingSection[] = [
       },
     ],
   },
+  {
+    id: 'gameux',
+    items: [
+      {
+        type: 'compact-roster',
+        id: 'compact-roster',
+        label: 'Compact Roster',
+        getEnabled: (s) => s.gameUX.compactRoster,
+        getLayout: (s) => s.gameUX.compactRosterLayout,
+        onToggle: (dispatch, val) => dispatch(setGameUX({ compactRoster: val })),
+        onLayoutChange: (dispatch, val) => dispatch(setGameUX({ compactRosterLayout: val })),
+      },
+    ],
+  },
 ];
 
 // ── Component ──────────────────────────────────────────────────────────────────
@@ -179,6 +204,65 @@ export default function Settings() {
     }
   }
 
+  function renderCompactRosterItem(item: CompactRosterItem) {
+    const enabled = item.getEnabled(settings);
+    const layout = item.getLayout(settings);
+    const options: { id: CompactRosterLayout; label: string; description: string }[] = [
+      {
+        id: 'slider',
+        label: 'Horizontal slider',
+        description: 'Show every avatar in one scrollable row.',
+      },
+      {
+        id: 'small',
+        label: 'Smaller tiles',
+        description: 'Keep the roster grid but shrink each tile to about half size.',
+      },
+      {
+        id: 'two-rows',
+        label: '2 rows of 8 avatars',
+        description: 'Spread the roster across two wide rows.',
+      },
+    ];
+
+    return (
+      <div key={item.id} className="settings-row settings-row--col">
+        <div className="settings-row settings-row--nested">
+          <label className="settings-row__label">{item.label}</label>
+          <input
+            type="checkbox"
+            className="settings-toggle"
+            checked={enabled}
+            onChange={(e) => item.onToggle(dispatch, e.target.checked)}
+            aria-label={`Toggle ${item.label.toLowerCase()}`}
+          />
+        </div>
+        {enabled && (
+          <div className="settings-choice-group" aria-label="Compact roster layout">
+            {options.map((option) => {
+              const selected = layout === option.id;
+              return (
+                <label
+                  key={option.id}
+                  className={`settings-choice ${selected ? 'settings-choice--active' : ''}`}
+                >
+                  <input
+                    type="radio"
+                    name="compact-roster-layout-basic"
+                    checked={selected}
+                    onChange={() => item.onLayoutChange(dispatch, option.id)}
+                  />
+                  <span className="settings-choice__title">{option.label}</span>
+                  <span className="settings-choice__description">{option.description}</span>
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="settings-screen settings-screen--basic">
       <header className="settings-screen__header">
@@ -195,7 +279,9 @@ export default function Settings() {
       <div className="settings-content settings-content--flat">
         {SECTIONS.map((section) => (
           <section key={section.id} className="settings-section">
-            {section.items.map(renderItem)}
+            {section.items.map((item) =>
+              item.type === 'compact-roster' ? renderCompactRosterItem(item) : renderItem(item),
+            )}
           </section>
         ))}
       </div>

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -22,6 +22,7 @@ export interface SettingsState {
   gameUX: {
     confirmMajorActions: boolean;
     showTooltips: boolean;
+    /** Enables the denser roster presentation when screens are constrained. */
     compactRoster: boolean;
     compactRosterLayout: CompactRosterLayout;
     useHaptics: boolean;

--- a/tests/settings.screen.test.tsx
+++ b/tests/settings.screen.test.tsx
@@ -168,6 +168,32 @@ describe('Settings screen', () => {
     });
   });
 
+  it('shows compact roster controls in the standard settings screen', async () => {
+    const { store } = renderSettings();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/toggle compact roster/i)).toBeTruthy();
+    });
+
+    const compactRosterToggle = screen.getByLabelText(/toggle compact roster/i);
+    if (!(compactRosterToggle as HTMLInputElement).checked) {
+      fireEvent.click(compactRosterToggle);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/compact roster layout/i)).toBeTruthy();
+    });
+
+    const compactRosterLayoutGroup = screen.getByLabelText(/compact roster layout/i);
+    expect(within(compactRosterLayoutGroup).getAllByRole('radio')).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole('radio', { name: /2 rows of 8 avatars/i }));
+
+    await waitFor(() => {
+      expect(store.getState().settings.gameUX.compactRosterLayout).toBe('two-rows');
+    });
+  });
+
   it('loads the requested default Game UX configuration for a fresh store', async () => {
     renderSettingsAdmin();
 


### PR DESCRIPTION
Adds a viewport-aware compact-roster prompt on the game screen and exposes Compact Roster in the standard Settings screen. The prompt suggests the 2-rows layout when the screen is cramped and remembers dismissals.