### PR TITLE
Refine public favorite vote board pacing and presentation

### DIFF
--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -135,8 +135,8 @@
 }
 
 .pf-overlay__subtitle {
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   font-weight: 700;
 }
@@ -145,10 +145,10 @@
 .pf-overlay__intro-title {
   margin: 0;
   color: #ffd979;
-  font-size: clamp(1.65rem, 4.8vw, 2.15rem);
+  font-size: clamp(1.5rem, 4.4vw, 2rem);
   font-weight: 900;
   line-height: 1;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   text-shadow: 0 0 22px rgba(251, 191, 36, 0.26);
 }
@@ -302,16 +302,19 @@
 .pf-overlay__percent-wrap {
   position: relative;
   display: inline-flex;
+  min-width: 3.3rem;
   min-height: 1.6rem;
   align-items: center;
+  justify-content: flex-end;
 }
 
 .pf-overlay__percent-value {
   display: inline-flex;
   align-items: center;
   color: #fff;
-  font-size: 1.15rem;
+  font-size: 1.08rem;
   font-weight: 900;
+  font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
@@ -332,24 +335,60 @@
 }
 
 .pf-overlay__accent-rail {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 0.32rem;
-}
-
-.pf-overlay__accent-segment {
-  height: 0.38rem;
+  position: relative;
+  display: block;
+  height: 0.74rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
 }
 
-.pf-overlay__accent-segment--active {
-  background: linear-gradient(90deg, rgba(168, 85, 247, 0.92), rgba(251, 191, 36, 0.95));
-  box-shadow: 0 0 12px rgba(251, 191, 36, 0.2);
+.pf-overlay__accent-track,
+.pf-overlay__accent-fill,
+.pf-overlay__accent-pip {
+  position: absolute;
 }
 
-.pf-overlay__accent-rail--leader .pf-overlay__accent-segment {
-  height: 0.42rem;
+.pf-overlay__accent-track {
+  inset: 0;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.04)),
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.1) 0,
+      rgba(255, 255, 255, 0.1) 1px,
+      transparent 1px,
+      transparent 26px
+    );
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.pf-overlay__accent-fill {
+  top: 0;
+  left: 0;
+  bottom: 0;
+  min-width: 0.75rem;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(168, 85, 247, 0.96), rgba(251, 191, 36, 0.96));
+  box-shadow: 0 0 18px rgba(251, 191, 36, 0.2);
+}
+
+.pf-overlay__accent-pip {
+  top: 50%;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: #fff2c5;
+  border: 2px solid rgba(18, 21, 35, 0.88);
+  box-shadow: 0 0 18px rgba(251, 191, 36, 0.34);
+  transform: translateY(-50%);
+}
+
+.pf-overlay__accent-rail--leader .pf-overlay__accent-fill {
+  box-shadow: 0 0 24px rgba(251, 191, 36, 0.28);
+}
+
+.pf-overlay__accent-rail--leader .pf-overlay__accent-pip {
+  background: #fff8dc;
 }
 
 .pf-overlay__leader-portrait-wrap,
@@ -412,25 +451,41 @@
   flex-direction: column;
   gap: 0.55rem;
   overflow-y: auto;
-  padding-right: 0.1rem;
+  padding-right: 0.25rem;
 }
 
 .pf-overlay__rank-card {
+  flex-shrink: 0;
   display: grid;
   grid-template-columns: auto auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.75rem;
   width: 100%;
-  padding: 0.72rem 0.78rem;
+  padding: 0.82rem 0.88rem 0.82rem 1rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 1.05rem;
-  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1.1rem;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.03));
   color: inherit;
   text-align: left;
 }
 
+.pf-overlay__rank-card::before {
+  content: '';
+  position: absolute;
+  left: 0.42rem;
+  top: 0.65rem;
+  bottom: 0.65rem;
+  width: 0.18rem;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(168, 85, 247, 0.32), rgba(251, 191, 36, 0.12));
+}
+
 .pf-overlay__rank-card--leader {
-  background: linear-gradient(135deg, rgba(255, 220, 125, 0.09), rgba(255, 255, 255, 0.05));
+  background: linear-gradient(90deg, rgba(255, 220, 125, 0.11), rgba(255, 255, 255, 0.05));
+}
+
+.pf-overlay__rank-card--leader::before {
+  background: linear-gradient(180deg, rgba(255, 220, 125, 0.86), rgba(168, 85, 247, 0.38));
 }
 
 .pf-overlay__rank-card--selected {
@@ -440,14 +495,13 @@
 .pf-overlay__rank-card--surge {
   border-color: rgba(251, 191, 36, 0.24);
   box-shadow: 0 0 22px rgba(251, 191, 36, 0.12);
-  transform: scale(1.01);
 }
 
 .pf-overlay__rank-copy,
 .pf-overlay__rank-tail {
   display: flex;
   flex-direction: column;
-  gap: 0.32rem;
+  gap: 0.38rem;
   min-width: 0;
 }
 
@@ -602,11 +656,11 @@
 }
 
 .pf-overlay__intro-title {
-  font-size: clamp(1.6rem, 6vw, 2.4rem);
+  font-size: clamp(1.55rem, 6vw, 2.2rem);
 }
 
 .pf-overlay__intro-subtitle {
-  max-width: 18rem;
+  max-width: 19rem;
   font-size: 0.92rem;
   line-height: 1.35;
 }

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -31,7 +31,7 @@ interface Props {
   candidates: Player[];
   seed: number;
   awardAmount?: number;
-  /** Override the elimination interval (ms). Default: 3500. Useful for QA slow-mode. */
+  /** Override the elimination interval (ms). Default: 4800. Useful for QA slow-mode. */
   eliminationIntervalMs?: number;
   onComplete: (winnerId: string) => void;
   onAudienceSurgeRequest?: (playerId: string) => Promise<boolean> | boolean;
@@ -64,7 +64,9 @@ interface VoteEntry {
   surgeActive: boolean;
 }
 
-const ELIM_INTERVAL_MS = 3500;
+const ELIM_INTERVAL_MS = 4800;
+const VOTE_TICK_INTERVAL_MS = 750;
+const VOTE_DRIFT_AMOUNT = 3;
 const INTRO_MS = 1600;
 const CLOCK_INTERVAL_MS = 200;
 const SURGE_SELECTION_WINDOW_MS = 6500;
@@ -99,7 +101,6 @@ function getStatusLine(args: {
   const {
     phase,
     countdown,
-    eliminationName,
     surgeActive,
     surgePlayerName,
     surgePending,
@@ -111,23 +112,23 @@ function getStatusLine(args: {
     return 'Public favorite locked in';
   }
   if (phase === 'intro') {
-    return 'Broadcast feed coming online';
+    return 'Standings are loading';
   }
-  if (phase === 'elimination' && eliminationName) {
-    return `${eliminationName} falls out of the public vote`;
+  if (phase === 'elimination') {
+    return 'Standings paused for elimination';
   }
   if (surgePending) {
-    return 'Preparing Audience Surge…';
+    return 'Connecting Audience Surge';
   }
   if (surgeActive && surgePlayerName) {
-    return `${surgePlayerName} is riding an Audience Surge · ${clampCountdown(
+    return `${surgePlayerName} has the audience boost · ${clampCountdown(
       surgeActive.endsAt - nowMs,
     )}s left`;
   }
   if (phase === 'audience_surge' && surgeWindowRemaining > 0) {
-    return `Viewer Spotlight closes in ${surgeWindowRemaining}s`;
+    return `Audience Surge closes in ${surgeWindowRemaining}s`;
   }
-  return `Next results shift in ${countdown}s`;
+  return `Board refresh in ${countdown}s`;
 }
 
 function AnimatedPercent({ percent }: { percent: number }) {
@@ -139,18 +140,25 @@ function AnimatedPercent({ percent }: { percent: number }) {
 }
 
 function VoteAccentRail({ percent, tone = 'default' }: { percent: number; tone?: 'default' | 'leader' }) {
-  const activeSegments = Math.max(1, Math.min(6, Math.round(percent / 17)));
+  const clampedPercent = Math.max(6, Math.min(100, percent));
   return (
     <div
       className={`pf-overlay__accent-rail${tone === 'leader' ? ' pf-overlay__accent-rail--leader' : ''}`}
       aria-hidden="true"
     >
-      {Array.from({ length: 6 }, (_, index) => (
-        <span
-          key={index}
-          className={`pf-overlay__accent-segment${index < activeSegments ? ' pf-overlay__accent-segment--active' : ''}`}
-        />
-      ))}
+      <span className="pf-overlay__accent-track" />
+      <motion.span
+        className="pf-overlay__accent-fill"
+        initial={false}
+        animate={{ width: `${clampedPercent}%` }}
+        transition={{ duration: 0.55, ease: 'easeOut' }}
+      />
+      <motion.span
+        className="pf-overlay__accent-pip"
+        initial={false}
+        animate={{ left: `calc(${clampedPercent}% - 0.45rem)` }}
+        transition={{ duration: 0.55, ease: 'easeOut' }}
+      />
     </div>
   );
 }
@@ -228,8 +236,8 @@ function PublicVoteIntro() {
       transition={{ duration: 0.35, ease: 'easeOut' }}
     >
       <span className="pf-overlay__intro-live">LIVE</span>
-      <p className="pf-overlay__intro-title">LIVE PUBLIC VOTE</p>
-      <p className="pf-overlay__intro-subtitle">Broadcast signal locked. Bringing the audience board into focus.</p>
+      <p className="pf-overlay__intro-title">PUBLIC FAVORITE VOTE</p>
+      <p className="pf-overlay__intro-subtitle">Audience numbers are coming in. Stand by for the first live board.</p>
     </motion.div>
   );
 }
@@ -373,6 +381,8 @@ function VoteRankingCard({
       className={`pf-overlay__rank-card${entry.isLeader ? ' pf-overlay__rank-card--leader' : ''}${entry.surgeActive ? ' pf-overlay__rank-card--surge' : ''}${isSelected ? ' pf-overlay__rank-card--selected' : ''}`}
       onClick={() => onSelect(entry.playerId)}
       aria-label={`${entry.name}, rank ${entry.rank}, ${entry.percent}%`}
+      layout
+      transition={{ layout: { duration: 0.42, ease: 'easeOut' } }}
     >
       <span className="pf-overlay__rank-number">#{entry.rank}</span>
       <PlayerPortrait candidate={candidate} />
@@ -381,11 +391,15 @@ function VoteRankingCard({
           <span className="pf-overlay__rank-name">{entry.name}</span>
           <VoteTrendChip trend={entry.trend} previousRank={entry.previousRank} rank={entry.rank} />
         </div>
-        <VoteAccentRail percent={entry.percent} />
+        <VoteAccentRail percent={entry.percent} tone={entry.isLeader ? 'leader' : 'default'} />
       </div>
       <div className="pf-overlay__rank-tail">
         <AnimatedPercent percent={entry.percent} />
-        {entry.surgeActive && <span className="pf-overlay__rank-tag">Surge</span>}
+        {entry.surgeActive ? (
+          <span className="pf-overlay__rank-tag">Surge</span>
+        ) : entry.isLeader ? (
+          <span className="pf-overlay__rank-tag">Live lead</span>
+        ) : null}
       </div>
     </motion.button>
   );
@@ -405,7 +419,7 @@ function VoteRankingBoard({
   return (
     <section className="pf-overlay__board" aria-label="Public vote ranking board">
       <div className="pf-overlay__board-header">
-        <p className="pf-overlay__board-title">Results board</p>
+        <p className="pf-overlay__board-title">Audience board</p>
       </div>
       <div className="pf-overlay__board-list">
         {entries.map((entry) => {
@@ -522,7 +536,8 @@ export default function PublicFavoriteOverlay({
     candidates: candidateIds,
     seed,
     eliminationIntervalMs,
-    tickIntervalMs: 400,
+    tickIntervalMs: VOTE_TICK_INTERVAL_MS,
+    driftAmount: VOTE_DRIFT_AMOUNT,
     surgeTargetId: surgeActive?.playerId ?? null,
   });
   const displayStep: Step = isComplete && step === 'voting' ? 'winner' : step;
@@ -762,8 +777,8 @@ export default function PublicFavoriteOverlay({
         <AnimatePresence>
           {phase !== 'final_reveal' && (
             <PublicVoteHeader
-              title="LIVE PUBLIC VOTE"
-              subtitle="Public Favorite Player"
+              title="PUBLIC FAVORITE VOTE"
+              subtitle="Viewer board"
               statusLine={statusLine}
             />
           )}

--- a/src/hooks/useBattleBackVoting.ts
+++ b/src/hooks/useBattleBackVoting.ts
@@ -33,6 +33,8 @@ interface Options {
   eliminationIntervalMs?: number;
   /** Tick interval for percentage drift in ms. Default: 400. */
   tickIntervalMs?: number;
+  /** Strength of each drift tick. Lower values create calmer vote swings. */
+  driftAmount?: number;
   /** Optional temporary momentum boost for a single active candidate. */
   surgeTargetId?: string | null;
 }
@@ -155,6 +157,7 @@ export function useBattleBackVoting({
   seed,
   eliminationIntervalMs = 3500,
   tickIntervalMs = 400,
+  driftAmount = 5,
   surgeTargetId = null,
 }: Options): BattleBackVoteState {
   const rngRef = useRef(mulberry32(seed));
@@ -208,13 +211,13 @@ export function useBattleBackVoting({
         pcts: driftPercentages(
           pctsRef.current,
           rngRef.current,
-          5,
+          driftAmount,
           currentSurgeIndex >= 0 ? currentSurgeIndex : null,
         ),
       });
     }, tickIntervalMs);
     return () => clearInterval(id);
-  }, [state.isComplete, tickIntervalMs]);
+  }, [state.isComplete, tickIntervalMs, driftAmount]);
 
   // ── Elimination tick ─────────────────────────────────────────────────────
   const eliminateLowest = useCallback(() => {


### PR DESCRIPTION
## Summary
- fix the results board row squashing after the sticky footer change
- slow the live voting drift and elimination cadence so the board is easier to follow
- refresh the panel styling and copy so it feels more like a TV voting board and less repetitive

## Testing
- not run per request