### PR TITLE
Implement Survivor Mode and IntroHub play selection

### DIFF
--- a/src/modes/gameModes.ts
+++ b/src/modes/gameModes.ts
@@ -1,4 +1,4 @@
-import type { GameMode } from '../types';
+import type { GameMode } from './modeTypes';
 
 export interface GameModeConfig {
   publicModeEnabled: boolean;

--- a/src/modes/gameModes.ts
+++ b/src/modes/gameModes.ts
@@ -1,0 +1,55 @@
+import type { GameMode } from '../types';
+
+export interface GameModeConfig {
+  publicModeEnabled: boolean;
+  socialModeEnabled: boolean;
+  competitionsEnabled: boolean;
+  nominationEvictionEnabled: boolean;
+  infiniteDaysEnabled: boolean;
+  replaceEvictedPlayers: boolean;
+  useRoboPlayers: boolean;
+}
+
+export const classicModeConfig: GameModeConfig = {
+  publicModeEnabled: true,
+  socialModeEnabled: true,
+  competitionsEnabled: true,
+  nominationEvictionEnabled: true,
+  infiniteDaysEnabled: false,
+  replaceEvictedPlayers: false,
+  useRoboPlayers: false,
+};
+
+export const survivorModeConfig: GameModeConfig = {
+  publicModeEnabled: false,
+  socialModeEnabled: false,
+  competitionsEnabled: true,
+  nominationEvictionEnabled: true,
+  infiniteDaysEnabled: true,
+  replaceEvictedPlayers: true,
+  useRoboPlayers: true,
+};
+
+export function normalizeGameMode(mode: GameMode | undefined | null): GameMode {
+  return mode === 'survivor' ? 'survivor' : 'classic';
+}
+
+export function getModeConfig(mode: GameMode | undefined | null): GameModeConfig {
+  return normalizeGameMode(mode) === 'survivor' ? survivorModeConfig : classicModeConfig;
+}
+
+export function isPublicModeEnabled(mode: GameMode | undefined | null): boolean {
+  return getModeConfig(mode).publicModeEnabled;
+}
+
+export function isSocialModeEnabled(mode: GameMode | undefined | null): boolean {
+  return getModeConfig(mode).socialModeEnabled;
+}
+
+export function isInfiniteMode(mode: GameMode | undefined | null): boolean {
+  return getModeConfig(mode).infiniteDaysEnabled;
+}
+
+export function shouldReplaceEvictedPlayers(mode: GameMode | undefined | null): boolean {
+  return getModeConfig(mode).replaceEvictedPlayers;
+}

--- a/src/modes/modeTypes.ts
+++ b/src/modes/modeTypes.ts
@@ -1,0 +1,53 @@
+import type { GameState as BaseGameState, Player as BasePlayer } from '../types';
+
+export type GameMode = 'classic' | 'survivor';
+export type GameRunStatus = 'active' | 'paused' | 'completed' | 'failed';
+
+export interface ClassicModeState {
+  kind: 'classic';
+}
+
+export interface SurvivorModeState {
+  kind: 'survivor';
+  currentDay: number;
+  totalRoboContestantsEvicted: number;
+  bestDayReached: number;
+  startingCastSize: number;
+  nextRoboIndex: number;
+  competitionRotation: {
+    usedKeys: string[];
+    round: number;
+  };
+}
+
+export type ModeSpecificState = ClassicModeState | SurvivorModeState;
+
+export type GameRunState = BaseGameState & {
+  runId?: string;
+  mode?: GameMode;
+  status?: GameRunStatus;
+  modeSpecific?: ModeSpecificState;
+  createdAt?: number;
+  lastPlayedAt?: number;
+  saveVersion?: number;
+};
+
+export type RoboPlayer = BasePlayer & {
+  isRobo?: boolean;
+};
+
+declare module '../types' {
+  interface Player {
+    isRobo?: boolean;
+  }
+
+  interface GameState {
+    runId?: string;
+    mode?: GameMode;
+    status?: GameRunStatus;
+    modeSpecific?: ModeSpecificState;
+    createdAt?: number;
+    lastPlayedAt?: number;
+    saveVersion?: number;
+  }
+}

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Middleware } from '@reduxjs/toolkit';
-import type { GameState, Player, SurvivorModeState } from '../types';
+import type { GameState, Player } from '../types';
+import type { SurvivorModeState } from './modeTypes';
 import { advance, hydrateGame } from '../store/gameSlice';
 import { getDefaultCompetitionSeasonState } from '../ai/competition';
 import { buildReplacementRobo, createSurvivorModeState } from './survivorRun';

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,10 +1,18 @@
 import type { Middleware } from '@reduxjs/toolkit';
 import type { GameState, Player } from '../types';
 import type { SurvivorModeState } from './modeTypes';
-import { advance, hydrateGame } from '../store/gameSlice';
+import { advance, consumeForcedShock, finalizePendingEviction, hydrateGame } from '../store/gameSlice';
 import { getDefaultCompetitionSeasonState } from '../ai/competition';
 import { buildReplacementRobo, createSurvivorModeState } from './survivorRun';
 import { isSocialModeEnabled, shouldReplaceEvictedPlayers } from './gameModes';
+
+const SURVIVOR_BLOCKED_SHOCK_ACTIONS = new Set([
+  'game/activateBattleBack',
+  'game/activateSpecialVeto',
+  'game/activateDayStartShock',
+  'game/activateDemocracia',
+  'game/triggerSecretMission',
+]);
 
 function isExited(player: Player | undefined): boolean {
   return player?.status === 'evicted' || player?.status === 'jury';
@@ -18,7 +26,8 @@ function getSurvivorState(game: GameState): SurvivorModeState {
 
 function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState | null {
   if (game.mode !== 'survivor' || !shouldReplaceEvictedPlayers(game.mode)) return null;
-  const evictee = game.players.find((player) => player.id === evicteeId);
+  const evicteeIndex = game.players.findIndex((player) => player.id === evicteeId);
+  const evictee = evicteeIndex >= 0 ? game.players[evicteeIndex] : undefined;
   if (!isExited(evictee) || evictee?.isUser) return null;
 
   const modeSpecific = getSurvivorState(game);
@@ -32,10 +41,11 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   };
   const totalRoboContestantsEvicted = modeSpecific.totalRoboContestantsEvicted + 1;
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
+  const players = game.players.map((player, index) => (index === evicteeIndex ? replacement : player));
 
   return {
     ...game,
-    players: [...game.players, replacement],
+    players,
     competitionSeasonStateByPlayerId: nextCompetitionState,
     modeSpecific: {
       ...modeSpecific,
@@ -76,9 +86,19 @@ function withSurvivorDaySync(game: GameState): GameState | null {
 }
 
 export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) => {
-  const result = next(action);
   const typedAction = action as { type?: string; payload?: unknown };
-  const game = storeApi.getState().game as GameState;
+  const stateBefore = storeApi.getState() as { game: GameState };
+
+  if (stateBefore.game.mode === 'survivor' && typedAction.type && SURVIVOR_BLOCKED_SHOCK_ACTIONS.has(typedAction.type)) {
+    if (stateBefore.game.pendingForcedShock?.type && stateBefore.game.pendingForcedShock.type !== 'doubleEviction') {
+      storeApi.dispatch(consumeForcedShock());
+    }
+    return undefined;
+  }
+
+  const result = next(action);
+  const stateAfter = storeApi.getState() as { game: GameState };
+  const game = stateAfter.game;
 
   if (game.mode !== 'survivor') return result;
 
@@ -90,14 +110,24 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
     }
   }
 
+  const latest = (storeApi.getState() as { game: GameState }).game;
+  if (
+    typedAction.type !== 'game/finalizePendingEviction' &&
+    latest.pendingEviction &&
+    !latest.voteResults
+  ) {
+    storeApi.dispatch(finalizePendingEviction(latest.pendingEviction.evicteeId));
+    return result;
+  }
+
   if (typedAction.type === 'game/advance') {
-    const latest = storeApi.getState().game as GameState;
-    if (!isSocialModeEnabled(latest.mode) && (latest.phase === 'social_1' || latest.phase === 'social_2')) {
+    const advanced = (storeApi.getState() as { game: GameState }).game;
+    if (!isSocialModeEnabled(advanced.mode) && (advanced.phase === 'social_1' || advanced.phase === 'social_2')) {
       storeApi.dispatch(advance());
       return result;
     }
 
-    const synced = withSurvivorDaySync(latest);
+    const synced = withSurvivorDaySync(advanced);
     if (synced) storeApi.dispatch(hydrateGame(synced));
   }
 

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Middleware } from '@reduxjs/toolkit';
-import type { GameState, Player } from '../types';
+import type { GameState, Player, TvEvent } from '../types';
 import type { SurvivorModeState } from './modeTypes';
 import { advance, consumeForcedShock, finalizePendingEviction, hydrateGame } from '../store/gameSlice';
 import { getDefaultCompetitionSeasonState } from '../ai/competition';
@@ -42,6 +42,13 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   const totalRoboContestantsEvicted = modeSpecific.totalRoboContestantsEvicted + 1;
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
   const players = game.players.map((player, index) => (index === evicteeIndex ? replacement : player));
+  const replacementEvent: TvEvent = {
+    id: `survivor-replacement-${replacement.id}`,
+    text: `${replacement.name} enters as a replacement synthetic contestant.`,
+    type: 'game',
+    timestamp: Date.now(),
+    meta: { phase: game.phase, week: game.week, mode: 'survivor' },
+  };
 
   return {
     ...game,
@@ -55,16 +62,7 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
       nextRoboIndex: modeSpecific.nextRoboIndex + 1,
     },
     lastPlayedAt: Date.now(),
-    tvFeed: [
-      {
-        id: `survivor-replacement-${replacement.id}`,
-        text: `${replacement.name} enters as a replacement synthetic contestant.`,
-        type: 'game',
-        timestamp: Date.now(),
-        meta: { phase: game.phase, week: game.week, mode: 'survivor' },
-      },
-      ...game.tvFeed,
-    ].slice(0, 50),
+    tvFeed: [replacementEvent, ...game.tvFeed].slice(0, 50),
   };
 }
 

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,0 +1,104 @@
+import type { Middleware } from '@reduxjs/toolkit';
+import type { GameState, Player, SurvivorModeState } from '../types';
+import { advance, hydrateGame } from '../store/gameSlice';
+import { getDefaultCompetitionSeasonState } from '../ai/competition';
+import { buildReplacementRobo, createSurvivorModeState } from './survivorRun';
+import { isSocialModeEnabled, shouldReplaceEvictedPlayers } from './gameModes';
+
+function isExited(player: Player | undefined): boolean {
+  return player?.status === 'evicted' || player?.status === 'jury';
+}
+
+function getSurvivorState(game: GameState): SurvivorModeState {
+  return game.modeSpecific?.kind === 'survivor'
+    ? game.modeSpecific
+    : createSurvivorModeState(game.players.filter((player) => !isExited(player)).length);
+}
+
+function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState | null {
+  if (game.mode !== 'survivor' || !shouldReplaceEvictedPlayers(game.mode)) return null;
+  const evictee = game.players.find((player) => player.id === evicteeId);
+  if (!isExited(evictee) || evictee?.isUser) return null;
+
+  const modeSpecific = getSurvivorState(game);
+  const activeCastSize = game.players.filter((player) => !isExited(player)).length;
+  if (activeCastSize >= modeSpecific.startingCastSize) return null;
+
+  const replacement = buildReplacementRobo(game);
+  const nextCompetitionState = {
+    ...(game.competitionSeasonStateByPlayerId ?? {}),
+    [replacement.id]: getDefaultCompetitionSeasonState(),
+  };
+  const totalRoboContestantsEvicted = modeSpecific.totalRoboContestantsEvicted + 1;
+  const currentDay = Math.max(modeSpecific.currentDay, game.week);
+
+  return {
+    ...game,
+    players: [...game.players, replacement],
+    competitionSeasonStateByPlayerId: nextCompetitionState,
+    modeSpecific: {
+      ...modeSpecific,
+      currentDay,
+      bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+      totalRoboContestantsEvicted,
+      nextRoboIndex: modeSpecific.nextRoboIndex + 1,
+    },
+    lastPlayedAt: Date.now(),
+    tvFeed: [
+      {
+        id: `survivor-replacement-${replacement.id}`,
+        text: `${replacement.name} enters as a replacement synthetic contestant.`,
+        type: 'game',
+        timestamp: Date.now(),
+        meta: { phase: game.phase, week: game.week, mode: 'survivor' },
+      },
+      ...game.tvFeed,
+    ].slice(0, 50),
+  };
+}
+
+function withSurvivorDaySync(game: GameState): GameState | null {
+  if (game.mode !== 'survivor') return null;
+  const modeSpecific = getSurvivorState(game);
+  const currentDay = Math.max(modeSpecific.currentDay, game.week);
+  const bestDayReached = Math.max(modeSpecific.bestDayReached, currentDay);
+  if (currentDay === modeSpecific.currentDay && bestDayReached === modeSpecific.bestDayReached) return null;
+  return {
+    ...game,
+    modeSpecific: {
+      ...modeSpecific,
+      currentDay,
+      bestDayReached,
+    },
+    lastPlayedAt: Date.now(),
+  };
+}
+
+export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) => {
+  const result = next(action);
+  const typedAction = action as { type?: string; payload?: unknown };
+  const game = storeApi.getState().game as GameState;
+
+  if (game.mode !== 'survivor') return result;
+
+  if (typedAction.type === 'game/finalizePendingEviction' && typeof typedAction.payload === 'string') {
+    const nextGame = withReplacementIfNeeded(game, typedAction.payload);
+    if (nextGame) {
+      storeApi.dispatch(hydrateGame(nextGame));
+      return result;
+    }
+  }
+
+  if (typedAction.type === 'game/advance') {
+    const latest = storeApi.getState().game as GameState;
+    if (!isSocialModeEnabled(latest.mode) && (latest.phase === 'social_1' || latest.phase === 'social_2')) {
+      storeApi.dispatch(advance());
+      return result;
+    }
+
+    const synced = withSurvivorDaySync(latest);
+    if (synced) storeApi.dispatch(hydrateGame(synced));
+  }
+
+  return result;
+};

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -9,6 +9,7 @@ const ROBO_NAMES = [
 ];
 
 const SAVE_VERSION = 2;
+const SURVIVOR_STARTING_CAST_SIZE = 9;
 
 function makeRunId(mode: 'classic' | 'survivor'): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -59,9 +60,9 @@ export function createSurvivorRun(): GameState {
   const base = createInitialGameState();
   const runId = makeRunId('survivor');
   const human = base.players.find((player) => player.isUser) ?? base.players[0];
-  const startingCastSize = Math.max(2, base.players.length);
+  const startingCastSize = SURVIVOR_STARTING_CAST_SIZE;
   const players = [
-    { ...human, id: 'user', status: 'active' as const, isUser: true },
+    { ...human, id: 'user', status: 'active' as const, isUser: true, isRobo: false },
     ...Array.from({ length: startingCastSize - 1 }, (_, index) => buildRoboPlayer(index, runId)),
   ];
   const now = Date.now();
@@ -79,20 +80,26 @@ export function createSurvivorRun(): GameState {
     season: 1,
     week: 1,
     publicModeEnabled: false,
+    cfg: {
+      ...(base.cfg ?? {}),
+      jurySize: 0,
+      enableJuryReturn: false,
+      enableSpectatorReact: false,
+    },
     players,
     competitionSeasonStateByPlayerId: buildCompetitionState(players),
     modeSpecific,
     tvFeed: [
       {
         id: 'survivor-e0',
-        text: 'Survivor Mode online. Synthetic contestants will be replaced after every eviction.',
+        text: 'Survivor Mode online. Nine contestants enter; synthetic replacements keep the board full after every robo eviction.',
         type: 'game',
         timestamp: now,
         meta: { phase: 'week_start', week: 1, mode: 'survivor' },
       },
       {
         id: 'survivor-e1',
-        text: '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON',
+        text: '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON | Double Elimination: possible',
         type: 'game',
         timestamp: now,
         meta: { phase: 'week_start', week: 1, mode: 'survivor' },

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -1,4 +1,5 @@
-import type { GameState, Player, SurvivorModeState } from '../types';
+import type { GameState, Player } from '../types';
+import type { SurvivorModeState } from './modeTypes';
 import { getDefaultCompetitionProfile, getDefaultCompetitionSeasonState } from '../ai/competition';
 import { createInitialGameState } from '../store/gameSlice';
 
@@ -41,6 +42,7 @@ function buildCompetitionState(players: Player[]): GameState['competitionSeasonS
 
 export function createSurvivorModeState(startingCastSize: number): SurvivorModeState {
   return {
+    kind: 'survivor',
     currentDay: 1,
     totalRoboContestantsEvicted: 0,
     bestDayReached: 1,

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -1,0 +1,123 @@
+import type { GameState, Player, SurvivorModeState } from '../types';
+import { getDefaultCompetitionProfile, getDefaultCompetitionSeasonState } from '../ai/competition';
+import { createInitialGameState } from '../store/gameSlice';
+
+const ROBO_NAMES = [
+  'Lira', 'Kang', 'Sora', 'Mako', 'Venn', 'Rika', 'Nexo', 'Zari', 'Kiro', 'Tavi',
+  'Oren', 'Miri', 'Juno', 'Rexo', 'Fenn', 'Kova', 'Lumi', 'Silo', 'Arin', 'Varo',
+];
+
+const SAVE_VERSION = 2;
+
+function makeRunId(mode: 'classic' | 'survivor'): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${mode}-${crypto.randomUUID()}`;
+  }
+  return `${mode}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function robotAvatar(seed: string): string {
+  return `https://api.dicebear.com/9.x/bottts/svg?seed=${encodeURIComponent(seed)}`;
+}
+
+function buildRoboPlayer(index: number, runId: string): Player {
+  const name = ROBO_NAMES[index % ROBO_NAMES.length];
+  const suffix = Math.floor(index / ROBO_NAMES.length);
+  const displayName = suffix > 0 ? `${name}-${suffix + 1}` : name;
+  const id = `robo-${runId}-${index}`;
+  return {
+    id,
+    name: displayName,
+    avatar: robotAvatar(id),
+    status: 'active',
+    isRobo: true,
+    competitionProfile: getDefaultCompetitionProfile(),
+  };
+}
+
+function buildCompetitionState(players: Player[]): GameState['competitionSeasonStateByPlayerId'] {
+  return Object.fromEntries(players.map((player) => [player.id, getDefaultCompetitionSeasonState()]));
+}
+
+export function createSurvivorModeState(startingCastSize: number): SurvivorModeState {
+  return {
+    currentDay: 1,
+    totalRoboContestantsEvicted: 0,
+    bestDayReached: 1,
+    startingCastSize,
+    nextRoboIndex: Math.max(0, startingCastSize - 1),
+    competitionRotation: {
+      usedKeys: [],
+      round: 1,
+    },
+  };
+}
+
+export function createSurvivorRun(): GameState {
+  const base = createInitialGameState();
+  const runId = makeRunId('survivor');
+  const human = base.players.find((player) => player.isUser) ?? base.players[0];
+  const startingCastSize = Math.max(2, base.players.length);
+  const players = [
+    { ...human, id: 'user', status: 'active' as const, isUser: true },
+    ...Array.from({ length: startingCastSize - 1 }, (_, index) => buildRoboPlayer(index, runId)),
+  ];
+  const now = Date.now();
+  const modeSpecific = createSurvivorModeState(startingCastSize);
+
+  return {
+    ...base,
+    gameId: runId,
+    runId,
+    mode: 'survivor',
+    status: 'active',
+    createdAt: now,
+    lastPlayedAt: now,
+    saveVersion: SAVE_VERSION,
+    season: 1,
+    week: 1,
+    publicModeEnabled: false,
+    players,
+    competitionSeasonStateByPlayerId: buildCompetitionState(players),
+    modeSpecific,
+    tvFeed: [
+      {
+        id: 'survivor-e0',
+        text: 'Survivor Mode online. Synthetic contestants will be replaced after every eviction.',
+        type: 'game',
+        timestamp: now,
+        meta: { phase: 'week_start', week: 1, mode: 'survivor' },
+      },
+      {
+        id: 'survivor-e1',
+        text: '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON',
+        type: 'game',
+        timestamp: now,
+        meta: { phase: 'week_start', week: 1, mode: 'survivor' },
+      },
+    ],
+  };
+}
+
+export function buildReplacementRobo(state: GameState): Player {
+  const survivorState = state.modeSpecific?.kind === 'survivor'
+    ? state.modeSpecific
+    : createSurvivorModeState(state.players.filter((player) => player.status !== 'evicted' && player.status !== 'jury').length + 1);
+  return buildRoboPlayer(survivorState.nextRoboIndex, state.runId ?? state.gameId);
+}
+
+export function markSurvivorDay(state: GameState): GameState {
+  if (state.mode !== 'survivor') return state;
+  const modeSpecific = state.modeSpecific?.kind === 'survivor'
+    ? state.modeSpecific
+    : createSurvivorModeState(state.players.length);
+  const currentDay = Math.max(modeSpecific.currentDay, state.week);
+  return {
+    ...state,
+    modeSpecific: {
+      ...modeSpecific,
+      currentDay,
+      bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+    },
+  };
+}

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -11,11 +11,13 @@ import {
   archiveKeyForProfile,
 } from '../../store/profilesSlice';
 import {
-  savedStateKeyForProfile,
-  loadSeasonSnapshot,
-  clearSeasonSnapshot,
+  getLastPlayedRun,
+  getSavedRun,
+  loadSavedRunProfile,
+  type SavedSeasonSnapshot,
 } from '../../store/saveStatePersistence';
-import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
+import type { GameMode } from '../../modes/modeTypes';
+import { createSurvivorRun } from '../../modes/survivorRun';
 import useBackgroundTheme from '../../hooks/useBackgroundTheme';
 import KolequantSplash from '../../components/KolequantSplash/KolequantSplash';
 import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOverlay';
@@ -59,10 +61,36 @@ const HUB_BUTTONS = [
   { to: '/credits',      label: 'Credits',     icon: '🎬', variant: 'secondary_small'  },
 ] as const satisfies ReadonlyArray<{ to: string; label: string; icon: string; variant: GameButtonVariant }>;
 
+function snapshotDay(snapshot: SavedSeasonSnapshot | null | undefined): number | null {
+  const day = snapshot?.game?.week;
+  return typeof day === 'number' && Number.isFinite(day) ? day : null;
+}
+
+function buildModeLabel(mode: GameMode, snapshot: SavedSeasonSnapshot | null | undefined): string {
+  const day = snapshotDay(snapshot);
+  if (mode === 'classic') return day ? `Classic Day ${day}` : 'Classic Campaign';
+  const survivorState = snapshot?.game?.modeSpecific?.kind === 'survivor'
+    ? snapshot.game.modeSpecific
+    : null;
+  if (day) return `Survivor Day ${day}`;
+  if (survivorState?.bestDayReached) return `Survivor Best ${survivorState.bestDayReached}`;
+  return 'Survivor Mode';
+}
+
+interface PlaySelectionButton {
+  key: string;
+  label: string;
+  icon: string;
+  variant: GameButtonVariant;
+  onClick: () => void;
+}
+
 interface HomeHubAssetLayerProps {
   splashDone: boolean;
   effectiveBgUrl: string | null;
   backgroundReady: boolean;
+  playSelectionOpen: boolean;
+  playSelectionButtons: PlaySelectionButton[];
   onPlay: () => void;
   onNavigate: NavigateFunction;
 }
@@ -71,6 +99,8 @@ function HomeHubAssetLayer({
   splashDone,
   effectiveBgUrl,
   backgroundReady,
+  playSelectionOpen,
+  playSelectionButtons,
   onPlay,
   onNavigate,
 }: HomeHubAssetLayerProps) {
@@ -97,16 +127,26 @@ function HomeHubAssetLayer({
         {/* Button stack: only rendered once the splash has dismissed and the
             full hub bundle is ready. */}
         {splashDone && homeHubReady && (
-          <nav className="home-hub__buttons" aria-label="Main menu">
-            {HUB_BUTTONS.map(({ to, label, icon, variant }) => (
-              <GameButton
-                key={to}
-                label={label}
-                icon={icon}
-                variant={variant}
-                onClick={to === '/game' ? onPlay : () => onNavigate(to)}
-              />
-            ))}
+          <nav className="home-hub__buttons" aria-label={playSelectionOpen ? 'Play menu' : 'Main menu'}>
+            {playSelectionOpen
+              ? playSelectionButtons.map(({ key, label, icon, variant, onClick }) => (
+                  <GameButton
+                    key={key}
+                    label={label}
+                    icon={icon}
+                    variant={variant}
+                    onClick={onClick}
+                  />
+                ))
+              : HUB_BUTTONS.map(({ to, label, icon, variant }) => (
+                  <GameButton
+                    key={to}
+                    label={label}
+                    icon={icon}
+                    variant={variant}
+                    onClick={to === '/game' ? onPlay : () => onNavigate(to)}
+                  />
+                ))}
           </nav>
         )}
       </div>
@@ -152,8 +192,18 @@ export default function HomeHub() {
   // reuse the existing Play → preloader → /game flow without setting state in
   // an effect on mount.
   const [preloading, setPreloading] = useState(autoStartGame);
-  // Resume-season prompt state for the Play flow.
-  const [showResumePrompt, setShowResumePrompt] = useState(false);
+  const [playSelectionOpen, setPlaySelectionOpen] = useState(false);
+
+  const savedRuns = useMemo(
+    () => (!isGuest && activeProfileId ? loadSavedRunProfile(activeProfileId) : null),
+    [activeProfileId, isGuest],
+  );
+  const classicSnapshot = savedRuns?.runs.classic ?? null;
+  const survivorSnapshot = savedRuns?.runs.survivor ?? null;
+  const lastSnapshot = useMemo(
+    () => (!isGuest && activeProfileId ? getLastPlayedRun(activeProfileId) : null),
+    [activeProfileId, isGuest, savedRuns?.lastPlayedRunId],
+  );
 
   useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
@@ -178,6 +228,95 @@ export default function HomeHub() {
     navigate('/', { replace: true });
   }, [autoStartGame, navigate]);
 
+  function hydrateSnapshot(snapshot: SavedSeasonSnapshot) {
+    dispatch(hydrateGame(snapshot.game));
+    dispatch(hydrateFinale(snapshot.finale));
+    dispatch(hydrateSocial(snapshot.social));
+    navigate('/game');
+  }
+
+  function startClassicRun() {
+    if (!isGuest && activeProfileId) {
+      const archives = loadSeasonArchives(archiveKeyForProfile(activeProfileId)) ?? [];
+      dispatch(resetGame(archives));
+    } else {
+      dispatch(resetGame(undefined));
+    }
+    setPreloading(true);
+  }
+
+  function startSurvivorRun() {
+    dispatch(hydrateGame(createSurvivorRun()));
+    setPreloading(true);
+  }
+
+  function startOrResumeMode(mode: GameMode) {
+    SoundManager.unlockFromGesture();
+    if (!isGuest && activeProfileId) {
+      const snapshot = getSavedRun(activeProfileId, mode);
+      if (snapshot?.profileId === activeProfileId) {
+        try {
+          hydrateSnapshot(snapshot);
+          return;
+        } catch {
+          // Bad snapshots fall through to a clean run for the selected mode.
+        }
+      }
+    }
+
+    if (mode === 'survivor') startSurvivorRun();
+    else startClassicRun();
+  }
+
+  function continueLastRun() {
+    SoundManager.unlockFromGesture();
+    if (lastSnapshot?.profileId === activeProfileId) {
+      try {
+        hydrateSnapshot(lastSnapshot);
+        return;
+      } catch {
+        setPlaySelectionOpen(true);
+      }
+    }
+  }
+
+  const playSelectionButtons = useMemo<PlaySelectionButton[]>(() => {
+    const buttons: PlaySelectionButton[] = [];
+    if (lastSnapshot) {
+      buttons.push({
+        key: 'continue-last',
+        label: 'Continue Last',
+        icon: '▶',
+        variant: 'primary_large',
+        onClick: continueLastRun,
+      });
+    }
+    buttons.push(
+      {
+        key: 'classic',
+        label: buildModeLabel('classic', classicSnapshot),
+        icon: '🎬',
+        variant: 'secondary_wide',
+        onClick: () => startOrResumeMode('classic'),
+      },
+      {
+        key: 'survivor',
+        label: buildModeLabel('survivor', survivorSnapshot),
+        icon: '◆',
+        variant: 'secondary_wide',
+        onClick: () => startOrResumeMode('survivor'),
+      },
+      {
+        key: 'back',
+        label: 'Back',
+        icon: '↩',
+        variant: 'secondary_medium',
+        onClick: () => setPlaySelectionOpen(false),
+      },
+    );
+    return buttons;
+  }, [classicSnapshot, lastSnapshot, survivorSnapshot]);
+
   const handlePlay = () => {
     // Unlock audio in the gesture context.  We intentionally do NOT follow up
     // with SoundManager.panicStopAllMusic() here — that used to race with the
@@ -186,53 +325,8 @@ export default function HomeHub() {
     // AudioStateSync via the resolver, which will transition the track
     // naturally when the route/phase changes below.
     SoundManager.unlockFromGesture();
-
-    // Check for a saved in-progress season for the active profile.
-    if (!isGuest && activeProfileId) {
-      const saveKey = savedStateKeyForProfile(activeProfileId);
-      const snapshot = loadSeasonSnapshot(saveKey);
-      if (snapshot && snapshot.profileId === activeProfileId) {
-        setShowResumePrompt(true);
-        return;
-      }
-    }
-    setPreloading(true);
+    setPlaySelectionOpen(true);
   };
-
-  function handleResume() {
-    setShowResumePrompt(false);
-    if (!activeProfileId) {
-      setPreloading(true);
-      return;
-    }
-    const saveKey = savedStateKeyForProfile(activeProfileId);
-    const snapshot = loadSeasonSnapshot(saveKey);
-    if (!snapshot || snapshot.profileId !== activeProfileId) {
-      // Snapshot vanished — fall back to fresh start.
-      handleNewSeason();
-      return;
-    }
-    try {
-      dispatch(hydrateGame(snapshot.game));
-      dispatch(hydrateFinale(snapshot.finale));
-      dispatch(hydrateSocial(snapshot.social));
-      navigate('/game');
-    } catch {
-      // Hydration failed — clear the bad snapshot and start fresh.
-      clearSeasonSnapshot(saveKey);
-      handleNewSeason();
-    }
-  }
-
-  function handleNewSeason() {
-    setShowResumePrompt(false);
-    if (!isGuest && activeProfileId) {
-      clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId));
-      const archives = loadSeasonArchives(archiveKeyForProfile(activeProfileId)) ?? [];
-      dispatch(resetGame(archives));
-    }
-    setPreloading(true);
-  }
 
   function handleSplashFinish() {
     markHomeHubSplashSeenForGame(gameId);
@@ -249,17 +343,6 @@ export default function HomeHub() {
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
       {preloading && <AssetPreloaderOverlay />}
-
-      {/* Resume saved season prompt — shown when Play is pressed and a save exists */}
-      <ConfirmExitModal
-        open={showResumePrompt}
-        title="Resume season?"
-        description="Pick up where you left off, or start fresh."
-        confirmLabel="Resume"
-        cancelLabel="New Season"
-        onConfirm={handleResume}
-        onCancel={handleNewSeason}
-      />
 
       <div className="homehub-shell">
         <div className="homehub-frame">
@@ -284,6 +367,8 @@ export default function HomeHub() {
             splashDone={splashDone}
             effectiveBgUrl={effectiveBgUrl}
             backgroundReady={introHubBgReady}
+            playSelectionOpen={playSelectionOpen}
+            playSelectionButtons={playSelectionButtons}
             onPlay={handlePlay}
             onNavigate={navigate}
           />

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -200,10 +200,7 @@ export default function HomeHub() {
   );
   const classicSnapshot = savedRuns?.runs.classic ?? null;
   const survivorSnapshot = savedRuns?.runs.survivor ?? null;
-  const lastSnapshot = useMemo(
-    () => (!isGuest && activeProfileId ? getLastPlayedRun(activeProfileId) : null),
-    [activeProfileId, isGuest, savedRuns?.lastPlayedRunId],
-  );
+  const lastSnapshot = !isGuest && activeProfileId ? getLastPlayedRun(activeProfileId) : null;
 
   useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
@@ -280,42 +277,39 @@ export default function HomeHub() {
     }
   }
 
-  const playSelectionButtons = useMemo<PlaySelectionButton[]>(() => {
-    const buttons: PlaySelectionButton[] = [];
-    if (lastSnapshot) {
-      buttons.push({
-        key: 'continue-last',
-        label: 'Continue Last',
-        icon: '▶',
-        variant: 'primary_large',
-        onClick: continueLastRun,
-      });
-    }
-    buttons.push(
-      {
-        key: 'classic',
-        label: buildModeLabel('classic', classicSnapshot),
-        icon: '🎬',
-        variant: 'secondary_wide',
-        onClick: () => startOrResumeMode('classic'),
-      },
-      {
-        key: 'survivor',
-        label: buildModeLabel('survivor', survivorSnapshot),
-        icon: '◆',
-        variant: 'secondary_wide',
-        onClick: () => startOrResumeMode('survivor'),
-      },
-      {
-        key: 'back',
-        label: 'Back',
-        icon: '↩',
-        variant: 'secondary_medium',
-        onClick: () => setPlaySelectionOpen(false),
-      },
-    );
-    return buttons;
-  }, [classicSnapshot, lastSnapshot, survivorSnapshot]);
+  const playSelectionButtons: PlaySelectionButton[] = [];
+  if (lastSnapshot) {
+    playSelectionButtons.push({
+      key: 'continue-last',
+      label: 'Continue Last',
+      icon: '▶',
+      variant: 'primary_large',
+      onClick: continueLastRun,
+    });
+  }
+  playSelectionButtons.push(
+    {
+      key: 'classic',
+      label: buildModeLabel('classic', classicSnapshot),
+      icon: '🎬',
+      variant: 'secondary_wide',
+      onClick: () => startOrResumeMode('classic'),
+    },
+    {
+      key: 'survivor',
+      label: buildModeLabel('survivor', survivorSnapshot),
+      icon: '◆',
+      variant: 'secondary_wide',
+      onClick: () => startOrResumeMode('survivor'),
+    },
+    {
+      key: 'back',
+      label: 'Back',
+      icon: '↩',
+      variant: 'secondary_medium',
+      onClick: () => setPlaySelectionOpen(false),
+    },
+  );
 
   const handlePlay = () => {
     // Unlock audio in the gesture context.  We intentionally do NOT follow up

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -16,7 +16,7 @@ import {
 } from '../ai/competition';
 import { selectNextCompetitionGame } from '../ai/competition/scheduling';
 import { getBracketPoolForContext } from '../ai/competition/bracketTemplate';
-import { applyCompetitionSeasonUpdate, selectAlivePlayers } from './gameSlice';
+import { applyCompetitionSeasonUpdate, hydrateGame, selectAlivePlayers } from './gameSlice';
 import { pickRandomGame, getGame, getPoolByFilter } from '../minigames/registry';
 import type { GameRegistryEntry, GameCategory } from '../minigames/registry';
 import { computeScores } from '../minigames/scoring';
@@ -196,6 +196,39 @@ export const startChallenge =
       if (pool.length > 0) return selectFromPool(pool);
       return pickRandomGame(gameSeed, { category, excludeKeys });
     };
+    const pickSurvivorGame = (category?: GameCategory, excludeKeys?: string[]) => {
+      const pool = getPoolByFilter({ retired: false, category, excludeKeys });
+      const modeSpecific = state.game.modeSpecific?.kind === 'survivor'
+        ? state.game.modeSpecific
+        : null;
+      if (pool.length === 0 || !modeSpecific) return pickFromRegistry(category, excludeKeys);
+
+      const usedKeys = modeSpecific.competitionRotation.usedKeys ?? [];
+      const used = new Set(usedKeys);
+      let available = pool.filter((game) => !used.has(game.key));
+      let nextUsedKeys = usedKeys;
+      let nextRound = modeSpecific.competitionRotation.round ?? 1;
+
+      if (available.length === 0) {
+        available = pool;
+        nextUsedKeys = [];
+        nextRound += 1;
+      }
+
+      const selected = selectFromPool(available);
+      dispatch(hydrateGame({
+        ...state.game,
+        modeSpecific: {
+          ...modeSpecific,
+          competitionRotation: {
+            usedKeys: [...nextUsedKeys, selected.key],
+            round: nextRound,
+          },
+        },
+        lastPlayedAt: Date.now(),
+      }));
+      return selected;
+    };
     const getBracketTemplatePool = (excludeKeys?: string[]) => {
       const bracketCompType =
         opts.prizeType === 'LOH' || opts.prizeType === 'POS'
@@ -219,6 +252,8 @@ export const startChallenge =
       const found = getGame(forceKey);
       if (!found) throw new Error(`[challengeSlice] Unknown game key: ${forceKey}`);
       gameEntry = found;
+    } else if (state.game.mode === 'survivor') {
+      gameEntry = pickSurvivorGame(opts.category, opts.excludeKeys);
     } else {
       // Remote live-config weekly mode takes priority over user settings.
       const remoteChallenge = state.remoteConfig?.config?.challenge;

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -4,20 +4,24 @@
 // Separate from season archives (which store completed seasons).
 //
 // Key behaviours:
-//  - Each profile has at most one in-progress save at a time.
+//  - Each profile can keep one Classic and one Survivor run side by side.
 //  - Guest mode never writes or reads snapshots.
 //  - Stale/invalid snapshots are silently discarded on load.
+//  - Legacy single-slot saves are migrated into the Classic slot on read.
 
 import type { GameState } from '../types';
+import type { GameMode } from '../modes/modeTypes';
+import { normalizeGameMode } from '../modes/gameModes';
 import type { FinaleState } from './finaleSlice';
 import type { SocialState } from '../social/types';
 
 /** Prefix for per-profile saved-season localStorage keys. */
 export const SAVED_STATE_KEY_PREFIX = 'bbmobilenew:savedSeason:';
+export const SAVED_RUNS_KEY_PREFIX = 'bbmobilenew:savedRuns:';
 
 /** Shape of what we persist for a manual season save. */
 export interface SavedSeasonSnapshot {
-  /** Snapshot format version — bump when the shape changes incompatibly. */
+  /** Snapshot format version - bump when the shape changes incompatibly. */
   version: 1;
   /** Profile ID that created this snapshot (cross-profile safety check). */
   profileId: string;
@@ -31,9 +35,83 @@ export interface SavedSeasonSnapshot {
   social: SocialState;
 }
 
+export interface SavedRunProfileStats {
+  maxSurvivorDaysSurvived: number;
+}
+
+export interface SavedRunProfile {
+  version: 2;
+  profileId: string;
+  savedAt: string;
+  activeRunId: string | null;
+  lastPlayedRunId: string | null;
+  runs: Partial<Record<GameMode, SavedSeasonSnapshot>>;
+  stats: SavedRunProfileStats;
+}
+
 /** Build the localStorage key for a specific profile's saved-season snapshot. */
 export function savedStateKeyForProfile(profileId: string): string {
   return `${SAVED_STATE_KEY_PREFIX}${encodeURIComponent(profileId)}`;
+}
+
+export function savedRunsKeyForProfile(profileId: string): string {
+  return `${SAVED_RUNS_KEY_PREFIX}${encodeURIComponent(profileId)}`;
+}
+
+function emptySavedRunProfile(profileId: string): SavedRunProfile {
+  return {
+    version: 2,
+    profileId,
+    savedAt: new Date(0).toISOString(),
+    activeRunId: null,
+    lastPlayedRunId: null,
+    runs: {},
+    stats: { maxSurvivorDaysSurvived: 0 },
+  };
+}
+
+function getRunId(snapshot: SavedSeasonSnapshot | undefined): string | null {
+  return snapshot?.game.runId ?? snapshot?.game.gameId ?? null;
+}
+
+function getSurvivorBestDay(snapshot: SavedSeasonSnapshot | undefined): number {
+  if (!snapshot || snapshot.game.mode !== 'survivor') return 0;
+  const modeSpecific = snapshot.game.modeSpecific?.kind === 'survivor'
+    ? snapshot.game.modeSpecific
+    : null;
+  return Math.max(snapshot.game.week ?? 1, modeSpecific?.bestDayReached ?? 1, modeSpecific?.currentDay ?? 1);
+}
+
+function coerceSnapshot(raw: unknown, profileId: string): SavedSeasonSnapshot | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const parsed = raw as Partial<SavedSeasonSnapshot>;
+  if (parsed.version !== 1) return null;
+  if (parsed.profileId !== profileId || !parsed.savedAt || !parsed.game || !parsed.finale || !parsed.social) {
+    return null;
+  }
+  return parsed as SavedSeasonSnapshot;
+}
+
+function normalizeRunProfile(profileId: string, parsed: Partial<SavedRunProfile>): SavedRunProfile | null {
+  if (parsed.version !== 2 || parsed.profileId !== profileId) return null;
+  const classic = coerceSnapshot(parsed.runs?.classic, profileId) ?? undefined;
+  const survivor = coerceSnapshot(parsed.runs?.survivor, profileId) ?? undefined;
+  const maxSurvivorDaysSurvived = Math.max(
+    typeof parsed.stats?.maxSurvivorDaysSurvived === 'number' ? parsed.stats.maxSurvivorDaysSurvived : 0,
+    getSurvivorBestDay(survivor),
+  );
+  return {
+    version: 2,
+    profileId,
+    savedAt: typeof parsed.savedAt === 'string' ? parsed.savedAt : new Date().toISOString(),
+    activeRunId: typeof parsed.activeRunId === 'string' ? parsed.activeRunId : null,
+    lastPlayedRunId: typeof parsed.lastPlayedRunId === 'string' ? parsed.lastPlayedRunId : null,
+    runs: {
+      ...(classic ? { classic } : {}),
+      ...(survivor ? { survivor } : {}),
+    },
+    stats: { maxSurvivorDaysSurvived },
+  };
 }
 
 /**
@@ -69,6 +147,94 @@ export function loadSeasonSnapshot(key: string): SavedSeasonSnapshot | null {
   } catch {
     return null;
   }
+}
+
+export function loadSavedRunProfile(profileId: string): SavedRunProfile {
+  const key = savedRunsKeyForProfile(profileId);
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<SavedRunProfile>;
+      const normalized = normalizeRunProfile(profileId, parsed);
+      if (normalized) return normalized;
+    }
+  } catch {
+    // Fall through to legacy migration.
+  }
+
+  const legacy = loadSeasonSnapshot(savedStateKeyForProfile(profileId));
+  if (legacy && legacy.profileId === profileId) {
+    return {
+      ...emptySavedRunProfile(profileId),
+      savedAt: legacy.savedAt,
+      activeRunId: getRunId(legacy),
+      lastPlayedRunId: getRunId(legacy),
+      runs: { classic: { ...legacy, game: { ...legacy.game, mode: 'classic' } } },
+    };
+  }
+
+  return emptySavedRunProfile(profileId);
+}
+
+export function saveRunProfile(profile: SavedRunProfile): boolean {
+  try {
+    localStorage.setItem(savedRunsKeyForProfile(profile.profileId), JSON.stringify(profile));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot): boolean {
+  const mode = normalizeGameMode(snapshot.game.mode);
+  const current = loadSavedRunProfile(profileId);
+  const runId = getRunId(snapshot);
+  const survivorBest = mode === 'survivor'
+    ? Math.max(current.stats.maxSurvivorDaysSurvived, getSurvivorBestDay(snapshot))
+    : current.stats.maxSurvivorDaysSurvived;
+  const next: SavedRunProfile = {
+    ...current,
+    savedAt: snapshot.savedAt,
+    activeRunId: runId,
+    lastPlayedRunId: runId,
+    runs: {
+      ...current.runs,
+      [mode]: snapshot,
+    },
+    stats: {
+      ...current.stats,
+      maxSurvivorDaysSurvived: survivorBest,
+    },
+  };
+  return saveRunProfile(next);
+}
+
+export function getSavedRun(profileId: string, mode: GameMode): SavedSeasonSnapshot | null {
+  return loadSavedRunProfile(profileId).runs[mode] ?? null;
+}
+
+export function getLastPlayedRun(profileId: string): SavedSeasonSnapshot | null {
+  const profile = loadSavedRunProfile(profileId);
+  const runs = Object.values(profile.runs).filter(Boolean) as SavedSeasonSnapshot[];
+  if (profile.lastPlayedRunId) {
+    const match = runs.find((snapshot) => getRunId(snapshot) === profile.lastPlayedRunId);
+    if (match) return match;
+  }
+  return runs.sort((a, b) => Date.parse(b.savedAt) - Date.parse(a.savedAt))[0] ?? null;
+}
+
+export function clearSavedRun(profileId: string, mode: GameMode): void {
+  const current = loadSavedRunProfile(profileId);
+  const nextRuns = { ...current.runs };
+  delete nextRuns[mode];
+  const removedRunId = getRunId(current.runs[mode]);
+  saveRunProfile({
+    ...current,
+    runs: nextRuns,
+    activeRunId: current.activeRunId === removedRunId ? null : current.activeRunId,
+    lastPlayedRunId: current.lastPlayedRunId === removedRunId ? null : current.lastPlayedRunId,
+    savedAt: new Date().toISOString(),
+  });
 }
 
 /** Remove a season snapshot from localStorage. */

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -11,12 +11,15 @@ import profilesReducer, {
 } from './profilesSlice';
 import socialReducer from '../social/socialSlice';
 import { socialMiddleware } from '../social/socialMiddleware';
+import { survivorMiddleware } from '../modes/survivorMiddleware';
 import { soundMiddleware } from './soundMiddleware';
 import uiReducer from './uiSlice';
 import { saveSeasonArchives, DEFAULT_ARCHIVE_KEY } from './archivePersistence';
 import {
   savedStateKeyForProfile,
   clearSeasonSnapshot,
+  clearSavedRun,
+  saveRunSnapshot,
 } from './saveStatePersistence';
 import cwgoReducer from '../features/cwgo/cwgoCompetitionSlice';
 import holdTheWallReducer from '../features/holdTheWall/holdTheWallSlice';
@@ -76,6 +79,7 @@ export const store = configureStore({
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
+      survivorMiddleware,
       socialMiddleware,
       soundMiddleware,
       publicOpinionMiddleware,
@@ -83,6 +87,15 @@ export const store = configureStore({
       secretMissionMiddleware,
     ),
 });
+
+function hasMeaningfulGameProgress(game: ReturnType<typeof store.getState>['game']): boolean {
+  return game.mode === 'survivor'
+    || game.week > 1
+    || game.phase !== 'week_start'
+    || Boolean(game.runId)
+    || Boolean(game.pendingEviction)
+    || Boolean(game.seasonFinale);
+}
 
 // Persist settings to localStorage whenever they change
 let prevSettings = store.getState().settings;
@@ -92,6 +105,8 @@ let prevUserProfile = store.getState().userProfile;
 let prevProfiles = store.getState().profiles;
 // Persist ads state to localStorage whenever it changes
 let prevAds = store.getState().ads;
+// Persist active mode runs whenever the game slice changes.
+let prevGame = store.getState().game;
 // Persist season archives to localStorage whenever they change
 let prevSeasonArchives = store.getState().game.seasonArchives;
 // Track archive length together with the profile that owns those archives.
@@ -122,6 +137,25 @@ store.subscribe(() => {
     prevAds = current.ads;
     saveAdsState(current.ads);
   }
+  if (current.game !== prevGame) {
+    prevGame = current.game;
+    const activeProfileId = current.profiles.activeProfileId;
+    if (!current.profiles.isGuest && activeProfileId && hasMeaningfulGameProgress(current.game)) {
+      saveRunSnapshot(activeProfileId, {
+        version: 1,
+        profileId: activeProfileId,
+        savedAt: new Date().toISOString(),
+        game: {
+          ...current.game,
+          mode: current.game.mode ?? 'classic',
+          lastPlayedAt: Date.now(),
+          saveVersion: current.game.saveVersion ?? 2,
+        },
+        finale: current.finale,
+        social: current.social,
+      });
+    }
+  }
   if (current.game.seasonArchives !== prevSeasonArchives) {
     prevSeasonArchives = current.game.seasonArchives;
     const newLength = current.game.seasonArchives?.length ?? 0;
@@ -142,6 +176,7 @@ store.subscribe(() => {
       // the previous in-progress save snapshot is now stale — clear it automatically.
       if (sameProfile && newLength > prevSeasonArchivesLength && archivesProfileId) {
         clearSeasonSnapshot(savedStateKeyForProfile(archivesProfileId));
+        clearSavedRun(archivesProfileId, 'classic');
       }
     }
     prevSeasonArchivesLength = newLength;


### PR DESCRIPTION
## Summary
- Adds Classic/Survivor mode metadata, separate per-profile run saves, and store autosave for active runs.
- Updates IntroHub Play to open an in-place mode picker with Continue Last, Classic, and Survivor choices.
- Adds Survivor Mode with a 9-contestant 3x3-friendly roster, robo replacements, disabled public/social shock flow, reduced eviction animation handling, and full-pool minigame rotation.

## Notes
- Survivor keeps Double Elimination as the remaining shock-style twist, while blocking Battle Back, Democracia, Morning Shock, special veto shocks, and secret missions.
- Robo replacements occupy the evicted robo's roster slot to preserve board density instead of growing the visible roster.

## Validation
- Not run locally per request to avoid local actions.