### PR TITLE
Fix mobile safe-area layout contract

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -1,23 +1,24 @@
 /* MinigameHost.css */
 .minigame-host {
-  position: fixed;
+  position: absolute;
   inset: 0;
-  --minigame-safe-top: var(--app-safe-area-top);
-  --minigame-safe-right: var(--safe-right);
-  --minigame-safe-bottom: var(--safe-bottom);
-  --minigame-safe-left: var(--safe-left);
-  --minigame-safe-padding-top: calc(var(--minigame-safe-top) + clamp(10px, 2.8vw, 18px));
-  --minigame-safe-padding-right: calc(var(--minigame-safe-right) + clamp(10px, 2.6vw, 18px));
-  --minigame-safe-padding-bottom: calc(var(--minigame-safe-bottom) + clamp(10px, 2.6vw, 18px));
-  --minigame-safe-padding-left: calc(var(--minigame-safe-left) + clamp(10px, 2.6vw, 18px));
-  --minigame-stage-top-gap: clamp(56px, 12vh, 92px);
-  --minigame-stage-top-padding: calc(var(--minigame-safe-top) + var(--minigame-stage-top-gap));
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  --minigame-safe-top: 0px;
+  --minigame-safe-right: 0px;
+  --minigame-safe-bottom: 0px;
+  --minigame-safe-left: 0px;
+  --minigame-safe-padding-top: clamp(10px, 2.8vw, 18px);
+  --minigame-safe-padding-right: clamp(10px, 2.6vw, 18px);
+  --minigame-safe-padding-bottom: clamp(10px, 2.6vw, 18px);
+  --minigame-safe-padding-left: clamp(10px, 2.6vw, 18px);
+  --minigame-stage-top-gap: clamp(56px, 12%, 92px);
+  --minigame-stage-top-padding: var(--minigame-stage-top-gap);
   --safe-top: var(--minigame-safe-top);
   --safe-right: var(--minigame-safe-right);
   --safe-bottom: var(--minigame-safe-bottom);
   --safe-left: var(--minigame-safe-left);
-  --floating-corner-top-base: 14px;
-  --floating-corner-top-safe-padding: 12px;
   background: #0d0d1a;
   display: flex;
   flex-direction: column;
@@ -35,7 +36,7 @@
   gap: 16px;
   width: 100%;
   max-width: 32rem;
-  max-height: 100dvh;
+  max-height: 100%;
   padding:
     var(--minigame-stage-top-padding)
     var(--minigame-safe-padding-right)
@@ -76,6 +77,9 @@
 .minigame-host-playing {
   position: absolute;
   inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -98,7 +102,7 @@
 }
 
 .minigame-host-playing > .pp .pp__card {
-  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .qtr {
@@ -120,7 +124,7 @@
 .minigame-host-playing > .qtr-canvas .qtr-canvas__card {
   max-height: min(
     760px,
-    calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom) - 24px)
+    calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom) - 24px)
   );
 }
 
@@ -141,7 +145,7 @@
 }
 
 .minigame-host-playing > .bbl .bbl__card {
-  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .tbg {
@@ -153,7 +157,7 @@
 }
 
 .minigame-host-playing > .tbg .tbg__card {
-  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .snake-root {
@@ -165,8 +169,8 @@
 }
 
 .minigame-host-playing > .snake-root .snake-phone {
-  height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
-  max-height: calc(100dvh - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+  max-height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
 }
 
 .minigame-host-playing > .cm {
@@ -250,8 +254,9 @@
   gap: 12px;
   width: 100%;
   max-width: 460px;
-  height: 100dvh;
-  max-height: 100dvh;
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
   padding:
     var(--minigame-stage-top-padding)
     max(24px, var(--minigame-safe-padding-right))
@@ -444,12 +449,9 @@
 }
 
 .minigame-host-close-btn {
-  --floating-corner-top-base: 12px;
-  --floating-corner-right-base: 14px;
-  --floating-corner-right-safe-padding: 14px;
   position: absolute;
-  top: var(--floating-corner-top-offset);
-  right: var(--floating-corner-right-offset);
+  top: 12px;
+  right: 14px;
   z-index: 9600;
   width: 36px;
   height: 36px;

--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -2,20 +2,21 @@
 .app-shell {
   display: flex;
   flex-direction: column;
-  height: 100dvh; /* dynamic viewport height – handles mobile browser chrome */
+  width: 100%;
+  height: 100%;
   max-width: 480px;
-  margin: 0 auto;
+  margin: 0;
   background: var(--color-bg);
   position: relative;
   overflow: hidden;
+  min-height: 0;
 }
 
 .app-shell__main {
+  position: relative;
   flex: 1 1 0;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior-y: contain;
-  padding-top: var(--app-safe-area-top);
-  /* Push content above bottom safe area */
-  padding-bottom: var(--safe-bottom);
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import NavBar from './NavBar';
+import SafeGameViewport from './SafeGameViewport';
 import DebugPanel from '../DebugPanel/DebugPanel';
 import FinalFaceoff from '../FinalFaceoff/FinalFaceoff';
 import SeasonFinaleOverlay from '../SeasonFinale/SeasonFinaleOverlay';
@@ -84,19 +85,21 @@ export default function AppShell() {
   }, [settings.gameUX.animations]);
 
   return (
-    <div className="app-shell">
-      <main className="app-shell__main">
-        <Outlet />
-      </main>
-      <NavBar />
-      <DebugPanel />
-      {/* Mount FinalFaceoff when entering jury so it can initialise the finale.
-          Also remount it for the rare recovery case where jury voting already
-          completed but the season finale overlay has not started yet. */}
-      {phase === 'jury' &&
-        seasonFinale == null &&
-        (finale.isActive || !finale.hasStarted || finale.isComplete) && <FinalFaceoff />}
-      {seasonFinale && <SeasonFinaleOverlay />}
-    </div>
+    <SafeGameViewport>
+      <div className="app-shell">
+        <main className="app-shell__main">
+          <Outlet />
+        </main>
+        <NavBar />
+        <DebugPanel />
+        {/* Mount FinalFaceoff when entering jury so it can initialise the finale.
+            Also remount it for the rare recovery case where jury voting already
+            completed but the season finale overlay has not started yet. */}
+        {phase === 'jury' &&
+          seasonFinale == null &&
+          (finale.isActive || !finale.hasStarted || finale.isComplete) && <FinalFaceoff />}
+        {seasonFinale && <SeasonFinaleOverlay />}
+      </div>
+    </SafeGameViewport>
   );
 }

--- a/src/components/layout/SafeGameViewport.css
+++ b/src/components/layout/SafeGameViewport.css
@@ -1,0 +1,88 @@
+.safe-game-viewport {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.safe-game-viewport__content {
+  position: absolute;
+  top: var(--safe-top);
+  right: var(--safe-right);
+  bottom: var(--safe-bottom);
+  left: var(--safe-left);
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Legacy fullscreen game roots must fill the safe viewport, not the raw screen. */
+.safe-game-viewport__content :is(
+  .minigame-host,
+  .qtr,
+  .qtr-canvas,
+  .pp,
+  .bbl,
+  .td,
+  .snake-root,
+  .spectator-overlay,
+  .pf-overlay,
+  .day-start-shock
+) {
+  position: absolute !important;
+  inset: 0 !important;
+}
+
+.safe-game-viewport__content :is(
+  .minigame-host,
+  .qtr,
+  .qtr-canvas,
+  .pp,
+  .bbl,
+  .td,
+  .snake-root,
+  .spectator-overlay,
+  .pf-overlay,
+  .day-start-shock
+) {
+  --safe-top: 0px;
+  --safe-right: 0px;
+  --safe-bottom: 0px;
+  --safe-left: 0px;
+  --app-safe-area-top: 0px;
+}
+
+.safe-game-viewport__content .pf-overlay__stage {
+  height: 100%;
+  max-height: 100%;
+  padding: 0.9rem 0.9rem 1rem;
+}
+
+.safe-game-viewport__content .pf-overlay__skip {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.safe-game-viewport--debug::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2147483646;
+  box-shadow: inset 0 0 0 2px rgba(255, 80, 80, 0.9);
+}
+
+.safe-game-viewport--debug .safe-game-viewport__content::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2147483647;
+  box-shadow: inset 0 0 0 2px rgba(80, 255, 160, 0.95);
+}

--- a/src/components/layout/SafeGameViewport.tsx
+++ b/src/components/layout/SafeGameViewport.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import './SafeGameViewport.css';
+
+type SafeGameViewportProps = {
+  children: ReactNode;
+  className?: string;
+  debug?: boolean;
+};
+
+function readSafeViewportDebugFlag(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const pageParams = new URLSearchParams(window.location.search);
+  const hashQueryStart = window.location.hash.indexOf('?');
+  const hashParams = new URLSearchParams(
+    hashQueryStart >= 0 ? window.location.hash.slice(hashQueryStart + 1) : '',
+  );
+
+  return pageParams.has('safeViewportDebug') || hashParams.has('safeViewportDebug');
+}
+
+/**
+ * Mandatory gameplay viewport contract.
+ * The outer shell covers the physical screen; the inner content is the only
+ * rectangle where game UI may render, inset by the device safe-area variables.
+ */
+export default function SafeGameViewport({ children, className = '', debug }: SafeGameViewportProps) {
+  const debugEnabled = debug ?? (import.meta.env.DEV && readSafeViewportDebugFlag());
+  const classes = [
+    'safe-game-viewport',
+    debugEnabled ? 'safe-game-viewport--debug' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} data-safe-game-viewport="outer">
+      <div className="safe-game-viewport__content" data-safe-game-viewport="content">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useGameMode.ts
+++ b/src/hooks/useGameMode.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
 
 interface WakeLockSentinelLike {
   released?: boolean;
@@ -16,6 +17,19 @@ interface LockableOrientationLike {
   unlock?: () => void;
 }
 
+interface NativeStatusBarLike {
+  hide?: () => Promise<void>;
+  show?: () => Promise<void>;
+  setOverlaysWebView?: (options: { overlay: boolean }) => Promise<void>;
+}
+
+function getNativeStatusBar(): NativeStatusBarLike | null {
+  if (!Capacitor.isNativePlatform()) return null;
+
+  const plugins = (Capacitor as unknown as { Plugins?: Record<string, unknown> }).Plugins;
+  return (plugins?.StatusBar as NativeStatusBarLike | undefined) ?? null;
+}
+
 /**
  * Keeps the game in an "active play" mode on supported mobile browsers.
  *
@@ -23,15 +37,18 @@ interface LockableOrientationLike {
  * - requests a screen wake lock so the display stays awake during play
  * - re-requests the wake lock when the tab becomes visible again
  * - attempts to keep the experience portrait-locked when the platform allows it
+ * - hides the native Capacitor status bar when the StatusBar plugin exists
  */
 export default function useGameMode(): void {
   useEffect(() => {
     let isMounted = true;
     let wakeLockSentinel: WakeLockSentinelLike | null = null;
     let wakeLockRequestInFlight: Promise<void> | null = null;
+    let statusBarHidden = false;
 
     const wakeLock = (navigator as Navigator & { wakeLock?: WakeLockControllerLike }).wakeLock;
     const orientation = screen.orientation as LockableOrientationLike | undefined;
+    const statusBar = getNativeStatusBar();
 
     function isWakeLockRequestAllowedByVisibility() {
       return document.visibilityState === 'visible';
@@ -106,23 +123,51 @@ export default function useGameMode(): void {
       }
     }
 
+    async function hideStatusBar() {
+      if (!statusBar || statusBarHidden) return;
+
+      try {
+        await statusBar.setOverlaysWebView?.({ overlay: false });
+        await statusBar.hide?.();
+        statusBarHidden = true;
+      } catch {
+        // SafeGameViewport owns layout correctness even when native APIs fail.
+      }
+    }
+
+    async function showStatusBar() {
+      if (!statusBar || !statusBarHidden) return;
+
+      try {
+        await statusBar.show?.();
+      } catch {
+        // Native status bar restoration is best-effort during teardown.
+      } finally {
+        statusBarHidden = false;
+      }
+    }
+
     function handleVisibilityChange() {
       if (document.visibilityState === 'visible') {
         void requestWakeLock();
         void lockOrientation();
+        void hideStatusBar();
       } else {
         void releaseWakeLock();
+        void showStatusBar();
       }
     }
 
     void requestWakeLock();
     void lockOrientation();
+    void hideStatusBar();
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       isMounted = false;
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       unlockOrientation();
+      void showStatusBar();
       void releaseWakeLock();
     };
   }, []);

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -1,14 +1,16 @@
 /* GameScreen */
 .game-screen {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 12px 12px calc(var(--nav-bar-height) + 10px + var(--safe-bottom));
+  min-height: 100%;
+  padding: 12px 12px calc(var(--nav-bar-height) + 10px);
 }
 
 .game-screen--compact-roster-balance {
   box-sizing: border-box;
-  min-height: calc(100dvh - 84px);
+  min-height: calc(100% - 84px);
 }
 
 .game-screen--compact-roster-balance > .tv-zone {
@@ -110,8 +112,8 @@
 
 /* ── Dev: nomination animation debug button (dev builds only) ────────────── */
 .dev-nom-anim-btn {
-  position: fixed;
-  bottom: calc(var(--nav-bar-height, 56px) + var(--safe-bottom) + 8px);
+  position: absolute;
+  bottom: calc(var(--nav-bar-height, 56px) + 8px);
   left: 8px;
   z-index: 9000;
   padding: 6px 10px;

--- a/src/screens/MinigameLab/MinigameLab.css
+++ b/src/screens/MinigameLab/MinigameLab.css
@@ -10,12 +10,12 @@
 }
 
 .minigame-lab__panel {
-  position: fixed;
+  position: absolute;
   top: 16px;
   left: 16px;
   z-index: 9601;
-  width: min(92vw, 392px);
-  max-height: calc(100dvh - 32px);
+  width: min(92%, 392px);
+  max-height: calc(100% - 32px);
   overflow: auto;
   padding: 18px;
   border-radius: 24px;
@@ -197,7 +197,7 @@
     right: 12px;
     bottom: 12px;
     width: auto;
-    max-height: 46dvh;
+    max-height: 46%;
     padding: 16px;
   }
 

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -7,87 +7,72 @@ function normalizeCss(css: string) {
 }
 
 describe('safe-area layout styles', () => {
-  it('defines a shared top safe-area fallback and applies it in the app shell', () => {
+  it('defines global safe-area tokens and a single safe game viewport contract', () => {
     const globalCss = normalizeCss(readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8'));
+    const safeViewportTsx = readFileSync(
+      resolve(process.cwd(), 'src/components/layout/SafeGameViewport.tsx'),
+      'utf8',
+    );
+    const safeViewportCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'), 'utf8'),
+    );
+    const appShellTsx = readFileSync(
+      resolve(process.cwd(), 'src/components/layout/AppShell.tsx'),
+      'utf8',
+    );
     const appShellCss = normalizeCss(
-      readFileSync(
-        resolve(process.cwd(), 'src/components/layout/AppShell.css'),
-        'utf8',
-      ),
+      readFileSync(resolve(process.cwd(), 'src/components/layout/AppShell.css'), 'utf8'),
     );
-    const juryRevealCss = normalizeCss(
-      readFileSync(
-        resolve(process.cwd(), 'src/components/JuryPhaseRevealOverlay/JuryPhaseRevealOverlay.css'),
-        'utf8',
-      ),
-    );
-    const evictionCss = normalizeCss(
-      readFileSync(
-        resolve(process.cwd(), 'src/components/Eviction/SpotlightEvictionOverlay.css'),
-        'utf8',
-      ),
+
+    expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);');
+    expect(globalCss).toContain('--safe-right: env(safe-area-inset-right, 0px);');
+    expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
+    expect(globalCss).toContain('--safe-left: env(safe-area-inset-left, 0px);');
+    expect(safeViewportTsx).toContain('export default function SafeGameViewport');
+    expect(appShellTsx).toContain('<SafeGameViewport>');
+
+    expect(safeViewportCss).toContain('.safe-game-viewport { position: fixed; inset: 0;');
+    expect(safeViewportCss).toContain('height: 100dvh;');
+    expect(safeViewportCss).toContain('top: var(--safe-top);');
+    expect(safeViewportCss).toContain('right: var(--safe-right);');
+    expect(safeViewportCss).toContain('bottom: var(--safe-bottom);');
+    expect(safeViewportCss).toContain('left: var(--safe-left);');
+    expect(safeViewportCss).toContain('.safe-game-viewport--debug::before');
+    expect(safeViewportCss).toContain('.safe-game-viewport--debug .safe-game-viewport__content::after');
+
+    expect(appShellCss).toContain('height: 100%;');
+    expect(appShellCss).toContain('min-height: 0;');
+    expect(appShellCss).not.toContain('padding-top: var(--app-safe-area-top);');
+    expect(appShellCss).not.toContain('padding-bottom: var(--safe-bottom);');
+  });
+
+  it('keeps minigames and old fullscreen game roots inside the safe viewport', () => {
+    const safeViewportCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'), 'utf8'),
     );
     const minigameHostCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/MinigameHost/MinigameHost.css'), 'utf8'),
     );
+    const gameScreenCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.css'), 'utf8'),
+    );
 
-    expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);');
-    expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
-    expect(globalCss).toContain('--safe-left: env(safe-area-inset-left, 0px);');
-    expect(globalCss).toContain('--safe-right: env(safe-area-inset-right, 0px);');
-    expect(globalCss).toContain('--safe-area-inset-top: var(--safe-top);');
-    expect(globalCss).toContain('--app-safe-area-top-fallback: 0px;');
-    expect(globalCss).toContain(
-      '--app-safe-area-top: max(var(--app-safe-area-top-fallback), var(--safe-top));',
-    );
-    expect(globalCss).toContain(
-      '--app-safe-area-top-extra: max(0px, calc(var(--app-safe-area-top) - 16px));',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-top-base: 12px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-top-safe-padding: 8px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-left-base: 16px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-left-safe-padding: 16px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-right-base: 16px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-right-safe-padding: 16px;',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-top-offset: max( var(--floating-corner-top-base), calc(var(--app-safe-area-top) + var(--floating-corner-top-safe-padding)) );',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-left-offset: max( var(--floating-corner-left-base), calc(var(--safe-left) + var(--floating-corner-left-safe-padding)) );',
-    );
-    expect(globalCss).toContain(
-      '--floating-corner-right-offset: max( var(--floating-corner-right-base), calc(var(--safe-right) + var(--floating-corner-right-safe-padding)) );',
-    );
-    expect(globalCss).toContain('html.is-capacitor,');
-    expect(globalCss).toContain('html.is-chrome-android {');
-    expect(globalCss).toContain('--app-safe-area-top-fallback: 16px;');
-    expect(appShellCss).toContain('padding-top: var(--app-safe-area-top);');
-    expect(appShellCss).toContain('padding-bottom: var(--safe-bottom);');
-    expect(juryRevealCss).toContain('--floating-corner-top-base: 12px;');
-    expect(juryRevealCss).toContain('top: var(--floating-corner-top-offset);');
-    expect(juryRevealCss).toContain('right: var(--floating-corner-right-offset);');
-    expect(evictionCss).toContain('--floating-corner-top-base: 1rem;');
-    expect(evictionCss).toContain('--floating-corner-left-base: 1rem;');
-    expect(evictionCss).toContain('top: var(--floating-corner-top-offset);');
-    expect(evictionCss).toContain('left: var(--floating-corner-left-offset);');
-    expect(minigameHostCss).toContain('--floating-corner-top-base: 12px;');
-    expect(minigameHostCss).toContain('--floating-corner-right-base: 14px;');
-    expect(minigameHostCss).toContain('--minigame-stage-top-gap: clamp(56px, 12vh, 92px);');
-    expect(minigameHostCss).toContain('--minigame-stage-top-padding: calc(var(--minigame-safe-top) + var(--minigame-stage-top-gap));');
-    expect(minigameHostCss).toContain('top: var(--floating-corner-top-offset);');
-    expect(minigameHostCss).toContain('right: var(--floating-corner-right-offset);');
+    expect(safeViewportCss).toContain('.minigame-host, .qtr, .qtr-canvas, .pp, .bbl, .td, .snake-root, .spectator-overlay, .pf-overlay, .day-start-shock');
+    expect(safeViewportCss).toContain('position: absolute !important;');
+    expect(safeViewportCss).toContain('--app-safe-area-top: 0px;');
+
+    expect(minigameHostCss).toContain('.minigame-host { position: absolute; inset: 0;');
+    expect(minigameHostCss).toContain('height: 100%;');
+    expect(minigameHostCss).toContain('max-height: 100%;');
+    expect(minigameHostCss).toContain('overflow-y: auto;');
+    expect(minigameHostCss).not.toContain('position: fixed;');
+    expect(minigameHostCss).not.toContain('100vh');
+    expect(minigameHostCss).not.toContain('100dvh');
+
+    expect(gameScreenCss).toContain('position: relative;');
+    expect(gameScreenCss).toContain('min-height: 100%;');
+    expect(gameScreenCss).not.toContain('100vh');
+    expect(gameScreenCss).not.toContain('100dvh');
   });
 
   it('keeps explicit back-header screens aligned to the shared 16px baseline', () => {


### PR DESCRIPTION
## Summary
- Adds `SafeGameViewport` as the mandatory fixed outer shell with an inner safe-area content rectangle.
- Wraps `AppShell` in the shared safe viewport and makes gameplay/minigame sizing parent-relative.
- Refactors `MinigameHost` away from its independent fixed fullscreen root and normalizes legacy fullscreen minigame roots inside the safe viewport.
- Adds best-effort Capacitor native status bar hide/show support in `useGameMode`.
- Updates the safe-area style contract test and adds a visual debug outline via `?safeViewportDebug`.

## Testing
- Not run locally per request. Remote-only changes made through GitHub.