### PR TITLE
[codex] add Survivor debug controls

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -32,6 +32,7 @@ import { INCOMING_INTERACTION_PHASE_ORDER } from '../../social/incomingInteracti
 import { socialConfig } from '../../social/socialConfig';
 import FinaleDebugControls from './FinaleControls.debug';
 import MinigameDebugControls from './MinigameDebugControls';
+import SurvivorDebugControls from './SurvivorDebugControls';
 import { isDebugAccessGranted } from '../../utils/debugMode';
 import type { ForcedShockType, Phase } from '../../types';
 import type { IncomingInteraction, IncomingInteractionType } from '../../social/types';
@@ -687,6 +688,9 @@ export default function DebugPanel() {
 
             {/* ── Minigame Debug Controls ── */}
             <MinigameDebugControls />
+
+            {/* ── Survivor Debug Controls ── */}
+            <SurvivorDebugControls />
           </div>
         </aside>
       )}

--- a/src/components/DebugPanel/SurvivorDebugControls.tsx
+++ b/src/components/DebugPanel/SurvivorDebugControls.tsx
@@ -1,0 +1,92 @@
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { clearSurvivorReplacementTransition, hydrateGame } from '../../store/gameSlice';
+import {
+  createSurvivorRun,
+  getSurvivorCurrentDay,
+  isSurvivorRunTerminal,
+  markSurvivorDay,
+  terminalizeSurvivorRun,
+} from '../../modes/survivorRun';
+
+export default function SurvivorDebugControls() {
+  const dispatch = useAppDispatch();
+  const game = useAppSelector((state) => state.game);
+
+  const isSurvivorMode = game.mode === 'survivor';
+  const survivorState = game.modeSpecific?.kind === 'survivor' ? game.modeSpecific : null;
+  const currentDay = isSurvivorMode ? getSurvivorCurrentDay(game) : null;
+  const isTerminal = isSurvivorMode ? isSurvivorRunTerminal(game) : false;
+  const replacementTransition = survivorState?.replacementTransition ?? null;
+
+  const handleStartRun = () => {
+    dispatch(hydrateGame(createSurvivorRun()));
+  };
+
+  const handleAdvanceDay = () => {
+    if (!isSurvivorMode) return;
+    dispatch(hydrateGame(markSurvivorDay(game)));
+  };
+
+  const handleTerminalizeRun = () => {
+    if (!isSurvivorMode) return;
+    dispatch(hydrateGame(terminalizeSurvivorRun(game)));
+  };
+
+  const handleClearTransition = () => {
+    dispatch(clearSurvivorReplacementTransition());
+  };
+
+  return (
+    <section className="dbg-section">
+      <h3 className="dbg-section__title">Survivor Debug</h3>
+
+      <div className="dbg-row">
+        <button className="dbg-btn dbg-btn--wide" onClick={handleStartRun}>
+          Start Survivor Run
+        </button>
+      </div>
+
+      <dl className="dbg-grid">
+        <dt>Mode</dt>
+        <dd>{isSurvivorMode ? 'survivor' : 'classic'}</dd>
+        <dt>Current Day</dt>
+        <dd>{currentDay ?? 'n/a'}</dd>
+        <dt>Best Day</dt>
+        <dd>{survivorState?.bestDayReached ?? 'n/a'}</dd>
+        <dt>Robo Evicted</dt>
+        <dd>{survivorState?.totalRoboContestantsEvicted ?? 'n/a'}</dd>
+        <dt>Replacement</dt>
+        <dd>
+          {replacementTransition
+            ? `${replacementTransition.outgoingPlayerSnapshot.name} -> ${replacementTransition.incomingPlayerId}`
+            : 'n/a'}
+        </dd>
+      </dl>
+
+      <div className="dbg-row">
+        <button
+          className="dbg-btn dbg-btn--wide"
+          onClick={handleAdvanceDay}
+          disabled={!isSurvivorMode || isTerminal}
+        >
+          Advance Survivor Day
+        </button>
+        <button
+          className="dbg-btn dbg-btn--wide"
+          onClick={handleTerminalizeRun}
+          disabled={!isSurvivorMode}
+        >
+          Terminalize Run
+        </button>
+      </div>
+
+      {replacementTransition && (
+        <div className="dbg-row">
+          <button className="dbg-btn dbg-btn--wide" onClick={handleClearTransition}>
+            Clear Replacement Transition
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/DebugPanel/__tests__/SurvivorDebugControls.test.tsx
+++ b/src/components/DebugPanel/__tests__/SurvivorDebugControls.test.tsx
@@ -1,0 +1,78 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import SurvivorDebugControls from '../SurvivorDebugControls';
+import gameReducer, { hydrateGame } from '../../../store/gameSlice';
+import { createSurvivorRun } from '../../../modes/survivorRun';
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+    },
+  });
+}
+
+describe('SurvivorDebugControls', () => {
+  it('starts a survivor run from the debug menu', async () => {
+    const user = userEvent.setup();
+    const store = makeStore();
+
+    render(
+      <Provider store={store}>
+        <SurvivorDebugControls />
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start Survivor Run' }));
+
+    expect(store.getState().game.mode).toBe('survivor');
+    expect(store.getState().game.players).toHaveLength(8);
+  });
+
+  it('advances the survivor day when the run is active', async () => {
+    const user = userEvent.setup();
+    const store = makeStore();
+    const survivorGame = createSurvivorRun();
+    survivorGame.week = 4;
+    if (survivorGame.modeSpecific?.kind === 'survivor') {
+      survivorGame.modeSpecific.currentDay = 2;
+      survivorGame.modeSpecific.bestDayReached = 2;
+    }
+    store.dispatch(hydrateGame(survivorGame));
+
+    render(
+      <Provider store={store}>
+        <SurvivorDebugControls />
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Advance Survivor Day' }));
+
+    const gameState = store.getState().game;
+    if (gameState.modeSpecific?.kind !== 'survivor') {
+      throw new Error('Expected survivor mode state');
+    }
+
+    expect(gameState.modeSpecific.currentDay).toBe(4);
+  });
+
+  it('terminalizes a survivor run for hard-stop testing', async () => {
+    const user = userEvent.setup();
+    const store = makeStore();
+    store.dispatch(hydrateGame(createSurvivorRun()));
+
+    render(
+      <Provider store={store}>
+        <SurvivorDebugControls />
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Terminalize Run' }));
+
+    expect(store.getState().game.status).toBe('failed');
+    expect(store.getState().game.tvFeed[0]?.text).toContain('Survivor run ended');
+  });
+});


### PR DESCRIPTION
Adds a Survivor-specific section to the debug panel so the mode can be tested from the same UI used for classic games.

What changed:
- Start or restart a Survivor run from the debug menu
- Advance the Survivor day counter for progression testing
- Terminalize a Survivor run to validate the hard-stop state
- Clear an active replacement transition when inspecting eviction/replacement behavior
- Add focused tests for the new Survivor debug controls

Verification:
- npm run lint
- npm run test -- SurvivorDebugControls
- npm run build