### PR TITLE
Reseed Famous Figures in production

### DIFF
--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -345,7 +345,7 @@ export default function MinigameHost({
                   participantIds={participantIds}
                   participants={participants}
                   prizeType={gameOptions?.prizeType as FamousFiguresPrizeType}
-                  seed={seed}
+                  seed={import.meta.env.PROD ? 0 : seed}
                   onComplete={handleReactComplete}
                   skipWinnerAnimation={true}
                 />


### PR DESCRIPTION
## Summary
- Stop forwarding the deterministic challenge seed into Famous Figures in production so each hosted run reshuffles the figures.
- Keep the existing seeded behavior in non-production runs for reproducibility.

## Notes
- This is the smallest possible production-only change for the reported reuse issue.
- No local tests were run per request.