### PR TITLE
Keep Audience Surge visible in public favorite overlay

### DIFF
--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -4,7 +4,7 @@
   position: fixed;
   inset: 0;
   z-index: 9200;
-  overflow-y: auto;
+  overflow: hidden;
   overscroll-behavior: contain;
   animation: pfFadeIn 0.32s ease;
 }
@@ -29,7 +29,8 @@
   z-index: 1;
   width: min(100%, 56rem);
   margin: 0 auto;
-  min-height: 100dvh;
+  height: 100dvh;
+  max-height: 100dvh;
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -70,6 +71,7 @@
 }
 
 .pf-overlay__header {
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
@@ -165,11 +167,19 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
+  overflow: hidden;
+}
+
+.pf-overlay__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  flex-shrink: 0;
 }
 
 .pf-overlay__board-shell {
   position: relative;
-  flex: 1;
+  flex: 1 1 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -562,6 +572,7 @@
 }
 
 .pf-overlay__elimination {
+  flex-shrink: 0;
   padding: 0.8rem 0.95rem;
   border-radius: 1.15rem;
   background: linear-gradient(90deg, rgba(101, 26, 26, 0.94), rgba(30, 18, 24, 0.96));


### PR DESCRIPTION
## Summary
- Add the missing footer layout rule for the Audience Surge wrapper
- Constrain the public favorite overlay to the viewport so the results board scrolls internally
- Keep the header, elimination banner, and surge footer from being pushed out of view

## Testing
- Not run per prior request