### PR TITLE
[codex] restore profile back navigation

### DIFF
--- a/src/screens/Profile/Profile.css
+++ b/src/screens/Profile/Profile.css
@@ -82,6 +82,19 @@
   text-align: center;
 }
 
+.profile-screen__back-btn {
+  align-self: flex-start;
+  margin-bottom: 14px;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .profile-screen__guest-banner a,
 .profile-screen__guest-link {
   color: rgba(107, 183, 255, 0.9);

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -48,6 +48,13 @@ export default function Profile() {
   );
 
   const gameInProgress = week > 1 || phase !== 'week_start';
+  const goBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+    navigate('/game');
+  };
 
   // Photo state loaded from IndexedDB
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
@@ -187,6 +194,14 @@ export default function Profile() {
 
   return (
     <div className="placeholder-screen profile-screen">
+      <button
+        type="button"
+        className="profile-screen__back-btn"
+        onClick={goBack}
+        aria-label="Go back"
+      >
+        ← Back
+      </button>
       {/* Header: avatar + name + action buttons */}
       <div className="profile-screen__header">
         {photoUrl ? (


### PR DESCRIPTION
## What changed
- Added a back button to the profile screen.
- The button returns to the previous screen when possible, and falls back to the game screen if there is no history.
- Added a small style tweak so the button fits the existing profile layout.

## Why
- Opening Profile mid-game could trap the player there with no obvious way back.
- This change lets players return without restarting the session.

## Impact
- Profile is no longer a dead end during gameplay.
- The current game state is preserved when leaving Profile.

## Validation
- Manual code review only, per request.