### PR TITLE
Stabilize HomeHub startup and native background paint

### DIFF
--- a/src/hooks/useHomeHubAssets.ts
+++ b/src/hooks/useHomeHubAssets.ts
@@ -53,10 +53,10 @@ function hasFontFaceSet(): boolean {
   return typeof document !== 'undefined' && 'fonts' in document && !!document.fonts;
 }
 
-export default function useHomeHubAssets(effectiveBgUrl: string | null): HomeHubAssetsState {
+export default function useHomeHubAssets(): HomeHubAssetsState {
   useLoadIntroHub();
 
-  const assetUrls = useMemo(() => getHomeHubAssetUrls(effectiveBgUrl), [effectiveBgUrl]);
+  const assetUrls = useMemo(() => getHomeHubAssetUrls(), []);
   const [imagesState, dispatchImages] = useReducer(imagesReducer, {
     loaded: 0,
     ready: assetUrls.length === 0,

--- a/src/hooks/useIntroHubBackground.ts
+++ b/src/hooks/useIntroHubBackground.ts
@@ -5,11 +5,6 @@ interface IntroHubBackgroundState {
   ready: boolean;
 }
 
-interface ValidationState {
-  resolvedFor: string | null;
-  url: string | null;
-}
-
 function loadImage(url: string): Promise<boolean> {
   return new Promise((resolve) => {
     const image = new Image();
@@ -26,52 +21,57 @@ function loadImage(url: string): Promise<boolean> {
  *   1. Preferred remote background, if it loads successfully.
  *   2. Local themed fallback background.
  *
- * The hook keeps a known-good fallback visible while the preferred image is
- * being validated so Capacitor/iOS never ends up with a broken background.
+ * The hook returns a usable URL immediately so the screen can paint on the
+ * first frame, then upgrades to the preferred remote image in the background
+ * if it loads.
  */
 export default function useIntroHubBackground(
   preferredUrl: string | null,
   fallbackUrl: string | null,
 ): IntroHubBackgroundState {
-  const isBypassed = preferredUrl == null || preferredUrl === fallbackUrl;
-  const [validation, setValidation] = useState<ValidationState>({ resolvedFor: null, url: null });
+  const [url, setUrl] = useState<string | null>(fallbackUrl ?? preferredUrl);
 
   useEffect(() => {
-    if (isBypassed || !preferredUrl) {
-      return;
-    }
-
     let cancelled = false;
+    const immediateUrl = fallbackUrl ?? preferredUrl;
+    setUrl(immediateUrl);
+
+    if (!preferredUrl || preferredUrl === fallbackUrl) {
+      return () => {
+        cancelled = true;
+      };
+    }
 
     void loadImage(preferredUrl).then((ok) => {
       if (cancelled) return;
 
       if (ok) {
-        setValidation({ resolvedFor: preferredUrl, url: preferredUrl });
+        if (import.meta.env.DEV) {
+          console.info('[HomeHub] Preferred intro background loaded', {
+            preferredUrl,
+            fallbackUrl: immediateUrl,
+          });
+        }
+        setUrl(preferredUrl);
         return;
       }
 
       if (import.meta.env.DEV) {
-        console.warn('[HomeHub] Preferred intro background failed to load; using fallback', preferredUrl);
+        console.warn('[HomeHub] Preferred intro background failed to load; using fallback', {
+          preferredUrl,
+          fallbackUrl: immediateUrl,
+        });
       }
-
-      setValidation({ resolvedFor: preferredUrl, url: fallbackUrl ?? preferredUrl });
+      setUrl(immediateUrl);
     });
 
     return () => {
       cancelled = true;
     };
-  }, [fallbackUrl, isBypassed, preferredUrl]);
-
-  if (isBypassed) {
-    return {
-      url: fallbackUrl ?? preferredUrl,
-      ready: true,
-    };
-  }
+  }, [fallbackUrl, preferredUrl]);
 
   return {
-    url: validation.resolvedFor === preferredUrl ? validation.url : (fallbackUrl ?? preferredUrl),
-    ready: validation.resolvedFor === preferredUrl,
+    url: url ?? fallbackUrl ?? preferredUrl,
+    ready: true,
   };
 }

--- a/src/hooks/useIntroHubBackground.ts
+++ b/src/hooks/useIntroHubBackground.ts
@@ -29,12 +29,10 @@ export default function useIntroHubBackground(
   preferredUrl: string | null,
   fallbackUrl: string | null,
 ): IntroHubBackgroundState {
-  const [url, setUrl] = useState<string | null>(fallbackUrl ?? preferredUrl);
+  const [preferredLoadedUrl, setPreferredLoadedUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    const immediateUrl = fallbackUrl ?? preferredUrl;
-    setUrl(immediateUrl);
 
     if (!preferredUrl || preferredUrl === fallbackUrl) {
       return () => {
@@ -49,20 +47,19 @@ export default function useIntroHubBackground(
         if (import.meta.env.DEV) {
           console.info('[HomeHub] Preferred intro background loaded', {
             preferredUrl,
-            fallbackUrl: immediateUrl,
+            fallbackUrl,
           });
         }
-        setUrl(preferredUrl);
+        setPreferredLoadedUrl(preferredUrl);
         return;
       }
 
       if (import.meta.env.DEV) {
         console.warn('[HomeHub] Preferred intro background failed to load; using fallback', {
           preferredUrl,
-          fallbackUrl: immediateUrl,
+          fallbackUrl,
         });
       }
-      setUrl(immediateUrl);
     });
 
     return () => {
@@ -70,8 +67,10 @@ export default function useIntroHubBackground(
     };
   }, [fallbackUrl, preferredUrl]);
 
+  const url = preferredLoadedUrl === preferredUrl ? preferredUrl : fallbackUrl ?? preferredUrl;
+
   return {
-    url: url ?? fallbackUrl ?? preferredUrl,
+    url,
     ready: true,
   };
 }

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -61,20 +61,17 @@ const HUB_BUTTONS = [
 
 interface HomeHubAssetLayerProps {
   splashDone: boolean;
-  effectiveBgUrl: string | null;
+  assetReady: boolean;
   onPlay: () => void;
   onNavigate: NavigateFunction;
 }
 
 function HomeHubAssetLayer({
   splashDone,
-  effectiveBgUrl,
+  assetReady,
   onPlay,
   onNavigate,
 }: HomeHubAssetLayerProps) {
-  const { ready: homeHubReady } = useHomeHubAssets();
-  const assetReady = homeHubReady;
-
   return (
     <>
       {splashDone && assetReady && (
@@ -88,7 +85,7 @@ function HomeHubAssetLayer({
 
         {/* Button stack: only rendered once the splash has dismissed and the
             full hub bundle is ready. */}
-        {splashDone && homeHubReady && (
+        {splashDone && assetReady && (
           <nav className="home-hub__buttons" aria-label="Main menu">
             {HUB_BUTTONS.map(({ to, label, icon, variant }) => (
               <GameButton
@@ -124,6 +121,7 @@ export default function HomeHub() {
   const dayCount = week;
   const activeProfileId = useAppSelector(selectActiveProfileId);
   const isGuest = useAppSelector(selectIsGuest);
+  const { ready: homeHubReady } = useHomeHubAssets();
   const { url: bgUrl } = useBackgroundTheme();
   const remoteBgUrl = useAppSelector(selectRemoteIntroHubBg);
   const remoteOverlayOpacity = useAppSelector(selectRemoteIntroHubOverlay);
@@ -231,8 +229,9 @@ export default function HomeHub() {
     setSplashDone(true);
   }
 
-  const splashDuration = homeHubAssetsReady ? 2000 : 86_400_000;
-  const showSplash = !splashDone || !homeHubAssetsReady;
+  const splashDuration = homeHubReady ? 2000 : 86_400_000;
+  const showSplash = !splashDone || !homeHubReady;
+  const assetReady = homeHubReady;
 
   return (
     <>
@@ -277,7 +276,7 @@ export default function HomeHub() {
 
           <HomeHubAssetLayer
             splashDone={splashDone}
-            effectiveBgUrl={effectiveBgUrl}
+            assetReady={assetReady}
             onPlay={handlePlay}
             onNavigate={navigate}
           />

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -18,7 +18,6 @@ import {
 import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
 import useBackgroundTheme from '../../hooks/useBackgroundTheme';
 import KolequantSplash from '../../components/KolequantSplash/KolequantSplash';
-import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOverlay';
 import AssetPreloaderOverlay from '../../components/AssetPreloaderOverlay/AssetPreloaderOverlay';
 import PermissionPrompts from '../../components/PermissionPrompts/PermissionPrompts';
 import { SoundManager } from '../../services/sound/SoundManager';
@@ -43,12 +42,13 @@ import './HomeHub.css';
  * To add a new hub button: add an entry to HUB_BUTTONS.
  *
  * Load ordering:
- *   1. KolequantSplash shown — logo only, no dialogs, hub preloads in background.
- *   2. Hub assets preload during the splash: background, buttons, fonts, and
- *      the intro-hub runtime are all loaded before the screen is revealed.
- *   3. If the splash finishes first, a loading overlay stays up until the full
- *      hub bundle is ready so the UI never appears half-built.
- *   4. After the hub is ready, PermissionPrompts appear over the hub (location only).
+ *   1. KolequantSplash is shown as the only loading surface while the hub assets
+ *      preload in the background.
+ *   2. The intro background starts with a guaranteed day/night fallback so the
+ *      native app never paints a blank screen.
+ *   3. Once the hub runtime and button art are ready, the splash dismisses and
+ *      the full intro hub appears in one reveal.
+ *   4. PermissionPrompts appear over the hub (location only).
  *   5. When Play is pressed AssetPreloaderOverlay runs then navigates to /game.
  */
 const HUB_BUTTONS = [
@@ -62,7 +62,6 @@ const HUB_BUTTONS = [
 interface HomeHubAssetLayerProps {
   splashDone: boolean;
   effectiveBgUrl: string | null;
-  backgroundReady: boolean;
   onPlay: () => void;
   onNavigate: NavigateFunction;
 }
@@ -70,14 +69,11 @@ interface HomeHubAssetLayerProps {
 function HomeHubAssetLayer({
   splashDone,
   effectiveBgUrl,
-  backgroundReady,
   onPlay,
   onNavigate,
 }: HomeHubAssetLayerProps) {
-  const { ready: homeHubReady, progress: homeHubLoadProgress, status: homeHubLoadStatus } =
-    useHomeHubAssets(effectiveBgUrl);
-  const assetReady = backgroundReady && homeHubReady;
-  const status = backgroundReady ? homeHubLoadStatus : 'Checking background...';
+  const { ready: homeHubReady } = useHomeHubAssets();
+  const assetReady = homeHubReady;
 
   return (
     <>
@@ -85,11 +81,7 @@ function HomeHubAssetLayer({
         <PermissionPrompts showSoundPrompt={false} />
       )}
 
-      {splashDone && !assetReady && (
-        <HubLoadingOverlay progress={homeHubLoadProgress} status={status} />
-      )}
-
-      {/* Foreground content — hidden until the full hub asset bundle is ready. */}
+      {/* Foreground content is hidden until the full hub bundle is ready. */}
       <div className="homehub-content home-hub">
         {/* Hero / icon area (no branding text — logo is shown in the splash) */}
         <div className="home-hub__hero" aria-hidden="true" />
@@ -135,7 +127,7 @@ export default function HomeHub() {
   const { url: bgUrl } = useBackgroundTheme();
   const remoteBgUrl = useAppSelector(selectRemoteIntroHubBg);
   const remoteOverlayOpacity = useAppSelector(selectRemoteIntroHubOverlay);
-  const { url: introHubBgUrl, ready: introHubBgReady } = useIntroHubBackground(remoteBgUrl, bgUrl);
+  const { url: introHubBgUrl } = useIntroHubBackground(remoteBgUrl, bgUrl);
   const achievementSummary = useMemo(
     () => buildAchievementSummary({
       userPlayer: introHubPlayer,
@@ -239,12 +231,16 @@ export default function HomeHub() {
     setSplashDone(true);
   }
 
+  const splashDuration = homeHubAssetsReady ? 2000 : 86_400_000;
+  const showSplash = !splashDone || !homeHubAssetsReady;
+
   return (
     <>
-      {/* Cold-load intro splash — logo only, hub preloads in background.
-          Exits automatically after the animation completes (~1.2s). */}
-      {!splashDone && (
-        <KolequantSplash onFinish={handleSplashFinish} />
+      {/* Cold-load intro splash — logo only, hub preloads in the background.
+          The splash stays up until the intro hub is actually ready so the
+          screen reveals all at once instead of in stages. */}
+      {showSplash && (
+        <KolequantSplash duration={splashDuration} onFinish={handleSplashFinish} />
       )}
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
@@ -280,10 +276,8 @@ export default function HomeHub() {
           )}
 
           <HomeHubAssetLayer
-            key={effectiveBgUrl ?? 'default'}
             splashDone={splashDone}
             effectiveBgUrl={effectiveBgUrl}
-            backgroundReady={introHubBgReady}
             onPlay={handlePlay}
             onNavigate={navigate}
           />

--- a/src/screens/HomeHub/homeHubAssets.ts
+++ b/src/screens/HomeHub/homeHubAssets.ts
@@ -32,12 +32,8 @@ function unique(values: string[]): string[] {
   return Array.from(new Set(values));
 }
 
-export function getHomeHubAssetUrls(effectiveBgUrl: string | null): string[] {
+export function getHomeHubAssetUrls(): string[] {
   const urls: string[] = [];
-
-  if (effectiveBgUrl) {
-    urls.push(effectiveBgUrl);
-  }
 
   BUTTON_VARIANTS.forEach((variant) => {
     BUTTON_STATES.forEach((state) => {

--- a/src/utils/backgroundTheme.ts
+++ b/src/utils/backgroundTheme.ts
@@ -1,15 +1,3 @@
-import {
-  getBinaryFallbackKey,
-  getGeolocationPermissionStatus,
-  getPlatformLabel,
-  resolveSkinAsset,
-  SKIN_REGISTRY,
-  type GeolocationPermissionStatus,
-  type SkinAssetSource,
-  type ThemeKey,
-  type PlatformLabel,
-} from './skinAssets';
-
 /**
  * backgroundTheme.ts
  *
@@ -21,6 +9,17 @@ import {
  * The skin lookup itself is handled by src/utils/skinAssets.ts, which provides
  * a shared native-safe registry and a bundled asset URL resolver.
  */
+import {
+  getBinaryFallbackKey,
+  getGeolocationPermissionStatus,
+  getPlatformLabel,
+  resolveSkinAsset,
+  SKIN_REGISTRY,
+  type GeolocationPermissionStatus,
+  type SkinAssetSource,
+  type ThemeKey,
+  type PlatformLabel,
+} from './skinAssets';
 
 const base = import.meta.env.BASE_URL ?? '/';
 const normalizedBase = base.endsWith('/') ? base : `${base}/`;


### PR DESCRIPTION
## What changed
- Give the intro background an immediate day/night fallback on first paint so iOS/native never starts blank.
- Stop remounting the intro hub when the background URL changes.
- Keep one loading surface only: the splash now stays up until the hub assets are actually ready, instead of flashing a second loading overlay.
- Remove the background URL from the blocking intro-hub preload list so background swaps no longer reset the button/runtime readiness gate.
- Keep the remote/weather background resolution working, but let it update in the background rather than blocking the screen.

## Notes
- Browser behavior remains intact.
- Native iOS should now reveal the intro hub in one piece instead of loading in stages.
- I did not run local CI in this pass because I worked through the GitHub branch directly.