### PR TITLE
Polish Survivor mode flow

### DIFF
--- a/src/components/ConfirmExitModal/ConfirmExitModal.css
+++ b/src/components/ConfirmExitModal/ConfirmExitModal.css
@@ -38,3 +38,13 @@
 .confirm-modal__btn {
   min-width: 112px;
 }
+
+.confirm-modal__btn--danger {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.38);
+}
+
+.confirm-modal__btn--danger:hover {
+  background: rgba(127, 29, 29, 0.32);
+  color: #fee2e2;
+}

--- a/src/components/ConfirmExitModal/ConfirmExitModal.tsx
+++ b/src/components/ConfirmExitModal/ConfirmExitModal.tsx
@@ -7,10 +7,12 @@ interface Props {
   description?: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  secondaryLabel?: string;
   /** When false, only the confirm button is rendered (info/notification dialogs). Defaults to true. */
   showCancel?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  onSecondary?: () => void;
 }
 
 /**
@@ -23,9 +25,11 @@ export default function ConfirmExitModal({
   description,
   confirmLabel = 'Exit',
   cancelLabel = 'Stay',
+  secondaryLabel,
   showCancel = true,
   onConfirm,
   onCancel,
+  onSecondary,
 }: Props) {
   const uid = useId();
   const titleId = `${uid}-title`;
@@ -61,14 +65,19 @@ export default function ConfirmExitModal({
         <h2 id={titleId} className="confirm-modal__title">{title}</h2>
         {description && <p id={descId} className="confirm-modal__desc">{description}</p>}
         <div className="confirm-modal__actions">
+          <button type="button" className="confirm-modal__btn game-button game-button--primary" onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+          {secondaryLabel && onSecondary && (
+            <button type="button" className="confirm-modal__btn confirm-modal__btn--danger game-button game-button--ghost" onClick={onSecondary}>
+              {secondaryLabel}
+            </button>
+          )}
           {showCancel && (
             <button type="button" className="confirm-modal__btn game-button game-button--ghost" onClick={onCancel}>
               {cancelLabel}
             </button>
           )}
-          <button type="button" className="confirm-modal__btn game-button game-button--primary" onClick={onConfirm}>
-            {confirmLabel}
-          </button>
         </div>
       </div>
     </div>

--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -73,6 +73,7 @@ export default function FloatingActionBar({
     [directions, humanPlayer],
   );
   const socialModuleAvailability = useMemo(() => getSocialModuleAvailability(game), [game]);
+  const socialModulesUnavailable = !canUseSocialModules;
 
   // Flash the social button whenever the human player's energy changes.
   const [isFlashing, setIsFlashing] = useState(false);
@@ -222,10 +223,13 @@ export default function FloatingActionBar({
         onPublicMeterClick={handlePublicMeterClick}
         onToolClick={handleToolClick}
         primaryDisabled={primaryDisabled}
-        chatBadgeCount={humanEnergy !== null ? humanEnergy : undefined}
-        chatFlash={isFlashing}
-        incomingRequestsBadgeCount={pendingCount > 0 ? pendingCount : undefined}
-        publicMeterBadgeCount={publicRequestCount > 0 ? publicRequestCount : undefined}
+        socialDisabled={socialModulesUnavailable}
+        incomingRequestsDisabled={socialModulesUnavailable}
+        publicMeterDisabled={game.publicModeEnabled !== true}
+        chatBadgeCount={!socialModulesUnavailable && humanEnergy !== null ? humanEnergy : undefined}
+        chatFlash={!socialModulesUnavailable && isFlashing}
+        incomingRequestsBadgeCount={!socialModulesUnavailable && pendingCount > 0 ? pendingCount : undefined}
+        publicMeterBadgeCount={game.publicModeEnabled === true && publicRequestCount > 0 ? publicRequestCount : undefined}
         primaryPulse={primaryPulse}
         confessionalBadgeCount={confessionalAlertCount > 0 ? confessionalAlertCount : undefined}
         confessionalFlash={isConfessionalFlashing}

--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -118,7 +118,8 @@
   transform: scale(0.985);
 }
 
-.dock-hit-area:disabled {
+.dock-hit-area:disabled,
+.dock-hit-area--unavailable {
   cursor: not-allowed;
 }
 
@@ -211,12 +212,22 @@
 }
 
 .game-control-dock__play--disabled,
+.game-control-dock__icon--unavailable,
 .game-control-dock:has(.dock-hit-area--play:disabled) .fab-play,
 .game-control-dock:has(.dock-hit-area--social:disabled) .fab-icon.social,
 .game-control-dock:has(.dock-hit-area--requests:disabled) .fab-icon.requests,
 .game-control-dock:has(.dock-hit-area--stats:disabled) .fab-icon.stats,
 .game-control-dock:has(.dock-hit-area--confessional:disabled) .fab-icon.confessional {
   opacity: 0.5;
+}
+
+.game-control-dock__icon--unavailable {
+  filter: grayscale(1) drop-shadow(0 0 3px rgba(75, 85, 99, 0.18));
+}
+
+.dock-hit-area--unavailable:hover,
+.dock-hit-area--unavailable:active {
+  transform: none;
 }
 
 @keyframes dock-icon-flash {

--- a/src/components/GameControlDock/GameControlDock.tsx
+++ b/src/components/GameControlDock/GameControlDock.tsx
@@ -15,6 +15,9 @@ export interface GameControlDockProps {
   onToolClick?: () => void;
   disabled?: boolean;
   primaryDisabled?: boolean;
+  socialDisabled?: boolean;
+  incomingRequestsDisabled?: boolean;
+  publicMeterDisabled?: boolean;
   chatBadgeCount?: number;
   /** Extra class name for the flash animation on chat node */
   chatFlash?: boolean;
@@ -44,6 +47,9 @@ export default function GameControlDock({
   onToolClick,
   disabled = false,
   primaryDisabled = false,
+  socialDisabled = false,
+  incomingRequestsDisabled = false,
+  publicMeterDisabled = false,
   chatBadgeCount,
   chatFlash = false,
   incomingRequestsBadgeCount,
@@ -57,6 +63,9 @@ export default function GameControlDock({
 }: GameControlDockProps) {
   const shellSrc = assetUrl('fab_shell_clean.svg');
   const playSrc = assetUrl('fab_center_play_clean.svg');
+  const socialUnavailableClass = socialDisabled ? ' dock-hit-area--unavailable' : '';
+  const requestsUnavailableClass = incomingRequestsDisabled ? ' dock-hit-area--unavailable' : '';
+  const publicUnavailableClass = publicMeterDisabled ? ' dock-hit-area--unavailable' : '';
 
   return (
     <div
@@ -79,21 +88,21 @@ export default function GameControlDock({
         draggable={false}
       />
       <img
-        className={`game-control-dock__icon fab-icon social${chatFlash ? ' game-control-dock__icon--flash' : ''}`}
+        className={`game-control-dock__icon fab-icon social${chatFlash ? ' game-control-dock__icon--flash' : ''}${socialDisabled ? ' game-control-dock__icon--unavailable' : ''}`}
         src={assetUrl('fab_icon_social_clean.svg')}
         alt=""
         aria-hidden="true"
         draggable={false}
       />
       <img
-        className="game-control-dock__icon fab-icon requests"
+        className={`game-control-dock__icon fab-icon requests${incomingRequestsDisabled ? ' game-control-dock__icon--unavailable' : ''}`}
         src={assetUrl('fab_icon_requests_clean.svg')}
         alt=""
         aria-hidden="true"
         draggable={false}
       />
       <img
-        className="game-control-dock__icon fab-icon stats"
+        className={`game-control-dock__icon fab-icon stats${publicMeterDisabled ? ' game-control-dock__icon--unavailable' : ''}`}
         src={assetUrl('fab_icon_stats_clean.svg')}
         alt=""
         aria-hidden="true"
@@ -109,26 +118,28 @@ export default function GameControlDock({
       />
 
       <button
-        className={`dock-hit-area hit-social dock-hit-area--social${chatFlash ? ' dock-hit-area--flash dock-node--flash' : ''}`}
+        className={`dock-hit-area hit-social dock-hit-area--social${chatFlash ? ' dock-hit-area--flash dock-node--flash' : ''}${socialUnavailableClass}`}
         type="button"
         aria-label={`Social${chatBadgeCount ? ` (${chatBadgeCount})` : ''}`}
+        aria-disabled={socialDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onChatClick}
       >
-        {chatBadgeCount != null && chatBadgeCount > 0 && (
+        {chatBadgeCount != null && chatBadgeCount > 0 && !socialDisabled && (
           <span className="dock-hit-area__badge" aria-hidden="true">
             {chatBadgeCount > 99 ? '99+' : chatBadgeCount}
           </span>
         )}
       </button>
       <button
-        className="dock-hit-area hit-requests dock-hit-area--requests"
+        className={`dock-hit-area hit-requests dock-hit-area--requests${requestsUnavailableClass}`}
         type="button"
         aria-label={`Incoming requests${incomingRequestsBadgeCount ? ` (${incomingRequestsBadgeCount})` : ''}`}
+        aria-disabled={incomingRequestsDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onIncomingRequestsClick}
       >
-        {incomingRequestsBadgeCount != null && incomingRequestsBadgeCount > 0 && (
+        {incomingRequestsBadgeCount != null && incomingRequestsBadgeCount > 0 && !incomingRequestsDisabled && (
           <span className="dock-hit-area__badge" aria-hidden="true">
             {incomingRequestsBadgeCount > 99 ? '99+' : incomingRequestsBadgeCount}
           </span>
@@ -142,13 +153,14 @@ export default function GameControlDock({
         onClick={primaryDisabled ? undefined : onPrimaryActionClick}
       />
       <button
-        className="dock-hit-area hit-stats dock-hit-area--stats"
+        className={`dock-hit-area hit-stats dock-hit-area--stats${publicUnavailableClass}`}
         type="button"
         aria-label={`Public meter${publicMeterBadgeCount ? ` (${publicMeterBadgeCount})` : ''}`}
+        aria-disabled={publicMeterDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onPublicMeterClick}
       >
-        {publicMeterBadgeCount != null && publicMeterBadgeCount > 0 && (
+        {publicMeterBadgeCount != null && publicMeterBadgeCount > 0 && !publicMeterDisabled && (
           <span className="dock-hit-area__badge" aria-hidden="true">
             {publicMeterBadgeCount > 99 ? '99+' : publicMeterBadgeCount}
           </span>

--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { avatarVariants } from '../../utils/avatarCase'
 import { getBadgesForPlayer } from '../../utils/statusBadges'
@@ -11,12 +12,22 @@ export const LONG_PRESS_CLICK_SUPPRESSION_MS = 600
 /** Pixel-distance threshold: if the finger moves more than this the long-press is cancelled. */
 export const LONG_PRESS_MOVE_THRESHOLD_PX = 10
 
+type RoboStatsSummary = {
+  daysInGame?: number | null
+  lohWins?: number | null
+  posWins?: number | null
+  averageLohRank?: number | null
+  averagePosRank?: number | null
+}
+
 type Props = {
   name: string
   avatarUrl?: string
   isEvicted?: boolean
   isYou?: boolean
   onClick?: () => void
+  /** Optional compact Survivor robo stats shown when tapping robo tiles. */
+  roboStats?: RoboStatsSummary
   /**
    * Called when the user has held their finger down long enough to trigger the
    * hold-preview threshold. The caller should show a transient profile preview.
@@ -61,7 +72,12 @@ type Props = {
   nominationCeremonyState?: 'loh' | 'danger' | 'locked'
 }
 
-export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick, onHoldPreviewStart, onHoldPreviewEnd, statuses, finalRank, showPermanentBadge = true, layoutId, isEvicting, nominationCeremonyState }: Props) {
+function formatStat(value: number | null | undefined, options: { decimals?: number } = {}) {
+  if (value == null || Number.isNaN(value)) return '—'
+  return options.decimals != null ? value.toFixed(options.decimals) : String(value)
+}
+
+export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick, roboStats, onHoldPreviewStart, onHoldPreviewEnd, statuses, finalRank, showPermanentBadge = true, layoutId, isEvicting, nominationCeremonyState }: Props) {
   const attemptRef = React.useRef(0)
   const variantsRef = React.useRef<string[] | null>(null)
   const exhaustedRef = React.useRef(false)
@@ -69,6 +85,8 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
   const suppressClickUntilRef = React.useRef(0)
   const touchStartPosRef = React.useRef<{ x: number; y: number } | null>(null)
   const isHoldActiveRef = React.useRef(false)
+  const [statsOpen, setStatsOpen] = React.useState(false)
+  const isSurvivorRoboTile = Boolean(roboStats) || Boolean(avatarUrl?.includes('bottts'))
 
   React.useEffect(() => {
     attemptRef.current = 0
@@ -166,125 +184,162 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
   }
 
   function handleClick(e: React.MouseEvent<HTMLDivElement>) {
-    if (!onClick) return
     if (Date.now() < suppressClickUntilRef.current) {
       e.preventDefault()
       e.stopPropagation()
       return
     }
-    onClick()
+    if (isSurvivorRoboTile && !isEvicted) {
+      setStatsOpen(true)
+    }
+    if (onClick) onClick()
   }
 
   function handleContextMenu(e: React.MouseEvent<HTMLDivElement>) {
-    if (!onClick && !onHoldPreviewStart) return
+    if (!onClick && !onHoldPreviewStart && !isSurvivorRoboTile) return
     e.preventDefault()
     e.stopPropagation()
   }
 
-  const isInteractive = Boolean(onClick ?? onHoldPreviewStart)
+  const isInteractive = Boolean(onClick ?? onHoldPreviewStart ?? isSurvivorRoboTile)
+
+  const statsSheet = statsOpen ? createPortal(
+    <div className={styles.roboStatsBackdrop} role="presentation" onClick={() => setStatsOpen(false)}>
+      <section
+        className={styles.roboStatsSheet}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${name} robo stats`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className={styles.roboStatsHandle} aria-hidden="true" />
+        <div className={styles.roboStatsHeader}>
+          <div>
+            <p className={styles.roboStatsEyebrow}>Synthetic Contestant</p>
+            <h2 className={styles.roboStatsName}>{name}</h2>
+          </div>
+          <button type="button" className={styles.roboStatsClose} onClick={() => setStatsOpen(false)} aria-label="Close stats">
+            ×
+          </button>
+        </div>
+        <dl className={styles.roboStatsGrid}>
+          <div><dt>Days in game</dt><dd>{formatStat(roboStats?.daysInGame)}</dd></div>
+          <div><dt>LOHs won</dt><dd>{formatStat(roboStats?.lohWins)}</dd></div>
+          <div><dt>POS won</dt><dd>{formatStat(roboStats?.posWins)}</dd></div>
+          <div><dt>Avg LOH rank</dt><dd>{formatStat(roboStats?.averageLohRank, { decimals: 1 })}</dd></div>
+          <div><dt>Avg POS rank</dt><dd>{formatStat(roboStats?.averagePosRank, { decimals: 1 })}</dd></div>
+        </dl>
+      </section>
+    </div>,
+    document.body,
+  ) : null
 
   return (
-    <div
-      className={`${styles.tile} ${isEvicted ? styles.evicted : ''}`}
-      aria-label={ariaLabel}
-      title={name}
-      role={isInteractive ? 'button' : 'group'}
-      tabIndex={isInteractive ? 0 : undefined}
-      onClick={handleClick}
-      onContextMenu={handleContextMenu}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
-      onKeyDown={
-        onClick
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onClick()
+    <>
+      <div
+        className={`${styles.tile} ${isEvicted ? styles.evicted : ''}`}
+        aria-label={ariaLabel}
+        title={name}
+        role={isInteractive ? 'button' : 'group'}
+        tabIndex={isInteractive ? 0 : undefined}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
+        onKeyDown={
+          isInteractive
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  if (isSurvivorRoboTile && !isEvicted) setStatsOpen(true)
+                  if (onClick) onClick()
+                }
               }
-            }
-          : undefined
-      }
-    >
-      <motion.div
-        className={[
-          styles.avatarWrap,
-          nominationCeremonyState ? styles[`nomination_${nominationCeremonyState}`] : '',
-        ].filter(Boolean).join(' ')}
-        layoutId={layoutId}
-        data-nomination-ceremony-state={nominationCeremonyState}
-        animate={
-          // Only apply opacity animation when layoutId is present (shared-layout path).
-          // isEvicting is only ever set to true for tiles participating in the match-cut
-          // animation which always have a layoutId, so this coupling is intentional.
-          layoutId ? { opacity: isEvicting ? 0 : 1 } : undefined
+            : undefined
         }
-        transition={layoutId ? {
-          opacity: isEvicting ? { duration: 0.1 } : { duration: 0.2, delay: 0.3 },
-        } : undefined}
       >
-        <div className={styles.nameOverlay} aria-hidden="true">
-          {name}
-        </div>
-
-        {isYou && (
-          <span className={styles.youBadge} aria-hidden="true">
-            YOU
-          </span>
-        )}
-
-        {avatarUrl ? (
-          <img
-            src={avatarUrl}
-            alt={name}
-            className={styles.avatar}
-            onError={handleImgError}
-            draggable={false}
-            onDragStart={(e) => e.preventDefault()}
-          />
-        ) : (
-          <div className={styles.avatarPlaceholder} aria-hidden="true" />
-        )}
-
-        {/* Status badge stack — top-left corner, stacked vertically */}
-        {showPermanentBadge && badges.length > 0 && (
-          <div className={styles.badgeStack} role="list">
-            {badges.map((b) => (
-              <span
-                key={b.code}
-                className={`${styles.statusBadge} ${styles[`badge_${b.code}`] ?? ''}`}
-                role="listitem"
-                aria-label={b.label}
-                title={b.label}
-              >
-                {b.imageSrc ? (
-                  <img
-                    src={b.imageSrc}
-                    alt=""
-                    aria-hidden="true"
-                    className={styles.statusBadgeImage}
-                  />
-                ) : (
-                  b.emoji
-                )}
-              </span>
-            ))}
+        <motion.div
+          className={[
+            styles.avatarWrap,
+            nominationCeremonyState ? styles[`nomination_${nominationCeremonyState}`] : '',
+          ].filter(Boolean).join(' ')}
+          layoutId={layoutId}
+          data-nomination-ceremony-state={nominationCeremonyState}
+          animate={
+            // Only apply opacity animation when layoutId is present (shared-layout path).
+            // isEvicting is only ever set to true for tiles participating in the match-cut
+            // animation which always have a layoutId, so this coupling is intentional.
+            layoutId ? { opacity: isEvicting ? 0 : 1 } : undefined
+          }
+          transition={layoutId ? {
+            opacity: isEvicting ? { duration: 0.1 } : { duration: 0.2, delay: 0.3 },
+          } : undefined}
+        >
+          <div className={styles.nameOverlay} aria-hidden="true">
+            {name}
           </div>
-        )}
 
-        {/* Evictee mark — paint brushstroke PNG overlay */}
-        {isEvicted && (
-          <img
-            src={`${(import.meta.env.BASE_URL ?? '').replace(/\/$/, '')}/evictionmark/evictionmark.png`}
-            alt=""
-            aria-hidden="true"
-            className={styles.cross}
-          />
-        )}
-      </motion.div>
+          {isYou && (
+            <span className={styles.youBadge} aria-hidden="true">
+              YOU
+            </span>
+          )}
 
-      <div className={styles.nameRow} aria-hidden="true" />
-    </div>
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt={name}
+              className={styles.avatar}
+              onError={handleImgError}
+              draggable={false}
+              onDragStart={(e) => e.preventDefault()}
+            />
+          ) : (
+            <div className={styles.avatarPlaceholder} aria-hidden="true" />
+          )}
+
+          {/* Status badge stack — top-left corner, stacked vertically */}
+          {showPermanentBadge && badges.length > 0 && (
+            <div className={styles.badgeStack} role="list">
+              {badges.map((b) => (
+                <span
+                  key={b.code}
+                  className={`${styles.statusBadge} ${styles[`badge_${b.code}`] ?? ''}`}
+                  role="listitem"
+                  aria-label={b.label}
+                  title={b.label}
+                >
+                  {b.imageSrc ? (
+                    <img
+                      src={b.imageSrc}
+                      alt=""
+                      aria-hidden="true"
+                      className={styles.statusBadgeImage}
+                    />
+                  ) : (
+                    b.emoji
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Evictee mark — paint brushstroke PNG overlay */}
+          {isEvicted && (
+            <img
+              src={`${(import.meta.env.BASE_URL ?? '').replace(/\/$/, '')}/evictionmark/evictionmark.png`}
+              alt=""
+              aria-hidden="true"
+              className={styles.cross}
+            />
+          )}
+        </motion.div>
+
+        <div className={styles.nameRow} aria-hidden="true" />
+      </div>
+      {statsSheet}
+    </>
   )
 }

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -52,6 +52,7 @@
 .gridItem {
   width: 100%;
   min-width: 0;
+  animation: survivorTileSettle 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .sliderItem {
@@ -260,6 +261,17 @@
   to   { opacity: 1; }
 }
 
+@keyframes survivorTileSettle {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @keyframes nominationLohGlow {
   0%, 100% {
     box-shadow:
@@ -417,9 +429,119 @@
   max-height: none;
 }
 
+.roboStatsBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 7800;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 16px;
+  background: linear-gradient(180deg, rgba(5, 8, 14, 0.18), rgba(5, 8, 14, 0.72));
+}
+
+.roboStatsSheet {
+  width: min(420px, 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 14px 14px 10px 10px;
+  background:
+    radial-gradient(circle at 16% 0%, rgba(96, 165, 250, 0.14), transparent 36%),
+    linear-gradient(180deg, rgba(13, 22, 35, 0.98), rgba(8, 13, 22, 0.98));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.62);
+  padding: 10px 14px 14px;
+  color: #f8fafc;
+  animation: roboStatsSheetIn 180ms ease-out both;
+}
+
+.roboStatsHandle {
+  width: 42px;
+  height: 4px;
+  margin: 0 auto 12px;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.28);
+}
+
+.roboStatsHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.roboStatsEyebrow {
+  margin: 0 0 3px;
+  color: rgba(203, 213, 225, 0.72);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.roboStatsName {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.roboStatsClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.88);
+  cursor: pointer;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.roboStatsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.roboStatsGrid div {
+  min-width: 0;
+  padding: 9px 10px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.roboStatsGrid dt {
+  color: rgba(203, 213, 225, 0.72);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.roboStatsGrid dd {
+  margin: 3px 0 0;
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 850;
+}
+
+@keyframes roboStatsSheetIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .gridItem,
   .nomination_loh,
-  .nomination_danger::before {
+  .nomination_danger::before,
+  .roboStatsSheet {
     animation: none !important;
   }
 }

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -13,6 +13,13 @@ export type Houseguest = {
   isEvicted?: boolean
   isYou?: boolean
   onClick?: () => void
+  roboStats?: {
+    daysInGame?: number | null
+    lohWins?: number | null
+    posWins?: number | null
+    averageLohRank?: number | null
+    averagePosRank?: number | null
+  }
   /**
    * Called when the user has held their finger down long enough to trigger the
    * hold-preview threshold. The caller should show a transient profile preview.
@@ -187,6 +194,7 @@ export default function HouseguestGrid({
               isEvicted={hg.isEvicted}
               isYou={hg.isYou}
               onClick={hg.onClick}
+              roboStats={hg.roboStats}
               onHoldPreviewStart={hg.onHoldPreviewStart}
               onHoldPreviewEnd={hg.onHoldPreviewEnd}
               statuses={hg.statuses}

--- a/src/components/TVLog/TVLog.tsx
+++ b/src/components/TVLog/TVLog.tsx
@@ -49,6 +49,9 @@ export default function TVLog({
   mobileTwoLineMode = false,
 }: TVLogProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const isSurvivorLog = entries.some((event) => event.meta?.mode === 'survivor');
+  const effectiveMaxVisible = isSurvivorLog ? Math.max(maxVisible, 5) : maxVisible;
+  const effectiveMobileTwoLineMode = isSurvivorLog ? false : mobileTwoLineMode;
 
   // Suppress the first entry when its text duplicates the main viewport message.
   const visible = useMemo(
@@ -75,8 +78,8 @@ export default function TVLog({
     <ul
       className="tv-log"
       data-testid="tv-feed"
-      data-mobile-two-line={mobileTwoLineMode ? 'true' : undefined}
-      style={{ '--tv-log-max-vis': maxVisible } as React.CSSProperties}
+      data-mobile-two-line={effectiveMobileTwoLineMode ? 'true' : undefined}
+      style={{ '--tv-log-max-vis': effectiveMaxVisible } as React.CSSProperties}
       aria-label="Game event log"
     >
       {visible.map((ev) => {

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,9 +1,12 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { useStore } from 'react-redux';
 import './NavBar.css';
 import ConfirmExitModal from '../ConfirmExitModal/ConfirmExitModal';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame } from '../../store/gameSlice';
+import { saveRunSnapshot } from '../../store/saveStatePersistence';
+import type { RootState } from '../../store/store';
 import GameBottomNav, { type NavTab } from '../GameBottomNav/GameBottomNav';
 
 /**
@@ -16,14 +19,18 @@ export default function NavBar() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const reduxStore = useStore<RootState>();
   const isGameOverRoute = pathname.startsWith('/game-over');
 
   // Heuristic: treat the game as "active/in-progress" when either we're past
   // week 1 or the phase is not the initial 'week_start'. This mirrors the
   // gameInProgress logic used elsewhere (e.g. in Settings).
   const isGameActive = useAppSelector(
-    (s) => s.game.week > 1 || s.game.phase !== 'week_start',
+    (s) => s.game.week > 1 || s.game.phase !== 'week_start' || s.game.mode === 'survivor',
   );
+  const activeProfileId = useAppSelector((s) => s.profiles.activeProfileId);
+  const isGuest = useAppSelector((s) => s.profiles.isGuest);
+  const canPersistActiveRun = !isGuest && Boolean(activeProfileId);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -34,13 +41,38 @@ export default function NavBar() {
       navigate('/');
       return;
     }
-    // Game in progress: open confirmation modal
     setConfirmOpen(true);
   }
 
-  function onConfirmExit() {
-    // Cancel the current game (non-destructive archive NOT performed).
-    // This resets the in-progress game — pressing Play later will start a fresh season.
+  function saveActiveRun(): boolean {
+    if (!activeProfileId || isGuest) return false;
+    const currentState = reduxStore.getState();
+    return saveRunSnapshot(activeProfileId, {
+      version: 1,
+      profileId: activeProfileId,
+      savedAt: new Date().toISOString(),
+      game: {
+        ...currentState.game,
+        mode: currentState.game.mode ?? 'classic',
+        lastPlayedAt: Date.now(),
+        saveVersion: currentState.game.saveVersion ?? 2,
+      },
+      finale: currentState.finale,
+      social: currentState.social,
+    });
+  }
+
+  function returnHome() {
+    setConfirmOpen(false);
+    navigate('/');
+  }
+
+  function saveThenReturnHome() {
+    saveActiveRun();
+    returnHome();
+  }
+
+  function quitWithoutSaving() {
     dispatch(resetGame());
     setConfirmOpen(false);
     navigate('/');
@@ -55,6 +87,12 @@ export default function NavBar() {
     return null;
   }
 
+  const hasSavedRun = canPersistActiveRun;
+  const modalTitle = hasSavedRun ? 'Return to Home hub?' : 'Unsaved progress';
+  const modalDescription = hasSavedRun
+    ? 'Your saved progress will be available when you come back.'
+    : 'Save before returning home, or quit without saving.';
+
   return (
     <GameBottomNav
       activeTab={getActiveTab()}
@@ -67,11 +105,13 @@ export default function NavBar() {
     >
       <ConfirmExitModal
         open={confirmOpen}
-        title="You are about to exit the house"
-        description="Exiting now will reset the current game. All scores and achievements for this season will be lost."
-        confirmLabel="Exit"
-        cancelLabel="Stay"
-        onConfirm={onConfirmExit}
+        title={modalTitle}
+        description={modalDescription}
+        confirmLabel={hasSavedRun ? 'Return Home' : 'Save first'}
+        secondaryLabel={hasSavedRun ? undefined : 'Quit without saving'}
+        cancelLabel="Cancel"
+        onConfirm={hasSavedRun ? returnHome : saveThenReturnHome}
+        onSecondary={hasSavedRun ? undefined : quitWithoutSaving}
         onCancel={() => setConfirmOpen(false)}
       />
     </GameBottomNav>

--- a/src/modes/modeTypes.ts
+++ b/src/modes/modeTypes.ts
@@ -34,11 +34,15 @@ export type GameRunState = BaseGameState & {
 
 export type RoboPlayer = BasePlayer & {
   isRobo?: boolean;
+  survivorEntryDay?: number;
+  survivorSlot?: number;
 };
 
 declare module '../types' {
   interface Player {
     isRobo?: boolean;
+    survivorEntryDay?: number;
+    survivorSlot?: number;
   }
 
   interface GameState {

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -3,7 +3,8 @@ import type { GameState, Player, TvEvent } from '../types';
 import type { SurvivorModeState } from './modeTypes';
 import { advance, consumeForcedShock, finalizePendingEviction, hydrateGame } from '../store/gameSlice';
 import { getDefaultCompetitionSeasonState } from '../ai/competition';
-import { buildReplacementRobo, createSurvivorModeState } from './survivorRun';
+import { drainEvictedPlayerSocial } from '../social/socialSlice';
+import { buildReplacementRobo, createSurvivorModeState, SURVIVOR_STARTING_CAST_SIZE } from './survivorRun';
 import { isSocialModeEnabled, shouldReplaceEvictedPlayers } from './gameModes';
 
 const SURVIVOR_BLOCKED_SHOCK_ACTIONS = new Set([
@@ -21,7 +22,108 @@ function isExited(player: Player | undefined): boolean {
 function getSurvivorState(game: GameState): SurvivorModeState {
   return game.modeSpecific?.kind === 'survivor'
     ? game.modeSpecific
-    : createSurvivorModeState(game.players.filter((player) => !isExited(player)).length);
+    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
+}
+
+function withSurvivorCompetitionState(
+  game: GameState,
+  players: Player[],
+): GameState['competitionSeasonStateByPlayerId'] {
+  const previous = game.competitionSeasonStateByPlayerId ?? {};
+  return Object.fromEntries(
+    players.map((player) => [
+      player.id,
+      previous[player.id] ?? getDefaultCompetitionSeasonState(),
+    ]),
+  );
+}
+
+function normalizeSurvivorPlayer(player: Player, slot: number, currentDay: number): Player {
+  if (player.isUser) {
+    return {
+      ...player,
+      status: isExited(player) ? player.status : 'active',
+      isUser: true,
+      isRobo: false,
+      survivorEntryDay: player.survivorEntryDay ?? 1,
+      survivorSlot: 0,
+    };
+  }
+
+  return {
+    ...player,
+    status: 'active',
+    isRobo: true,
+    survivorEntryDay: player.survivorEntryDay ?? currentDay,
+    survivorSlot: player.survivorSlot ?? slot,
+    stats: player.stats ?? { lohWins: 0, posWins: 0, timesNominated: 0 },
+  };
+}
+
+function withNormalizedSurvivorCast(game: GameState): GameState | null {
+  if (game.mode !== 'survivor') return null;
+
+  const modeSpecific = getSurvivorState(game);
+  const currentDay = Math.max(modeSpecific.currentDay, game.week);
+  const human = game.players.find((player) => player.isUser);
+  if (!human) return null;
+
+  const targetRoboCount = SURVIVOR_STARTING_CAST_SIZE - 1;
+  const activeRobos = game.players.filter((player) => !player.isUser && !isExited(player));
+  const keptRobos = activeRobos.slice(0, targetRoboCount).map((player, index) => (
+    normalizeSurvivorPlayer(player, index + 1, currentDay)
+  ));
+
+  let nextRoboIndex = Math.max(modeSpecific.nextRoboIndex, targetRoboCount);
+  while (keptRobos.length < targetRoboCount) {
+    const replacement = buildReplacementRobo(
+      {
+        ...game,
+        modeSpecific: {
+          ...modeSpecific,
+          currentDay,
+          startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
+          nextRoboIndex,
+        },
+      },
+      keptRobos.length + 1,
+    );
+    keptRobos.push(replacement);
+    nextRoboIndex += 1;
+  }
+
+  const players = [normalizeSurvivorPlayer(human, 0, currentDay), ...keptRobos];
+  const validIds = new Set(players.map((player) => player.id));
+  const normalizedModeSpecific: SurvivorModeState = {
+    ...modeSpecific,
+    currentDay,
+    bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+    startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
+    nextRoboIndex,
+  };
+
+  const unchanged =
+    game.players.length === players.length &&
+    game.players.every((player, index) => player.id === players[index]?.id) &&
+    modeSpecific.startingCastSize === SURVIVOR_STARTING_CAST_SIZE &&
+    modeSpecific.nextRoboIndex === nextRoboIndex &&
+    modeSpecific.currentDay === currentDay &&
+    game.players.every((player) => player.survivorEntryDay != null && player.survivorSlot != null);
+
+  if (unchanged) return null;
+
+  return {
+    ...game,
+    players,
+    lohId: game.lohId && validIds.has(game.lohId) ? game.lohId : null,
+    prevHohId: game.prevHohId && validIds.has(game.prevHohId) ? game.prevHohId : null,
+    posWinnerId: game.posWinnerId && validIds.has(game.posWinnerId) ? game.posWinnerId : null,
+    nomineeIds: game.nomineeIds.filter((id) => validIds.has(id)),
+    povProtectedIds: game.povProtectedIds?.filter((id) => validIds.has(id)) ?? [],
+    competitionSeasonStateByPlayerId: withSurvivorCompetitionState(game, players),
+    modeSpecific: normalizedModeSpecific,
+    lastPlayedAt: Date.now(),
+  };
 }
 
 function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState | null {
@@ -32,9 +134,9 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
 
   const modeSpecific = getSurvivorState(game);
   const activeCastSize = game.players.filter((player) => !isExited(player)).length;
-  if (activeCastSize >= modeSpecific.startingCastSize) return null;
+  if (activeCastSize >= SURVIVOR_STARTING_CAST_SIZE) return null;
 
-  const replacement = buildReplacementRobo(game);
+  const replacement = buildReplacementRobo(game, evictee.survivorSlot ?? evicteeIndex);
   const nextCompetitionState = {
     ...(game.competitionSeasonStateByPlayerId ?? {}),
     [replacement.id]: getDefaultCompetitionSeasonState(),
@@ -58,6 +160,7 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
       ...modeSpecific,
       currentDay,
       bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
       totalRoboContestantsEvicted,
       nextRoboIndex: modeSpecific.nextRoboIndex + 1,
     },
@@ -71,11 +174,16 @@ function withSurvivorDaySync(game: GameState): GameState | null {
   const modeSpecific = getSurvivorState(game);
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
   const bestDayReached = Math.max(modeSpecific.bestDayReached, currentDay);
-  if (currentDay === modeSpecific.currentDay && bestDayReached === modeSpecific.bestDayReached) return null;
+  if (
+    currentDay === modeSpecific.currentDay &&
+    bestDayReached === modeSpecific.bestDayReached &&
+    modeSpecific.startingCastSize === SURVIVOR_STARTING_CAST_SIZE
+  ) return null;
   return {
     ...game,
     modeSpecific: {
       ...modeSpecific,
+      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
       currentDay,
       bestDayReached,
     },
@@ -83,9 +191,24 @@ function withSurvivorDaySync(game: GameState): GameState | null {
   };
 }
 
+function drainSurvivorSocial(storeApi: Parameters<Middleware>[0], game: GameState, actionType?: string) {
+  if (actionType === drainEvictedPlayerSocial.type) return;
+  const humanPlayer = game.players.find((player) => player.isUser);
+  if (!humanPlayer) return;
+  storeApi.dispatch(drainEvictedPlayerSocial({ playerId: humanPlayer.id, week: game.week }));
+}
+
 export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) => {
   const typedAction = action as { type?: string; payload?: unknown };
   const stateBefore = storeApi.getState() as { game: GameState };
+
+  if (
+    stateBefore.game.mode === 'survivor' &&
+    typedAction.type?.startsWith('social/') &&
+    typedAction.type !== drainEvictedPlayerSocial.type
+  ) {
+    return undefined;
+  }
 
   if (stateBefore.game.mode === 'survivor' && typedAction.type && SURVIVOR_BLOCKED_SHOCK_ACTIONS.has(typedAction.type)) {
     if (stateBefore.game.pendingForcedShock?.type && stateBefore.game.pendingForcedShock.type !== 'doubleEviction') {
@@ -99,6 +222,14 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
   const game = stateAfter.game;
 
   if (game.mode !== 'survivor') return result;
+
+  drainSurvivorSocial(storeApi, game, typedAction.type);
+
+  const normalized = withNormalizedSurvivorCast(game);
+  if (normalized) {
+    storeApi.dispatch(hydrateGame(normalized));
+    return result;
+  }
 
   if (typedAction.type === 'game/finalizePendingEviction' && typeof typedAction.payload === 'string') {
     const nextGame = withReplacementIfNeeded(game, typedAction.payload);

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -136,7 +136,8 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   const activeCastSize = game.players.filter((player) => !isExited(player)).length;
   if (activeCastSize >= SURVIVOR_STARTING_CAST_SIZE) return null;
 
-  const replacement = buildReplacementRobo(game, evictee.survivorSlot ?? evicteeIndex);
+  const replacementSlot = evictee?.survivorSlot ?? evicteeIndex;
+  const replacement = buildReplacementRobo(game, replacementSlot);
   const nextCompetitionState = {
     ...(game.competitionSeasonStateByPlayerId ?? {}),
     [replacement.id]: getDefaultCompetitionSeasonState(),

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from '@reduxjs/toolkit';
+import type { Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
 import type { GameState, Player, TvEvent } from '../types';
 import type { SurvivorModeState } from './modeTypes';
 import { advance, consumeForcedShock, finalizePendingEviction, hydrateGame } from '../store/gameSlice';
@@ -191,7 +191,7 @@ function withSurvivorDaySync(game: GameState): GameState | null {
   };
 }
 
-function drainSurvivorSocial(storeApi: Parameters<Middleware>[0], game: GameState, actionType?: string) {
+function drainSurvivorSocial(storeApi: MiddlewareAPI, game: GameState, actionType?: string) {
   if (actionType === drainEvictedPlayerSocial.type) return;
   const humanPlayer = game.players.find((player) => player.isUser);
   if (!humanPlayer) return;
@@ -225,18 +225,18 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
 
   drainSurvivorSocial(storeApi, game, typedAction.type);
 
-  const normalized = withNormalizedSurvivorCast(game);
-  if (normalized) {
-    storeApi.dispatch(hydrateGame(normalized));
-    return result;
-  }
-
   if (typedAction.type === 'game/finalizePendingEviction' && typeof typedAction.payload === 'string') {
     const nextGame = withReplacementIfNeeded(game, typedAction.payload);
     if (nextGame) {
       storeApi.dispatch(hydrateGame(nextGame));
       return result;
     }
+  }
+
+  const normalized = withNormalizedSurvivorCast((storeApi.getState() as { game: GameState }).game);
+  if (normalized) {
+    storeApi.dispatch(hydrateGame(normalized));
+    return result;
   }
 
   const latest = (storeApi.getState() as { game: GameState }).game;

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -9,7 +9,7 @@ const ROBO_NAMES = [
 ];
 
 const SAVE_VERSION = 2;
-const SURVIVOR_STARTING_CAST_SIZE = 9;
+export const SURVIVOR_STARTING_CAST_SIZE = 8;
 
 function makeRunId(mode: 'classic' | 'survivor'): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -22,7 +22,7 @@ function robotAvatar(seed: string): string {
   return `https://api.dicebear.com/9.x/bottts/svg?seed=${encodeURIComponent(seed)}`;
 }
 
-function buildRoboPlayer(index: number, runId: string): Player {
+function buildRoboPlayer(index: number, runId: string, entryDay = 1, slot = index + 1): Player {
   const name = ROBO_NAMES[index % ROBO_NAMES.length];
   const suffix = Math.floor(index / ROBO_NAMES.length);
   const displayName = suffix > 0 ? `${name}-${suffix + 1}` : name;
@@ -33,6 +33,9 @@ function buildRoboPlayer(index: number, runId: string): Player {
     avatar: robotAvatar(id),
     status: 'active',
     isRobo: true,
+    survivorEntryDay: entryDay,
+    survivorSlot: slot,
+    stats: { lohWins: 0, posWins: 0, timesNominated: 0 },
     competitionProfile: getDefaultCompetitionProfile(),
   };
 }
@@ -62,8 +65,8 @@ export function createSurvivorRun(): GameState {
   const human = base.players.find((player) => player.isUser) ?? base.players[0];
   const startingCastSize = SURVIVOR_STARTING_CAST_SIZE;
   const players = [
-    { ...human, id: 'user', status: 'active' as const, isUser: true, isRobo: false },
-    ...Array.from({ length: startingCastSize - 1 }, (_, index) => buildRoboPlayer(index, runId)),
+    { ...human, id: 'user', status: 'active' as const, isUser: true, isRobo: false, survivorEntryDay: 1, survivorSlot: 0 },
+    ...Array.from({ length: startingCastSize - 1 }, (_, index) => buildRoboPlayer(index, runId, 1, index + 1)),
   ];
   const now = Date.now();
   const modeSpecific = createSurvivorModeState(startingCastSize);
@@ -92,7 +95,7 @@ export function createSurvivorRun(): GameState {
     tvFeed: [
       {
         id: 'survivor-e0',
-        text: 'Survivor Mode online. Nine contestants enter; synthetic replacements keep the board full after every robo eviction.',
+        text: 'Survivor Mode online. Eight contestants enter; synthetic replacements keep the board full after every robo eviction.',
         type: 'game',
         timestamp: now,
         meta: { phase: 'week_start', week: 1, mode: 'survivor' },
@@ -108,23 +111,30 @@ export function createSurvivorRun(): GameState {
   };
 }
 
-export function buildReplacementRobo(state: GameState): Player {
+export function buildReplacementRobo(state: GameState, slot?: number): Player {
   const survivorState = state.modeSpecific?.kind === 'survivor'
     ? state.modeSpecific
-    : createSurvivorModeState(state.players.filter((player) => player.status !== 'evicted' && player.status !== 'jury').length + 1);
-  return buildRoboPlayer(survivorState.nextRoboIndex, state.runId ?? state.gameId);
+    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
+  const currentDay = Math.max(survivorState.currentDay, state.week);
+  return buildRoboPlayer(
+    survivorState.nextRoboIndex,
+    state.runId ?? state.gameId,
+    currentDay,
+    slot ?? survivorState.nextRoboIndex + 1,
+  );
 }
 
 export function markSurvivorDay(state: GameState): GameState {
   if (state.mode !== 'survivor') return state;
   const modeSpecific = state.modeSpecific?.kind === 'survivor'
     ? state.modeSpecific
-    : createSurvivorModeState(state.players.length);
+    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
   const currentDay = Math.max(modeSpecific.currentDay, state.week);
   return {
     ...state,
     modeSpecific: {
       ...modeSpecific,
+      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
       currentDay,
       bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
     },

--- a/src/social/socialModuleAvailability.ts
+++ b/src/social/socialModuleAvailability.ts
@@ -1,9 +1,12 @@
 import type { Phase, PlayerStatus } from '../types';
+import type { GameMode } from '../modes/modeTypes';
 
 const SOCIAL_MODULE_BLOCKED_PHASES: ReadonlySet<Phase> = new Set<Phase>([
   'live_vote',
   'eviction_results',
 ]);
+
+const SURVIVOR_SOCIAL_BLOCK_REASON = 'Survivor mode disables social modules.';
 
 interface HumanPlayerLike {
   id: string;
@@ -12,6 +15,7 @@ interface HumanPlayerLike {
 }
 
 interface GameLike {
+  mode?: GameMode | null;
   phase?: Phase | null;
   players?: ReadonlyArray<HumanPlayerLike>;
 }
@@ -28,6 +32,16 @@ export const SOCIAL_MODULE_BLOCKED_IN_GAME_MESSAGE =
   'Everybody is currently waiting to vote or be voted, so no time for chit-chat now.';
 export const SOCIAL_MODULE_BLOCKED_OUT_OF_GAME_MESSAGE =
   'You are no longer in the house. But maybe try telepathy?';
+export const SURVIVOR_SOCIAL_BLOCKED_MESSAGES = [
+  'The AI players do not feel the need to socialize. They are only after the win.',
+  'Nobody replied to you. You should improve your AI hacking skills and program some friends.',
+  'The AI players are in standby mode for the next challenge. Nobody seems to react to your social attempts.',
+] as const;
+
+function pickSurvivorSocialBlockedMessage(): string {
+  const index = Math.floor(Math.random() * SURVIVOR_SOCIAL_BLOCKED_MESSAGES.length);
+  return SURVIVOR_SOCIAL_BLOCKED_MESSAGES[index];
+}
 
 export function getSocialModuleAvailability(game: GameLike): SocialModuleAvailability {
   const phase = game.phase ?? null;
@@ -47,6 +61,16 @@ export function getSocialModuleAvailability(game: GameLike): SocialModuleAvailab
     return {
       canOpen: false,
       reason: `Human player is out of the house (status: ${humanPlayer.status}).`,
+      phase,
+      humanPlayerId: humanPlayer.id,
+      humanStatus: humanPlayer.status,
+    };
+  }
+
+  if (game.mode === 'survivor') {
+    return {
+      canOpen: false,
+      reason: SURVIVOR_SOCIAL_BLOCK_REASON,
       phase,
       humanPlayerId: humanPlayer.id,
       humanStatus: humanPlayer.status,
@@ -96,6 +120,10 @@ export function getBlockedSocialModuleAnnouncementMessage(
 ): string | null {
   if (availability.canOpen) {
     return null;
+  }
+
+  if (availability.reason === SURVIVOR_SOCIAL_BLOCK_REASON) {
+    return pickSurvivorSocialBlockedMessage();
   }
 
   if (


### PR DESCRIPTION
## Summary
- Set Survivor to an 8-contestant board and normalize older Survivor saves back to 1 human + 7 robo contestants.
- Lock Survivor social systems more firmly: disabled dock affordances, randomized blocked-social copy, and social queue drainage/blocking.
- Add compact robo tile stats sheet with safe fallbacks, expanded Survivor log rows, and lighter roster entry polish.
- Update Home navigation confirmation copy/actions so saved runs return to hub and unsaved runs offer save/quit/cancel.

## Notes
- Kept Classic behavior scoped away from Survivor-specific gates where practical.
- Build/lint not run locally because this task was constrained to GitHub-only work.