### PR TITLE
Fix Survivor replacement handoff and live vote blur

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
-import { useAppSelector } from '../../store/hooks'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { clearSurvivorReplacementTransition } from '../../store/gameSlice'
 import type { CompactRosterLayout } from '../../store/settingsSlice'
 
 const HOUSEMATES_SECTION_TITLE = 'HOUSEMATES'
-const SURVIVOR_REPLACEMENT_HOLD_MS = 2000
 
 type RoboStatsSummary = {
   daysInGame?: number | null
@@ -88,33 +88,6 @@ const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
 
-function buildSurvivorReplacementHold(
-  previous: Houseguest[],
-  current: Houseguest[],
-  hiddenIds: Set<string>,
-  restoredIds: Set<string>,
-): Houseguest[] {
-  const visible = current
-    .filter((houseguest) => !hiddenIds.has(String(houseguest.id)))
-    .map((houseguest) => ({ ...houseguest }))
-
-  const visibleIds = new Set(visible.map((houseguest) => String(houseguest.id)))
-  restoredIds.forEach((id) => {
-    if (visibleIds.has(id)) return
-    const restored = previous.find((houseguest) => String(houseguest.id) === id)
-    if (!restored) return
-    visible.push({ ...restored, isEvicted: true })
-    visibleIds.add(id)
-  })
-
-  const order = new Map(previous.map((houseguest, index) => [String(houseguest.id), index]))
-  return visible
-    .sort((left, right) => (order.get(String(left.id)) ?? 0) - (order.get(String(right.id)) ?? 0))
-    .map((houseguest) => (restoredIds.has(String(houseguest.id))
-      ? { ...houseguest, isEvicted: true }
-      : houseguest))
-}
-
 export default function HouseguestGrid({
   houseguests,
   showCountInHeader = false,
@@ -128,14 +101,11 @@ export default function HouseguestGrid({
   occupancyLabel,
 }: Props) {
   const containerRef = useRef<HTMLElement | null>(null)
-  const previousHouseguestsRef = useRef<Houseguest[]>(houseguests)
-  const survivorHoldTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
-  const survivorHoldClearTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null)
+  const dispatch = useAppDispatch()
   const game = useAppSelector((s) => s.game)
-  const gamePlayersById = useMemo(
-    () => new Map(game.players.map((player) => [String(player.id), player])),
-    [game.players],
-  )
+  const survivorReplacementTransition = game.modeSpecific?.kind === 'survivor'
+    ? game.modeSpecific.replacementTransition ?? null
+    : null
   const survivorRoboStatsById = useMemo(() => {
     const statsById = new Map<string, RoboStatsSummary>()
     if (game.mode !== 'survivor') return statsById
@@ -155,77 +125,52 @@ export default function HouseguestGrid({
     })
     return statsById
   }, [game.mode, game.modeSpecific, game.players, game.week])
-  const [survivorHoldRoster, setSurvivorHoldRoster] = useState<Houseguest[] | null>(null)
-  const renderedHouseguests = game.mode === 'survivor' && survivorHoldRoster !== null
-    ? survivorHoldRoster
-    : houseguests
+  const renderedHouseguests = useMemo(() => {
+    if (game.mode !== 'survivor' || survivorReplacementTransition === null) return houseguests
+
+    const outgoing = survivorReplacementTransition.outgoingPlayerSnapshot
+    const incomingId = survivorReplacementTransition.incomingPlayerId
+    const slot = survivorReplacementTransition.slot
+    const incomingIndex = houseguests.findIndex((houseguest) => String(houseguest.id) === incomingId)
+    const slotIndex = game.players.findIndex((player) => player.survivorSlot === slot)
+    const targetIndex = incomingIndex >= 0 ? incomingIndex : slotIndex
+    if (targetIndex < 0 || targetIndex >= houseguests.length) return houseguests
+
+    return houseguests.map((houseguest, index) => (
+      index === targetIndex
+        ? {
+            id: outgoing.id,
+            name: outgoing.name,
+            avatarUrl: outgoing.avatar,
+            isEvicted: true,
+            isYou: outgoing.isUser,
+            roboStats: outgoing.isRobo
+              ? {
+                  daysInGame: Math.max(1, game.week - (outgoing.survivorEntryDay ?? 1) + 1),
+                  lohWins: outgoing.stats?.lohWins ?? 0,
+                  posWins: outgoing.stats?.posWins ?? 0,
+                  averageLohRank: null,
+                  averagePosRank: null,
+                }
+              : undefined,
+            statuses: [],
+            showPermanentBadge: false,
+          }
+        : houseguest
+    ))
+  }, [game.mode, game.players, game.week, houseguests, survivorReplacementTransition])
 
   useEffect(() => {
-    return () => {
-      if (survivorHoldTimerRef.current !== null) {
-        window.clearTimeout(survivorHoldTimerRef.current)
-        survivorHoldTimerRef.current = null
-      }
-      if (survivorHoldClearTimerRef.current !== null) {
-        window.clearTimeout(survivorHoldClearTimerRef.current)
-        survivorHoldClearTimerRef.current = null
-      }
-    }
-  }, [])
-
-  useLayoutEffect(() => {
-    const previous = previousHouseguestsRef.current
-    previousHouseguestsRef.current = houseguests
-
-    if (game.mode !== 'survivor') {
-      if (survivorHoldTimerRef.current !== null) {
-        window.clearTimeout(survivorHoldTimerRef.current)
-        survivorHoldTimerRef.current = null
-      }
-      if (survivorHoldClearTimerRef.current !== null) {
-        window.clearTimeout(survivorHoldClearTimerRef.current)
-      }
-      if (survivorHoldRoster !== null) {
-        survivorHoldClearTimerRef.current = window.setTimeout(() => {
-          survivorHoldClearTimerRef.current = null
-          setSurvivorHoldRoster(null)
-        }, 0)
-      }
-      return
-    }
-
-    const currentDay = game.modeSpecific?.kind === 'survivor' ? game.modeSpecific.currentDay : null
-    if (currentDay == null || currentDay <= 1) return
-    if (survivorHoldRoster !== null) return
-
-    const previousIds = new Set(previous.map((houseguest) => String(houseguest.id)))
-    const currentIds = new Set(houseguests.map((houseguest) => String(houseguest.id)))
-    const addedIds = houseguests
-      .map((houseguest) => String(houseguest.id))
-      .filter((id) => !previousIds.has(id))
-    const addedRoboIds = addedIds.filter((id) => gamePlayersById.get(id)?.isRobo)
-    if (addedRoboIds.length === 0) return
-
-    const removedIds = previous
-      .map((houseguest) => String(houseguest.id))
-      .filter((id) => !currentIds.has(id))
-
-    const holdRoster = buildSurvivorReplacementHold(
-      previous,
-      houseguests,
-      new Set(addedRoboIds),
-      new Set(removedIds),
+    if (survivorReplacementTransition === null) return undefined
+    const remainingMs = Math.max(
+      0,
+      survivorReplacementTransition.startedAt + survivorReplacementTransition.durationMs - Date.now(),
     )
-
-    setSurvivorHoldRoster(holdRoster)
-    if (survivorHoldTimerRef.current !== null) {
-      window.clearTimeout(survivorHoldTimerRef.current)
-    }
-    survivorHoldTimerRef.current = window.setTimeout(() => {
-      survivorHoldTimerRef.current = null
-      setSurvivorHoldRoster(null)
-    }, SURVIVOR_REPLACEMENT_HOLD_MS)
-  }, [game.mode, game.modeSpecific, gamePlayersById, houseguests, survivorHoldRoster])
+    const timer = window.setTimeout(() => {
+      dispatch(clearSurvivorReplacementTransition())
+    }, remainingMs)
+    return () => window.clearTimeout(timer)
+  }, [dispatch, survivorReplacementTransition])
 
   useEffect(() => {
     function setAvailableHeight() {

--- a/src/components/TvStingerOverlay/TvStingerOverlay.css
+++ b/src/components/TvStingerOverlay/TvStingerOverlay.css
@@ -12,8 +12,6 @@
   justify-content: center;
   background: rgba(0, 0, 0, 0.72);
   animation: stingerFadeIn 0.18s ease;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
 }
 
 .tv-stinger__content {

--- a/src/components/VoteResultsPopup/VoteResultsPopup.css
+++ b/src/components/VoteResultsPopup/VoteResultsPopup.css
@@ -15,10 +15,6 @@
   cursor: pointer;
 }
 
-@supports (backdrop-filter: blur(6px)) {
-  .vrp { backdrop-filter: blur(6px); }
-}
-
 @keyframes vrpFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -587,7 +587,7 @@
 /* ── Double Eviction spotlight effect ──────────────────────────────────────── */
 
 /**
- * Full-screen dim + blur backdrop rendered via React portal to document.body.
+ * Full-screen dim backdrop rendered via React portal to document.body.
  * Sits below the TvZone spotlight (z-index: 9998) so the TV appears to be
  * spotlit while the rest of the screen recedes into the background.
  */
@@ -607,8 +607,6 @@
       rgba(40, 0, 8, 0.84) 0%,
       rgba(14, 0, 4, 0.78) 100%
     );
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
   pointer-events: none;
   animation: deBackdropPulse var(--de-spotlight-ms, 1700ms) ease-out forwards;
 }

--- a/src/modes/modeTypes.ts
+++ b/src/modes/modeTypes.ts
@@ -14,10 +14,20 @@ export interface SurvivorModeState {
   bestDayReached: number;
   startingCastSize: number;
   nextRoboIndex: number;
+  replacementTransition?: SurvivorReplacementTransition | null;
   competitionRotation: {
     usedKeys: string[];
     round: number;
   };
+}
+
+export interface SurvivorReplacementTransition {
+  mode: 'survivor';
+  outgoingPlayerSnapshot: BasePlayer;
+  incomingPlayerId: string;
+  slot: number;
+  startedAt: number;
+  durationMs: number;
 }
 
 export type ModeSpecificState = ClassicModeState | SurvivorModeState;

--- a/src/modes/survivorMiddleware.ts
+++ b/src/modes/survivorMiddleware.ts
@@ -29,6 +29,8 @@ const SURVIVOR_BLOCKED_TERMINAL_ACTIONS = new Set([
   'game/applyF3MinigameWinner',
 ]);
 
+const SURVIVOR_REPLACEMENT_TRANSITION_MS = 2000;
+
 function isExited(player: Player | undefined): boolean {
   return player?.status === 'evicted' || player?.status === 'jury';
 }
@@ -177,7 +179,7 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   if (game.mode !== 'survivor' || isSurvivorRunTerminal(game) || !shouldReplaceEvictedPlayers(game.mode)) return null;
   const evicteeIndex = game.players.findIndex((player) => player.id === evicteeId);
   const evictee = evicteeIndex >= 0 ? game.players[evicteeIndex] : undefined;
-  if (!isExited(evictee) || evictee?.isUser) return null;
+  if (!evictee || !isExited(evictee) || evictee.isUser) return null;
 
   const modeSpecific = getSurvivorState(game);
   const activeCastSize = game.players.filter((player) => !isExited(player)).length;
@@ -191,12 +193,13 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
   };
   const totalRoboContestantsEvicted = modeSpecific.totalRoboContestantsEvicted + 1;
   const currentDay = Math.max(modeSpecific.currentDay, game.week);
+  const startedAt = Date.now();
   const players = game.players.map((player, index) => (index === evicteeIndex ? replacement : player));
   const replacementEvent = {
     id: `survivor-replacement-${replacement.id}`,
     text: `${replacement.name} enters as a replacement synthetic contestant.`,
     type: 'game' as const,
-    timestamp: Date.now(),
+    timestamp: startedAt,
     meta: { phase: game.phase, week: game.week, mode: 'survivor' },
   };
 
@@ -211,8 +214,16 @@ function withReplacementIfNeeded(game: GameState, evicteeId: string): GameState 
       startingCastSize: SURVIVOR_STARTING_CAST_SIZE,
       totalRoboContestantsEvicted,
       nextRoboIndex: modeSpecific.nextRoboIndex + 1,
+      replacementTransition: {
+        mode: 'survivor',
+        outgoingPlayerSnapshot: { ...evictee, status: 'evicted' },
+        incomingPlayerId: replacement.id,
+        slot: replacementSlot,
+        startedAt,
+        durationMs: SURVIVOR_REPLACEMENT_TRANSITION_MS,
+      },
     },
-    lastPlayedAt: Date.now(),
+    lastPlayedAt: startedAt,
     tvFeed: [replacementEvent, ...game.tvFeed].slice(0, 50),
   };
 }

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -3117,6 +3117,11 @@ const gameSlice = createSlice({
       };
     },
 
+    clearSurvivorReplacementTransition(state) {
+      if (state.modeSpecific?.kind !== 'survivor') return;
+      state.modeSpecific.replacementTransition = null;
+    },
+
     setHasSeenConfessionalSpotlight(state, action: PayloadAction<boolean>) {
       state.hasSeenConfessionalSpotlight = action.payload;
     },
@@ -5177,6 +5182,7 @@ export const {
   clearBlockingFlags,
   archiveSeason,
   replacePlayers,
+  clearSurvivorReplacementTransition,
   resetGame,
   rerollSeed,
   hydrateGame,

--- a/tests/liveVoteOverlayBlur.test.ts
+++ b/tests/liveVoteOverlayBlur.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const BLUR_PATTERN = /(?:-webkit-)?backdrop-filter\s*:\s*blur\(|filter\s*:\s*blur\(|blur\(/i;
+const LIVE_VOTE_OVERLAY_FILES = [
+  'src/components/TvStingerOverlay/TvStingerOverlay.css',
+  'src/components/VoteResultsPopup/VoteResultsPopup.css',
+  'src/components/AnimatedVoteResultsModal/AnimatedVoteResultsModal.css',
+  'src/components/TiebreakerModal/TiebreakerModal.css',
+  'src/components/TvBinaryDecisionModal/TvBinaryDecisionModal.css',
+  'src/components/TvDecisionModal/TvMultiSelectModal.css',
+];
+
+function readSource(filePath: string): string {
+  return readFileSync(join(process.cwd(), filePath), 'utf8');
+}
+
+function cssBlock(source: string, selector: string): string {
+  const start = source.indexOf(`${selector} {`);
+  expect(start, `${selector} should exist`).toBeGreaterThanOrEqual(0);
+  const end = source.indexOf('\n}', start);
+  expect(end, `${selector} block should close`).toBeGreaterThan(start);
+  return source.slice(start, end + 2);
+}
+
+describe('live vote gameplay overlays avoid large-area blur', () => {
+  for (const path of LIVE_VOTE_OVERLAY_FILES) {
+    it(`${path} does not reintroduce overlay blur`, () => {
+      expect(readSource(path)).not.toMatch(BLUR_PATTERN);
+    });
+  }
+
+  it('TvZone full-screen live-vote backdrops do not blur the gameplay surface', () => {
+    const source = readSource('src/components/ui/TvZone.css');
+    expect(cssBlock(source, '.tv-zone-live-vote-backdrop')).not.toMatch(BLUR_PATTERN);
+    expect(cssBlock(source, '.tv-zone-de-backdrop')).not.toMatch(BLUR_PATTERN);
+  });
+});

--- a/tests/survivorReplacementTransition.test.ts
+++ b/tests/survivorReplacementTransition.test.ts
@@ -1,0 +1,52 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { describe, expect, it } from 'vitest';
+import gameReducer, {
+  finalizePendingEviction,
+  hydrateGame,
+} from '../src/store/gameSlice';
+import { survivorMiddleware } from '../src/modes/survivorMiddleware';
+import { createSurvivorRun, SURVIVOR_STARTING_CAST_SIZE } from '../src/modes/survivorRun';
+
+function makeStore() {
+  return configureStore({
+    reducer: { game: gameReducer },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(survivorMiddleware),
+  });
+}
+
+describe('Survivor replacement transition', () => {
+  it('stores outgoing and incoming metadata when a robo eviction is replaced', () => {
+    const store = makeStore();
+    const survivorRun = createSurvivorRun();
+    const outgoing = survivorRun.players.find((player) => player.isRobo);
+    expect(outgoing).toBeTruthy();
+
+    store.dispatch(hydrateGame({
+      ...survivorRun,
+      pendingEviction: {
+        evicteeId: outgoing!.id,
+        evictionMessage: `${outgoing!.name} has been evicted.`,
+      },
+    }));
+
+    store.dispatch(finalizePendingEviction(outgoing!.id));
+
+    const game = store.getState().game;
+    const transition = game.modeSpecific?.kind === 'survivor'
+      ? game.modeSpecific.replacementTransition
+      : null;
+    const activePlayers = game.players.filter((player) => player.status !== 'evicted' && player.status !== 'jury');
+    const replacement = transition
+      ? game.players.find((player) => player.id === transition.incomingPlayerId)
+      : null;
+
+    expect(activePlayers).toHaveLength(SURVIVOR_STARTING_CAST_SIZE);
+    expect(game.players.some((player) => player.id === outgoing!.id)).toBe(false);
+    expect(transition?.outgoingPlayerSnapshot.id).toBe(outgoing!.id);
+    expect(transition?.outgoingPlayerSnapshot.status).toBe('evicted');
+    expect(transition?.slot).toBe(outgoing!.survivorSlot);
+    expect(transition?.durationMs).toBe(2000);
+    expect(replacement?.isRobo).toBe(true);
+    expect(replacement?.survivorSlot).toBe(outgoing!.survivorSlot);
+  });
+});


### PR DESCRIPTION
## Summary

This is the cleanup/root-cause PR for the Survivor robo replacement animation and live-vote blur issues.

## What failed in the previous PRs

PRs #1057/#1058 were still patching symptoms in the UI layer. The Survivor fix tried to infer the outgoing evictee by comparing previous/current rosters inside `HouseguestGrid`, but by that point Survivor middleware had already swapped the evicted robo out of `game.players`. Depending on timing/remounts, the grid could simply never see the old player.

The blur fixes removed blur from some modal surfaces, but the runtime live-vote flow still had gameplay-wide blur sources in the TV stinger / vote-results path. Those are the surfaces that can smear the faux TV and grid, especially on iPhone/Safari.

## Cleanup removed

- Removed the fragile `HouseguestGrid` previous/current roster-diff replacement hold.
- Removed the timing-only Survivor hold workaround as the primary mechanism.
- Kept Classic eviction visuals intact; Survivor now feeds the Classic `isEvicted` tile path instead of inventing a separate visual effect.

## Root blur fix

Removed large-area blur from gameplay-wide live-vote/vote-result overlays:

- `TvStingerOverlay.css`: removed fixed full-screen `backdrop-filter` blur.
- `VoteResultsPopup.css`: removed supported `backdrop-filter` blur around the full-screen vote tally overlay.
- `TvZone.css`: removed blur from the full-screen double-eviction backdrop path.

Contained decorative blur inside the faux TV / small badges remains untouched because it does not blur the whole gameplay surface.

Added `tests/liveVoteOverlayBlur.test.ts` so known live-vote overlay CSS files fail if `backdrop-filter: blur(...)`, `-webkit-backdrop-filter: blur(...)`, or `filter: blur(...)` comes back.

## Root Survivor replacement fix

Survivor middleware now records explicit replacement transition metadata at the actual runtime swap point:

- outgoing evicted robo snapshot
- incoming replacement robo id
- survivor slot
- start time
- `durationMs: 2000`

`HouseguestGrid` reads that metadata and temporarily renders the outgoing snapshot in the incoming player’s slot with `isEvicted=true`, which reuses the Classic grayscale/red eviction mark. After the 2-second hold, the transition metadata is cleared and the already-present replacement robo appears in that same slot.

Added `tests/survivorReplacementTransition.test.ts` to verify the active Survivor cast remains full, the outgoing robo is not kept in active players, and the transition contains the outgoing/incoming/slot metadata.

## Validation

- `npm run typecheck` passed.
- `npx vitest run tests/liveVoteOverlayBlur.test.ts tests/survivorReplacementTransition.test.ts` passed.
- `npm run build` passed.

Manual visual note: I could not complete a full iPhone/Safari capture in this run, but the runtime paths that were still applying large-area blur are now covered by the static regression guard.