### PR TITLE
Fix active homebar and TV vote dimmer

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -21,28 +21,20 @@ export default function NavBar() {
   const dispatch = useAppDispatch();
   const reduxStore = useStore<RootState>();
   const isGameOverRoute = pathname.startsWith('/game-over');
-  const isActiveGameplayRoute =
-    pathname === '/game' ||
-    pathname.startsWith('/game/') ||
-    pathname.startsWith('/diary-room') ||
-    pathname.startsWith('/public-meter');
-
-  // Heuristic: treat the game as "active/in-progress" when either we're past
-  // week 1 or the phase is not the initial 'week_start'. This mirrors the
-  // gameInProgress logic used elsewhere (e.g. in Settings).
-  const isGameActive = useAppSelector(
-    (s) => s.game.week > 1 || s.game.phase !== 'week_start' || s.game.mode === 'survivor',
-  );
+  // The homebar should appear as soon as a run is launched from IntroHub, so
+  // we key visibility off the run state that resetGame/hydrateGame now mark
+  // active immediately.
+  const isGameActive = useAppSelector((s) => s.game.status === 'active');
   const activeProfileId = useAppSelector((s) => s.profiles.activeProfileId);
   const isGuest = useAppSelector((s) => s.profiles.isGuest);
   const canPersistActiveRun = !isGuest && Boolean(activeProfileId);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  if (pathname === '/' || pathname.startsWith('/credits') || !isGameActive) return null;
+  if (pathname === '/' || pathname.startsWith('/credits') || (!isGameActive && !isGameOverRoute)) return null;
 
   function handleHomeClick() {
-    if (!isGameActive || !isActiveGameplayRoute) {
+    if (!isGameActive) {
       navigate('/');
       return;
     }

--- a/src/components/layout/__tests__/NavBar.test.tsx
+++ b/src/components/layout/__tests__/NavBar.test.tsx
@@ -4,12 +4,21 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import gameReducer from '../../../store/gameSlice';
+import profilesReducer from '../../../store/profilesSlice';
 import NavBar from '../NavBar';
 
 function renderNavBar(initialEntry = '/game') {
+  const initialGameState = gameReducer(undefined, { type: '@@INIT' });
   const store = configureStore({
     reducer: {
       game: gameReducer,
+      profiles: profilesReducer,
+    },
+    preloadedState: {
+      game: {
+        ...initialGameState,
+        status: 'active' as const,
+      },
     },
   });
 
@@ -23,7 +32,7 @@ function renderNavBar(initialEntry = '/game') {
 }
 
 describe('NavBar', () => {
-  it('shows the updated bottom navigation labels', () => {
+  it('shows the updated bottom navigation labels once a game is active', () => {
     renderNavBar('/game');
 
     expect(screen.getByRole('button', { name: 'RULES' })).toBeDefined();
@@ -32,6 +41,14 @@ describe('NavBar', () => {
     expect(screen.getByRole('button', { name: 'USER' })).toBeDefined();
     expect(screen.queryByRole('button', { name: 'LEADERBOARD' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'PROFILE' })).toBeNull();
+  });
+
+  it('keeps the bottom navigation available on profile routes during an active game', () => {
+    renderNavBar('/profile');
+
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'HOME' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'USER' })).toBeDefined();
   });
 
   it('hides the bottom navigation on the credits route', () => {

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -395,24 +395,19 @@
   z-index: 9997;
 }
 
+/* Full-screen dimmer with a cutout over the TV zone so the broadcast stays crisp. */
 .tv-zone-live-vote-backdrop {
   position: fixed;
   inset: 0;
   z-index: 9996;
-  background:
-    radial-gradient(
-      circle at 50% 34%,
-      rgba(120, 168, 255, 0.08) 0%,
-      rgba(120, 168, 255, 0.04) 16%,
-      rgba(0, 0, 0, 0) 30%
-    ),
-    linear-gradient(
-      180deg,
-      rgba(3, 8, 18, 0.38) 0%,
-      rgba(2, 6, 12, 0.56) 100%
-    );
   pointer-events: none;
   animation: liveVoteBackdropFadeIn 220ms ease-out both;
+}
+
+.tv-zone-live-vote-backdrop__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 @keyframes liveVoteBackdropFadeIn {

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -340,15 +340,16 @@ export default function TvZone(props: TvZoneProps) {
   const latestEventRef = useRef(latestEvent);
   // Update the ref after each render so the phase-transition effect always has
   // the freshest value without needing latestEvent in its own dependency array.
+  const tvZoneRef = useRef<HTMLElement | null>(null);
+  const liveVoteBackdropMaskId = useId().replace(/:/g, '-') + '-live-vote-mask';
+  const [liveVoteBackdropMetrics, setLiveVoteBackdropMetrics] = useState<LiveVoteBackdropMetrics | null>(null);
+
   useLayoutEffect(() => {
     latestEventRef.current = latestEvent;
   });
 
   useLayoutEffect(() => {
-    if (!voteResultsRevealActive) {
-      setLiveVoteBackdropMetrics(null);
-      return;
-    }
+    if (!voteResultsRevealActive) return;
 
     const updateBackdropMetrics = () => {
       const zone = tvZoneRef.current;
@@ -390,9 +391,6 @@ export default function TvZone(props: TvZoneProps) {
   const activeDetoxEvent = detoxMessageQueue[detoxMessageIndex];
   const displayedEvent = activeDetoxEvent ?? latestEvent;
   const detoxMessageActive = Boolean(activeDetoxEvent);
-  const tvZoneRef = useRef<HTMLElement | null>(null);
-  const liveVoteBackdropMaskId = useId().replace(/:/g, '-') + '-live-vote-mask';
-  const [liveVoteBackdropMetrics, setLiveVoteBackdropMetrics] = useState<LiveVoteBackdropMetrics | null>(null);
 
   // ── Shock announcement sequence state ────────────────────────────────────────
   // Phase A: full-screen shock stinger (ShockIntroOverlay).

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef, startTransition, type CSSProperties } from 'react';
+import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef, useId, startTransition, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import type { Phase, Player } from '../../types';
 import { useStore } from 'react-redux';
@@ -174,6 +174,8 @@ function getPhaseAnnouncementKey(
 // preventing jarring text transitions between the overlay disappearing and new text.
 const POST_DISMISS_FADE_MS = 300;
 const DOUBLE_EVICTION_SPOTLIGHT_MS = 1700;
+const LIVE_VOTE_CUTOUT_PADDING = 12;
+const LIVE_VOTE_CUTOUT_RADIUS = 18;
 const DETOX_MESSAGE_HOLD_MS = 1500;
 const CONTINUOUS_MAJOR_ANNOUNCEMENT_KEYS = new Set([
   'loh_tiebreak_tie',
@@ -226,6 +228,17 @@ type TvZoneDemocraciaResultsReveal = {
     voteCount: number;
   }>;
   onDone: () => void;
+};
+
+type LiveVoteBackdropMetrics = {
+  viewportWidth: number;
+  viewportHeight: number;
+  cutout: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
 };
 
 type TvZoneProps = {
@@ -331,9 +344,55 @@ export default function TvZone(props: TvZoneProps) {
     latestEventRef.current = latestEvent;
   });
 
+  useLayoutEffect(() => {
+    if (!voteResultsRevealActive) {
+      setLiveVoteBackdropMetrics(null);
+      return;
+    }
+
+    const updateBackdropMetrics = () => {
+      const zone = tvZoneRef.current;
+      if (!zone || typeof window === 'undefined') return;
+
+      const rect = zone.getBoundingClientRect();
+      const viewportWidth = window.innerWidth || document.documentElement.clientWidth || Math.ceil(rect.right);
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || Math.ceil(rect.bottom);
+
+      setLiveVoteBackdropMetrics({
+        viewportWidth,
+        viewportHeight,
+        cutout: {
+          x: rect.left - LIVE_VOTE_CUTOUT_PADDING,
+          y: rect.top - LIVE_VOTE_CUTOUT_PADDING,
+          w: rect.width + LIVE_VOTE_CUTOUT_PADDING * 2,
+          h: rect.height + LIVE_VOTE_CUTOUT_PADDING * 2,
+        },
+      });
+    };
+
+    updateBackdropMetrics();
+    const handleViewportChange = () => updateBackdropMetrics();
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+
+    const observer = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(handleViewportChange)
+      : null;
+    if (observer && tvZoneRef.current) observer.observe(tvZoneRef.current);
+
+    return () => {
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+      observer?.disconnect();
+    };
+  }, [voteResultsRevealActive]);
+
   const activeDetoxEvent = detoxMessageQueue[detoxMessageIndex];
   const displayedEvent = activeDetoxEvent ?? latestEvent;
   const detoxMessageActive = Boolean(activeDetoxEvent);
+  const tvZoneRef = useRef<HTMLElement | null>(null);
+  const liveVoteBackdropMaskId = useId().replace(/:/g, '-') + '-live-vote-mask';
+  const [liveVoteBackdropMetrics, setLiveVoteBackdropMetrics] = useState<LiveVoteBackdropMetrics | null>(null);
 
   // ── Shock announcement sequence state ────────────────────────────────────────
   // Phase A: full-screen shock stinger (ShockIntroOverlay).
@@ -726,6 +785,7 @@ export default function TvZone(props: TvZoneProps) {
         isLiveVoteFocus ? 'tv-zone--live-vote-focus' : '',
         detoxMessageActive ? 'tv-zone--detox-stream' : '',
       ].filter(Boolean).join(' ')}
+      ref={tvZoneRef}
       aria-label="Game action zone"
       style={{ '--de-spotlight-ms': `${DOUBLE_EVICTION_SPOTLIGHT_MS}ms` } as CSSProperties}
     >
@@ -734,8 +794,61 @@ export default function TvZone(props: TvZoneProps) {
         <div className="tv-zone-de-backdrop" aria-hidden="true" />,
         document.body,
       )}
-      {isLiveVoteFocus && createPortal(
-        <div className="tv-zone-live-vote-backdrop" aria-hidden="true" />,
+      {isLiveVoteFocus && liveVoteBackdropMetrics && createPortal(
+        <div className="tv-zone-live-vote-backdrop" aria-hidden="true">
+          <svg
+            className="tv-zone-live-vote-backdrop__svg"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox={`0 0 ${liveVoteBackdropMetrics.viewportWidth} ${liveVoteBackdropMetrics.viewportHeight}`}
+            preserveAspectRatio="none"
+          >
+            <defs>
+              <mask id={liveVoteBackdropMaskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">
+                <rect
+                  x={0}
+                  y={0}
+                  width={liveVoteBackdropMetrics.viewportWidth}
+                  height={liveVoteBackdropMetrics.viewportHeight}
+                  fill="white"
+                />
+                <rect
+                  x={liveVoteBackdropMetrics.cutout.x}
+                  y={liveVoteBackdropMetrics.cutout.y}
+                  width={liveVoteBackdropMetrics.cutout.w}
+                  height={liveVoteBackdropMetrics.cutout.h}
+                  rx={LIVE_VOTE_CUTOUT_RADIUS}
+                  ry={LIVE_VOTE_CUTOUT_RADIUS}
+                  fill="black"
+                />
+              </mask>
+              <linearGradient id={`${liveVoteBackdropMaskId}-shade`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#030812" stopOpacity="0.38" />
+                <stop offset="100%" stopColor="#02060c" stopOpacity="0.56" />
+              </linearGradient>
+              <radialGradient id={`${liveVoteBackdropMaskId}-glow`} cx="50%" cy="34%" r="70%">
+                <stop offset="0%" stopColor="#78a8ff" stopOpacity="0.08" />
+                <stop offset="16%" stopColor="#78a8ff" stopOpacity="0.04" />
+                <stop offset="30%" stopColor="#000000" stopOpacity="0" />
+              </radialGradient>
+            </defs>
+            <rect
+              x={0}
+              y={0}
+              width={liveVoteBackdropMetrics.viewportWidth}
+              height={liveVoteBackdropMetrics.viewportHeight}
+              fill={`url(#${liveVoteBackdropMaskId}-glow)`}
+              mask={`url(#${liveVoteBackdropMaskId})`}
+            />
+            <rect
+              x={0}
+              y={0}
+              width={liveVoteBackdropMetrics.viewportWidth}
+              height={liveVoteBackdropMetrics.viewportHeight}
+              fill={`url(#${liveVoteBackdropMaskId}-shade)`}
+              mask={`url(#${liveVoteBackdropMaskId})`}
+            />
+          </svg>
+        </div>,
         document.body,
       )}
 

--- a/src/components/ui/__tests__/TvZone.announcement.test.tsx
+++ b/src/components/ui/__tests__/TvZone.announcement.test.tsx
@@ -297,6 +297,19 @@ describe('TvZone — announcement overlay', () => {
 
   it('dims the surrounding screen while the vote results reveal is active', () => {
     const store = makeStore();
+    const tvZoneRect = {
+      left: 80,
+      top: 120,
+      width: 420,
+      height: 260,
+      right: 500,
+      bottom: 380,
+      x: 80,
+      y: 120,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(tvZoneRect);
 
     renderTvZone(store, {
       voteResultsReveal: {
@@ -310,7 +323,13 @@ describe('TvZone — announcement overlay', () => {
     });
 
     expect(screen.getByLabelText('Game action zone')).toHaveClass('tv-zone--live-vote-focus');
-    expect(document.body.querySelector('.tv-zone-live-vote-backdrop')).not.toBeNull();
+    const backdrop = document.body.querySelector('.tv-zone-live-vote-backdrop');
+    expect(backdrop).not.toBeNull();
+    expect(backdrop?.querySelector('svg')).not.toBeNull();
+    const cutout = backdrop?.querySelector('rect[fill="black"]');
+    expect(cutout).not.toBeNull();
+    expect(cutout?.getAttribute('x')).toBe('68');
+    expect(cutout?.getAttribute('y')).toBe('108');
   });
 
   it('restores normal brightness for the post-vote summary announcement state', () => {

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -446,6 +446,7 @@ export default function Profile() {
   const season = useAppSelector((s) => s.game.season);
   const week = useAppSelector((s) => s.game.week);
   const phase = useAppSelector((s) => s.game.phase);
+  const isGameActive = useAppSelector((s) => s.game.status === 'active');
   const lohId = useAppSelector((s) => s.game.lohId);
   const nomineeIds = useAppSelector((s) => s.game.nomineeIds);
   const posWinnerId = useAppSelector((s) => s.game.posWinnerId);
@@ -478,7 +479,7 @@ export default function Profile() {
   }, [profile, userPlayer]);
   const careerStats = useCareerStats(userIdentity);
 
-  const gameInProgress = week > 1 || phase !== 'week_start';
+  const gameInProgress = isGameActive || week > 1 || phase !== 'week_start';
   const goBack = () => {
     if (window.history.length > 1) {
       navigate(-1);

--- a/src/screens/ProfilePicker/ProfilePicker.tsx
+++ b/src/screens/ProfilePicker/ProfilePicker.tsx
@@ -48,8 +48,10 @@ export default function ProfilePicker() {
   const isGuest = useAppSelector(selectIsGuest);
 
   // Is there an in-progress game (non-trivial state) that would be lost?
+  // Fresh launches are marked active immediately so the warning still shows
+  // before the first week advances.
   const isGameActive = useAppSelector(
-    (s) => s.game.week > 1 || s.game.phase !== 'week_start',
+    (s) => s.game.status === 'active' || s.game.week > 1 || s.game.phase !== 'week_start',
   );
 
   // Photo cache: profileId → dataUrl

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -3083,7 +3083,13 @@ const gameSlice = createSlice({
       const season = nextSeasonNumber(seasonArchives);
       // Use the factory to build a fully fresh initial state from the latest
       // persisted settings/profile, then override seed, seasonArchives, and season.
-      const fresh = { ...createInitialGameState(), seed, seasonArchives, season };
+      const fresh = {
+        ...createInitialGameState(),
+        seed,
+        seasonArchives,
+        season,
+        status: 'active' as const,
+      };
       // Update the welcome message to reflect the actual season number.
       // publicModeEnabled is already derived from settings inside createInitialGameState().
       fresh.tvFeed = [
@@ -3114,6 +3120,7 @@ const gameSlice = createSlice({
         ...action.payload,
         gameId: action.payload.gameId ?? crypto.randomUUID(),
         hasSeenConfessionalSpotlight: action.payload.hasSeenConfessionalSpotlight ?? false,
+        status: action.payload.status ?? 'active',
       };
     },
 


### PR DESCRIPTION
## Summary
- Show the homebar as soon as a game is started from IntroHub, instead of waiting for a later in-game navbar action.
- Keep the live-vote dim effect, but cut out the faux TV zone so the broadcast stays crisp and fully visible.

## Validation
- `npm run typecheck`
- `npx vitest run src/components/layout/__tests__/NavBar.test.tsx src/components/ui/__tests__/TvZone.announcement.test.tsx`