### PR TITLE
Polish Survivor eviction and remove phone live-vote blur

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -48,11 +48,10 @@
   scroll-snap-type: x proximity;
 }
 
-
 .gridItem {
   width: 100%;
   min-width: 0;
-  animation: survivorTileSettle 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: survivorTileSettle 760ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .sliderItem {
@@ -136,12 +135,21 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(
-    to top,
-    rgba(0, 0, 0, 0.58) 0%,
-    rgba(0, 0, 0, 0.2) 38%,
-    transparent 60%
-  );
+  background:
+    linear-gradient(
+      135deg,
+      transparent 0 42.5%,
+      rgba(239, 68, 68, 0.94) 42.5% 50.5%,
+      rgba(255, 255, 255, 0.05) 50.5% 52.5%,
+      rgba(239, 68, 68, 0.92) 52.5% 59%,
+      transparent 59% 100%
+    ),
+    linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.62) 0%,
+      rgba(0, 0, 0, 0.24) 38%,
+      transparent 60%
+    );
   pointer-events: none;
   z-index: 2;
 }
@@ -214,14 +222,49 @@
 
 .evicted .avatar,
 .evicted .avatarPlaceholder {
-  filter: grayscale(100%) brightness(0.65) opacity(0.7);
-  transition: filter 0.6s ease;
+  filter: grayscale(100%) contrast(1.2) brightness(0.58) opacity(0.82);
+  transition: filter 0.45s ease;
+}
+
+.evicted .avatarWrap {
+  border-color: rgba(255, 72, 72, 0.82);
+  box-shadow:
+    0 8px 18px rgba(0, 0, 0, 0.48),
+    0 0 0 1px rgba(255, 72, 72, 0.22),
+    0 0 18px rgba(255, 52, 52, 0.24),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 0 0 1px rgba(255, 72, 72, 0.24),
+    inset 0 0 18px rgba(0, 0, 0, 0.35);
+}
+
+.evicted .avatarWrap::after {
+  background:
+    linear-gradient(
+      135deg,
+      transparent 0 42.5%,
+      rgba(239, 68, 68, 0.98) 42.5% 50.5%,
+      rgba(255, 255, 255, 0.08) 50.5% 52.5%,
+      rgba(239, 68, 68, 0.96) 52.5% 59%,
+      transparent 59% 100%
+    ),
+    linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.84) 0%,
+      rgba(0, 0, 0, 0.32) 40%,
+      transparent 62%
+    );
+}
+
+.evicted .avatarWrap::before {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 84, 84, 0.18),
+    inset 0 0 18px 6px rgba(0, 0, 0, 0.68);
 }
 
 .evicted {
-  opacity: 0.6;
-  transform: scale(0.96);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  opacity: 0.86;
+  transform: scale(0.975);
+  transition: opacity 0.45s ease, transform 0.45s ease, box-shadow 0.45s ease;
 }
 
 /* ── Interactive hover / active states ───────────────────────────────────── */
@@ -253,6 +296,9 @@
   display: block;
   object-fit: contain;
   z-index: 5;
+  opacity: 0.96;
+  mix-blend-mode: normal;
+  filter: saturate(1.2) contrast(1.15);
   animation: crossFadeIn 0.35s ease-out forwards;
 }
 
@@ -264,11 +310,11 @@
 @keyframes survivorTileSettle {
   from {
     opacity: 0;
-    transform: scale(0.92);
+    transform: translate3d(18px, 10px, 0) scale(0.92);
   }
   to {
     opacity: 1;
-    transform: scale(1);
+    transform: translate3d(0, 0, 0) scale(1);
   }
 }
 

--- a/src/components/TvStingerOverlay/TvStingerOverlay.css
+++ b/src/components/TvStingerOverlay/TvStingerOverlay.css
@@ -10,10 +10,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.72);
+  background: rgba(0, 0, 0, 0.78);
   animation: stingerFadeIn 0.18s ease;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .tv-stinger__content {


### PR DESCRIPTION
This PR tightens the Survivor eviction moment and removes the Safari live-vote blur.

Changes:
- Evicted Survivor tiles now read as a hard eviction state: grayscale, stronger contrast, a red slash treatment, and a clearer hold before the replacement appears.
- Replacement tiles now enter with a more visible slide-in motion.
- The TV stinger overlay no longer applies backdrop blur, so the iPhone live-vote screen stays crisp.

I kept the scope limited to the visual issues reported on laptop and iPhone Safari.