### PR TITLE
Housemate spotlight timing and Audience Surge footer anchor

### DIFF
--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -493,6 +493,14 @@
   object-fit: cover;
 }
 
+.pf-overlay__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  margin-top: auto;
+  padding-top: 0.15rem;
+}
+
 .pf-overlay__surge-panel {
   padding: 0.95rem;
   border-radius: 1.35rem;

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -4,7 +4,7 @@
  * UX flow:
  *  1. intro            — brief live-broadcast sting over the fullscreen board
  *  2. audience_surge   — optional rewarded-ad hook that boosts temporary momentum
- *  3. live_results     — animated ranking board and timed houseguest trivia spotlight
+ *  3. live_results     — animated ranking board and timed housemate trivia spotlight
  *  4. elimination      — short tension beat when a player drops out
  *  5. final_reveal     — winner reveal card; tap to close
  *
@@ -20,9 +20,9 @@ import type { Player } from '../../types';
 import { useBattleBackVoting } from '../../hooks/useBattleBackVoting';
 import { resolveAvatar } from '../../utils/avatar';
 import {
-  SPOTLIGHT_ROTATION_MS,
   buildHouseguestSpotlightItems,
   getActiveSpotlightPlayers,
+  getSpotlightRotationDelayMs,
   selectSpotlightItem,
 } from './publicFavoriteSpotlight';
 import './PublicFavoriteOverlay.css';
@@ -257,57 +257,59 @@ function AudienceSurgePanel({
   const selectedName = activePlayers.find((candidate) => candidate.id === selectedPlayerId)?.name ?? null;
 
   return (
-    <section className="pf-overlay__surge-panel" aria-label="Audience Surge">
-      <div className="pf-overlay__surge-copy">
-        <p className="pf-overlay__surge-kicker">Audience Surge</p>
-        <p className="pf-overlay__surge-description">
-          {surgeActive && activeSurgeName
-            ? `${activeSurgeName} is getting a temporary Viewer Spotlight boost.`
-            : 'Choose one eligible player and watch to give them a short burst of audience momentum.'}
-        </p>
-      </div>
+    <footer className="pf-overlay__footer">
+      <section className="pf-overlay__surge-panel" aria-label="Audience Surge">
+        <div className="pf-overlay__surge-copy">
+          <p className="pf-overlay__surge-kicker">Audience Surge</p>
+          <p className="pf-overlay__surge-description">
+            {surgeActive && activeSurgeName
+              ? `${activeSurgeName} is getting a temporary Viewer Spotlight boost.`
+              : 'Choose one eligible player and watch to give them a short burst of audience momentum.'}
+          </p>
+        </div>
 
-      <div className="pf-overlay__surge-options" role="list" aria-label="Eligible players for Audience Surge">
-        {activePlayers.map((candidate) => {
-          const isSelected = selectedPlayerId === candidate.id;
-          const isActive = surgeActive?.playerId === candidate.id;
-          return (
-            <div key={candidate.id} role="listitem">
-              <button
-                type="button"
-                className={`pf-overlay__surge-option${isSelected ? ' pf-overlay__surge-option--selected' : ''}${isActive ? ' pf-overlay__surge-option--active' : ''}`}
-                onClick={() => onSelect(candidate.id)}
-                disabled={surgePending}
-                aria-pressed={isSelected}
-              >
-                <PlayerPortrait candidate={candidate} className="pf-overlay__portrait--chip" />
-                <span className="pf-overlay__surge-option-name">{candidate.name}</span>
-                {isActive && <span className="pf-overlay__surge-option-tag">Active</span>}
-              </button>
-            </div>
-          );
-        })}
-      </div>
+        <div className="pf-overlay__surge-options" role="list" aria-label="Eligible players for Audience Surge">
+          {activePlayers.map((candidate) => {
+            const isSelected = selectedPlayerId === candidate.id;
+            const isActive = surgeActive?.playerId === candidate.id;
+            return (
+              <div key={candidate.id} role="listitem">
+                <button
+                  type="button"
+                  className={`pf-overlay__surge-option${isSelected ? ' pf-overlay__surge-option--selected' : ''}${isActive ? ' pf-overlay__surge-option--active' : ''}`}
+                  onClick={() => onSelect(candidate.id)}
+                  disabled={surgePending}
+                  aria-pressed={isSelected}
+                >
+                  <PlayerPortrait candidate={candidate} className="pf-overlay__portrait--chip" />
+                  <span className="pf-overlay__surge-option-name">{candidate.name}</span>
+                  {isActive && <span className="pf-overlay__surge-option-tag">Active</span>}
+                </button>
+              </div>
+            );
+          })}
+        </div>
 
-      <button
-        type="button"
-        className="pf-overlay__surge-cta"
-        onClick={onActivate}
-        disabled={!selectedPlayerId || !canUseSurge || surgePending}
-      >
-        {surgePending
-          ? 'Connecting…'
-          : surgeActive
-            ? 'Audience Surge Active'
-            : surgeUsed
-              ? 'Audience Surge Used'
-              : `Watch to Boost${selectedName ? ` ${selectedName}` : ''}`}
-      </button>
-    </section>
+        <button
+          type="button"
+          className="pf-overlay__surge-cta"
+          onClick={onActivate}
+          disabled={!selectedPlayerId || !canUseSurge || surgePending}
+        >
+          {surgePending
+            ? 'Connecting…'
+            : surgeActive
+              ? 'Audience Surge Active'
+              : surgeUsed
+                ? 'Audience Surge Used'
+                : `Watch to Boost${selectedName ? ` ${selectedName}` : ''}`}
+        </button>
+      </section>
+    </footer>
   );
 }
 
-function HouseguestSpotlightCard({
+function HousemateSpotlightCard({
   spotlight,
   finalTwoNames,
 }: {
@@ -319,10 +321,10 @@ function HouseguestSpotlightCard({
   const { player } = item;
 
   return (
-    <motion.section className="pf-overlay__spotlight" aria-label="Houseguest Spotlight" layout>
+    <motion.section className="pf-overlay__spotlight" aria-label="Housemate Spotlight" layout>
       <div className="pf-overlay__leader-copy">
         <p className="pf-overlay__leader-kicker">
-          {finalTwoNames ? `Final two: ${finalTwoNames}` : 'Houseguest Spotlight'}
+          {finalTwoNames ? `Final two: ${finalTwoNames}` : 'Housemate Spotlight'}
         </p>
         <h3 className="pf-overlay__leader-name">{player.name}</h3>
         <motion.p
@@ -575,7 +577,6 @@ export default function PublicFavoriteOverlay({
     [activePlayers, votes],
   );
   const spotlightItems = useMemo(() => buildHouseguestSpotlightItems(activePlayers), [activePlayers]);
-  const hasSpotlightItems = spotlightItems.length > 0;
   const spotlight = selectSpotlightItem(spotlightItems, spotlightRotation);
   const finalTwoNames =
     activePlayers.length === 2
@@ -587,12 +588,13 @@ export default function PublicFavoriteOverlay({
   }, [candidateIds]);
 
   useEffect(() => {
-    if (displayStep !== 'voting' || !hasSpotlightItems) return;
-    const id = window.setInterval(() => {
+    if (displayStep !== 'voting' || !spotlight) return;
+    const timeoutMs = getSpotlightRotationDelayMs(spotlight.fact);
+    const id = window.setTimeout(() => {
       setSpotlightRotation((rotation) => rotation + 1);
-    }, SPOTLIGHT_ROTATION_MS);
-    return () => window.clearInterval(id);
-  }, [displayStep, hasSpotlightItems]);
+    }, timeoutMs);
+    return () => window.clearTimeout(id);
+  }, [displayStep, spotlight?.fact]);
 
   useEffect(() => {
     const firstActiveId = activePlayers[0]?.id ?? null;
@@ -764,7 +766,7 @@ export default function PublicFavoriteOverlay({
         {displayStep === 'voting' && (
           <div className="pf-overlay__broadcast">
             <div className={`pf-overlay__board-shell pf-overlay__board-shell--${phase}`}>
-              <HouseguestSpotlightCard spotlight={spotlight} finalTwoNames={finalTwoNames} />
+              <HousemateSpotlightCard spotlight={spotlight} finalTwoNames={finalTwoNames} />
               <VoteRankingBoard
                 entries={voteEntries}
                 candidatesById={candidatesById}

--- a/src/components/PublicFavoriteOverlay/publicFavoriteSpotlight.ts
+++ b/src/components/PublicFavoriteOverlay/publicFavoriteSpotlight.ts
@@ -2,12 +2,13 @@ import { getById } from '../../data/houseguests';
 import type { Houseguest } from '../../types/houseguest';
 import type { Player } from '../../types';
 
-export const SPOTLIGHT_ROTATION_MS = 4000;
-
 export interface HouseguestSpotlightItem {
   player: Player;
   facts: string[];
 }
+
+const SPOTLIGHT_ROTATION_MIN_MS = 3000;
+const SPOTLIGHT_ROTATION_MAX_MS = 5000;
 
 function cleanText(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
@@ -79,6 +80,12 @@ export function buildHouseguestSpotlightItems(candidates: Player[]): HouseguestS
       facts: facts.length > 0 ? facts : [`${profile.name} remains one of the houseguests to watch.`],
     };
   });
+}
+
+export function getSpotlightRotationDelayMs(fact: string): number {
+  const wordCount = Math.max(1, fact.split(/\s+/).filter(Boolean).length);
+  const scaledDelay = 3000 + Math.min(2000, Math.max(0, (wordCount - 8) * 110));
+  return Math.max(SPOTLIGHT_ROTATION_MIN_MS, Math.min(SPOTLIGHT_ROTATION_MAX_MS, scaledDelay));
 }
 
 export function selectSpotlightItem(


### PR DESCRIPTION
## Summary
- rename the spotlight copy to Housemate Spotlight
- vary spotlight rotation timing between 3 and 5 seconds based on fact length
- keep the Audience Surge panel anchored to the bottom of the overlay

## Notes
- per request, no local tests were run
- changes were made directly on the GitHub branch
