### PR TITLE
Emergency fix Survivor terminal restart flow

### DIFF
--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -248,7 +248,15 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
   if (game.mode !== 'survivor') return result;
 
   if (isSurvivorHumanEliminated(game)) {
-    storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(game)));
+    const needsTerminalHydration =
+      game.status !== 'failed' ||
+      game.pendingEviction != null ||
+      game.voteResults != null ||
+      game.awaitingHumanVote === true ||
+      game.awaitingTieBreak === true;
+    if (needsTerminalHydration) {
+      storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(game)));
+    }
     return result;
   }
 

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -33,6 +33,25 @@ function isExited(player: Player | undefined): boolean {
   return player?.status === 'evicted' || player?.status === 'jury';
 }
 
+function isTerminalActionBlocked(actionType?: string): boolean {
+  return Boolean(
+    actionType &&
+    (SURVIVOR_BLOCKED_TERMINAL_ACTIONS.has(actionType) || actionType.startsWith('challenge/')),
+  );
+}
+
+function needsSurvivorTerminalHydration(game: GameState): boolean {
+  return isSurvivorHumanEliminated(game) && (
+    game.status !== 'failed' ||
+    game.pendingEviction != null ||
+    game.voteResults != null ||
+    game.awaitingHumanVote === true ||
+    game.awaitingTieBreak === true ||
+    game.pendingMinigame != null ||
+    game.minigameResult != null
+  );
+}
+
 function getSurvivorState(game: GameState): SurvivorModeState {
   return game.modeSpecific?.kind === 'survivor'
     ? game.modeSpecific
@@ -220,10 +239,9 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
   if (
     stateBefore.game.mode === 'survivor' &&
     isSurvivorRunTerminal(stateBefore.game) &&
-    typedAction.type &&
-    SURVIVOR_BLOCKED_TERMINAL_ACTIONS.has(typedAction.type)
+    isTerminalActionBlocked(typedAction.type)
   ) {
-    if (isSurvivorHumanEliminated(stateBefore.game) && stateBefore.game.status !== 'failed') {
+    if (needsSurvivorTerminalHydration(stateBefore.game)) {
       storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(stateBefore.game)));
     }
     return undefined;
@@ -251,13 +269,7 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
   if (game.mode !== 'survivor') return result;
 
   if (isSurvivorHumanEliminated(game)) {
-    const needsTerminalHydration =
-      game.status !== 'failed' ||
-      game.pendingEviction != null ||
-      game.voteResults != null ||
-      game.awaitingHumanVote === true ||
-      game.awaitingTieBreak === true;
-    if (needsTerminalHydration) {
+    if (needsSurvivorTerminalHydration(game)) {
       storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(game)));
     }
     return result;

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -1,10 +1,17 @@
 import type { Middleware, MiddlewareAPI } from '@reduxjs/toolkit';
-import type { GameState, Player, TvEvent } from '../types';
+import type { GameState, Player } from '../types';
 import type { SurvivorModeState } from './modeTypes';
 import { advance, consumeForcedShock, finalizePendingEviction, hydrateGame } from '../store/gameSlice';
 import { getDefaultCompetitionSeasonState } from '../ai/competition';
 import { drainEvictedPlayerSocial } from '../social/socialSlice';
-import { buildReplacementRobo, createSurvivorModeState, SURVIVOR_STARTING_CAST_SIZE } from './survivorRun';
+import {
+  buildReplacementRobo,
+  createSurvivorModeState,
+  isSurvivorHumanEliminated,
+  isSurvivorRunTerminal,
+  SURVIVOR_STARTING_CAST_SIZE,
+  terminalizeSurvivorRun,
+} from './survivorRun';
 import { isSocialModeEnabled, shouldReplaceEvictedPlayers } from './gameModes';
 
 const SURVIVOR_BLOCKED_SHOCK_ACTIONS = new Set([
@@ -13,6 +20,13 @@ const SURVIVOR_BLOCKED_SHOCK_ACTIONS = new Set([
   'game/activateDayStartShock',
   'game/activateDemocracia',
   'game/triggerSecretMission',
+]);
+
+const SURVIVOR_BLOCKED_TERMINAL_ACTIONS = new Set([
+  'game/advance',
+  'game/finalizePendingEviction',
+  'game/applyMinigameWinner',
+  'game/applyF3MinigameWinner',
 ]);
 
 function isExited(player: Player | undefined): boolean {
@@ -61,12 +75,12 @@ function normalizeSurvivorPlayer(player: Player, slot: number, currentDay: numbe
 }
 
 function withNormalizedSurvivorCast(game: GameState): GameState | null {
-  if (game.mode !== 'survivor') return null;
+  if (game.mode !== 'survivor' || isSurvivorRunTerminal(game)) return null;
 
   const modeSpecific = getSurvivorState(game);
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
   const human = game.players.find((player) => player.isUser);
-  if (!human) return null;
+  if (!human) return terminalizeSurvivorRun(game);
 
   const targetRoboCount = SURVIVOR_STARTING_CAST_SIZE - 1;
   const activeRobos = game.players.filter((player) => !player.isUser && !isExited(player));
@@ -126,39 +140,8 @@ function withNormalizedSurvivorCast(game: GameState): GameState | null {
   };
 }
 
-function withSurvivorFailureIfHumanEvicted(game: GameState, evicteeId: string): GameState | null {
-  if (game.mode !== 'survivor') return null;
-  const evictee = game.players.find((player) => player.id === evicteeId);
-  if (!evictee?.isUser || !isExited(evictee)) return null;
-
-  const modeSpecific = getSurvivorState(game);
-  const currentDay = Math.max(modeSpecific.currentDay, game.week);
-  const gameOverEvent: TvEvent = {
-    id: `survivor-failed-${game.runId ?? game.gameId}-${currentDay}`,
-    text: `Survivor run ended. You were eliminated on Day ${currentDay}.`,
-    type: 'game',
-    timestamp: Date.now(),
-    meta: { phase: game.phase, week: game.week, mode: 'survivor' },
-  };
-
-  return {
-    ...game,
-    status: 'failed',
-    modeSpecific: {
-      ...modeSpecific,
-      currentDay,
-      bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
-      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
-    },
-    pendingEviction: undefined,
-    voteResults: null,
-    lastPlayedAt: Date.now(),
-    tvFeed: [gameOverEvent, ...game.tvFeed].slice(0, 50),
-  };
-}
-
 function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState | null {
-  if (game.mode !== 'survivor' || !shouldReplaceEvictedPlayers(game.mode)) return null;
+  if (game.mode !== 'survivor' || isSurvivorRunTerminal(game) || !shouldReplaceEvictedPlayers(game.mode)) return null;
   const evicteeIndex = game.players.findIndex((player) => player.id === evicteeId);
   const evictee = evicteeIndex >= 0 ? game.players[evicteeIndex] : undefined;
   if (!isExited(evictee) || evictee?.isUser) return null;
@@ -176,10 +159,10 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   const totalRoboContestantsEvicted = modeSpecific.totalRoboContestantsEvicted + 1;
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
   const players = game.players.map((player, index) => (index === evicteeIndex ? replacement : player));
-  const replacementEvent: TvEvent = {
+  const replacementEvent = {
     id: `survivor-replacement-${replacement.id}`,
     text: `${replacement.name} enters as a replacement synthetic contestant.`,
-    type: 'game',
+    type: 'game' as const,
     timestamp: Date.now(),
     meta: { phase: game.phase, week: game.week, mode: 'survivor' },
   };
@@ -202,7 +185,7 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
 }
 
 function withSurvivorDaySync(game: GameState): GameState | null {
-  if (game.mode !== 'survivor') return null;
+  if (game.mode !== 'survivor' || isSurvivorRunTerminal(game)) return null;
   const modeSpecific = getSurvivorState(game);
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
   const bestDayReached = Math.max(modeSpecific.bestDayReached, currentDay);
@@ -236,6 +219,15 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
 
   if (
     stateBefore.game.mode === 'survivor' &&
+    isSurvivorRunTerminal(stateBefore.game) &&
+    typedAction.type &&
+    SURVIVOR_BLOCKED_TERMINAL_ACTIONS.has(typedAction.type)
+  ) {
+    return undefined;
+  }
+
+  if (
+    stateBefore.game.mode === 'survivor' &&
     typedAction.type?.startsWith('social/') &&
     typedAction.type !== drainEvictedPlayerSocial.type
   ) {
@@ -255,23 +247,22 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
 
   if (game.mode !== 'survivor') return result;
 
+  if (isSurvivorHumanEliminated(game)) {
+    storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(game)));
+    return result;
+  }
+
+  if (isSurvivorRunTerminal(game)) return result;
+
   drainSurvivorSocial(storeApi, game, typedAction.type);
 
   if (typedAction.type === 'game/finalizePendingEviction' && typeof typedAction.payload === 'string') {
-    const failedGame = withSurvivorFailureIfHumanEvicted(game, typedAction.payload);
-    if (failedGame) {
-      storeApi.dispatch(hydrateGame(failedGame));
-      return result;
-    }
-
     const nextGame = withReplacementIfNeeded(game, typedAction.payload);
     if (nextGame) {
       storeApi.dispatch(hydrateGame(nextGame));
       return result;
     }
   }
-
-  if (game.status === 'failed' || game.status === 'completed') return result;
 
   const normalized = withNormalizedSurvivorCast((storeApi.getState() as { game: GameState }).game);
   if (normalized) {

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -223,6 +223,9 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
     typedAction.type &&
     SURVIVOR_BLOCKED_TERMINAL_ACTIONS.has(typedAction.type)
   ) {
+    if (isSurvivorHumanEliminated(stateBefore.game) && stateBefore.game.status !== 'failed') {
+      storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(stateBefore.game)));
+    }
     return undefined;
   }
 

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -1,4 +1,4 @@
-import type { GameState, Player } from '../types';
+import type { GameState, Player, TvEvent } from '../types';
 import type { SurvivorModeState } from './modeTypes';
 import { getDefaultCompetitionProfile, getDefaultCompetitionSeasonState } from '../ai/competition';
 import { createInitialGameState } from '../store/gameSlice';
@@ -20,6 +20,74 @@ function makeRunId(mode: 'classic' | 'survivor'): string {
 
 function robotAvatar(seed: string): string {
   return `https://api.dicebear.com/9.x/bottts/svg?seed=${encodeURIComponent(seed)}`;
+}
+
+function isPlayerExited(player: Player | undefined): boolean {
+  return player?.status === 'evicted' || player?.status === 'jury';
+}
+
+function getSurvivorModeState(state: GameState): SurvivorModeState {
+  return state.modeSpecific?.kind === 'survivor'
+    ? state.modeSpecific
+    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
+}
+
+export function getSurvivorCurrentDay(state: GameState): number {
+  const survivorState = getSurvivorModeState(state);
+  return Math.max(survivorState.currentDay, state.week ?? 1);
+}
+
+export function isSurvivorHumanEliminated(state: GameState): boolean {
+  if (state.mode !== 'survivor') return false;
+  const human = state.players.find((player) => player.isUser);
+  return !human || isPlayerExited(human);
+}
+
+export function isSurvivorRunTerminal(state: GameState): boolean {
+  if (state.mode !== 'survivor') return false;
+  return state.status === 'failed' || state.status === 'completed' || isSurvivorHumanEliminated(state);
+}
+
+export function terminalizeSurvivorRun(state: GameState): GameState {
+  if (state.mode !== 'survivor') return state;
+
+  const modeSpecific = getSurvivorModeState(state);
+  const currentDay = getSurvivorCurrentDay(state);
+  const eventId = `survivor-failed-${state.runId ?? state.gameId}-${currentDay}`;
+  const hasTerminalEvent = state.tvFeed.some((event) => event.id === eventId);
+  const gameOverEvent: TvEvent = {
+    id: eventId,
+    text: `Survivor run ended. You were eliminated on Day ${currentDay}.`,
+    type: 'game',
+    timestamp: Date.now(),
+    meta: { phase: state.phase, week: state.week, mode: 'survivor' },
+  };
+
+  return {
+    ...state,
+    status: state.status === 'completed' ? 'completed' : 'failed',
+    pendingEviction: null,
+    voteResults: null,
+    votes: {},
+    awaitingHumanVote: false,
+    awaitingTieBreak: false,
+    tiedNomineeIds: null,
+    replacementNeeded: false,
+    awaitingNominations: false,
+    pendingNominee1Id: null,
+    awaitingPovDecision: false,
+    awaitingPovSaveTarget: false,
+    pendingMinigame: null,
+    minigameResult: null,
+    modeSpecific: {
+      ...modeSpecific,
+      currentDay,
+      bestDayReached: Math.max(modeSpecific.bestDayReached, currentDay),
+      startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
+    },
+    lastPlayedAt: Date.now(),
+    tvFeed: hasTerminalEvent ? state.tvFeed : [gameOverEvent, ...state.tvFeed].slice(0, 50),
+  };
 }
 
 function buildRoboPlayer(index: number, runId: string, entryDay = 1, slot = index + 1): Player {
@@ -112,9 +180,7 @@ export function createSurvivorRun(): GameState {
 }
 
 export function buildReplacementRobo(state: GameState, slot?: number): Player {
-  const survivorState = state.modeSpecific?.kind === 'survivor'
-    ? state.modeSpecific
-    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
+  const survivorState = getSurvivorModeState(state);
   const currentDay = Math.max(survivorState.currentDay, state.week);
   return buildRoboPlayer(
     survivorState.nextRoboIndex,
@@ -126,9 +192,7 @@ export function buildReplacementRobo(state: GameState, slot?: number): Player {
 
 export function markSurvivorDay(state: GameState): GameState {
   if (state.mode !== 'survivor') return state;
-  const modeSpecific = state.modeSpecific?.kind === 'survivor'
-    ? state.modeSpecific
-    : createSurvivorModeState(SURVIVOR_STARTING_CAST_SIZE);
+  const modeSpecific = getSurvivorModeState(state);
   const currentDay = Math.max(modeSpecific.currentDay, state.week);
   return {
     ...state,

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -11,18 +11,20 @@ import {
   archiveKeyForProfile,
 } from '../../store/profilesSlice';
 import {
+  clearSavedRun,
   getLastPlayedRun,
   getSavedRun,
   loadSavedRunProfile,
   type SavedSeasonSnapshot,
 } from '../../store/saveStatePersistence';
 import type { GameMode } from '../../modes/modeTypes';
-import { createSurvivorRun } from '../../modes/survivorRun';
+import { createSurvivorRun, isSurvivorRunTerminal } from '../../modes/survivorRun';
 import useBackgroundTheme from '../../hooks/useBackgroundTheme';
 import KolequantSplash from '../../components/KolequantSplash/KolequantSplash';
 import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOverlay';
 import AssetPreloaderOverlay from '../../components/AssetPreloaderOverlay/AssetPreloaderOverlay';
 import PermissionPrompts from '../../components/PermissionPrompts/PermissionPrompts';
+import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
 import { SoundManager } from '../../services/sound/SoundManager';
 import GameButton, { type GameButtonVariant } from '../../components/GameButton/GameButton';
 import useHomeHubAssets from '../../hooks/useHomeHubAssets';
@@ -60,6 +62,8 @@ const HUB_BUTTONS = [
   { to: '/leaderboard',  label: 'Leaderboard', icon: '🏆', variant: 'secondary_wide'   },
   { to: '/credits',      label: 'Credits',     icon: '🎬', variant: 'secondary_small'  },
 ] as const satisfies ReadonlyArray<{ to: string; label: string; icon: string; variant: GameButtonVariant }>;
+
+type SurvivorPrompt = 'resume-or-new' | 'ended' | 'confirm-new' | null;
 
 function snapshotDay(snapshot: SavedSeasonSnapshot | null | undefined): number | null {
   const day = snapshot?.game?.week;
@@ -193,6 +197,7 @@ export default function HomeHub() {
   // an effect on mount.
   const [preloading, setPreloading] = useState(autoStartGame);
   const [playSelectionOpen, setPlaySelectionOpen] = useState(false);
+  const [survivorPrompt, setSurvivorPrompt] = useState<SurvivorPrompt>(null);
 
   const savedRuns = useMemo(
     () => (!isGuest && activeProfileId ? loadSavedRunProfile(activeProfileId) : null),
@@ -201,6 +206,7 @@ export default function HomeHub() {
   const classicSnapshot = savedRuns?.runs.classic ?? null;
   const survivorSnapshot = savedRuns?.runs.survivor ?? null;
   const lastSnapshot = !isGuest && activeProfileId ? getLastPlayedRun(activeProfileId) : null;
+  const hasEndedSurvivorRecord = !survivorSnapshot && (savedRuns?.stats.maxSurvivorDaysSurvived ?? 0) > 0;
 
   useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
@@ -226,6 +232,11 @@ export default function HomeHub() {
   }, [autoStartGame, navigate]);
 
   function hydrateSnapshot(snapshot: SavedSeasonSnapshot) {
+    if (isSurvivorRunTerminal(snapshot.game)) {
+      setSurvivorPrompt('ended');
+      setPlaySelectionOpen(true);
+      return;
+    }
     dispatch(hydrateGame(snapshot.game));
     dispatch(hydrateFinale(snapshot.finale));
     dispatch(hydrateSocial(snapshot.social));
@@ -243,12 +254,43 @@ export default function HomeHub() {
   }
 
   function startSurvivorRun() {
+    if (!isGuest && activeProfileId) {
+      clearSavedRun(activeProfileId, 'survivor');
+    }
+    setSurvivorPrompt(null);
     dispatch(hydrateGame(createSurvivorRun()));
     setPreloading(true);
   }
 
+  function resumeSurvivorRun() {
+    if (!survivorSnapshot) {
+      setSurvivorPrompt('ended');
+      return;
+    }
+    setSurvivorPrompt(null);
+    hydrateSnapshot(survivorSnapshot);
+  }
+
+  function openSurvivorMode() {
+    SoundManager.unlockFromGesture();
+    if (survivorSnapshot) {
+      setSurvivorPrompt('resume-or-new');
+      return;
+    }
+    if (hasEndedSurvivorRecord) {
+      setSurvivorPrompt('ended');
+      return;
+    }
+    startSurvivorRun();
+  }
+
   function startOrResumeMode(mode: GameMode) {
     SoundManager.unlockFromGesture();
+    if (mode === 'survivor') {
+      openSurvivorMode();
+      return;
+    }
+
     if (!isGuest && activeProfileId) {
       const snapshot = getSavedRun(activeProfileId, mode);
       if (snapshot?.profileId === activeProfileId) {
@@ -261,8 +303,7 @@ export default function HomeHub() {
       }
     }
 
-    if (mode === 'survivor') startSurvivorRun();
-    else startClassicRun();
+    startClassicRun();
   }
 
   function continueLastRun() {
@@ -337,6 +378,41 @@ export default function HomeHub() {
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
       {preloading && <AssetPreloaderOverlay />}
+
+      <ConfirmExitModal
+        open={survivorPrompt === 'resume-or-new'}
+        title="Survivor Mode"
+        description="Resume your saved run or start over?"
+        confirmLabel="Resume Saved Run"
+        secondaryLabel="Start New Survivor"
+        cancelLabel="Cancel"
+        onConfirm={resumeSurvivorRun}
+        onSecondary={() => setSurvivorPrompt('confirm-new')}
+        onCancel={() => setSurvivorPrompt(null)}
+      />
+
+      <ConfirmExitModal
+        open={survivorPrompt === 'ended'}
+        title="Survivor Mode"
+        description="Your previous Survivor run has ended."
+        confirmLabel="Start New Survivor"
+        cancelLabel="Return Home"
+        onConfirm={startSurvivorRun}
+        onCancel={() => {
+          setSurvivorPrompt(null);
+          setPlaySelectionOpen(false);
+        }}
+      />
+
+      <ConfirmExitModal
+        open={survivorPrompt === 'confirm-new'}
+        title="Start new Survivor run?"
+        description="This will replace your saved Survivor run only. Classic progress will not be affected."
+        confirmLabel="Start New"
+        cancelLabel="Cancel"
+        onConfirm={startSurvivorRun}
+        onCancel={() => setSurvivorPrompt('resume-or-new')}
+      />
 
       <div className="homehub-shell">
         <div className="homehub-frame">

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -12,6 +12,7 @@
 import type { GameState } from '../types';
 import type { GameMode } from '../modes/modeTypes';
 import { normalizeGameMode } from '../modes/gameModes';
+import { isSurvivorRunTerminal } from '../modes/survivorRun';
 import type { FinaleState } from './finaleSlice';
 import type { SocialState } from '../social/types';
 
@@ -76,6 +77,7 @@ function getRunId(snapshot: SavedSeasonSnapshot | undefined): string | null {
 
 function isRunSnapshotResumable(snapshot: SavedSeasonSnapshot | undefined): snapshot is SavedSeasonSnapshot {
   if (!snapshot) return false;
+  if (isSurvivorRunTerminal(snapshot.game)) return false;
   return snapshot.game.status !== 'completed' && snapshot.game.status !== 'failed';
 }
 
@@ -200,7 +202,8 @@ export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot
     ? Math.max(current.stats.maxSurvivorDaysSurvived, getSurvivorBestDay(snapshot))
     : current.stats.maxSurvivorDaysSurvived;
   const nextRuns = { ...current.runs };
-  if (isRunSnapshotResumable(snapshot)) {
+  const resumable = isRunSnapshotResumable(snapshot);
+  if (resumable) {
     nextRuns[mode] = snapshot;
   } else {
     delete nextRuns[mode];
@@ -208,8 +211,8 @@ export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot
   const next: SavedRunProfile = {
     ...current,
     savedAt: snapshot.savedAt,
-    activeRunId: isRunSnapshotResumable(snapshot) ? runId : null,
-    lastPlayedRunId: isRunSnapshotResumable(snapshot) ? runId : current.lastPlayedRunId,
+    activeRunId: resumable ? runId : null,
+    lastPlayedRunId: resumable ? runId : current.lastPlayedRunId,
     runs: nextRuns,
     stats: {
       ...current.stats,


### PR DESCRIPTION
## Summary
- Adds canonical Survivor terminal helpers for human-eliminated and terminal run detection.
- Terminalizes Survivor immediately when the human is missing/evicted/jury, clears blocking vote/decision state, and prevents further AI-only progression.
- Filters corrupted active Survivor saves through the same terminal helper so they cannot resume into gameplay.
- Adds HomeHub Survivor resume/start-over flow, including a confirmation before replacing an active Survivor save and preserving Classic progress.

## Validation
- Not run locally per request; changes were made directly on GitHub.

## Scope
- Only touches Survivor terminal handling, save resume filtering, and HomeHub restart/resume flow.