### PR TITLE
[codex] Add profile career stats and status pills

### DIFF
--- a/src/screens/GameOver/GameOver.tsx
+++ b/src/screens/GameOver/GameOver.tsx
@@ -12,17 +12,36 @@ import { computeAllTimeLeaderboard } from '../../scoring/computeAllTime';
 import { DEFAULT_WEIGHTS } from '../../scoring/weights';
 import { SoundManager } from '../../services/sound/SoundManager';
 import { buildAftermathStories } from './aftermath';
+import { buildSeasonRecapData } from '../../components/SeasonRecapCinematic/seasonRecapData';
+import type { PublicOpinionState } from '../../publicOpinion/types';
 import './GameOver.css';
 
 const CAROUSEL_INTERVAL_MS = 5000;
 const LOGO_SRC = `${import.meta.env.BASE_URL}assets/kolequant.png`;
 
-/** Build PlayerSeasonSummary array from current player state - pure (no Date.now). */
-function buildSummaries(players: Player[], favoriteWinnerId: string | null, week: number): PlayerSeasonSummary[] {
+function buildTitleMap(
+  players: Player[],
+  week: number,
+  publicOpinion: PublicOpinionState | null | undefined,
+): Map<string, string[]> {
+  const titlesByPlayerId = new Map<string, string[]>();
+  buildSeasonRecapData(players, week, publicOpinion).categories.forEach((category) => {
+    const existing = titlesByPlayerId.get(category.winner.id) ?? [];
+    existing.push(category.name);
+    titlesByPlayerId.set(category.winner.id, existing);
+  });
+  return titlesByPlayerId;
+}
+
+function buildSummaries(
+  players: Player[],
+  favoriteWinnerId: string | null,
+  week: number,
+  publicOpinion: PublicOpinionState | null | undefined,
+): PlayerSeasonSummary[] {
+  const titlesByPlayerId = buildTitleMap(players, week, publicOpinion);
+
   return players.map((p) => {
-    // Only players with status 'jury' are actual jury members.
-    // The winner (finalRank=1) and runner-up (finalRank=2) are NOT jury members
-    // and should not receive the madeJury bonus.
     const madeJury = p.status === 'jury';
     const lohWins = p.stats?.lohWins ?? 0;
     const posWins = p.stats?.posWins ?? 0;
@@ -30,16 +49,13 @@ function buildSummaries(players: Player[], favoriteWinnerId: string | null, week
     const battleBackWins = p.stats?.battleBackWins ?? 0;
     const wonPublicFavorite = favoriteWinnerId != null && p.id === favoriteWinnerId;
     const wonFinalHoh = p.stats?.wonFinalHoh ?? false;
-    // The internal `week` counter now represents in-game days, so archive the
-    // survival duration as daysAlive. Keep weeksAlive populated too as a
-    // backwards-compatible fallback for any older consumers still reading it.
     const daysAlive = p.evictedAtWeek ?? week;
     const survivedDoubleEviction = p.stats?.survivedDoubleEviction ?? false;
 
     const summary: PlayerSeasonSummary = {
       playerId: p.id,
       displayName: p.name,
-      finalPlacement: p.finalRank ?? null,
+      finalPlacement: p.finalRank ?? p.seasonPlacement ?? null,
       isEvicted: p.status === 'evicted' || p.status === 'jury',
       lohWins,
       posWins,
@@ -53,6 +69,8 @@ function buildSummaries(players: Player[], favoriteWinnerId: string | null, week
       daysAlive,
       weeksAlive: daysAlive,
       survivedDoubleEviction: survivedDoubleEviction ? true : undefined,
+      finalPublicApproval: publicOpinion?.profiles[p.id]?.approval,
+      titlesWon: titlesByPlayerId.get(p.id) ?? [],
       leaderboardScore: 0,
     };
     summary.leaderboardScore = computeLeaderboardScore(summary, DEFAULT_WEIGHTS);
@@ -60,7 +78,6 @@ function buildSummaries(players: Player[], favoriteWinnerId: string | null, week
   });
 }
 
-/** Build a SeasonArchive from pre-computed summaries - called only from event handlers. */
 function buildArchive(season: number, summaries: PlayerSeasonSummary[]): SeasonArchive {
   return {
     seasonIndex: season,
@@ -80,10 +97,9 @@ export default function GameOver() {
   const week = useAppSelector((s) => s.game.week);
   const seasonArchives = useAppSelector((s) => s.game.seasonArchives ?? []);
   const favoriteWinnerId = useAppSelector((s) => s.game.favoritePlayer?.winnerId ?? null);
+  const publicOpinion = useAppSelector((s) => s.publicOpinion);
   const activeProfileId = useAppSelector(selectActiveProfileId);
   const isGuest = useAppSelector(selectIsGuest);
-  // Use a ref so the guard is synchronously readable and prevents double-archiving
-  // even if the button is clicked multiple times before React re-renders.
   const archivedRef = useRef(false);
 
   const [carouselSlide, setCarouselSlide] = useState(0);
@@ -92,16 +108,13 @@ export default function GameOver() {
 
   const winner = players.find((p) => p.isWinner) ?? players.find((p) => p.finalRank === 1);
   const runnerUp = players.find((p) => p.finalRank === 2);
-
-  // Compute per-player summaries (pure - no impure calls)
-  const summaries = buildSummaries(players, favoriteWinnerId, week);
+  const summaries = buildSummaries(players, favoriteWinnerId, week, publicOpinion);
 
   const seasonLeaderboard = computeSeasonLeaderboard(summaries, DEFAULT_WEIGHTS).slice(0, 5);
   const allTimeLeaderboard = computeAllTimeLeaderboard(seasonArchives, DEFAULT_WEIGHTS).slice(0, 5);
   const aftermathStories = useMemo(() => buildAftermathStories(players, season), [players, season]);
   const activeStory = aftermathStories[storyIndex] ?? aftermathStories[0];
 
-  // Auto-advance carousel
   useEffect(() => {
     const id = setInterval(() => {
       setCarouselSlide((s) => (s + 1) % 3);
@@ -118,8 +131,6 @@ export default function GameOver() {
 
   function startNewSeason() {
     archiveCompletedSeason();
-    // Clear any stale mid-season snapshot so the Play prompt won't offer
-    // to resume an outdated save after the season has been completed.
     if (!isGuest && activeProfileId) {
       clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId));
     }
@@ -130,8 +141,6 @@ export default function GameOver() {
 
   function exitToHome() {
     archiveCompletedSeason();
-    // Clear any stale mid-season snapshot so HomeHub does not offer to resume
-    // a season that has already been completed.
     if (!isGuest && activeProfileId) {
       clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId));
     }
@@ -176,9 +185,7 @@ export default function GameOver() {
         <h1 className="gameover-title">Season Complete</h1>
         <p className="gameover-sub">Thanks for playing - here are the results</p>
 
-        {/* -- Carousel -- */}
         <div className="gameover-carousel" aria-live="polite">
-          {/* Slide 0: Winner / Runner-up */}
           <div
             className={`gameover-carousel__slide${carouselSlide === 0 ? ' gameover-carousel__slide--active' : ''}`}
           >
@@ -195,7 +202,6 @@ export default function GameOver() {
             )}
           </div>
 
-          {/* Slide 1: Season top 5 */}
           <div
             className={`gameover-carousel__slide${carouselSlide === 1 ? ' gameover-carousel__slide--active' : ''}`}
           >
@@ -211,7 +217,6 @@ export default function GameOver() {
             </ul>
           </div>
 
-          {/* Slide 2: All-time top 5 */}
           <div
             className={`gameover-carousel__slide${carouselSlide === 2 ? ' gameover-carousel__slide--active' : ''}`}
           >
@@ -228,7 +233,6 @@ export default function GameOver() {
           </div>
         </div>
 
-        {/* -- Carousel dots -- */}
         <div className="gameover-carousel__dots">
           {[0, 1, 2].map((i) => (
             <button

--- a/src/screens/Profile/Profile.css
+++ b/src/screens/Profile/Profile.css
@@ -6,7 +6,6 @@
   padding-bottom: 40px;
 }
 
-/* Header card */
 .profile-screen__header {
   display: flex;
   align-items: center;
@@ -63,7 +62,6 @@
   white-space: nowrap;
 }
 
-/* Guest banner */
 .profile-screen__guest-banner {
   background: rgba(255, 180, 60, 0.08);
   border: 1px solid rgba(255, 180, 60, 0.2);
@@ -100,8 +98,10 @@
   text-decoration: underline;
 }
 
-/* Game status chips */
-.profile-screen__status-card {
+.profile-screen__status-card,
+.profile-screen__bio-card,
+.profile-screen__stats-card,
+.profile-screen__titles-card {
   background: linear-gradient(180deg, #0d1728, #091220);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 14px;
@@ -124,18 +124,53 @@
   gap: 7px;
 }
 
-.profile-screen__no-game {
-  font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.35);
+.profile-screen__hold-pill {
+  touch-action: manipulation;
+  user-select: none;
 }
 
-/* Bio card */
-.profile-screen__bio-card {
-  background: linear-gradient(180deg, #0d1728, #091220);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
-  padding: 14px;
-  margin-bottom: 14px;
+.profile-screen__hold-pill--revealed {
+  align-items: flex-start;
+  min-width: 160px;
+  padding: 8px 12px;
+  white-space: normal;
+}
+
+.profile-screen__hold-pill-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: 0;
+  line-height: 1.15;
+}
+
+.profile-screen__hold-pill-caption {
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+
+.profile-screen__hold-pill-value {
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.profile-screen__hold-pill-hint {
+  font-size: 0.62rem;
+  font-weight: 600;
+  opacity: 0.86;
+}
+
+.profile-screen__no-game,
+.profile-screen__empty-text {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .profile-screen__bio-story {
@@ -166,15 +201,6 @@
   font-weight: 600;
 }
 
-/* Stats card */
-.profile-screen__stats-card {
-  background: linear-gradient(180deg, #0d1728, #091220);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 14px;
-  padding: 14px;
-  margin-bottom: 14px;
-}
-
 .profile-screen__stats-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -199,9 +225,36 @@
   letter-spacing: 0.04em;
 }
 
-/* Switch profile button */
+.profile-screen__titles-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.profile-screen__title-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(107, 183, 255, 0.12);
+  border: 1px solid rgba(107, 183, 255, 0.22);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.profile-screen__title-count {
+  color: rgba(107, 183, 255, 0.92);
+}
+
 .profile-screen__switch-btn {
   width: 100%;
   color: rgba(255, 255, 255, 0.8);
 }
 
+@media (max-width: 480px) {
+  .profile-screen__stats-grid {
+    gap: 8px;
+  }
+}

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../store/hooks';
 import {
@@ -6,46 +6,477 @@ import {
   selectIsGuest,
 } from '../../store/profilesSlice';
 import { findArchiveUserSummary } from '../../store/achievementSummary';
-import StatusPill from '../../components/ui/StatusPill';
 import { imageIdToDataUrl } from '../../utils/imageDb';
+import { publicOpinionConfig } from '../../publicOpinion/publicOpinionConfig';
+import { normalizeAffinity } from '../../social/affinityUtils';
+import type { Phase, Player, StatusPillVariant } from '../../types';
 import './Profile.css';
 
-/** Build career stat totals from season archives stored in game state. */
-function useCareerStats() {
+const HOLD_REVEAL_DELAY_MS = 360;
+
+const PHASE_SHORT_LABELS: Partial<Record<Phase, string>> = {
+  week_start: 'Start',
+  loh_comp_announcement: 'LOH',
+  loh_comp: 'LOH',
+  loh_results: 'LOH',
+  social_1: 'Social',
+  nominations: 'Noms',
+  nomination_results: 'Noms',
+  pre_veto_public_save: 'Public',
+  pos_comp_announcement: 'POS',
+  pos_comp: 'POS',
+  pos_results: 'POS',
+  pos_ceremony: 'Safety',
+  pos_ceremony_results: 'Safety',
+  social_2: 'Social',
+  live_vote: 'Vote',
+  eviction_results: 'Evict',
+  week_end: 'End',
+  final4_eviction: 'F4',
+  final3: 'Finale',
+  final3_comp1: 'F3 P1',
+  final3_comp1_minigame: 'F3 P1',
+  final3_comp2: 'F3 P2',
+  final3_comp2_minigame: 'F3 P2',
+  final3_comp3: 'F3 P3',
+  final3_comp3_minigame: 'F3 P3',
+  final3_decision: 'Final LOH',
+  jury_announcement: 'Tribunal',
+  jury_cinematic: 'Tribunal',
+  jury: 'Tribunal',
+};
+
+type TitleCounter = {
+  title: string;
+  count: number;
+};
+
+type CareerStats = {
+  seasons: number;
+  wins: number;
+  lohWins: number;
+  posWins: number;
+  compsWon: number;
+  lastPlaces: number;
+  nominations: number;
+  fanFaves: number;
+  avgRating: number | null;
+  titlesWon: TitleCounter[];
+};
+
+type StatusChipData = {
+  id: string;
+  icon: string;
+  variant: StatusPillVariant;
+  shortValue: string;
+  detailLabel: string;
+  detailValue: string;
+  detailHint?: string;
+};
+
+function toNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function normalizeStoredTitle(title: string): string {
+  return title.trim().replace(/_/g, ' ').replace(/\s+/g, ' ').toUpperCase();
+}
+
+function formatTitleLabel(title: string): string {
+  return normalizeStoredTitle(title)
+    .toLowerCase()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function getSummaryCompWins(summary: {
+  lohWins?: number;
+  posWins?: number;
+  battleBackWins?: number;
+  compsWon?: number;
+}): number {
+  const explicitComps = toNumber(summary.compsWon);
+  const derivedComps =
+    toNumber(summary.lohWins) + toNumber(summary.posWins) + toNumber(summary.battleBackWins);
+  return Math.max(explicitComps, derivedComps);
+}
+
+function selectHighestSummary<T extends { playerId: string }>(
+  summaries: T[],
+  score: (summary: T) => number,
+  options: { preferDifferentFromId?: string; allowZero?: boolean } = {},
+): T | null {
+  const ranked = [...summaries].sort((a, b) => score(b) - score(a));
+  if (ranked.length === 0) return null;
+  const allowZero = options.allowZero ?? true;
+  const preferred = ranked.find(
+    (summary) =>
+      summary.playerId !== options.preferDifferentFromId && (allowZero || score(summary) > 0),
+  );
+  return preferred ?? ranked.find((summary) => allowZero || score(summary) > 0) ?? ranked[0];
+}
+
+function selectLowestSummary<T extends { playerId: string }>(
+  summaries: T[],
+  score: (summary: T) => number,
+): T | null {
+  if (summaries.length === 0) return null;
+  return [...summaries].sort((a, b) => score(a) - score(b))[0] ?? null;
+}
+
+function addArchiveTitle(
+  titlesByPlayerId: Map<string, string[]>,
+  playerId: string | undefined,
+  title: string,
+): void {
+  if (!playerId) return;
+  const normalizedTitle = normalizeStoredTitle(title);
+  const existing = titlesByPlayerId.get(playerId) ?? [];
+  if (!existing.includes(normalizedTitle)) existing.push(normalizedTitle);
+  titlesByPlayerId.set(playerId, existing);
+}
+
+function deriveArchiveTitleMap(archive: {
+  playerSummaries?: Array<{
+    playerId: string;
+    lohWins?: number;
+    posWins?: number;
+    battleBackWins?: number;
+    compsWon?: number;
+    timesNominated?: number;
+    noms?: number;
+    finalPublicApproval?: number;
+  }>;
+}): Map<string, string[]> {
+  const summaries = Array.isArray(archive.playerSummaries) ? archive.playerSummaries : [];
+  const titlesByPlayerId = new Map<string, string[]>();
+  if (summaries.length === 0) return titlesByPlayerId;
+
+  const nominations = (summary: { timesNominated?: number; noms?: number }) =>
+    Math.max(toNumber(summary.timesNominated), toNumber(summary.noms));
+
+  const compzilla = selectHighestSummary(summaries, getSummaryCompWins, { allowZero: true });
+  const headHoncho = selectHighestSummary(summaries, (summary) => toNumber(summary.lohWins), {
+    preferDifferentFromId: compzilla?.playerId,
+    allowZero: true,
+  });
+  const messFactory = selectHighestSummary(summaries, nominations, { allowZero: true });
+  const ghostMode = selectLowestSummary(summaries, nominations);
+
+  addArchiveTitle(titlesByPlayerId, compzilla?.playerId, 'COMPZILLA');
+  addArchiveTitle(titlesByPlayerId, headHoncho?.playerId, 'HEAD HONCHO');
+  addArchiveTitle(titlesByPlayerId, messFactory?.playerId, 'MESS FACTORY');
+  addArchiveTitle(titlesByPlayerId, ghostMode?.playerId, 'GHOST MODE');
+
+  const ratedSummaries = summaries.filter(
+    (summary) => typeof summary.finalPublicApproval === 'number',
+  );
+  if (ratedSummaries.length > 0) {
+    const vibeCurator = selectHighestSummary(
+      ratedSummaries,
+      (summary) => toNumber(summary.finalPublicApproval),
+      { allowZero: true },
+    );
+    const heatMagnet = selectLowestSummary(
+      ratedSummaries,
+      (summary) => toNumber(summary.finalPublicApproval),
+    );
+    addArchiveTitle(titlesByPlayerId, vibeCurator?.playerId, 'VIBE CURATOR');
+    addArchiveTitle(titlesByPlayerId, heatMagnet?.playerId, 'HEAT MAGNET');
+  }
+
+  return titlesByPlayerId;
+}
+
+function getArchiveUserTitles(
+  archive: {
+    playerSummaries?: Array<{ playerId: string; titlesWon?: string[] }>;
+  },
+  userSummary: { playerId: string; titlesWon?: string[] },
+): string[] {
+  const storedTitles = Array.isArray(userSummary.titlesWon)
+    ? userSummary.titlesWon.map(normalizeStoredTitle).filter(Boolean)
+    : [];
+  if (storedTitles.length > 0) return storedTitles;
+  return deriveArchiveTitleMap(archive).get(userSummary.playerId) ?? [];
+}
+
+function findApprovalBand(approval: number): string {
+  return publicOpinionConfig.approvalBands.find(
+    (band) => approval >= band.min && approval <= band.max,
+  )?.label ?? 'mixed';
+}
+
+function formatPercent(value: number, digits = 0): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+function formatPhaseLabel(phase: Phase): string {
+  const short = PHASE_SHORT_LABELS[phase];
+  if (short) return short;
+  return phase
+    .split('_')
+    .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+    .join(' ');
+}
+
+function describeHouseRating(rating: number): string {
+  if (rating >= 80) return 'Trusted';
+  if (rating >= 60) return 'Liked';
+  if (rating >= 40) return 'Mixed';
+  if (rating >= 20) return 'Distrusted';
+  return 'Targeted';
+}
+
+function buildNominationChip(
+  nomineeIds: string[],
+  userPlayer: Player | null,
+): StatusChipData {
+  if (userPlayer?.finalRank === 1) {
+    return {
+      id: 'winner',
+      icon: '🏆',
+      variant: 'success',
+      shortValue: 'Winner',
+      detailLabel: 'Season result',
+      detailValue: 'Winner',
+    };
+  }
+  if (userPlayer?.finalRank === 2) {
+    return {
+      id: 'runner-up',
+      icon: '🥈',
+      variant: 'info',
+      shortValue: 'Runner-up',
+      detailLabel: 'Season result',
+      detailValue: 'Runner-up',
+    };
+  }
+  if (userPlayer?.status === 'jury') {
+    return {
+      id: 'jury',
+      icon: '⚖️',
+      variant: 'info',
+      shortValue: 'Tribunal',
+      detailLabel: 'House status',
+      detailValue: 'Tribunal member',
+    };
+  }
+  if (userPlayer?.status === 'evicted') {
+    return {
+      id: 'evicted',
+      icon: '🚪',
+      variant: 'neutral',
+      shortValue: 'Out',
+      detailLabel: 'House status',
+      detailValue: 'Eliminated',
+    };
+  }
+  if (nomineeIds.includes('user')) {
+    return {
+      id: 'nominated',
+      icon: '🎯',
+      variant: 'danger',
+      shortValue: 'Nominated',
+      detailLabel: 'Nomination status',
+      detailValue: 'On the block',
+    };
+  }
+  return {
+    id: 'safe',
+    icon: '🛡️',
+    variant: 'success',
+    shortValue: 'Safe',
+    detailLabel: 'Nomination status',
+    detailValue: 'Safe this round',
+  };
+}
+
+function useCareerStats(userIdentity: Pick<Player, 'id' | 'name'> | null): CareerStats {
   return useAppSelector((s) => {
     const archives = s.game.seasonArchives ?? [];
-    const userPlayer = s.game.players.find((player) => player.isUser) ?? null;
     let seasons = 0;
     let lohWins = 0;
     let posWins = 0;
     let wins = 0;
-    for (const arc of archives) {
-      const me = findArchiveUserSummary(arc, userPlayer);
+    let compsWon = 0;
+    let lastPlaces = 0;
+    let nominations = 0;
+    let fanFaves = 0;
+    let ratingTotal = 0;
+    let ratedSeasons = 0;
+    const titlesByName = new Map<string, number>();
+
+    for (const archive of archives) {
+      const me = findArchiveUserSummary(archive, userIdentity);
       if (!me) continue;
-      seasons++;
-      lohWins += me.lohWins ?? 0;
-      posWins += me.posWins ?? 0;
-      if (me.finalPlacement === 1) wins++;
+
+      seasons += 1;
+      lohWins += toNumber(me.lohWins);
+      posWins += toNumber(me.posWins);
+      compsWon += getSummaryCompWins(me);
+      nominations += Math.max(toNumber(me.timesNominated), toNumber(me.noms));
+      if (me.finalPlacement === 1) wins += 1;
+      if (me.wonPublicFavorite) fanFaves += 1;
+      if (typeof me.finalPublicApproval === 'number') {
+        ratingTotal += me.finalPublicApproval;
+        ratedSeasons += 1;
+      }
+
+      const archivePlacements = archive.playerSummaries
+        .map((summary) => toNumber(summary.finalPlacement))
+        .filter((placement) => placement > 0);
+      const worstPlacement = archivePlacements.length > 0 ? Math.max(...archivePlacements) : 0;
+      if (worstPlacement > 0 && me.finalPlacement === worstPlacement) {
+        lastPlaces += 1;
+      } else if (worstPlacement === 0) {
+        const archiveDaysAlive = archive.playerSummaries
+          .map((summary) => toNumber(summary.daysAlive ?? summary.weeksAlive))
+          .filter((daysAlive) => daysAlive > 0);
+        const earliestExit = archiveDaysAlive.length > 0 ? Math.min(...archiveDaysAlive) : 0;
+        const myDaysAlive = toNumber(me.daysAlive ?? me.weeksAlive);
+        if (earliestExit > 0 && myDaysAlive === earliestExit) {
+          lastPlaces += 1;
+        }
+      }
+
+      getArchiveUserTitles(archive, me).forEach((title) => {
+        titlesByName.set(title, (titlesByName.get(title) ?? 0) + 1);
+      });
     }
-    return { seasons, lohWins, posWins, wins };
+
+    return {
+      seasons,
+      lohWins,
+      posWins,
+      wins,
+      compsWon,
+      lastPlaces,
+      nominations,
+      fanFaves,
+      avgRating: ratedSeasons > 0 ? ratingTotal / ratedSeasons : null,
+      titlesWon: [...titlesByName.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([title, count]) => ({ title: formatTitleLabel(title), count })),
+    };
   });
+}
+
+function HoldRevealPill({
+  icon,
+  variant,
+  shortValue,
+  detailLabel,
+  detailValue,
+  detailHint,
+}: StatusChipData) {
+  const [revealed, setRevealed] = useState(false);
+  const revealTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function clearRevealTimeout() {
+    if (!revealTimeoutRef.current) return;
+    clearTimeout(revealTimeoutRef.current);
+    revealTimeoutRef.current = null;
+  }
+
+  function startReveal() {
+    clearRevealTimeout();
+    revealTimeoutRef.current = setTimeout(() => {
+      setRevealed(true);
+      revealTimeoutRef.current = null;
+    }, HOLD_REVEAL_DELAY_MS);
+  }
+
+  function stopReveal() {
+    clearRevealTimeout();
+    setRevealed(false);
+  }
+
+  useEffect(() => () => clearRevealTimeout(), []);
+
+  const ariaLabel = detailHint
+    ? `${detailLabel}: ${detailValue}. ${detailHint}. Press and hold for details.`
+    : `${detailLabel}: ${detailValue}. Press and hold for details.`;
+  const title = detailHint
+    ? `${detailLabel}: ${detailValue} • ${detailHint}`
+    : `${detailLabel}: ${detailValue}`;
+
+  return (
+    <button
+      type="button"
+      className={`status-pill status-pill--${variant} profile-screen__hold-pill${revealed ? ' profile-screen__hold-pill--revealed' : ''}`}
+      aria-label={ariaLabel}
+      title={title}
+      onPointerDown={startReveal}
+      onPointerUp={stopReveal}
+      onPointerLeave={stopReveal}
+      onPointerCancel={stopReveal}
+      onBlur={stopReveal}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          setRevealed(true);
+        }
+      }}
+      onKeyUp={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') stopReveal();
+      }}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <span className="status-pill__icon" aria-hidden="true">{icon}</span>
+      {!revealed ? (
+        <span className="status-pill__label">{shortValue}</span>
+      ) : (
+        <span className="profile-screen__hold-pill-copy">
+          <span className="profile-screen__hold-pill-caption">{detailLabel}</span>
+          <span className="profile-screen__hold-pill-value">{detailValue}</span>
+          {detailHint ? (
+            <span className="profile-screen__hold-pill-hint">{detailHint}</span>
+          ) : null}
+        </span>
+      )}
+    </button>
+  );
 }
 
 export default function Profile() {
   const navigate = useNavigate();
   const profile = useAppSelector(selectCurrentProfile);
   const isGuest = useAppSelector(selectIsGuest);
-  const careerStats = useCareerStats();
 
-  // Game state for chips
+  const season = useAppSelector((s) => s.game.season);
   const week = useAppSelector((s) => s.game.week);
   const phase = useAppSelector((s) => s.game.phase);
   const lohId = useAppSelector((s) => s.game.lohId);
   const nomineeIds = useAppSelector((s) => s.game.nomineeIds);
   const posWinnerId = useAppSelector((s) => s.game.posWinnerId);
-  const userPlayer = useAppSelector((s) =>
-    s.game.players.find((p) => p.isUser),
-  );
+  const userPlayer = useAppSelector((s) => s.game.players.find((p) => p.isUser) ?? null);
+  const publicApproval = useAppSelector((s) => {
+    const userId = s.game.players.find((player) => player.isUser)?.id ?? 'user';
+    return s.publicOpinion?.profiles?.[userId]?.approval ?? publicOpinionConfig.DEFAULT_APPROVAL;
+  });
+  const houseRating = useAppSelector((s) => {
+    const userId = s.game.players.find((player) => player.isUser)?.id ?? 'user';
+    const housePlayers = s.game.players.filter(
+      (player) =>
+        !player.isUser &&
+        player.status !== 'evicted' &&
+        player.status !== 'jury',
+    );
+    const ratings = housePlayers
+      .map((player) => s.social?.relationships?.[player.id]?.[userId]?.affinity)
+      .filter((affinity): affinity is number => typeof affinity === 'number');
+
+    if (ratings.length === 0) return null;
+    const averageAffinity = ratings.reduce((sum, affinity) => sum + affinity, 0) / ratings.length;
+    return (normalizeAffinity(averageAffinity) + 1) * 50;
+  });
+
+  const userIdentity = useMemo<Pick<Player, 'id' | 'name'> | null>(() => {
+    if (userPlayer) return { id: userPlayer.id, name: userPlayer.name };
+    if (profile) return { id: 'user', name: profile.name };
+    return null;
+  }, [profile, userPlayer]);
+  const careerStats = useCareerStats(userIdentity);
 
   const gameInProgress = week > 1 || phase !== 'week_start';
   const goBack = () => {
@@ -56,92 +487,117 @@ export default function Profile() {
     navigate('/game');
   };
 
-  // Photo state loaded from IndexedDB
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
+
     async function load() {
       if (profile?.photoId) {
         const url = await imageIdToDataUrl(profile.photoId);
         if (!cancelled) setPhotoUrl(url ?? null);
-      } else {
-        if (!cancelled) setPhotoUrl(null);
+      } else if (!cancelled) {
+        setPhotoUrl(null);
       }
     }
+
     void load();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [profile?.photoId]);
 
-  // ── Chips derived from game state ───────────────────────────────────────────
-  function renderChips() {
-    if (!gameInProgress) {
-      return (
-        <p className="profile-screen__no-game">No active game — start playing to see live status.</p>
-      );
+  const statusChips = useMemo<StatusChipData[]>(() => {
+    if (!gameInProgress) return [];
+
+    const chips: StatusChipData[] = [
+      {
+        id: 'season',
+        icon: '🎬',
+        variant: 'info',
+        shortValue: `S${season}`,
+        detailLabel: 'Season',
+        detailValue: `Season ${season}`,
+      },
+      {
+        id: 'day',
+        icon: '🗓️',
+        variant: 'week',
+        shortValue: String(week),
+        detailLabel: 'Day',
+        detailValue: `Day ${week}`,
+      },
+      {
+        id: 'phase',
+        icon: '📡',
+        variant: 'phase',
+        shortValue: formatPhaseLabel(phase),
+        detailLabel: 'Phase',
+        detailValue: formatPhaseLabel(phase),
+      },
+      buildNominationChip(nomineeIds, userPlayer),
+      {
+        id: 'public-rating',
+        icon: '📣',
+        variant: 'info',
+        shortValue: formatPercent(publicApproval, 0),
+        detailLabel: "Viewer's rating",
+        detailValue: formatPercent(publicApproval, 1),
+        detailHint: findApprovalBand(publicApproval),
+      },
+    ];
+
+    if (houseRating != null) {
+      chips.push({
+        id: 'house-rating',
+        icon: '🏠',
+        variant: 'neutral',
+        shortValue: formatPercent(houseRating, 0),
+        detailLabel: 'House rating',
+        detailValue: formatPercent(houseRating, 1),
+        detailHint: describeHouseRating(houseRating),
+      });
     }
 
-    const chips: React.ReactNode[] = [];
-
-    // Day
-    chips.push(
-      <StatusPill key="week" variant="week" icon="📅" label={`Day ${week}`} />,
-    );
-
-    // LOH
     if (lohId === 'user') {
-      chips.push(
-        <StatusPill key="hoh" variant="success" icon="👑" label="LOH" />,
-      );
+      chips.push({
+        id: 'loh',
+        icon: '👑',
+        variant: 'success',
+        shortValue: 'LOH',
+        detailLabel: 'House power',
+        detailValue: 'Leader of the House',
+      });
     }
 
-    // Nominated
-    if (nomineeIds.includes('user')) {
-      chips.push(
-        <StatusPill key="nom" variant="danger" icon="🎯" label="Nominated" />,
-      );
-    }
-
-    // POS holder
     if (posWinnerId === 'user') {
-      chips.push(
-        <StatusPill key="pov" variant="warning" icon="🔑" label="POS Holder" />,
-      );
-    }
-
-    // Status chips for evicted / jury / winner
-    if (userPlayer?.status === 'evicted') {
-      chips.push(
-        <StatusPill key="evicted" variant="neutral" icon="🚪" label="Eliminated" />,
-      );
-    } else if (userPlayer?.status === 'jury') {
-      chips.push(
-        <StatusPill key="jury" variant="info" icon="⚖️" label="Tribunal" />,
-      );
-    }
-
-    // Placement medal (after finale)
-    if (userPlayer?.finalRank === 1) {
-      chips.push(
-        <StatusPill key="winner" variant="success" icon="🏆" label="Winner!" />,
-      );
-    } else if (userPlayer?.finalRank === 2) {
-      chips.push(
-        <StatusPill key="runner-up" variant="info" icon="🥈" label="Runner-up" />,
-      );
+      chips.push({
+        id: 'pos',
+        icon: '🔑',
+        variant: 'warning',
+        shortValue: 'POS',
+        detailLabel: 'Safety power',
+        detailValue: 'Power of Safety holder',
+      });
     }
 
     return chips;
+  }, [gameInProgress, houseRating, lohId, nomineeIds, phase, posWinnerId, publicApproval, season, userPlayer, week]);
+
+  function renderStatusChips() {
+    if (statusChips.length === 0) {
+      return (
+        <p className="profile-screen__no-game">No active game - start playing to see live status.</p>
+      );
+    }
+    return statusChips.map((chip) => <HoldRevealPill key={chip.id} {...chip} />);
   }
 
-  // ── Render ──────────────────────────────────────────────────────────────────
-
-  // Guest mode
   if (isGuest) {
     return (
       <div className="placeholder-screen profile-screen">
         <div className="profile-screen__guest-banner">
           <p style={{ margin: '0 0 6px' }}>
-            👤 You are playing as <strong>Guest</strong>
+            You are playing as <strong>Guest</strong>
           </p>
           <p style={{ margin: 0, fontSize: '0.78rem', color: 'rgba(255,255,255,0.6)' }}>
             Stats and season archives are not saved in guest mode.
@@ -152,26 +608,25 @@ export default function Profile() {
               className="profile-screen__guest-link"
               onClick={() => navigate('/profile-picker')}
             >
-              Create a profile to save progress →
+              Create a profile to save progress ->
             </button>
           </p>
         </div>
         <div className="profile-screen__status-card">
           <p className="profile-screen__section-title">Game Status</p>
-          <div className="profile-screen__chips">{renderChips()}</div>
+          <div className="profile-screen__chips">{renderStatusChips()}</div>
         </div>
         <button
           type="button"
           className="profile-screen__switch-btn game-button game-button--secondary"
           onClick={() => navigate('/profile-picker')}
         >
-          👥 Select Profile
+          Select Profile
         </button>
       </div>
     );
   }
 
-  // No profile selected
   if (!profile) {
     return (
       <div className="placeholder-screen profile-screen">
@@ -184,7 +639,7 @@ export default function Profile() {
           onClick={() => navigate('/profile-picker')}
           style={{ marginBottom: 12 }}
         >
-          👥 Select or Create a Profile
+          Select or Create a Profile
         </button>
       </div>
     );
@@ -200,9 +655,8 @@ export default function Profile() {
         onClick={goBack}
         aria-label="Go back"
       >
-        ← Back
+        {'<- Back'}
       </button>
-      {/* Header: avatar + name + action buttons */}
       <div className="profile-screen__header">
         {photoUrl ? (
           <img className="profile-screen__avatar-img" src={photoUrl} alt={profile.name} />
@@ -211,12 +665,8 @@ export default function Profile() {
         )}
         <div className="profile-screen__identity">
           <p className="profile-screen__name">{profile.name}</p>
-          {bio?.profession && (
-            <p className="profile-screen__sub">{bio.profession}</p>
-          )}
-          {bio?.location && (
-            <p className="profile-screen__sub">📍 {bio.location}</p>
-          )}
+          {bio?.profession && <p className="profile-screen__sub">{bio.profession}</p>}
+          {bio?.location && <p className="profile-screen__sub">📍 {bio.location}</p>}
         </div>
         <div className="profile-screen__header-btns">
           <button
@@ -225,7 +675,7 @@ export default function Profile() {
             onClick={() => navigate('/profile-edit')}
             aria-label="Edit profile"
           >
-            ✏️ Edit
+            Edit
           </button>
           <button
             type="button"
@@ -233,24 +683,20 @@ export default function Profile() {
             onClick={() => navigate('/profile-picker')}
             aria-label="Switch profile"
           >
-            👥 Switch
+            Switch
           </button>
         </div>
       </div>
 
-      {/* Live game-state chips */}
       <div className="profile-screen__status-card">
         <p className="profile-screen__section-title">Current Status</p>
-        <div className="profile-screen__chips">{renderChips()}</div>
+        <div className="profile-screen__chips">{renderStatusChips()}</div>
       </div>
 
-      {/* Bio card — only shown if there's content */}
-      {bio && (bio.story || bio.location || bio.profession || bio.age) && (
+      {bio && (bio.story || bio.location || bio.profession || bio.age || bio.zodiac || bio.funFact || bio.motto) && (
         <div className="profile-screen__bio-card">
           <p className="profile-screen__section-title">About</p>
-          {bio.story && (
-            <p className="profile-screen__bio-story">{bio.story}</p>
-          )}
+          {bio.story && <p className="profile-screen__bio-story">{bio.story}</p>}
           <div className="profile-screen__bio-grid">
             {bio.profession && (
               <div className="profile-screen__bio-item">
@@ -292,7 +738,6 @@ export default function Profile() {
         </div>
       )}
 
-      {/* Career stats */}
       {careerStats.seasons > 0 && (
         <div className="profile-screen__stats-card">
           <p className="profile-screen__section-title">Career Stats</p>
@@ -313,7 +758,47 @@ export default function Profile() {
               <span className="profile-screen__stat-val">{careerStats.posWins}</span>
               <span className="profile-screen__stat-key">POS Wins</span>
             </div>
+            <div className="profile-screen__stat">
+              <span className="profile-screen__stat-val">{careerStats.compsWon}</span>
+              <span className="profile-screen__stat-key">Comps Won</span>
+            </div>
+            <div className="profile-screen__stat">
+              <span className="profile-screen__stat-val">{careerStats.lastPlaces}</span>
+              <span className="profile-screen__stat-key">Last Places</span>
+            </div>
+            <div className="profile-screen__stat">
+              <span className="profile-screen__stat-val">{careerStats.nominations}</span>
+              <span className="profile-screen__stat-key">Nominations</span>
+            </div>
+            <div className="profile-screen__stat">
+              <span className="profile-screen__stat-val">{careerStats.fanFaves}</span>
+              <span className="profile-screen__stat-key">Fan Fave</span>
+            </div>
+            <div className="profile-screen__stat">
+              <span className="profile-screen__stat-val">
+                {careerStats.avgRating == null ? '-' : formatPercent(careerStats.avgRating, 1)}
+              </span>
+              <span className="profile-screen__stat-key">Avg Rating</span>
+            </div>
           </div>
+        </div>
+      )}
+
+      {careerStats.seasons > 0 && (
+        <div className="profile-screen__titles-card">
+          <p className="profile-screen__section-title">Titles Won</p>
+          {careerStats.titlesWon.length > 0 ? (
+            <div className="profile-screen__titles-grid">
+              {careerStats.titlesWon.map((title) => (
+                <div key={title.title} className="profile-screen__title-chip">
+                  <span>{title.title}</span>
+                  <span className="profile-screen__title-count">x{title.count}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="profile-screen__empty-text">No titles won yet.</p>
+          )}
         </div>
       )}
     </div>

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -608,7 +608,7 @@ export default function Profile() {
               className="profile-screen__guest-link"
               onClick={() => navigate('/profile-picker')}
             >
-              Create a profile to save progress ->
+              Create a profile to save progress -&gt;
             </button>
           </p>
         </div>

--- a/src/store/seasonArchive.ts
+++ b/src/store/seasonArchive.ts
@@ -38,6 +38,10 @@ export interface PlayerSeasonSummary {
   weeksAlive?: number;
   /** True if the player was evicted at some point (including jury). */
   isEvicted?: boolean;
+  /** Final public approval captured when the season ended. */
+  finalPublicApproval?: number;
+  /** Wrap-up titles this player won in the season recap. */
+  titlesWon?: string[];
   /** Computed total leaderboard score using the scoring module weights. */
   leaderboardScore?: number;
 }


### PR DESCRIPTION
## What changed
- expanded the profile career stats card with comps won, last places, nominations, fan fave, and average final public rating
- added a Titles Won section sourced from season recap title data and archived season summaries
- upgraded Current Status into press-and-hold result pills for season, day, phase, nomination state, public rating, in-house rating, and active power states
- archived final public approval and recap titles at season end so future profile totals stay accurate

## Why
- the profile needed deeper long-term progression stats and a cleaner live-status summary without crowding the default pill labels

## Validation
- not run locally per request