### PR TITLE
[codex] Fix Survivor replacement beat and live vote blur

### DIFF
--- a/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.css
+++ b/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.css
@@ -25,10 +25,19 @@
   background:
     radial-gradient(circle at 50% 20%, rgba(120, 168, 255, 0.14), transparent 36%),
     linear-gradient(180deg, rgba(7, 12, 22, 0.18) 0%, rgba(3, 7, 14, 0.34) 100%);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 @supports (backdrop-filter: blur(6px)) {
   .avrm { backdrop-filter: blur(6px); }
+}
+
+@supports (backdrop-filter: blur(6px)) or (-webkit-backdrop-filter: blur(6px)) {
+  .avrm--tv {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 @keyframes avrmFadeIn {

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -6,7 +6,7 @@ import { useAppSelector } from '../../store/hooks'
 import type { CompactRosterLayout } from '../../store/settingsSlice'
 
 const HOUSEMATES_SECTION_TITLE = 'HOUSEMATES'
-const SURVIVOR_REPLACEMENT_HOLD_MS = 900
+const SURVIVOR_REPLACEMENT_HOLD_MS = 2000
 
 type RoboStatsSummary = {
   daysInGame?: number | null

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -408,11 +408,9 @@
     ),
     linear-gradient(
       180deg,
-      rgba(3, 8, 18, 0.24) 0%,
-      rgba(2, 6, 12, 0.38) 100%
+      rgba(3, 8, 18, 0.38) 0%,
+      rgba(2, 6, 12, 0.56) 100%
     );
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
   pointer-events: none;
   animation: liveVoteBackdropFadeIn 220ms ease-out both;
 }


### PR DESCRIPTION
## What changed
This fixes two focused visual issues in the Survivor/live-vote flow.

- Hold the outgoing Survivor AI tile for about 2 seconds before replacement so the existing Classic eviction treatment has time to land.
- Remove fullscreen blur from the active live-vote TV reveal path and keep the separation with darker translucent overlays instead.

## Why
- Survivor AI replacements were appearing too quickly, which skipped the intended grayscale plus red eviction beat.
- On iPhone Safari, the live vote tally and reveal flow could blur or smudge the whole screen.

## Impact
- Survivor now reuses the existing Classic evicted-tile visual more cleanly before the replacement enters.
- The faux TV and houseguest grid stay sharp during live vote tally and reveal.
- Classic gameplay logic and eviction rules are unchanged.

## Root cause
- The Survivor grid hold was shorter than the requested dramatic beat.
- The active TV tally layers were still using fullscreen blur in the live-vote reveal path.

## Validation
- `npm run typecheck`