### PR TITLE
[codex] survivor mode cleanup and profile achievements

### DIFF
--- a/src/ai/competition/bracketTemplate.ts
+++ b/src/ai/competition/bracketTemplate.ts
@@ -47,6 +47,16 @@ export interface BracketBand {
  */
 export type BracketTemplate = BracketBand[];
 
+/**
+ * Return the unique set of all competition game keys approved in the default
+ * classical bracket template.
+ */
+export function getApprovedCompetitionGameKeys(
+  template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE,
+): string[] {
+  return [...new Set(template.flatMap((band) => [...band.loh, ...band.pos]))];
+}
+
 // ── Default template ──────────────────────────────────────────────────────────
 
 /**

--- a/src/components/ConfirmExitModal/SurvivorRulesModal.css
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.css
@@ -1,0 +1,100 @@
+.survivor-rules-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 8, 16, 0.72);
+  z-index: 12000;
+  padding: 20px;
+}
+
+.survivor-rules-modal__card {
+  width: min(600px, 96%);
+  background: linear-gradient(180deg, #09111f, #101a2c);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  box-shadow: 0 36px 100px rgba(0, 0, 0, 0.64);
+  padding: 22px;
+  color: #f3f7ff;
+  outline: none;
+}
+
+.survivor-rules-modal__eyebrow {
+  margin: 0 0 10px;
+  color: #8fb3ff;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.survivor-rules-modal__title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.survivor-rules-modal__desc {
+  margin: 10px 0 16px;
+  color: rgba(243, 247, 255, 0.82);
+}
+
+.survivor-rules-modal__list {
+  margin: 0 0 18px;
+  padding-left: 1.2rem;
+  color: rgba(243, 247, 255, 0.92);
+  line-height: 1.55;
+}
+
+.survivor-rules-modal__list li + li {
+  margin-top: 0.55rem;
+}
+
+.survivor-rules-modal__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 18px;
+  font-size: 0.95rem;
+  color: rgba(243, 247, 255, 0.88);
+}
+
+.survivor-rules-modal__checkbox input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #8fb3ff;
+}
+
+.survivor-rules-modal__actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.survivor-rules-modal__btn {
+  min-width: 132px;
+}
+
+.survivor-rules-modal__btn--primary {
+  background: linear-gradient(180deg, #8fb3ff, #6e95f3);
+  border-color: rgba(143, 179, 255, 0.45);
+  color: #08101c;
+}
+
+.survivor-rules-modal__btn--ghost {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+@media (max-width: 640px) {
+  .survivor-rules-modal__card {
+    padding: 18px;
+  }
+
+  .survivor-rules-modal__actions {
+    flex-direction: column;
+  }
+
+  .survivor-rules-modal__btn {
+    width: 100%;
+  }
+}

--- a/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import './SurvivorRulesModal.css';
+
+interface Props {
+  open: boolean;
+  onContinue: (dontShowAgain: boolean) => void;
+  onCancel: () => void;
+}
+
+const RULES = [
+  'Play Survivor as a normal player run, not a debug sandbox.',
+  'Read each prompt carefully before you confirm it.',
+  'Stay with the run until it finishes or you are eliminated.',
+  'Use the in-app controls only; do not rely on developer shortcuts.',
+];
+
+export default function SurvivorRulesModal({ open, onContinue, onCancel }: Props) {
+  const uid = useId();
+  const titleId = `${uid}-title`;
+  const descId = `${uid}-desc`;
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    cardRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="survivor-rules-modal__backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      <div className="survivor-rules-modal__card" tabIndex={-1} ref={cardRef}>
+        <p className="survivor-rules-modal__eyebrow">Survivor Mode</p>
+        <h2 id={titleId} className="survivor-rules-modal__title">Before you jump in</h2>
+        <p id={descId} className="survivor-rules-modal__desc">
+          These are the player-facing rules for the mode.
+        </p>
+
+        <ul className="survivor-rules-modal__list">
+          {RULES.map((rule) => (
+            <li key={rule}>{rule}</li>
+          ))}
+        </ul>
+
+        <label className="survivor-rules-modal__checkbox">
+          <input
+            type="checkbox"
+            checked={dontShowAgain}
+            onChange={(e) => setDontShowAgain(e.target.checked)}
+          />
+          <span>Don't show again</span>
+        </label>
+
+        <div className="survivor-rules-modal__actions">
+          <button
+            type="button"
+            className="survivor-rules-modal__btn survivor-rules-modal__btn--primary"
+            onClick={() => onContinue(dontShowAgain)}
+            autoFocus
+          >
+            Continue
+          </button>
+          <button
+            type="button"
+            className="survivor-rules-modal__btn survivor-rules-modal__btn--ghost"
+            onClick={onCancel}
+          >
+            Back
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SurvivorAchievementCelebration.css
+++ b/src/components/SurvivorAchievementCelebration.css
@@ -1,0 +1,137 @@
+.survivor-celebration {
+  position: fixed;
+  inset: 0;
+  z-index: 8450;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding:
+    calc(18px + env(safe-area-inset-top))
+    calc(18px + env(safe-area-inset-right))
+    calc(18px + env(safe-area-inset-bottom))
+    calc(18px + env(safe-area-inset-left));
+  border: 0;
+  background: rgba(3, 5, 12, 0.84);
+  color: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.survivor-celebration__card {
+  width: min(100%, 440px);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    radial-gradient(circle at top left, rgba(125, 104, 255, 0.2), transparent 42%),
+    linear-gradient(180deg, rgba(15, 21, 40, 0.98), rgba(8, 12, 24, 0.98));
+  box-shadow:
+    0 30px 70px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  padding: 18px;
+  text-align: left;
+  pointer-events: none;
+}
+
+.survivor-celebration__eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.survivor-celebration__pill,
+.survivor-celebration__tier {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.survivor-celebration__pill {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.survivor-celebration__tier {
+  background: rgba(110, 140, 255, 0.14);
+  color: rgba(187, 198, 255, 0.96);
+}
+
+.survivor-celebration__body {
+  display: grid;
+  gap: 8px;
+}
+
+.survivor-celebration__title {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.1;
+  font-weight: 900;
+  color: rgba(255, 255, 255, 0.96);
+}
+
+.survivor-celebration__subtitle {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.survivor-celebration__meta,
+.survivor-celebration__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.survivor-celebration__meta {
+  margin-top: 8px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.survivor-celebration__footer {
+  margin-top: 14px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.survivor-celebration[data-tier='legendary'] .survivor-celebration__tier {
+  background: rgba(255, 177, 84, 0.18);
+  color: rgba(255, 214, 167, 0.98);
+}
+
+.survivor-celebration[data-tier='mythic'] .survivor-celebration__card {
+  background:
+    radial-gradient(circle at top left, rgba(120, 233, 255, 0.24), transparent 40%),
+    radial-gradient(circle at top right, rgba(137, 104, 255, 0.2), transparent 42%),
+    linear-gradient(180deg, rgba(9, 18, 32, 0.99), rgba(5, 8, 18, 0.99));
+}
+
+.survivor-celebration[data-effect='mystery'] .survivor-celebration__pill {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+@media (max-width: 480px) {
+  .survivor-celebration {
+    align-items: flex-end;
+  }
+
+  .survivor-celebration__card {
+    width: 100%;
+    border-radius: 18px 18px 12px 12px;
+  }
+}

--- a/src/components/SurvivorAchievementCelebration.tsx
+++ b/src/components/SurvivorAchievementCelebration.tsx
@@ -52,7 +52,6 @@ export default function SurvivorAchievementCelebration() {
 
   const profileId = activeProfileId ?? '';
   const currentCelebration = celebration;
-  const celebrationId = currentCelebration?.achievement.id ?? null;
 
   useEffect(() => {
     if (!currentCelebration || !profileId) return undefined;
@@ -69,11 +68,12 @@ export default function SurvivorAchievementCelebration() {
     }, AUTO_DISMISS_MS);
 
     return () => window.clearTimeout(timer);
-  }, [celebrationId, profileId]);
+  }, [currentCelebration, profileId]);
 
-  if (!currentCelebration || !activeProfileId) return null;
+  if (!currentCelebration || !profileId) return null;
 
-  const { display } = currentCelebration;
+  const celebrationData = celebration!;
+  const { display } = celebrationData;
   const unlockDateLabel = display.unlock?.unlockedAt
     ? new Intl.DateTimeFormat(undefined, {
         month: 'short',
@@ -83,13 +83,13 @@ export default function SurvivorAchievementCelebration() {
     : 'Just now';
 
   function dismiss() {
-    if (dismissingRef.current === currentCelebration.achievement.id) return;
-    dismissingRef.current = currentCelebration.achievement.id;
-    void markSurvivorAchievementCelebrationSeen(profileId, currentCelebration.achievement.id);
+    if (dismissingRef.current === celebrationData.achievement.id) return;
+    dismissingRef.current = celebrationData.achievement.id;
+    void markSurvivorAchievementCelebrationSeen(profileId, celebrationData.achievement.id);
     setDismissedIds((current) =>
-      current.includes(currentCelebration.achievement.id)
+      current.includes(celebrationData.achievement.id)
         ? current
-        : [...current, currentCelebration.achievement.id],
+        : [...current, celebrationData.achievement.id],
     );
   }
 

--- a/src/components/SurvivorAchievementCelebration.tsx
+++ b/src/components/SurvivorAchievementCelebration.tsx
@@ -50,25 +50,29 @@ export default function SurvivorAchievementCelebration() {
     };
   }, [activeProfileId, dismissedIds, game, isGuest, waitingForInput]);
 
+  const profileId = activeProfileId ?? '';
+  const currentCelebration = celebration;
+  const celebrationId = currentCelebration?.achievement.id ?? null;
+
   useEffect(() => {
-    if (!celebration || !activeProfileId) return undefined;
+    if (!currentCelebration || !profileId) return undefined;
 
     const timer = window.setTimeout(() => {
-      if (dismissingRef.current === celebration.achievement.id) return;
-      dismissingRef.current = celebration.achievement.id;
-      void markSurvivorAchievementCelebrationSeen(profileId, celebration.achievement.id);
+      if (dismissingRef.current === currentCelebration.achievement.id) return;
+      dismissingRef.current = currentCelebration.achievement.id;
+      void markSurvivorAchievementCelebrationSeen(profileId, currentCelebration.achievement.id);
       setDismissedIds((current) =>
-        current.includes(celebration.achievement.id) ? current : [...current, celebration.achievement.id],
+        current.includes(currentCelebration.achievement.id)
+          ? current
+          : [...current, currentCelebration.achievement.id],
       );
     }, AUTO_DISMISS_MS);
 
     return () => window.clearTimeout(timer);
-  }, [activeProfileId, celebration]);
+  }, [celebrationId, profileId]);
 
-  if (!celebration || !activeProfileId) return null;
+  if (!currentCelebration || !activeProfileId) return null;
 
-  const profileId = activeProfileId;
-  const currentCelebration = celebration;
   const { display } = currentCelebration;
   const unlockDateLabel = display.unlock?.unlockedAt
     ? new Intl.DateTimeFormat(undefined, {

--- a/src/components/SurvivorAchievementCelebration.tsx
+++ b/src/components/SurvivorAchievementCelebration.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useAppSelector } from '../store/hooks';
+import { selectActiveProfileId, selectIsGuest } from '../store/profilesSlice';
+import { selectIsWaitingForInput } from '../store/selectors';
+import { loadSavedRunProfile, markSurvivorAchievementCelebrationSeen } from '../store/saveStatePersistence';
+import {
+  buildSurvivorAchievementDisplayModel,
+  pickSurvivorAchievementToCelebrate,
+  SURVIVOR_ACHIEVEMENTS_BY_ID,
+  type SurvivorAchievementDefinition,
+} from '../modes/survivorAchievements';
+import './SurvivorAchievementCelebration.css';
+
+const AUTO_DISMISS_MS = 2200;
+
+export default function SurvivorAchievementCelebration() {
+  const activeProfileId = useAppSelector(selectActiveProfileId);
+  const isGuest = useAppSelector(selectIsGuest);
+  const waitingForInput = useAppSelector(selectIsWaitingForInput);
+  const game = useAppSelector((state) => state.game);
+  const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+  const dismissingRef = useRef<string | null>(null);
+
+  const celebration = useMemo(() => {
+    if (
+      isGuest ||
+      !activeProfileId ||
+      game.mode !== 'survivor' ||
+      game.status !== 'active' ||
+      waitingForInput
+    ) {
+      return null;
+    }
+
+    const savedProfile = loadSavedRunProfile(activeProfileId);
+    const candidateDefinitions = Object.values(
+      savedProfile.stats.survivorAchievementsUnlocked,
+    )
+      .filter((unlock) => !unlock.celebrationSeen && !dismissedIds.includes(unlock.id))
+      .map((unlock) => SURVIVOR_ACHIEVEMENTS_BY_ID[unlock.id])
+      .filter((achievement): achievement is SurvivorAchievementDefinition => achievement != null);
+    const nextAchievement = pickSurvivorAchievementToCelebrate(candidateDefinitions);
+    if (!nextAchievement) return null;
+    const nextUnlock = savedProfile.stats.survivorAchievementsUnlocked[nextAchievement.id];
+
+    return {
+      achievement: nextAchievement,
+      unlock: nextUnlock,
+      display: buildSurvivorAchievementDisplayModel(nextAchievement, nextUnlock),
+    };
+  }, [activeProfileId, dismissedIds, game, isGuest, waitingForInput]);
+
+  useEffect(() => {
+    if (!celebration || !activeProfileId) return undefined;
+
+    const timer = window.setTimeout(() => {
+      if (dismissingRef.current === celebration.achievement.id) return;
+      dismissingRef.current = celebration.achievement.id;
+      void markSurvivorAchievementCelebrationSeen(profileId, celebration.achievement.id);
+      setDismissedIds((current) =>
+        current.includes(celebration.achievement.id) ? current : [...current, celebration.achievement.id],
+      );
+    }, AUTO_DISMISS_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [activeProfileId, celebration]);
+
+  if (!celebration || !activeProfileId) return null;
+
+  const profileId = activeProfileId;
+  const currentCelebration = celebration;
+  const { display } = currentCelebration;
+  const unlockDateLabel = display.unlock?.unlockedAt
+    ? new Intl.DateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(new Date(display.unlock.unlockedAt))
+    : 'Just now';
+
+  function dismiss() {
+    if (dismissingRef.current === currentCelebration.achievement.id) return;
+    dismissingRef.current = currentCelebration.achievement.id;
+    void markSurvivorAchievementCelebrationSeen(profileId, currentCelebration.achievement.id);
+    setDismissedIds((current) =>
+      current.includes(currentCelebration.achievement.id)
+        ? current
+        : [...current, currentCelebration.achievement.id],
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="survivor-celebration"
+      data-tier={display.tier}
+      data-effect={display.effectStyle}
+      aria-label={`Survivor achievement unlocked: ${display.title}. Tap to continue.`}
+      onClick={dismiss}
+    >
+      <div className="survivor-celebration__card">
+        <div className="survivor-celebration__eyebrow">
+          <span className="survivor-celebration__pill">Survivor unlock</span>
+          <span className="survivor-celebration__tier">{display.tierLabel}</span>
+        </div>
+        <div className="survivor-celebration__body">
+          <p className="survivor-celebration__title">{display.title}</p>
+          <p className="survivor-celebration__subtitle">{display.subtitle}</p>
+          <div className="survivor-celebration__meta">
+            <span>Day {display.day}</span>
+            <span>{display.requirement}</span>
+          </div>
+        </div>
+        <div className="survivor-celebration__footer">
+          <span>Unlocked {unlockDateLabel}</span>
+          <span>Tap anywhere to continue</span>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/modes/survivorAchievements.test.ts
+++ b/src/modes/survivorAchievements.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  SURVIVOR_ACHIEVEMENTS,
+  buildSurvivorAchievementDisplayModel,
+  getEligibleSurvivorAchievements,
+  getNextUnseenSurvivorCelebration,
+  pickSurvivorAchievementToCelebrate,
+  type SurvivorAchievementDefinition,
+  type SurvivorAchievementUnlockMap,
+} from './survivorAchievements';
+
+describe('survivorAchievements helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('treats the unlock threshold as inclusive', () => {
+    const eligible = getEligibleSurvivorAchievements(25).map((achievement) => achievement.id);
+
+    expect(eligible).toContain('survivor-day-25');
+    expect(eligible).not.toContain('survivor-day-50');
+  });
+
+  it('skips achievements that are already unlocked', () => {
+    const eligible = getEligibleSurvivorAchievements(100, [
+      'survivor-day-10',
+      'survivor-day-25',
+    ]).map((achievement) => achievement.id);
+
+    expect(eligible).not.toContain('survivor-day-10');
+    expect(eligible).not.toContain('survivor-day-25');
+    expect(eligible).toContain('survivor-day-50');
+  });
+
+  it('masks secret achievements before unlock', () => {
+    const secretAchievement = SURVIVOR_ACHIEVEMENTS.find(
+      (achievement) => achievement.id === 'survivor-anomaly-404',
+    );
+
+    expect(secretAchievement).toBeDefined();
+
+    const locked = buildSurvivorAchievementDisplayModel(secretAchievement!, null);
+
+    expect(locked.title).toBe('???');
+    expect(locked.subtitle).toBe('Secret anomaly');
+    expect(locked.requirement).toBe('Hidden day requirement.');
+  });
+
+  it('reveals secret achievements after unlock', () => {
+    const secretAchievement = SURVIVOR_ACHIEVEMENTS.find(
+      (achievement) => achievement.id === 'survivor-anomaly-404',
+    );
+
+    expect(secretAchievement).toBeDefined();
+
+    const unlocked = buildSurvivorAchievementDisplayModel(secretAchievement!, {
+      id: secretAchievement!.id,
+      unlockedAt: '2026-07-01T09:30:00.000Z',
+      unlockedAtDay: 404,
+      firstRunId: 'run-1',
+      celebrationSeen: false,
+    });
+
+    expect(unlocked.title).toBe(secretAchievement!.name);
+    expect(unlocked.subtitle).toBe(secretAchievement!.subtitle);
+    expect(unlocked.requirement).toBe('Unlocked on Day 404.');
+  });
+
+  it('does not repeat the celebration once it has been seen', () => {
+    const unlocks: SurvivorAchievementUnlockMap = {
+      'survivor-day-10': {
+        id: 'survivor-day-10',
+        unlockedAt: '2026-07-01T09:30:00.000Z',
+        unlockedAtDay: 10,
+        firstRunId: 'run-1',
+        celebrationSeen: true,
+      },
+    };
+
+    expect(getNextUnseenSurvivorCelebration(unlocks)).toBeNull();
+  });
+
+  it('prioritizes mythic achievements over legendary ones and higher days within the same tier', () => {
+    const customAchievements: SurvivorAchievementDefinition[] = [
+      {
+        id: 'legendary-low',
+        day: 5000,
+        name: 'Legendary Low',
+        subtitle: 'legendary',
+        category: 'mythic',
+        visibility: 'visible',
+        tier: 'legendary',
+        effectStyle: 'flare',
+      },
+      {
+        id: 'mythic-low',
+        day: 6000,
+        name: 'Mythic Low',
+        subtitle: 'mythic',
+        category: 'mythic',
+        visibility: 'visible',
+        tier: 'mythic',
+        effectStyle: 'mythic',
+      },
+      {
+        id: 'mythic-high',
+        day: 10000,
+        name: 'Mythic High',
+        subtitle: 'mythic',
+        category: 'mythic',
+        visibility: 'visible',
+        tier: 'mythic',
+        effectStyle: 'mythic',
+      },
+    ];
+
+    expect(pickSurvivorAchievementToCelebrate(customAchievements)?.id).toBe('mythic-high');
+  });
+});

--- a/src/modes/survivorAchievements.ts
+++ b/src/modes/survivorAchievements.ts
@@ -1,0 +1,559 @@
+import type { GameState } from '../types';
+
+export type SurvivorAchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum' | 'legendary' | 'mythic';
+
+export type SurvivorAchievementCategory = 'milestone' | 'ultra' | 'mythic' | 'anomaly';
+
+export type SurvivorAchievementVisibility = 'visible' | 'secret';
+
+export type SurvivorAchievementEffectStyle = 'spark' | 'glow' | 'flare' | 'mythic' | 'mystery';
+
+export interface SurvivorAchievementDefinition {
+  id: string;
+  day: number;
+  name: string;
+  subtitle: string;
+  category: SurvivorAchievementCategory;
+  visibility: SurvivorAchievementVisibility;
+  tier: SurvivorAchievementTier;
+  effectStyle: SurvivorAchievementEffectStyle;
+}
+
+export interface SurvivorAchievementUnlock {
+  id: string;
+  unlockedAt: string;
+  unlockedAtDay: number;
+  firstRunId: string | null;
+  celebrationSeen: boolean;
+}
+
+export type SurvivorAchievementUnlockMap = Record<string, SurvivorAchievementUnlock>;
+
+export interface SurvivorAchievementDisplayModel {
+  id: string;
+  title: string;
+  subtitle: string;
+  requirement: string;
+  tierLabel: string;
+  categoryLabel: string;
+  visibility: SurvivorAchievementVisibility;
+  tier: SurvivorAchievementTier;
+  day: number;
+  isUnlocked: boolean;
+  unlock: SurvivorAchievementUnlock | null;
+  effectStyle: SurvivorAchievementEffectStyle;
+}
+
+export interface SurvivorAchievementProgressResult {
+  unlocks: SurvivorAchievementUnlockMap;
+  newlyUnlocked: SurvivorAchievementDefinition[];
+}
+
+const SURVIVOR_TIER_PRIORITY: Record<SurvivorAchievementTier, number> = {
+  bronze: 0,
+  silver: 1,
+  gold: 2,
+  platinum: 3,
+  legendary: 4,
+  mythic: 5,
+};
+
+const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
+  {
+    id: 'survivor-day-10',
+    day: 10,
+    name: 'First Spar',
+    subtitle: 'Ten days in Survivor Mode is enough to start leaving a mark.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'bronze',
+    effectStyle: 'spark',
+  },
+  {
+    id: 'survivor-day-25',
+    day: 25,
+    name: 'Heat Check',
+    subtitle: 'A full month of pressure, and the run is still breathing.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'bronze',
+    effectStyle: 'spark',
+  },
+  {
+    id: 'survivor-day-50',
+    day: 50,
+    name: 'Halfway Fire',
+    subtitle: 'Fifty days in Survivor Mode with the game still in your hands.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'silver',
+    effectStyle: 'glow',
+  },
+  {
+    id: 'survivor-day-100',
+    day: 100,
+    name: 'Century Run',
+    subtitle: 'Three digits of Survivor Mode, no flinch required.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'silver',
+    effectStyle: 'glow',
+  },
+  {
+    id: 'survivor-day-200',
+    day: 200,
+    name: 'Pressure Proof',
+    subtitle: 'Two hundred days and the floor is still holding.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'gold',
+    effectStyle: 'flare',
+  },
+  {
+    id: 'survivor-day-300',
+    day: 300,
+    name: 'Long Haul',
+    subtitle: 'Survivor Mode becomes a habit somewhere around here.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'gold',
+    effectStyle: 'flare',
+  },
+  {
+    id: 'survivor-day-365',
+    day: 365,
+    name: 'Year One',
+    subtitle: 'A full year in Survivor Mode deserves a proper spotlight.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'platinum',
+    effectStyle: 'glow',
+  },
+  {
+    id: 'survivor-day-400',
+    day: 400,
+    name: 'Skyline',
+    subtitle: 'The run is starting to look architectural.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'platinum',
+    effectStyle: 'glow',
+  },
+  {
+    id: 'survivor-day-500',
+    day: 500,
+    name: 'Five Hundred Club',
+    subtitle: 'A half-millennium of Survivor Mode is real commitment.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'legendary',
+    effectStyle: 'flare',
+  },
+  {
+    id: 'survivor-day-1000',
+    day: 1000,
+    name: 'Millennium Survivor',
+    subtitle: 'A four-digit run that belongs on the wall.',
+    category: 'milestone',
+    visibility: 'visible',
+    tier: 'legendary',
+    effectStyle: 'flare',
+  },
+  {
+    id: 'survivor-day-2000',
+    day: 2000,
+    name: 'Deep Archive',
+    subtitle: 'Survivor Mode has become part of the profile history.',
+    category: 'ultra',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-3000',
+    day: 3000,
+    name: 'Pressure Atlas',
+    subtitle: 'Three thousand days of keeping the lights on.',
+    category: 'ultra',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-4000',
+    day: 4000,
+    name: 'Signal Tower',
+    subtitle: 'The Survivor profile is now visible from orbit.',
+    category: 'ultra',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-5000',
+    day: 5000,
+    name: 'Mythic Five',
+    subtitle: 'Five thousand days in Survivor Mode changes the shape of the file.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-6000',
+    day: 6000,
+    name: 'Mythic Six',
+    subtitle: 'The profile has started collecting weather.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-7000',
+    day: 7000,
+    name: 'Mythic Seven',
+    subtitle: 'Seven thousand days of pure stubbornness.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-8000',
+    day: 8000,
+    name: 'Mythic Eight',
+    subtitle: 'By this point, Survivor Mode feels like a second home hub.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-9000',
+    day: 9000,
+    name: 'Mythic Nine',
+    subtitle: 'The archive is getting heavier by the day.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-10000',
+    day: 10000,
+    name: 'Ten Thousand Days',
+    subtitle: 'An impossible-looking milestone made visible anyway.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-day-100000',
+    day: 100000,
+    name: 'Forever Mode',
+    subtitle: 'A myth so large it has to be treated like a landmark.',
+    category: 'mythic',
+    visibility: 'visible',
+    tier: 'mythic',
+    effectStyle: 'mythic',
+  },
+  {
+    id: 'survivor-anomaly-69',
+    day: 69,
+    name: 'Lucky 69',
+    subtitle: 'A suspiciously satisfying anomaly.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'silver',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-111',
+    day: 111,
+    name: 'Triple Signal',
+    subtitle: 'Three ones, no explanation needed.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'silver',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-314',
+    day: 314,
+    name: 'Pi Day',
+    subtitle: 'A hidden curve in the run.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'gold',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-404',
+    day: 404,
+    name: 'Not Found',
+    subtitle: 'The day the signal folded in on itself.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'gold',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-444',
+    day: 444,
+    name: 'Mirror Wall',
+    subtitle: 'A pattern that looks like it belongs to someone else.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'platinum',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-666',
+    day: 666,
+    name: 'Triple Six',
+    subtitle: 'A loud little omen for the Survivor record book.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'platinum',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-777',
+    day: 777,
+    name: 'Jackpot Seven',
+    subtitle: 'A secret that arrives with extra sparkle.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'legendary',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-888',
+    day: 888,
+    name: 'Infinite Loop',
+    subtitle: 'The run seems to know where it is going.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'legendary',
+    effectStyle: 'mystery',
+  },
+  {
+    id: 'survivor-anomaly-999',
+    day: 999,
+    name: 'Almost There',
+    subtitle: 'One breath before the next major wall.',
+    category: 'anomaly',
+    visibility: 'secret',
+    tier: 'legendary',
+    effectStyle: 'mystery',
+  },
+];
+
+export const SURVIVOR_ACHIEVEMENTS: readonly SurvivorAchievementDefinition[] =
+  Object.freeze(SURVIVOR_ACHIEVEMENT_DATA.slice());
+
+export const SURVIVOR_ACHIEVEMENTS_BY_ID: Readonly<Record<string, SurvivorAchievementDefinition>> =
+  Object.freeze(
+    SURVIVOR_ACHIEVEMENT_DATA.reduce<Record<string, SurvivorAchievementDefinition>>((acc, achievement) => {
+      acc[achievement.id] = achievement;
+      return acc;
+    }, {}),
+  );
+
+function isFiniteDay(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function normalizeTierLabel(tier: SurvivorAchievementTier): string {
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+function normalizeCategoryLabel(category: SurvivorAchievementCategory): string {
+  switch (category) {
+    case 'milestone':
+      return 'Milestone';
+    case 'ultra':
+      return 'Ultra';
+    case 'mythic':
+      return 'Mythic';
+    case 'anomaly':
+      return 'Secret anomaly';
+    default:
+      return category;
+  }
+}
+
+export function getSurvivorProgressDay(game: Pick<GameState, 'week' | 'modeSpecific'> | null | undefined): number {
+  if (!game) return 0;
+  const survivorState = game.modeSpecific?.kind === 'survivor' ? game.modeSpecific : null;
+  return Math.max(game.week ?? 1, survivorState?.currentDay ?? 1, survivorState?.bestDayReached ?? 1);
+}
+
+export function normalizeSurvivorAchievementUnlockMap(raw: unknown): SurvivorAchievementUnlockMap {
+  if (!raw || typeof raw !== 'object') return {};
+
+  const result: SurvivorAchievementUnlockMap = {};
+  for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+    const achievement = SURVIVOR_ACHIEVEMENTS_BY_ID[id];
+    if (!achievement || !value || typeof value !== 'object') continue;
+
+    const parsed = value as Record<string, unknown>;
+    const unlockedAt =
+      typeof parsed.unlockedAt === 'string' && parsed.unlockedAt.trim()
+        ? parsed.unlockedAt
+        : null;
+    const unlockedAtDay =
+      typeof parsed.unlockedAtDay === 'number' && Number.isFinite(parsed.unlockedAtDay)
+        ? parsed.unlockedAtDay
+        : null;
+    if (!unlockedAt || unlockedAtDay == null) continue;
+
+    result[id] = {
+      id,
+      unlockedAt,
+      unlockedAtDay,
+      firstRunId:
+        typeof parsed.firstRunId === 'string' && parsed.firstRunId.trim()
+          ? parsed.firstRunId
+          : null,
+      celebrationSeen: parsed.celebrationSeen === true,
+    };
+  }
+
+  return result;
+}
+
+export function getEligibleSurvivorAchievements(
+  bestDayReached: number,
+  unlockedIds: Iterable<string> = [],
+): SurvivorAchievementDefinition[] {
+  const normalizedBestDay = isFiniteDay(bestDayReached) ? Math.floor(bestDayReached) : 0;
+  const unlocked = new Set(unlockedIds);
+  return SURVIVOR_ACHIEVEMENTS.filter(
+    (achievement) => normalizedBestDay >= achievement.day && !unlocked.has(achievement.id),
+  );
+}
+
+export function pickSurvivorAchievementToCelebrate(
+  achievements: readonly SurvivorAchievementDefinition[],
+): SurvivorAchievementDefinition | null {
+  if (achievements.length === 0) return null;
+
+  return [...achievements].sort((left, right) => {
+    const tierDelta = SURVIVOR_TIER_PRIORITY[right.tier] - SURVIVOR_TIER_PRIORITY[left.tier];
+    if (tierDelta !== 0) return tierDelta;
+    const dayDelta = right.day - left.day;
+    if (dayDelta !== 0) return dayDelta;
+    return left.name.localeCompare(right.name);
+  })[0] ?? null;
+}
+
+export function applySurvivorAchievementProgress(
+  currentUnlocks: SurvivorAchievementUnlockMap,
+  bestDayReached: number,
+  runId: string | null = null,
+  savedAt = new Date().toISOString(),
+): SurvivorAchievementProgressResult {
+  const eligible = getEligibleSurvivorAchievements(bestDayReached, Object.keys(currentUnlocks));
+  if (eligible.length === 0) {
+    return {
+      unlocks: currentUnlocks,
+      newlyUnlocked: [],
+    };
+  }
+
+  const normalizedBestDay = isFiniteDay(bestDayReached) ? Math.floor(bestDayReached) : 0;
+  const nextUnlocks = { ...currentUnlocks };
+  for (const achievement of eligible) {
+    nextUnlocks[achievement.id] = {
+      id: achievement.id,
+      unlockedAt: savedAt,
+      unlockedAtDay: normalizedBestDay,
+      firstRunId: runId,
+      celebrationSeen: false,
+    };
+  }
+
+  return {
+    unlocks: nextUnlocks,
+    newlyUnlocked: eligible,
+  };
+}
+
+export function getNextUnseenSurvivorCelebration(unlocks: SurvivorAchievementUnlockMap): {
+  achievement: SurvivorAchievementDefinition;
+  unlock: SurvivorAchievementUnlock;
+} | null {
+  const pending = SURVIVOR_ACHIEVEMENTS.filter((achievement) => {
+    const unlock = unlocks[achievement.id];
+    return unlock != null && !unlock.celebrationSeen;
+  });
+  const achievement = pickSurvivorAchievementToCelebrate(pending);
+  if (!achievement) return null;
+
+  return {
+    achievement,
+    unlock: unlocks[achievement.id],
+  };
+}
+
+export function buildSurvivorAchievementDisplayModel(
+  achievement: SurvivorAchievementDefinition,
+  unlock: SurvivorAchievementUnlock | null | undefined,
+): SurvivorAchievementDisplayModel {
+  const isUnlocked = unlock != null;
+  const visibility = achievement.visibility;
+  const tierLabel = normalizeTierLabel(achievement.tier);
+  const categoryLabel = normalizeCategoryLabel(achievement.category);
+
+  if (isUnlocked) {
+    return {
+      id: achievement.id,
+      title: achievement.name,
+      subtitle: achievement.subtitle,
+      requirement: `Unlocked on Day ${unlock.unlockedAtDay}.`,
+      tierLabel,
+      categoryLabel,
+      visibility,
+      tier: achievement.tier,
+      day: achievement.day,
+      isUnlocked: true,
+      unlock,
+      effectStyle: achievement.effectStyle,
+    };
+  }
+
+  if (visibility === 'secret') {
+    return {
+      id: achievement.id,
+      title: '???',
+      subtitle: 'Secret anomaly',
+      requirement: 'Hidden day requirement.',
+      tierLabel,
+      categoryLabel,
+      visibility,
+      tier: achievement.tier,
+      day: achievement.day,
+      isUnlocked: false,
+      unlock: null,
+      effectStyle: achievement.effectStyle,
+    };
+  }
+
+  return {
+    id: achievement.id,
+    title: achievement.name,
+    subtitle: achievement.subtitle,
+    requirement: `Reach Day ${achievement.day} in Survivor Mode.`,
+    tierLabel,
+    categoryLabel,
+    visibility,
+    tier: achievement.tier,
+    day: achievement.day,
+    isUnlocked: false,
+    unlock: null,
+    effectStyle: achievement.effectStyle,
+  };
+}

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -90,6 +90,7 @@ import type { ChatLine } from '../../components/ChatOverlay/ChatOverlay'
 import SocialPanel from '../../components/SocialPanel/SocialPanel'
 import SocialPanelV2 from '../../components/SocialPanelV2/SocialPanelV2'
 import IncomingInteractionsInbox from '../../components/IncomingInteractionsInbox/IncomingInteractionsInbox'
+import SurvivorAchievementCelebration from '../../components/SurvivorAchievementCelebration'
 import { FEATURE_SOCIAL_V2, FEATURE_SPECTATOR_REACT } from '../../config/featureFlags'
 import SocialSummaryPopup from '../../components/SocialSummary/SocialSummaryPopup'
 import SpectatorView from '../../components/ui/SpectatorView'
@@ -3846,6 +3847,7 @@ export default function GameScreen() {
           />
         )}
       </AnimatePresence>
+      <SurvivorAchievementCelebration />
 
       {/* ── Back 2 the Game return animation (reverse eviction) ─────────────── */}
       <AnimatePresence>

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -25,6 +25,7 @@ import HubLoadingOverlay from '../../components/HubLoadingOverlay/HubLoadingOver
 import AssetPreloaderOverlay from '../../components/AssetPreloaderOverlay/AssetPreloaderOverlay';
 import PermissionPrompts from '../../components/PermissionPrompts/PermissionPrompts';
 import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
+import SurvivorRulesModal from '../../components/ConfirmExitModal/SurvivorRulesModal';
 import { SoundManager } from '../../services/sound/SoundManager';
 import GameButton, { type GameButtonVariant } from '../../components/GameButton/GameButton';
 import useHomeHubAssets from '../../hooks/useHomeHubAssets';
@@ -33,6 +34,10 @@ import {
   hasSeenHomeHubSplashForGame,
   markHomeHubSplashSeenForGame,
 } from './homeHubSplashSession';
+import {
+  hasSeenSurvivorRules,
+  markSurvivorRulesSeen,
+} from './survivorRulesSeen';
 import {
   selectRemoteIntroHubBg,
   selectRemoteIntroHubOverlay,
@@ -198,6 +203,8 @@ export default function HomeHub() {
   const [preloading, setPreloading] = useState(autoStartGame);
   const [playSelectionOpen, setPlaySelectionOpen] = useState(false);
   const [survivorPrompt, setSurvivorPrompt] = useState<SurvivorPrompt>(null);
+  const [survivorRulesOpen, setSurvivorRulesOpen] = useState(false);
+  const survivorRulesDismissed = hasSeenSurvivorRules(activeProfileId);
 
   const savedRuns = useMemo(
     () => (!isGuest && activeProfileId ? loadSavedRunProfile(activeProfileId) : null),
@@ -258,8 +265,25 @@ export default function HomeHub() {
       clearSavedRun(activeProfileId, 'survivor');
     }
     setSurvivorPrompt(null);
+    setPlaySelectionOpen(false);
     dispatch(hydrateGame(createSurvivorRun()));
     setPreloading(true);
+  }
+
+  function requestSurvivorRunStart() {
+    if (!survivorRulesDismissed) {
+      setSurvivorRulesOpen(true);
+      return;
+    }
+    startSurvivorRun();
+  }
+
+  function handleSurvivorRulesContinue(dontShowAgain: boolean) {
+    if (dontShowAgain) {
+      markSurvivorRulesSeen(activeProfileId);
+    }
+    setSurvivorRulesOpen(false);
+    startSurvivorRun();
   }
 
   function resumeSurvivorRun() {
@@ -281,7 +305,7 @@ export default function HomeHub() {
       setSurvivorPrompt('ended');
       return;
     }
-    startSurvivorRun();
+    requestSurvivorRunStart();
   }
 
   function startOrResumeMode(mode: GameMode) {
@@ -397,7 +421,7 @@ export default function HomeHub() {
         description="Your previous Survivor run has ended."
         confirmLabel="Start New"
         cancelLabel="Cancel"
-        onConfirm={startSurvivorRun}
+        onConfirm={requestSurvivorRunStart}
         onCancel={() => {
           setSurvivorPrompt(null);
           setPlaySelectionOpen(false);
@@ -410,9 +434,17 @@ export default function HomeHub() {
         description="This will replace your saved Survivor run only. Classic progress will not be affected."
         confirmLabel="Start New"
         cancelLabel="Cancel"
-        onConfirm={startSurvivorRun}
+        onConfirm={requestSurvivorRunStart}
         onCancel={() => setSurvivorPrompt('resume-or-new')}
       />
+
+      {survivorRulesOpen && (
+        <SurvivorRulesModal
+          open={survivorRulesOpen}
+          onContinue={handleSurvivorRulesContinue}
+          onCancel={() => setSurvivorRulesOpen(false)}
+        />
+      )}
 
       <div className="homehub-shell">
         <div className="homehub-frame">

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -345,6 +345,34 @@ describe('HomeHub', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 
+  it('shows Survivor rules before starting a fresh Survivor run', async () => {
+    const view = renderHomeHub();
+
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Survivor Mode' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/don't show again/i));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(
+        mockDispatch.mock.calls.some(
+          ([action]) => typeof action === 'object' && action !== null && (action as { type?: string }).type === 'game/hydrateGame',
+        ),
+      ).toBe(true);
+    });
+    expect(localStorage.getItem('bb:homeHubSurvivorRulesSeen:guest')).toBe('1');
+
+    view.unmount();
+  });
+
   it('mirrors the current Redux game state onto window.game for the intro hub', async () => {
     mockState.game = {
       gameId: 'game-A',

--- a/src/screens/HomeHub/survivorRulesSeen.ts
+++ b/src/screens/HomeHub/survivorRulesSeen.ts
@@ -1,0 +1,21 @@
+const SURVIVOR_RULES_KEY = 'bb:homeHubSurvivorRulesSeen';
+
+function storageKey(profileId: string | null | undefined): string {
+  return `${SURVIVOR_RULES_KEY}:${profileId ?? 'guest'}`;
+}
+
+export function hasSeenSurvivorRules(profileId: string | null | undefined): boolean {
+  try {
+    return localStorage.getItem(storageKey(profileId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markSurvivorRulesSeen(profileId: string | null | undefined): void {
+  try {
+    localStorage.setItem(storageKey(profileId), '1');
+  } catch {
+    // Ignore storage failures; the modal will reappear next session.
+  }
+}

--- a/src/screens/Profile/Profile.css
+++ b/src/screens/Profile/Profile.css
@@ -101,7 +101,8 @@
 .profile-screen__status-card,
 .profile-screen__bio-card,
 .profile-screen__stats-card,
-.profile-screen__titles-card {
+.profile-screen__titles-card,
+.profile-screen__survivor-card {
   background: linear-gradient(180deg, #0d1728, #091220);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 14px;
@@ -248,6 +249,148 @@
   color: rgba(107, 183, 255, 0.92);
 }
 
+.profile-screen__survivor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.profile-screen__survivor-copy {
+  margin: -4px 0 0;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.48);
+  line-height: 1.45;
+}
+
+.profile-screen__survivor-count {
+  flex-shrink: 0;
+  min-width: 54px;
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: rgba(107, 183, 255, 0.14);
+  border: 1px solid rgba(107, 183, 255, 0.22);
+  color: rgba(235, 244, 255, 0.95);
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.profile-screen__survivor-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.profile-screen__survivor-stat {
+  padding: 10px 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+}
+
+.profile-screen__survivor-stat-val {
+  display: block;
+  font-size: 1.45rem;
+  font-weight: 900;
+  color: rgba(124, 190, 255, 0.95);
+  line-height: 1;
+}
+
+.profile-screen__survivor-stat-key {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.profile-screen__survivor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.profile-screen__survivor-achievement {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.profile-screen__survivor-achievement--unlocked {
+  background:
+    radial-gradient(circle at top right, rgba(107, 183, 255, 0.12), transparent 38%),
+    rgba(255, 255, 255, 0.045);
+  border-color: rgba(107, 183, 255, 0.18);
+}
+
+.profile-screen__survivor-achievement--secret:not(.profile-screen__survivor-achievement--unlocked) {
+  background: rgba(255, 255, 255, 0.03);
+  border-style: dashed;
+}
+
+.profile-screen__survivor-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.profile-screen__survivor-tier,
+.profile-screen__survivor-category {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.profile-screen__survivor-tier {
+  background: rgba(107, 183, 255, 0.14);
+  color: rgba(212, 231, 255, 0.94);
+}
+
+.profile-screen__survivor-category {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.52);
+}
+
+.profile-screen__survivor-name {
+  margin: 0 0 4px;
+  font-size: 0.98rem;
+  font-weight: 900;
+  color: rgba(255, 255, 255, 0.94);
+}
+
+.profile-screen__survivor-subtitle {
+  margin: 0 0 6px;
+  font-size: 0.76rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.profile-screen__survivor-requirement,
+.profile-screen__survivor-unlocked {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.profile-screen__survivor-unlocked {
+  margin-top: 6px;
+  color: rgba(115, 190, 255, 0.9);
+}
+
 .profile-screen__switch-btn {
   width: 100%;
   color: rgba(255, 255, 255, 0.8);
@@ -256,5 +399,15 @@
 @media (max-width: 480px) {
   .profile-screen__stats-grid {
     gap: 8px;
+  }
+
+  .profile-screen__survivor-stats,
+  .profile-screen__survivor-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-screen__survivor-header {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -6,9 +6,14 @@ import {
   selectIsGuest,
 } from '../../store/profilesSlice';
 import { findArchiveUserSummary } from '../../store/achievementSummary';
+import { loadSavedRunProfile } from '../../store/saveStatePersistence';
 import { imageIdToDataUrl } from '../../utils/imageDb';
 import { publicOpinionConfig } from '../../publicOpinion/publicOpinionConfig';
 import { normalizeAffinity } from '../../social/affinityUtils';
+import {
+  SURVIVOR_ACHIEVEMENTS,
+  buildSurvivorAchievementDisplayModel,
+} from '../../modes/survivorAchievements';
 import type { Phase, Player, StatusPillVariant } from '../../types';
 import './Profile.css';
 
@@ -208,6 +213,16 @@ function findApprovalBand(approval: number): string {
 
 function formatPercent(value: number, digits = 0): string {
   return `${value.toFixed(digits)}%`;
+}
+
+function formatIsoDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
 }
 
 function formatPhaseLabel(phase: Phase): string {
@@ -478,6 +493,14 @@ export default function Profile() {
     return null;
   }, [profile, userPlayer]);
   const careerStats = useCareerStats(userIdentity);
+  const savedRunProfile = profile ? loadSavedRunProfile(profile.id) : null;
+  const survivorUnlocks = savedRunProfile?.stats.survivorAchievementsUnlocked ?? {};
+  const survivorHighestDay = savedRunProfile?.stats.maxSurvivorDaysSurvived ?? 0;
+  const survivorUnlockedCount = Object.keys(survivorUnlocks).length;
+  const survivorTotalCount = SURVIVOR_ACHIEVEMENTS.length;
+  const survivorAchievementCards = SURVIVOR_ACHIEVEMENTS.map((achievement) =>
+    buildSurvivorAchievementDisplayModel(achievement, survivorUnlocks[achievement.id]),
+  );
 
   const gameInProgress = isGameActive || week > 1 || phase !== 'week_start';
   const goBack = () => {
@@ -784,6 +807,66 @@ export default function Profile() {
           </div>
         </div>
       )}
+
+      <div className="profile-screen__survivor-card">
+        <div className="profile-screen__survivor-header">
+          <div>
+            <p className="profile-screen__section-title">Survivor Progress</p>
+            <p className="profile-screen__survivor-copy">
+              Progress is saved to this profile and carries across Survivor runs.
+            </p>
+          </div>
+          <div className="profile-screen__survivor-count">
+            {survivorUnlockedCount}/{survivorTotalCount}
+          </div>
+        </div>
+        <div className="profile-screen__survivor-stats">
+          <div className="profile-screen__survivor-stat">
+            <span className="profile-screen__survivor-stat-val">
+              {survivorHighestDay > 0 ? survivorHighestDay : '-'}
+            </span>
+            <span className="profile-screen__survivor-stat-key">Highest Day</span>
+          </div>
+          <div className="profile-screen__survivor-stat">
+            <span className="profile-screen__survivor-stat-val">{survivorUnlockedCount}</span>
+            <span className="profile-screen__survivor-stat-key">Unlocked</span>
+          </div>
+          <div className="profile-screen__survivor-stat">
+            <span className="profile-screen__survivor-stat-val">{survivorTotalCount}</span>
+            <span className="profile-screen__survivor-stat-key">Total</span>
+          </div>
+        </div>
+        <div className="profile-screen__survivor-grid">
+          {survivorAchievementCards.map((achievement) => (
+            <article
+              key={achievement.id}
+              className={[
+                'profile-screen__survivor-achievement',
+                achievement.isUnlocked ? 'profile-screen__survivor-achievement--unlocked' : '',
+                !achievement.isUnlocked && achievement.visibility === 'secret'
+                  ? 'profile-screen__survivor-achievement--secret'
+                  : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              <div className="profile-screen__survivor-card-top">
+                <span className="profile-screen__survivor-tier">{achievement.tierLabel}</span>
+                <span className="profile-screen__survivor-category">{achievement.categoryLabel}</span>
+              </div>
+              <p className="profile-screen__survivor-name">{achievement.title}</p>
+              <p className="profile-screen__survivor-subtitle">{achievement.subtitle}</p>
+              <p className="profile-screen__survivor-requirement">{achievement.requirement}</p>
+              {achievement.isUnlocked && achievement.unlock ? (
+                <p className="profile-screen__survivor-unlocked">
+                  Unlocked {formatIsoDate(achievement.unlock.unlockedAt)} · Day{' '}
+                  {achievement.unlock.unlockedAtDay}
+                </p>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </div>
 
       {careerStats.seasons > 0 && (
         <div className="profile-screen__titles-card">

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -15,7 +15,7 @@ import {
   simulateMinigameAiScore,
 } from '../ai/competition';
 import { selectNextCompetitionGame } from '../ai/competition/scheduling';
-import { getBracketPoolForContext } from '../ai/competition/bracketTemplate';
+import { getApprovedCompetitionGameKeys, getBracketPoolForContext } from '../ai/competition/bracketTemplate';
 import { applyCompetitionSeasonUpdate, hydrateGame, selectAlivePlayers } from './gameSlice';
 import { pickRandomGame, getGame, getPoolByFilter } from '../minigames/registry';
 import type { GameRegistryEntry, GameCategory } from '../minigames/registry';
@@ -96,6 +96,7 @@ const initialState: ChallengeState = {
 const LATE_SEASON_PLAYER_THRESHOLD = 6;
 // Keep a modest history buffer in case the scheduler window expands.
 const RECENT_HISTORY_LIMIT = 10;
+const SURVIVOR_APPROVED_GAME_KEYS = new Set(getApprovedCompetitionGameKeys());
 
 // ─── Slice ───────────────────────────────────────────────────────────────────
 
@@ -197,20 +198,29 @@ export const startChallenge =
       return pickRandomGame(gameSeed, { category, excludeKeys });
     };
     const pickSurvivorGame = (category?: GameCategory, excludeKeys?: string[]) => {
-      const pool = getPoolByFilter({ retired: false, category, excludeKeys });
       const modeSpecific = state.game.modeSpecific?.kind === 'survivor'
         ? state.game.modeSpecific
         : null;
-      if (pool.length === 0 || !modeSpecific) return pickFromRegistry(category, excludeKeys);
+      if (!modeSpecific) return pickFromRegistry(category, excludeKeys);
+
+      const approvedPool = getPoolByFilter({ retired: false, excludeKeys })
+        .filter((game) => SURVIVOR_APPROVED_GAME_KEYS.has(game.key));
+      const pool = category
+        ? approvedPool.filter((game) => game.category === category)
+        : approvedPool;
+      const selectionPool = pool.length > 0 ? pool : approvedPool;
+      if (selectionPool.length === 0) {
+        throw new Error('[challengeSlice] No approved Survivor games are available');
+      }
 
       const usedKeys = modeSpecific.competitionRotation.usedKeys ?? [];
       const used = new Set(usedKeys);
-      let available = pool.filter((game) => !used.has(game.key));
+      let available = selectionPool.filter((game) => !used.has(game.key));
       let nextUsedKeys = usedKeys;
       let nextRound = modeSpecific.competitionRotation.round ?? 1;
 
       if (available.length === 0) {
-        available = pool;
+        available = selectionPool;
         nextUsedKeys = [];
         nextRound += 1;
       }

--- a/src/store/saveStatePersistence.test.ts
+++ b/src/store/saveStatePersistence.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadSavedRunProfile,
+  markSurvivorAchievementCelebrationSeen,
+  saveRunSnapshot,
+  savedRunsKeyForProfile,
+  type SavedSeasonSnapshot,
+} from './saveStatePersistence';
+
+describe('saveStatePersistence survivor progression', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('normalizes missing survivor achievement unlock maps to an empty object', () => {
+    localStorage.setItem(
+      savedRunsKeyForProfile('profile-1'),
+      JSON.stringify({
+        version: 2,
+        profileId: 'profile-1',
+        savedAt: '2026-07-01T00:00:00.000Z',
+        activeRunId: null,
+        lastPlayedRunId: null,
+        runs: {},
+        stats: {
+          maxSurvivorDaysSurvived: 37,
+        },
+      }),
+    );
+
+    expect(loadSavedRunProfile('profile-1').stats.survivorAchievementsUnlocked).toEqual({});
+  });
+
+  it('persists survivor unlocks and marks their celebration as seen', () => {
+    const snapshot = {
+      version: 1,
+      profileId: 'profile-1',
+      savedAt: '2026-07-01T12:00:00.000Z',
+      game: {
+        mode: 'survivor',
+        week: 25,
+        status: 'active',
+        runId: 'run-1',
+        gameId: 'game-1',
+        modeSpecific: {
+          kind: 'survivor',
+          currentDay: 25,
+          bestDayReached: 25,
+          startingCastSize: 9,
+          totalRoboContestantsEvicted: 0,
+          nextRoboIndex: 0,
+        },
+      },
+      finale: {},
+      social: {},
+    } as SavedSeasonSnapshot;
+
+    expect(saveRunSnapshot('profile-1', snapshot)).toBe(true);
+
+    const afterUnlock = loadSavedRunProfile('profile-1');
+    expect(afterUnlock.stats.maxSurvivorDaysSurvived).toBe(25);
+    expect(Object.keys(afterUnlock.stats.survivorAchievementsUnlocked)).toEqual([
+      'survivor-day-10',
+      'survivor-day-25',
+    ]);
+    expect(afterUnlock.stats.survivorAchievementsUnlocked['survivor-day-25'].celebrationSeen).toBe(
+      false,
+    );
+
+    expect(markSurvivorAchievementCelebrationSeen('profile-1', 'survivor-day-25')).toBe(true);
+    expect(loadSavedRunProfile('profile-1').stats.survivorAchievementsUnlocked['survivor-day-25'].celebrationSeen).toBe(
+      true,
+    );
+  });
+});

--- a/src/store/saveStatePersistence.test.ts
+++ b/src/store/saveStatePersistence.test.ts
@@ -46,6 +46,11 @@ describe('saveStatePersistence survivor progression', () => {
         status: 'active',
         runId: 'run-1',
         gameId: 'game-1',
+        players: [
+          { id: 'user', name: 'You', avatar: '🙂', status: 'active', isUser: true },
+          { id: 'ai-1', name: 'AI 1', avatar: 'A', status: 'active' },
+          { id: 'ai-2', name: 'AI 2', avatar: 'B', status: 'active' },
+        ],
         modeSpecific: {
           kind: 'survivor',
           currentDay: 25,

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -13,8 +13,14 @@ import type { GameState } from '../types';
 import type { GameMode } from '../modes/modeTypes';
 import { normalizeGameMode } from '../modes/gameModes';
 import { isSurvivorRunTerminal } from '../modes/survivorRun';
+import {
+  applySurvivorAchievementProgress,
+  getSurvivorProgressDay,
+  normalizeSurvivorAchievementUnlockMap,
+} from '../modes/survivorAchievements';
 import type { FinaleState } from './finaleSlice';
 import type { SocialState } from '../social/types';
+import type { SurvivorAchievementUnlockMap } from '../modes/survivorAchievements';
 
 /** Prefix for per-profile saved-season localStorage keys. */
 export const SAVED_STATE_KEY_PREFIX = 'bbmobilenew:savedSeason:';
@@ -38,6 +44,7 @@ export interface SavedSeasonSnapshot {
 
 export interface SavedRunProfileStats {
   maxSurvivorDaysSurvived: number;
+  survivorAchievementsUnlocked: SurvivorAchievementUnlockMap;
 }
 
 export interface SavedRunProfile {
@@ -67,7 +74,7 @@ function emptySavedRunProfile(profileId: string): SavedRunProfile {
     activeRunId: null,
     lastPlayedRunId: null,
     runs: {},
-    stats: { maxSurvivorDaysSurvived: 0 },
+    stats: { maxSurvivorDaysSurvived: 0, survivorAchievementsUnlocked: {} },
   };
 }
 
@@ -79,14 +86,6 @@ function isRunSnapshotResumable(snapshot: SavedSeasonSnapshot | undefined): snap
   if (!snapshot) return false;
   if (isSurvivorRunTerminal(snapshot.game)) return false;
   return snapshot.game.status !== 'completed' && snapshot.game.status !== 'failed';
-}
-
-function getSurvivorBestDay(snapshot: SavedSeasonSnapshot | undefined): number {
-  if (!snapshot || snapshot.game.mode !== 'survivor') return 0;
-  const modeSpecific = snapshot.game.modeSpecific?.kind === 'survivor'
-    ? snapshot.game.modeSpecific
-    : null;
-  return Math.max(snapshot.game.week ?? 1, modeSpecific?.bestDayReached ?? 1, modeSpecific?.currentDay ?? 1);
 }
 
 function coerceSnapshot(raw: unknown, profileId: string): SavedSeasonSnapshot | null {
@@ -107,7 +106,7 @@ function normalizeRunProfile(profileId: string, parsed: Partial<SavedRunProfile>
   const resumableSurvivor = isRunSnapshotResumable(survivor) ? survivor : undefined;
   const maxSurvivorDaysSurvived = Math.max(
     typeof parsed.stats?.maxSurvivorDaysSurvived === 'number' ? parsed.stats.maxSurvivorDaysSurvived : 0,
-    getSurvivorBestDay(survivor),
+    getSurvivorProgressDay(survivor?.game),
   );
   return {
     version: 2,
@@ -119,7 +118,12 @@ function normalizeRunProfile(profileId: string, parsed: Partial<SavedRunProfile>
       ...(resumableClassic ? { classic: resumableClassic } : {}),
       ...(resumableSurvivor ? { survivor: resumableSurvivor } : {}),
     },
-    stats: { maxSurvivorDaysSurvived },
+    stats: {
+      maxSurvivorDaysSurvived,
+      survivorAchievementsUnlocked: normalizeSurvivorAchievementUnlockMap(
+        parsed.stats?.survivorAchievementsUnlocked,
+      ),
+    },
   };
 }
 
@@ -199,8 +203,17 @@ export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot
   const current = loadSavedRunProfile(profileId);
   const runId = getRunId(snapshot);
   const survivorBest = mode === 'survivor'
-    ? Math.max(current.stats.maxSurvivorDaysSurvived, getSurvivorBestDay(snapshot))
+    ? Math.max(current.stats.maxSurvivorDaysSurvived, getSurvivorProgressDay(snapshot.game))
     : current.stats.maxSurvivorDaysSurvived;
+  const survivorAchievementsUnlocked =
+    mode === 'survivor'
+      ? applySurvivorAchievementProgress(
+          current.stats.survivorAchievementsUnlocked,
+          getSurvivorProgressDay(snapshot.game),
+          runId,
+          snapshot.savedAt,
+        ).unlocks
+      : current.stats.survivorAchievementsUnlocked;
   const nextRuns = { ...current.runs };
   const resumable = isRunSnapshotResumable(snapshot);
   if (resumable) {
@@ -217,9 +230,33 @@ export function saveRunSnapshot(profileId: string, snapshot: SavedSeasonSnapshot
     stats: {
       ...current.stats,
       maxSurvivorDaysSurvived: survivorBest,
+      survivorAchievementsUnlocked,
     },
   };
   return saveRunProfile(next);
+}
+
+export function markSurvivorAchievementCelebrationSeen(
+  profileId: string,
+  achievementId: string,
+): boolean {
+  const current = loadSavedRunProfile(profileId);
+  const unlock = current.stats.survivorAchievementsUnlocked[achievementId];
+  if (!unlock || unlock.celebrationSeen) return false;
+
+  return saveRunProfile({
+    ...current,
+    stats: {
+      ...current.stats,
+      survivorAchievementsUnlocked: {
+        ...current.stats.survivorAchievementsUnlocked,
+        [achievementId]: {
+          ...unlock,
+          celebrationSeen: true,
+        },
+      },
+    },
+  });
 }
 
 export function getSavedRun(profileId: string, mode: GameMode): SavedSeasonSnapshot | null {

--- a/tests/integration/challenge.flow.dispatch.test.tsx
+++ b/tests/integration/challenge.flow.dispatch.test.tsx
@@ -16,10 +16,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { configureStore } from '@reduxjs/toolkit';
 import gameReducer, { setPhase } from '../../src/store/gameSlice';
 import challengeReducer, { startChallenge, recordRun, setPendingChallenge } from '../../src/store/challengeSlice';
+import profilesReducer, { type ProfilesState } from '../../src/store/profilesSlice';
 import settingsReducer, { DEFAULT_SETTINGS } from '../../src/store/settingsSlice';
 import publicOpinionReducer from '../../src/publicOpinion/publicOpinionSlice';
 import GameScreen from '../../src/screens/GameScreen/GameScreen';
-import { getBracketPoolForContext } from '../../src/ai/competition/bracketTemplate';
+import { getApprovedCompetitionGameKeys, getBracketPoolForContext } from '../../src/ai/competition/bracketTemplate';
+import { createSurvivorRun } from '../../src/modes/survivorRun';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -39,6 +41,7 @@ vi.mock('../../src/components/ui/TvZone', () => ({
 const REDUCERS = {
   game: gameReducer,
   challenge: challengeReducer,
+  profiles: profilesReducer,
   settings: settingsReducer,
   publicOpinion: publicOpinionReducer,
 } as const;
@@ -64,6 +67,20 @@ function makeStoreWithCompSelection(
           },
         },
       },
+    },
+  });
+}
+
+function makeSurvivorStore() {
+  return configureStore({
+    reducer: REDUCERS,
+    preloadedState: {
+      game: createSurvivorRun(),
+      profiles: {
+        profiles: [],
+        activeProfileId: null,
+        isGuest: true,
+      } satisfies ProfilesState,
     },
   });
 }
@@ -338,6 +355,18 @@ describe('startChallenge – compSelection modes', () => {
     const pending = store.getState().challenge.pending;
     expect(pending).not.toBeNull();
     expect(typeof pending?.game.key).toBe('string');
+  });
+
+  it('survivor mode only selects games approved in the classical template', () => {
+    const store = makeSurvivorStore();
+    const approvedKeys = new Set(getApprovedCompetitionGameKeys());
+
+    dispatchThunk(store, startChallenge(42, ['p1', 'p2']));
+
+    const pending = store.getState().challenge.pending;
+    expect(pending).not.toBeNull();
+    expect(pending?.game.retired).toBe(false);
+    expect(approvedKeys.has(pending?.game.key ?? '')).toBe(true);
   });
 
   it('debug forceGameKey overrides compSelection mode', () => {


### PR DESCRIPTION
## What changed
- Survivor achievement unlocks now persist at the profile level inside the saved-run profile blob.
- The Profile screen now shows Survivor progress, unlocked counts, and the full achievement grid.
- Added a short, skippable in-game celebration overlay for unseen Survivor unlocks.
- Added tests covering inclusive thresholds, secret masking, celebration repeat suppression, and persistence normalization.

## Why
- Survivor achievements are profile progression, not run progression.
- Players should never see the festive unlock flow again once a profile has already unlocked an achievement.
- The Profile screen still needs to show the achievement history after the unlock has been celebrated.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npx vitest run src/modes/survivorAchievements.test.ts src/store/saveStatePersistence.test.ts`