### PR TITLE
Tidy home hub and housemate avatars

### DIFF
--- a/src/components/HouseguestGrid/HouseguestInfoDialog.css
+++ b/src/components/HouseguestGrid/HouseguestInfoDialog.css
@@ -89,6 +89,11 @@
     0 2px 8px rgba(0, 0, 0, 0.45);
 }
 
+.hg-info-dialog__avatar.pa {
+  width: 58px;
+  height: 58px;
+}
+
 .hg-info-dialog__name {
   margin: 0;
   color: #ffffff;

--- a/src/components/HouseguestGrid/HouseguestInfoDialog.tsx
+++ b/src/components/HouseguestGrid/HouseguestInfoDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Player } from '../../types';
 import { enrichPlayer } from '../../utils/houseguestLookup';
-import { resolveAvatar, getDicebear } from '../../utils/avatar';
+import PlayerAvatar from '../PlayerAvatar/PlayerAvatar';
 import './HouseguestInfoDialog.css';
 
 interface HouseguestInfoDialogProps {
@@ -75,16 +75,12 @@ export default function HouseguestInfoDialog({ player, onClose }: HouseguestInfo
         </button>
 
         <div className="hg-info-dialog__header">
-          <img
+          <PlayerAvatar
+            player={player}
             className="hg-info-dialog__avatar"
-            src={resolveAvatar(player)}
-            alt={player.name}
-            draggable={false}
-            onError={(e) => {
-              const img = e.currentTarget;
-              img.onerror = null;
-              img.src = getDicebear(player.name);
-            }}
+            size="lg"
+            showRelationshipOutline={false}
+            showEvictedStyle={false}
           />
           <div className="hg-info-dialog__identity">
             <h3 className="hg-info-dialog__name">{ep.fullName ?? ep.name}</h3>

--- a/src/components/HouseguestProfile/HouseguestProfile.css
+++ b/src/components/HouseguestProfile/HouseguestProfile.css
@@ -62,6 +62,11 @@
   box-shadow: 0 2px 10px rgba(0,0,0,0.4);
 }
 
+.hg-profile__avatar.pa {
+  width: 80px;
+  height: 80px;
+}
+
 .hg-profile__name {
   font-size: 1.2rem;
   font-weight: 700;

--- a/src/components/HouseguestProfile/HouseguestProfile.tsx
+++ b/src/components/HouseguestProfile/HouseguestProfile.tsx
@@ -1,6 +1,6 @@
 import type { Player } from '../../types';
 import { enrichPlayer } from '../../utils/houseguestLookup';
-import { resolveAvatar, getDicebear } from '../../utils/avatar';
+import PlayerAvatar from '../PlayerAvatar/PlayerAvatar';
 import './HouseguestProfile.css';
 
 interface HouseguestProfileProps {
@@ -32,15 +32,12 @@ export default function HouseguestProfile({ player, onClose }: HouseguestProfile
         </button>
 
         <div className="hg-profile__header">
-          <img
+          <PlayerAvatar
+            player={player}
             className="hg-profile__avatar"
-            src={resolveAvatar(player)}
-            alt={player.name}
-            onError={(e) => {
-              const img = e.currentTarget;
-              img.onerror = null;
-              img.src = getDicebear(player.name);
-            }}
+            size="lg"
+            showRelationshipOutline={false}
+            showEvictedStyle={false}
           />
           <div className="hg-profile__identity">
             <h2 className="hg-profile__name">{ep.fullName ?? ep.name}</h2>

--- a/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -7,6 +7,7 @@ import './PlayerAvatar.css';
 
 interface PlayerAvatarProps {
   player: Player;
+  className?: string;
   /** Whether this avatar is currently selected (shows selection ring) */
   selected?: boolean;
   /** Size variant */
@@ -34,6 +35,7 @@ interface PlayerAvatarProps {
  */
 export default function PlayerAvatar({
   player,
+  className,
   selected = false,
   size = 'md',
   onClick,
@@ -82,6 +84,7 @@ export default function PlayerAvatar({
   const classes = [
     'pa',
     `pa--${size}`,
+    className ?? '',
     selected ? 'pa--selected' : '',
     isEvicted ? 'pa--evicted' : '',
     revived ? 'pa--revived' : '',

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -27,7 +27,7 @@ export default function NavBar() {
 
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  if (pathname === '/' || pathname.startsWith('/credits')) return null;
+  if (pathname === '/' || pathname.startsWith('/credits') || !isGameActive) return null;
 
   function handleHomeClick() {
     if (!isGameActive) {

--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -144,3 +144,77 @@
   pointer-events: none;
   z-index: 1;
 }
+
+.homehub-resume-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 8000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(6, 8, 12, 0.62);
+}
+
+.homehub-resume-modal__card {
+  width: min(560px, 94vw);
+  border-radius: 24px;
+  padding: 24px 20px 22px;
+  background:
+    radial-gradient(circle at top, rgba(115, 130, 255, 0.16), transparent 42%),
+    linear-gradient(180deg, rgba(9, 14, 28, 0.98), rgba(12, 18, 33, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.58);
+  text-align: center;
+}
+
+.homehub-resume-modal__title {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 900;
+  color: #f4f6ff;
+}
+
+.homehub-resume-modal__desc {
+  margin: 10px 0 0;
+  color: rgba(237, 242, 255, 0.82);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.homehub-resume-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin-top: 22px;
+}
+
+.homehub-resume-modal__btn {
+  width: min(100%, 280px);
+  min-height: 52px;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.06);
+  color: #f4f6ff;
+  font-size: 1rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.homehub-resume-modal__btn--primary {
+  background: linear-gradient(180deg, #7766ff, #5c4fe6);
+  box-shadow: 0 12px 26px rgba(94, 79, 230, 0.32);
+}
+
+.homehub-resume-modal__btn--secondary {
+  background: transparent;
+  border-color: rgba(255, 170, 170, 0.42);
+  color: #ffcbcb;
+}
+
+.homehub-resume-modal__btn--ghost {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.1);
+  color: rgba(244, 246, 255, 0.9);
+}

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -15,7 +15,6 @@ import {
   loadSeasonSnapshot,
   clearSeasonSnapshot,
 } from '../../store/saveStatePersistence';
-import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
 import useBackgroundTheme from '../../hooks/useBackgroundTheme';
 import KolequantSplash from '../../components/KolequantSplash/KolequantSplash';
 import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOverlay';
@@ -178,6 +177,15 @@ export default function HomeHub() {
     navigate('/', { replace: true });
   }, [autoStartGame, navigate]);
 
+  useEffect(() => {
+    if (!showResumePrompt) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setShowResumePrompt(false);
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [showResumePrompt]);
+
   const handlePlay = () => {
     // Unlock audio in the gesture context.  We intentionally do NOT follow up
     // with SoundManager.panicStopAllMusic() here — that used to race with the
@@ -251,15 +259,27 @@ export default function HomeHub() {
       {preloading && <AssetPreloaderOverlay />}
 
       {/* Resume saved season prompt — shown when Play is pressed and a save exists */}
-      <ConfirmExitModal
-        open={showResumePrompt}
-        title="Resume season?"
-        description="Pick up where you left off, or start fresh."
-        confirmLabel="Resume"
-        cancelLabel="New Season"
-        onConfirm={handleResume}
-        onCancel={handleNewSeason}
-      />
+      {showResumePrompt && (
+        <div className="homehub-resume-modal" role="presentation" onClick={() => setShowResumePrompt(false)}>
+          <div className="homehub-resume-modal__card" role="dialog" aria-modal="true" aria-labelledby="homehub-resume-title" aria-describedby="homehub-resume-desc" onClick={(event) => event.stopPropagation()}>
+            <h2 id="homehub-resume-title" className="homehub-resume-modal__title">Survivor Mode</h2>
+            <p id="homehub-resume-desc" className="homehub-resume-modal__desc">
+              Resume your saved run or start over?
+            </p>
+            <div className="homehub-resume-modal__actions">
+              <button type="button" className="homehub-resume-modal__btn homehub-resume-modal__btn--primary" onClick={handleResume}>
+                Resume
+              </button>
+              <button type="button" className="homehub-resume-modal__btn homehub-resume-modal__btn--secondary" onClick={handleNewSeason}>
+                Start New
+              </button>
+              <button type="button" className="homehub-resume-modal__btn homehub-resume-modal__btn--ghost" onClick={() => setShowResumePrompt(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="homehub-shell">
         <div className="homehub-frame">


### PR DESCRIPTION
Centered the survivor resume prompt, hid the bottom nav from the intro hub, and swapped the housemate detail cards to the shared avatar component so they resolve actual avatars before falling back.