### PR TITLE
Fix Survivor disabled actions and save-flow edge cases

### DIFF
--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../store/selectors';
 import { selectActiveConfessionalDecision } from '../../store/confessionalDecisionSelectors';
 import {
+  getBlockedSocialModuleAnnouncementMessage,
   getSocialModuleAvailability,
   type SocialModuleAvailability,
   logBlockedSocialModuleOpen,
@@ -25,6 +26,8 @@ import GameControlDock from '../GameControlDock/GameControlDock';
 import ConfessionalSpotlightOverlay from './ConfessionalSpotlightOverlay';
 
 const CONFESSIONAL_FLASH_DURATION_MS = 1800;
+const SURVIVOR_DISABLED_MESSAGE_MS = 5000;
+const SURVIVOR_PUBLIC_MODE_MESSAGE = 'Public mode is available in Classic campaign mode only.';
 
 type FloatingActionBarProps = {
   /** Called when the player activates Public Meter while public mode is disabled. */
@@ -60,6 +63,7 @@ export default function FloatingActionBar({
   const players = useAppSelector((s) => s.game.players);
   const energyBank = useAppSelector(selectEnergyBank);
   const directions = useAppSelector(selectAllDirections);
+  const isSurvivorMode = game.mode === 'survivor';
 
   const humanPlayer = players.find((p) => p.isUser);
   const humanEnergy = humanPlayer ? (energyBank?.[humanPlayer.id] ?? 0) : null;
@@ -77,6 +81,7 @@ export default function FloatingActionBar({
 
   // Flash the social button whenever the human player's energy changes.
   const [isFlashing, setIsFlashing] = useState(false);
+  const [blockedAnnouncement, setBlockedAnnouncement] = useState<{ id: number; message: string } | null>(null);
   const prevEnergyRef = useRef(humanEnergy);
   useEffect(() => {
     if (humanEnergy === null || humanEnergy === prevEnergyRef.current) {
@@ -92,6 +97,19 @@ export default function FloatingActionBar({
       clearTimeout(flashOff);
     };
   }, [humanEnergy]);
+
+  useEffect(() => {
+    if (!blockedAnnouncement) return undefined;
+    const timeout = window.setTimeout(() => {
+      setBlockedAnnouncement((current) => (current?.id === blockedAnnouncement.id ? null : current));
+    }, SURVIVOR_DISABLED_MESSAGE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [blockedAnnouncement]);
+
+  const showSurvivorBlockedMessage = useCallback((message: string | null) => {
+    if (!message) return;
+    setBlockedAnnouncement({ id: Date.now(), message });
+  }, []);
 
   const [isConfessionalFlashing, setIsConfessionalFlashing] = useState(false);
   const [confessionalFlashTick, setConfessionalFlashTick] = useState(0);
@@ -151,11 +169,22 @@ export default function FloatingActionBar({
         socialModuleAvailability,
         'FloatingActionBar chat button',
       );
+      if (isSurvivorMode) {
+        showSurvivorBlockedMessage(getBlockedSocialModuleAnnouncementMessage(socialModuleAvailability));
+        return;
+      }
       onSocialModuleBlocked?.(socialModuleAvailability);
       return;
     }
     dispatch(openSocialPanel());
-  }, [canUseSocialModules, dispatch, onSocialModuleBlocked, socialModuleAvailability]);
+  }, [
+    canUseSocialModules,
+    dispatch,
+    isSurvivorMode,
+    onSocialModuleBlocked,
+    showSurvivorBlockedMessage,
+    socialModuleAvailability,
+  ]);
 
   const handleIncomingRequestsClick = useCallback(() => {
     if (!canUseSocialModules) {
@@ -164,11 +193,22 @@ export default function FloatingActionBar({
         socialModuleAvailability,
         'FloatingActionBar incoming requests button',
       );
+      if (isSurvivorMode) {
+        showSurvivorBlockedMessage(getBlockedSocialModuleAnnouncementMessage(socialModuleAvailability));
+        return;
+      }
       onSocialModuleBlocked?.(socialModuleAvailability);
       return;
     }
     dispatch(openIncomingInbox());
-  }, [canUseSocialModules, dispatch, onSocialModuleBlocked, socialModuleAvailability]);
+  }, [
+    canUseSocialModules,
+    dispatch,
+    isSurvivorMode,
+    onSocialModuleBlocked,
+    showSurvivorBlockedMessage,
+    socialModuleAvailability,
+  ]);
 
   const dispatchPlayPressedEvent = useCallback(() => {
     try {
@@ -179,6 +219,7 @@ export default function FloatingActionBar({
   }, []);
 
   const handlePrimaryActionClick = useCallback(() => {
+    setBlockedAnnouncement(null);
     if (hasPendingConfessionalDecision) {
       setTriggeredConfessionalDecisionKey(activeConfessionalDecisionKey);
       setConfessionalFlashTick((tick) => tick + 1);
@@ -208,14 +249,30 @@ export default function FloatingActionBar({
 
   const handlePublicMeterClick = useCallback(() => {
     if (game.publicModeEnabled !== true) {
+      if (isSurvivorMode) {
+        showSurvivorBlockedMessage(SURVIVOR_PUBLIC_MODE_MESSAGE);
+        return;
+      }
       onPublicMeterBlocked?.();
       return;
     }
     navigate(publicRequestCount > 0 ? '/public-meter?tab=requests' : '/public-meter');
-  }, [game.publicModeEnabled, navigate, onPublicMeterBlocked, publicRequestCount]);
+  }, [
+    game.publicModeEnabled,
+    isSurvivorMode,
+    navigate,
+    onPublicMeterBlocked,
+    publicRequestCount,
+    showSurvivorBlockedMessage,
+  ]);
 
   return (
     <>
+      {blockedAnnouncement && (
+        <div className="floating-action-bar__blocked-message" role="status" aria-live="polite">
+          {blockedAnnouncement.message}
+        </div>
+      )}
       <GameControlDock
         onChatClick={handleChatClick}
         onIncomingRequestsClick={handleIncomingRequestsClick}

--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -11,6 +11,26 @@
   user-select: none;
 }
 
+.floating-action-bar__blocked-message {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--nav-bar-height) + 78px + env(safe-area-inset-bottom, 0px));
+  z-index: 115;
+  width: min(88vw, 420px);
+  transform: translateX(-50%);
+  border: 1px solid rgba(151, 164, 207, 0.28);
+  border-radius: 14px;
+  padding: 12px 16px;
+  background: rgba(15, 20, 34, 0.94);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.38);
+  color: rgba(247, 249, 255, 0.94);
+  font-size: 0.94rem;
+  font-weight: 650;
+  line-height: 1.35;
+  text-align: center;
+  pointer-events: none;
+}
+
 .fab-clean {
   position: fixed;
 }

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
+import { useAppSelector } from '../../store/hooks'
 import type { CompactRosterLayout } from '../../store/settingsSlice'
 
 const HOUSEMATES_SECTION_TITLE = 'HOUSEMATES'
+
+type RoboStatsSummary = {
+  daysInGame?: number | null
+  lohWins?: number | null
+  posWins?: number | null
+  averageLohRank?: number | null
+  averagePosRank?: number | null
+}
 
 export type Houseguest = {
   id: string | number
@@ -13,13 +22,7 @@ export type Houseguest = {
   isEvicted?: boolean
   isYou?: boolean
   onClick?: () => void
-  roboStats?: {
-    daysInGame?: number | null
-    lohWins?: number | null
-    posWins?: number | null
-    averageLohRank?: number | null
-    averagePosRank?: number | null
-  }
+  roboStats?: RoboStatsSummary
   /**
    * Called when the user has held their finger down long enough to trigger the
    * hold-preview threshold. The caller should show a transient profile preview.
@@ -84,6 +87,10 @@ const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
 
+function buildSurvivorRoboStatsById(game: ReturnType<typeof useAppSelector> extends never ? never : unknown) {
+  return game
+}
+
 export default function HouseguestGrid({
   houseguests,
   showCountInHeader = false,
@@ -97,6 +104,26 @@ export default function HouseguestGrid({
   occupancyLabel,
 }: Props) {
   const containerRef = useRef<HTMLElement | null>(null)
+  const game = useAppSelector((s) => s.game)
+  const survivorRoboStatsById = useMemo(() => {
+    const statsById = new Map<string, RoboStatsSummary>()
+    if (game.mode !== 'survivor') return statsById
+    const currentDay = game.modeSpecific?.kind === 'survivor'
+      ? game.modeSpecific.currentDay
+      : game.week
+    game.players.forEach((player) => {
+      if (!player.isRobo) return
+      const entryDay = player.survivorEntryDay ?? 1
+      statsById.set(player.id, {
+        daysInGame: Math.max(1, currentDay - entryDay + 1),
+        lohWins: player.stats?.lohWins ?? 0,
+        posWins: player.stats?.posWins ?? 0,
+        averageLohRank: null,
+        averagePosRank: null,
+      })
+    })
+    return statsById
+  }, [game.mode, game.modeSpecific, game.players, game.week])
 
   useEffect(() => {
     function setAvailableHeight() {
@@ -186,26 +213,29 @@ export default function HouseguestGrid({
       </div>
 
       <ul className={listClassName} role="list">
-        {houseguests.map((hg) => (
-          <li key={hg.id} className={itemClassName} data-player-id={String(hg.id)}>
-            <AvatarTile
-              name={hg.name}
-              avatarUrl={hg.avatarUrl}
-              isEvicted={hg.isEvicted}
-              isYou={hg.isYou}
-              onClick={hg.onClick}
-              roboStats={hg.roboStats}
-              onHoldPreviewStart={hg.onHoldPreviewStart}
-              onHoldPreviewEnd={hg.onHoldPreviewEnd}
-              statuses={hg.statuses}
-              finalRank={hg.finalRank}
-              showPermanentBadge={hg.showPermanentBadge}
-              layoutId={hg.layoutId}
-              isEvicting={hg.isEvicting}
-              nominationCeremonyState={hg.nominationCeremonyState}
-            />
-          </li>
-        ))}
+        {houseguests.map((hg) => {
+          const resolvedRoboStats = hg.roboStats ?? survivorRoboStatsById.get(String(hg.id))
+          return (
+            <li key={hg.id} className={itemClassName} data-player-id={String(hg.id)}>
+              <AvatarTile
+                name={hg.name}
+                avatarUrl={hg.avatarUrl}
+                isEvicted={hg.isEvicted}
+                isYou={hg.isYou}
+                onClick={hg.onClick}
+                roboStats={resolvedRoboStats}
+                onHoldPreviewStart={hg.onHoldPreviewStart}
+                onHoldPreviewEnd={hg.onHoldPreviewEnd}
+                statuses={hg.statuses}
+                finalRank={hg.finalRank}
+                showPermanentBadge={hg.showPermanentBadge}
+                layoutId={hg.layoutId}
+                isEvicting={hg.isEvicting}
+                nominationCeremonyState={hg.nominationCeremonyState}
+              />
+            </li>
+          )
+        })}
         {Array.from({ length: placeholderCount }).map((_, i) => (
           <li key={`placeholder-${i}`} className={`${itemClassName} ${styles.hgTileInactive}`}>
             <img

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -87,10 +87,6 @@ const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
 
-function buildSurvivorRoboStatsById(game: ReturnType<typeof useAppSelector> extends never ? never : unknown) {
-  return game
-}
-
 export default function HouseguestGrid({
   houseguests,
   showCountInHeader = false,

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -21,6 +21,11 @@ export default function NavBar() {
   const dispatch = useAppDispatch();
   const reduxStore = useStore<RootState>();
   const isGameOverRoute = pathname.startsWith('/game-over');
+  const isActiveGameplayRoute =
+    pathname === '/game' ||
+    pathname.startsWith('/game/') ||
+    pathname.startsWith('/diary-room') ||
+    pathname.startsWith('/public-meter');
 
   // Heuristic: treat the game as "active/in-progress" when either we're past
   // week 1 or the phase is not the initial 'week_start'. This mirrors the
@@ -37,7 +42,7 @@ export default function NavBar() {
   if (pathname === '/' || pathname.startsWith('/credits')) return null;
 
   function handleHomeClick() {
-    if (!isGameActive) {
+    if (!isGameActive || !isActiveGameplayRoute) {
       navigate('/');
       return;
     }

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -126,6 +126,37 @@ function withNormalizedSurvivorCast(game: GameState): GameState | null {
   };
 }
 
+function withSurvivorFailureIfHumanEvicted(game: GameState, evicteeId: string): GameState | null {
+  if (game.mode !== 'survivor') return null;
+  const evictee = game.players.find((player) => player.id === evicteeId);
+  if (!evictee?.isUser || !isExited(evictee)) return null;
+
+  const modeSpecific = getSurvivorState(game);
+  const currentDay = Math.max(modeSpecific.currentDay, game.week);
+  const gameOverEvent: TvEvent = {
+    id: `survivor-failed-${game.runId ?? game.gameId}-${currentDay}`,
+    text: `Survivor run ended. You were eliminated on Day ${currentDay}.`,
+    type: 'game',
+    timestamp: Date.now(),
+    meta: { phase: game.phase, week: game.week, mode: 'survivor' },
+  };
+
+  return {
+    ...game,
+    status: 'failed',
+    modeSpecific: {
+      ...modeSpecific,
+      currentDay,
+      bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
+    },
+    pendingEviction: undefined,
+    voteResults: null,
+    lastPlayedAt: Date.now(),
+    tvFeed: [gameOverEvent, ...game.tvFeed].slice(0, 50),
+  };
+}
+
 function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState | null {
   if (game.mode !== 'survivor' || !shouldReplaceEvictedPlayers(game.mode)) return null;
   const evicteeIndex = game.players.findIndex((player) => player.id === evicteeId);
@@ -227,12 +258,20 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
   drainSurvivorSocial(storeApi, game, typedAction.type);
 
   if (typedAction.type === 'game/finalizePendingEviction' && typeof typedAction.payload === 'string') {
+    const failedGame = withSurvivorFailureIfHumanEvicted(game, typedAction.payload);
+    if (failedGame) {
+      storeApi.dispatch(hydrateGame(failedGame));
+      return result;
+    }
+
     const nextGame = withReplacementIfNeeded(game, typedAction.payload);
     if (nextGame) {
       storeApi.dispatch(hydrateGame(nextGame));
       return result;
     }
   }
+
+  if (game.status === 'failed' || game.status === 'completed') return result;
 
   const normalized = withNormalizedSurvivorCast((storeApi.getState() as { game: GameState }).game);
   if (normalized) {

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -97,7 +97,7 @@ const LATE_SEASON_PLAYER_THRESHOLD = 6;
 // Keep a modest history buffer in case the scheduler window expands.
 const RECENT_HISTORY_LIMIT = 10;
 
-// ─── Slice ────────────────────────────────────────────────────────────────────
+// ─── Slice ───────────────────────────────────────────────────────────────────
 
 const challengeSlice = createSlice({
   name: 'challenge',
@@ -382,13 +382,20 @@ export const startChallenge =
       : ((mulberry32((challengeSeed ^ nextNonce) >>> 0)() * 0x100000000) >>> 0);
     dispatch(incrementNonce());
 
+    const latestState = getState();
+    const gameState = latestState.game;
+    const resolvedParticipants = gameState.mode === 'survivor'
+      ? selectAlivePlayers(latestState)
+        .slice(0, gameState.modeSpecific?.kind === 'survivor' ? gameState.modeSpecific.startingCastSize : 8)
+        .map((player) => player.id)
+      : participants;
+
     // Pre-compute AI scores for all non-human participants.
-    const gameState = getState().game;
     const humanId = gameState?.players?.find((p) => p.isUser)?.id;
     const aiScores: Record<string, number> = {};
     const minigameModel = getMinigameAiModelForGame(gameEntry);
     const timeLimitMs = gameEntry.timeLimitMs > 0 ? gameEntry.timeLimitMs : undefined;
-    participants.forEach((pid, index) => {
+    resolvedParticipants.forEach((pid, index) => {
       if (pid !== humanId) {
         const player = gameState?.players?.find((p) => p.id === pid);
         aiScores[pid] = simulateMinigameAiScore({
@@ -417,7 +424,7 @@ export const startChallenge =
       const scoreRange = Math.max(1, maxScore - minScore);
       const maxMs = minigameModel.tiebreakerMaxMs;
       aiTiebreakers = {};
-      participants.forEach((pid) => {
+      resolvedParticipants.forEach((pid) => {
         if (pid === humanId || aiScores[pid] == null) return;
         // Seed the jitter RNG differently from the score RNG by XOR-ing a fixed salt.
         const rng = mulberry32(((perChallengeSeed >>> 0) ^ (hashStringU32(pid) ^ 0xbeef_cafe)) >>> 0);
@@ -435,7 +442,7 @@ export const startChallenge =
       id,
       game: gameEntry,
       seed: perChallengeSeed,
-      participants,
+      participants: resolvedParticipants,
       phase: 'rules',
       aiScores,
       aiTiebreakers,

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -74,6 +74,11 @@ function getRunId(snapshot: SavedSeasonSnapshot | undefined): string | null {
   return snapshot?.game.runId ?? snapshot?.game.gameId ?? null;
 }
 
+function isRunSnapshotResumable(snapshot: SavedSeasonSnapshot | undefined): snapshot is SavedSeasonSnapshot {
+  if (!snapshot) return false;
+  return snapshot.game.status !== 'completed' && snapshot.game.status !== 'failed';
+}
+
 function getSurvivorBestDay(snapshot: SavedSeasonSnapshot | undefined): number {
   if (!snapshot || snapshot.game.mode !== 'survivor') return 0;
   const modeSpecific = snapshot.game.modeSpecific?.kind === 'survivor'
@@ -96,6 +101,8 @@ function normalizeRunProfile(profileId: string, parsed: Partial<SavedRunProfile>
   if (parsed.version !== 2 || parsed.profileId !== profileId) return null;
   const classic = coerceSnapshot(parsed.runs?.classic, profileId) ?? undefined;
   const survivor = coerceSnapshot(parsed.runs?.survivor, profileId) ?? undefined;
+  const resumableClassic = isRunSnapshotResumable(classic) ? classic : undefined;
+  const resumableSurvivor = isRunSnapshotResumable(survivor) ? survivor : undefined;
   const maxSurvivorDaysSurvived = Math.max(
     typeof parsed.stats?.maxSurvivorDaysSurvived === 'number' ? parsed.stats.maxSurvivorDaysSurvived : 0,
     getSurvivorBestDay(survivor),
@@ -107,8 +114,8 @@ function normalizeRunProfile(profileId: string, parsed: Partial<SavedRunProfile>
     activeRunId: typeof parsed.activeRunId === 'string' ? parsed.activeRunId : null,
     lastPlayedRunId: typeof parsed.lastPlayedRunId === 'string' ? parsed.lastPlayedRunId : null,
     runs: {
-      ...(classic ? { classic } : {}),
-      ...(survivor ? { survivor } : {}),
+      ...(resumableClassic ? { classic: resumableClassic } : {}),
+      ...(resumableSurvivor ? { survivor: resumableSurvivor } : {}),
     },
     stats: { maxSurvivorDaysSurvived },
   };
@@ -192,15 +199,18 @@ export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot
   const survivorBest = mode === 'survivor'
     ? Math.max(current.stats.maxSurvivorDaysSurvived, getSurvivorBestDay(snapshot))
     : current.stats.maxSurvivorDaysSurvived;
+  const nextRuns = { ...current.runs };
+  if (isRunSnapshotResumable(snapshot)) {
+    nextRuns[mode] = snapshot;
+  } else {
+    delete nextRuns[mode];
+  }
   const next: SavedRunProfile = {
     ...current,
     savedAt: snapshot.savedAt,
-    activeRunId: runId,
-    lastPlayedRunId: runId,
-    runs: {
-      ...current.runs,
-      [mode]: snapshot,
-    },
+    activeRunId: isRunSnapshotResumable(snapshot) ? runId : null,
+    lastPlayedRunId: isRunSnapshotResumable(snapshot) ? runId : current.lastPlayedRunId,
+    runs: nextRuns,
     stats: {
       ...current.stats,
       maxSurvivorDaysSurvived: survivorBest,


### PR DESCRIPTION
## Summary
- Shows Survivor-only disabled Social/Public messages locally for 5 seconds without mutating social/log state.
- Limits the Return Home confirmation to active gameplay routes so Rules/Leaderboard/Profile return home directly.
- Forces Survivor challenge setup to use the full active cast so first Crystal Path-style challenges receive 8 participants.
- Populates Survivor robo tile stats from current player state for days in game and LOH/POS wins.
- Marks Survivor runs failed when the human is eliminated and filters failed/completed runs out of resume slots while preserving best-day stats.

## Notes
- Average LOH/POS rank fields remain blank because the current persisted player model does not yet store rank history. This PR avoids inventing fake averages and keeps wins/days live.

## Testing
- Not run locally per request; changes were made directly on GitHub.