### PR TITLE
Emergency fix Survivor hard-stop game over flow

### DIFF
--- a/src/components/ConfirmExitModal/ConfirmExitModal.css
+++ b/src/components/ConfirmExitModal/ConfirmExitModal.css
@@ -5,7 +5,7 @@
   align-items: center;
   justify-content: center;
   background: rgba(6, 8, 12, 0.6);
-  z-index: 8000; /* above app shell UI but below topmost overlays if needed */
+  z-index: 12000;
   padding: 20px;
 }
 

--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { advance, setHasSeenConfessionalSpotlight } from '../../store/gameSlice';
+import { advance, hydrateGame, setHasSeenConfessionalSpotlight } from '../../store/gameSlice';
 import {
   openIncomingInbox,
   openSocialPanel,
@@ -19,9 +19,13 @@ import { selectActiveConfessionalDecision } from '../../store/confessionalDecisi
 import {
   getBlockedSocialModuleAnnouncementMessage,
   getSocialModuleAvailability,
-  type SocialModuleAvailability,
   logBlockedSocialModuleOpen,
+  type SocialModuleAvailability,
 } from '../../social/socialModuleAvailability';
+import { selectActiveProfileId, selectIsGuest } from '../../store/profilesSlice';
+import { clearSavedRun, loadSavedRunProfile } from '../../store/saveStatePersistence';
+import { createSurvivorRun, getSurvivorCurrentDay, isSurvivorRunTerminal } from '../../modes/survivorRun';
+import ConfirmExitModal from '../ConfirmExitModal/ConfirmExitModal';
 import GameControlDock from '../GameControlDock/GameControlDock';
 import ConfessionalSpotlightOverlay from './ConfessionalSpotlightOverlay';
 
@@ -59,11 +63,14 @@ export default function FloatingActionBar({
   const confessionalAlertCount = useAppSelector(selectConfessionalAlertCount);
   const canUseSocialModules = useAppSelector(selectHumanCanUseSocialModules);
   const activeConfessionalDecision = useAppSelector(selectActiveConfessionalDecision);
+  const activeProfileId = useAppSelector(selectActiveProfileId);
+  const isGuest = useAppSelector(selectIsGuest);
   const game = useAppSelector((s) => s.game);
   const players = useAppSelector((s) => s.game.players);
   const energyBank = useAppSelector(selectEnergyBank);
   const directions = useAppSelector(selectAllDirections);
   const isSurvivorMode = game.mode === 'survivor';
+  const survivorTerminalActive = isSurvivorRunTerminal(game);
 
   const humanPlayer = players.find((p) => p.isUser);
   const humanEnergy = humanPlayer ? (energyBank?.[humanPlayer.id] ?? 0) : null;
@@ -78,6 +85,14 @@ export default function FloatingActionBar({
   );
   const socialModuleAvailability = useMemo(() => getSocialModuleAvailability(game), [game]);
   const socialModulesUnavailable = !canUseSocialModules;
+  const survivorDay = getSurvivorCurrentDay(game);
+  const bestSurvivorRecord = useMemo(
+    () => (!isGuest && activeProfileId ? loadSavedRunProfile(activeProfileId).stats.maxSurvivorDaysSurvived : 0),
+    [activeProfileId, isGuest],
+  );
+  const survivorEndDescription = bestSurvivorRecord > survivorDay
+    ? `You were eliminated on Day ${survivorDay}. Best survival record: ${bestSurvivorRecord} days.`
+    : `You were eliminated on Day ${survivorDay}.`;
 
   // Flash the social button whenever the human player's energy changes.
   const [isFlashing, setIsFlashing] = useState(false);
@@ -145,10 +160,12 @@ export default function FloatingActionBar({
   const confessionalPromptActivated =
     activeConfessionalDecisionKey !== null &&
     triggeredConfessionalDecisionKey === activeConfessionalDecisionKey;
-  const primaryDisabled = hasPendingConfessionalDecision ? confessionalPromptActivated : isWaiting;
-  const primaryPulse = hasPendingConfessionalDecision
-    ? !confessionalPromptActivated
-    : canAdvance && !isWaiting;
+  const primaryDisabled = survivorTerminalActive || (hasPendingConfessionalDecision ? confessionalPromptActivated : isWaiting);
+  const primaryPulse = survivorTerminalActive
+    ? false
+    : hasPendingConfessionalDecision
+      ? !confessionalPromptActivated
+      : canAdvance && !isWaiting;
   const confessionalPersistentFlash = hasPendingConfessionalDecision && confessionalPromptActivated;
   const confessionalSpotlightEligible =
     hasPendingConfessionalDecision &&
@@ -219,6 +236,7 @@ export default function FloatingActionBar({
   }, []);
 
   const handlePrimaryActionClick = useCallback(() => {
+    if (survivorTerminalActive) return;
     setBlockedAnnouncement(null);
     if (hasPendingConfessionalDecision) {
       setTriggeredConfessionalDecisionKey(activeConfessionalDecisionKey);
@@ -237,6 +255,7 @@ export default function FloatingActionBar({
     dispatchPlayPressedEvent,
     hasPendingConfessionalDecision,
     hasSeenConfessionalSpotlight,
+    survivorTerminalActive,
   ]);
 
   const handleToolClick = useCallback(() => {
@@ -266,6 +285,20 @@ export default function FloatingActionBar({
     showSurvivorBlockedMessage,
   ]);
 
+  const handleStartNewSurvivor = useCallback(() => {
+    if (!isGuest && activeProfileId) {
+      clearSavedRun(activeProfileId, 'survivor');
+    }
+    dispatch({ type: 'challenge/setPendingChallenge', payload: null });
+    dispatch(hydrateGame(createSurvivorRun()));
+    navigate('/game', { replace: true });
+  }, [activeProfileId, dispatch, isGuest, navigate]);
+
+  const handleReturnHome = useCallback(() => {
+    dispatch({ type: 'challenge/setPendingChallenge', payload: null });
+    navigate('/');
+  }, [dispatch, navigate]);
+
   return (
     <>
       {blockedAnnouncement && (
@@ -273,12 +306,22 @@ export default function FloatingActionBar({
           {blockedAnnouncement.message}
         </div>
       )}
+      <ConfirmExitModal
+        open={survivorTerminalActive}
+        title="Survivor run ended"
+        description={survivorEndDescription}
+        confirmLabel="Start New Survivor"
+        cancelLabel="Return Home"
+        onConfirm={handleStartNewSurvivor}
+        onCancel={handleReturnHome}
+      />
       <GameControlDock
         onChatClick={handleChatClick}
         onIncomingRequestsClick={handleIncomingRequestsClick}
         onPrimaryActionClick={handlePrimaryActionClick}
         onPublicMeterClick={handlePublicMeterClick}
         onToolClick={handleToolClick}
+        disabled={survivorTerminalActive}
         primaryDisabled={primaryDisabled}
         socialDisabled={socialModulesUnavailable}
         incomingRequestsDisabled={socialModulesUnavailable}

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -47,9 +47,23 @@ function needsSurvivorTerminalHydration(game: GameState): boolean {
     game.voteResults != null ||
     game.awaitingHumanVote === true ||
     game.awaitingTieBreak === true ||
+    game.replacementNeeded === true ||
+    game.awaitingNominations === true ||
+    game.awaitingPovDecision === true ||
+    game.awaitingPovSaveTarget === true ||
     game.pendingMinigame != null ||
-    game.minigameResult != null
+    game.minigameResult != null ||
+    game.awaitingFinal3Eviction === true ||
+    game.awaitingFinal3Plea === true ||
+    game.dayStartShock != null
   );
+}
+
+function clearPendingChallenge(storeApi: MiddlewareAPI) {
+  const state = storeApi.getState() as { challenge?: { pending?: unknown } };
+  if (state.challenge?.pending != null) {
+    storeApi.dispatch({ type: 'challenge/setPendingChallenge', payload: null });
+  }
 }
 
 function getSurvivorState(game: GameState): SurvivorModeState {
@@ -244,6 +258,7 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
     if (needsSurvivorTerminalHydration(stateBefore.game)) {
       storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(stateBefore.game)));
     }
+    clearPendingChallenge(storeApi);
     return undefined;
   }
 
@@ -272,10 +287,14 @@ export const survivorMiddleware: Middleware = (storeApi) => (next) => (action) =
     if (needsSurvivorTerminalHydration(game)) {
       storeApi.dispatch(hydrateGame(terminalizeSurvivorRun(game)));
     }
+    clearPendingChallenge(storeApi);
     return result;
   }
 
-  if (isSurvivorRunTerminal(game)) return result;
+  if (isSurvivorRunTerminal(game)) {
+    clearPendingChallenge(storeApi);
+    return result;
+  }
 
   drainSurvivorSocial(storeApi, game, typedAction.type);
 

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -77,8 +77,12 @@ export function terminalizeSurvivorRun(state: GameState): GameState {
     pendingNominee1Id: null,
     awaitingPovDecision: false,
     awaitingPovSaveTarget: false,
+    awaitingMissionImmunityOffer: false,
     pendingMinigame: null,
     minigameResult: null,
+    awaitingFinal3Eviction: false,
+    awaitingFinal3Plea: false,
+    dayStartShock: null,
     modeSpecific: {
       ...modeSpecific,
       currentDay,


### PR DESCRIPTION
## Summary
- hard-stop Survivor runs the moment the human is terminal, with broader cleanup of pending gameplay state
- clear any pending challenge/minigame flow so old or edge-case Survivor eliminations cannot keep the game moving underneath the end state
- add a blocking in-game "Survivor run ended" modal with Start New Survivor and Return Home actions, preserving Classic progress
- raise the modal overlay layer so it fully blocks gameplay interaction behind it

## Validation
- Not run locally per request; changes were made directly on GitHub.

## Scope
- Survivor elimination, terminal blocking, restart, and resume safety only
- No Classic mode changes
- No unrelated animation or UI polish work