### PR TITLE
[codex] Fix Survivor eviction beat and remove remaining vote blur

### DIFF
--- a/src/components/AdPrompt/AdPrompt.css
+++ b/src/components/AdPrompt/AdPrompt.css
@@ -8,7 +8,6 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.65);
-  backdrop-filter: blur(3px);
   animation: ad-prompt-fadein 0.18s ease;
 }
 

--- a/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.css
+++ b/src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.css
@@ -29,17 +29,6 @@
   -webkit-backdrop-filter: none;
 }
 
-@supports (backdrop-filter: blur(6px)) {
-  .avrm { backdrop-filter: blur(6px); }
-}
-
-@supports (backdrop-filter: blur(6px)) or (-webkit-backdrop-filter: blur(6px)) {
-  .avrm--tv {
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-  }
-}
-
 @keyframes avrmFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
@@ -173,7 +173,7 @@ export default function HouseguestGrid({
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const previous = previousHouseguestsRef.current
     previousHouseguestsRef.current = houseguests
 

--- a/src/components/TiebreakerModal/TiebreakerModal.css
+++ b/src/components/TiebreakerModal/TiebreakerModal.css
@@ -14,10 +14,6 @@
   animation: tbmFadeIn 0.3s ease;
 }
 
-@supports (backdrop-filter: blur(6px)) {
-  .tbm { backdrop-filter: blur(6px); }
-}
-
 @keyframes tbmFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/src/components/TvBinaryDecisionModal/TvBinaryDecisionModal.css
+++ b/src/components/TvBinaryDecisionModal/TvBinaryDecisionModal.css
@@ -21,13 +21,6 @@
   animation: tvbmFadeIn 0.22s ease;
 }
 
-@supports (backdrop-filter: blur(4px)) or (-webkit-backdrop-filter: blur(4px)) {
-  .tv-binary-modal {
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-  }
-}
-
 @keyframes tvbmFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/src/components/TvDecisionModal/TvMultiSelectModal.css
+++ b/src/components/TvDecisionModal/TvMultiSelectModal.css
@@ -14,13 +14,6 @@
   animation: tvmsFadeIn 0.22s ease;
 }
 
-@supports (backdrop-filter: blur(4px)) or (-webkit-backdrop-filter: blur(4px)) {
-  .tv-ms-modal {
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-  }
-}
-
 @keyframes tvmsFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }


### PR DESCRIPTION
## What changed
This follow-up fix addresses the parts that were still wrong after the previous visual PR.

- Apply the Survivor replacement hold in a layout-timed effect so the outgoing evicted tile stays on screen before the replacement can paint.
- Remove the remaining fullscreen backdrop blur from the live-vote modal family and post-vote prompt overlays.

## Why
- The outgoing Survivor evictee could still fail to visibly land on the classic grayscale plus red-stripe state because the hold roster swap happened too late in the render cycle.
- Vote-related fullscreen overlays were still using backdrop blur in parts of the live-vote and post-vote flow.

## Impact
- Survivor AI evictions should now visibly keep the outgoing tile in place for the intended beat before replacement.
- Live vote, tie-break, and post-vote prompt overlays keep the game screen sharp instead of blurring it.

## Validation
- `npm run typecheck`