### PR TITLE
[codex] Fix Survivor achievement profile and reveal flow

### DIFF
--- a/src/components/SurvivorAchievementCelebration.css
+++ b/src/components/SurvivorAchievementCelebration.css
@@ -6,30 +6,117 @@
   align-items: center;
   justify-content: center;
   padding:
-    calc(18px + env(safe-area-inset-top))
-    calc(18px + env(safe-area-inset-right))
-    calc(18px + env(safe-area-inset-bottom))
-    calc(18px + env(safe-area-inset-left));
-  border: 0;
-  background: rgba(3, 5, 12, 0.84);
-  color: inherit;
-  cursor: pointer;
-  touch-action: manipulation;
+    calc(20px + env(safe-area-inset-top))
+    calc(20px + env(safe-area-inset-right))
+    calc(20px + env(safe-area-inset-bottom))
+    calc(20px + env(safe-area-inset-left));
+  background:
+    radial-gradient(circle at top, rgba(118, 100, 255, 0.18), transparent 38%),
+    rgba(3, 5, 12, 0.9);
+  isolation: isolate;
+}
+
+.survivor-celebration__backdrop {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.survivor-celebration__ray,
+.survivor-celebration__glow {
+  position: absolute;
+  display: block;
+}
+
+.survivor-celebration__ray {
+  top: 50%;
+  width: 46vmax;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(175, 192, 255, 0.7), transparent);
+  opacity: 0.42;
+}
+
+.survivor-celebration__ray--left {
+  left: -6vmax;
+  transform: rotate(-18deg);
+}
+
+.survivor-celebration__ray--right {
+  right: -6vmax;
+  transform: rotate(18deg);
+}
+
+.survivor-celebration__glow {
+  border-radius: 999px;
+  filter: blur(24px);
+}
+
+.survivor-celebration__glow--top {
+  top: 10%;
+  left: 14%;
+  width: 220px;
+  height: 220px;
+  background: rgba(95, 144, 255, 0.2);
+}
+
+.survivor-celebration__glow--bottom {
+  right: 12%;
+  bottom: 12%;
+  width: 280px;
+  height: 280px;
+  background: rgba(144, 108, 255, 0.18);
 }
 
 .survivor-celebration__card {
-  width: min(100%, 440px);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  position: relative;
+  width: min(100%, 560px);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   background:
-    radial-gradient(circle at top left, rgba(125, 104, 255, 0.2), transparent 42%),
-    linear-gradient(180deg, rgba(15, 21, 40, 0.98), rgba(8, 12, 24, 0.98));
+    radial-gradient(circle at top left, rgba(125, 104, 255, 0.24), transparent 34%),
+    radial-gradient(circle at top right, rgba(77, 198, 255, 0.16), transparent 32%),
+    linear-gradient(180deg, rgba(16, 22, 44, 0.98), rgba(7, 10, 20, 0.99));
   box-shadow:
-    0 30px 70px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  padding: 18px;
-  text-align: left;
+    0 35px 90px rgba(0, 0, 0, 0.52),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  padding: 24px;
+  overflow: hidden;
+}
+
+.survivor-celebration__card::before,
+.survivor-celebration__card::after {
+  content: '';
+  position: absolute;
   pointer-events: none;
+}
+
+.survivor-celebration__card::before {
+  inset: 0;
+  background:
+    linear-gradient(120deg, transparent 28%, rgba(255, 255, 255, 0.09) 46%, transparent 62%);
+  opacity: 0.22;
+}
+
+.survivor-celebration__card::after {
+  left: 16px;
+  right: 16px;
+  top: 16px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.26), transparent);
+}
+
+.survivor-celebration__chrome {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.survivor-celebration__chrome span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
 }
 
 .survivor-celebration__eyebrow {
@@ -37,101 +124,165 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 16px;
 }
 
 .survivor-celebration__pill,
 .survivor-celebration__tier {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  padding: 0 10px;
+  min-height: 30px;
+  padding: 0 12px;
   border-radius: 999px;
-  font-size: 0.66rem;
-  font-weight: 800;
+  font-size: 0.7rem;
+  font-weight: 900;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .survivor-celebration__pill {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.09);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .survivor-celebration__tier {
-  background: rgba(110, 140, 255, 0.14);
-  color: rgba(187, 198, 255, 0.96);
+  background: rgba(107, 183, 255, 0.16);
+  color: rgba(213, 232, 255, 0.98);
 }
 
-.survivor-celebration__body {
+.survivor-celebration__hero {
+  position: relative;
+  z-index: 1;
   display: grid;
-  gap: 8px;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.survivor-celebration__day {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(151, 196, 255, 0.84);
 }
 
 .survivor-celebration__title {
   margin: 0;
-  font-size: 1.35rem;
-  line-height: 1.1;
+  font-size: clamp(2rem, 5vw, 2.9rem);
+  line-height: 1.02;
   font-weight: 900;
-  color: rgba(255, 255, 255, 0.96);
+  color: rgba(255, 255, 255, 0.98);
+  text-wrap: balance;
 }
 
 .survivor-celebration__subtitle {
   margin: 0;
-  font-size: 0.92rem;
-  line-height: 1.5;
-  color: rgba(255, 255, 255, 0.74);
-}
-
-.survivor-celebration__meta,
-.survivor-celebration__footer {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  max-width: 36ch;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .survivor-celebration__meta {
-  margin-top: 8px;
-  padding: 12px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.76);
-  font-size: 0.82rem;
-  line-height: 1.4;
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.survivor-celebration__meta-block {
+  padding: 14px 14px 15px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.survivor-celebration__meta-label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.survivor-celebration__meta-value {
+  display: block;
+  font-size: 0.96rem;
+  font-weight: 800;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .survivor-celebration__footer {
-  margin-top: 14px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.42);
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.survivor-celebration__continue {
+  min-height: 56px;
+  border: 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #6f79ff, #9d64ff);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  box-shadow: 0 18px 34px rgba(95, 94, 255, 0.34);
+}
+
+.survivor-celebration__hint {
+  margin: 0;
+  text-align: center;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.52);
 }
 
 .survivor-celebration[data-tier='legendary'] .survivor-celebration__tier {
-  background: rgba(255, 177, 84, 0.18);
-  color: rgba(255, 214, 167, 0.98);
+  background: rgba(255, 181, 93, 0.18);
+  color: rgba(255, 222, 182, 0.98);
 }
 
 .survivor-celebration[data-tier='mythic'] .survivor-celebration__card {
   background:
-    radial-gradient(circle at top left, rgba(120, 233, 255, 0.24), transparent 40%),
-    radial-gradient(circle at top right, rgba(137, 104, 255, 0.2), transparent 42%),
-    linear-gradient(180deg, rgba(9, 18, 32, 0.99), rgba(5, 8, 18, 0.99));
+    radial-gradient(circle at top left, rgba(115, 238, 255, 0.22), transparent 34%),
+    radial-gradient(circle at top right, rgba(157, 113, 255, 0.24), transparent 32%),
+    linear-gradient(180deg, rgba(10, 19, 35, 0.99), rgba(4, 8, 17, 1));
 }
 
-.survivor-celebration[data-effect='mystery'] .survivor-celebration__pill {
-  background: rgba(255, 255, 255, 0.12);
+.survivor-celebration[data-effect='mystery'] .survivor-celebration__card::before {
+  background:
+    linear-gradient(90deg, transparent 0, rgba(255, 255, 255, 0.05) 18%, transparent 34%),
+    linear-gradient(115deg, transparent 30%, rgba(199, 129, 255, 0.12) 50%, transparent 68%);
+  opacity: 0.34;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .survivor-celebration {
     align-items: flex-end;
   }
 
   .survivor-celebration__card {
     width: 100%;
-    border-radius: 18px 18px 12px 12px;
+    border-radius: 24px;
+    padding: 22px 18px 18px;
+  }
+
+  .survivor-celebration__meta {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .survivor-celebration__card::before,
+  .survivor-celebration__backdrop {
+    display: none;
   }
 }

--- a/src/components/SurvivorAchievementCelebration.tsx
+++ b/src/components/SurvivorAchievementCelebration.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useAppSelector } from '../store/hooks';
 import { selectActiveProfileId, selectIsGuest } from '../store/profilesSlice';
 import { selectIsWaitingForInput } from '../store/selectors';
@@ -11,7 +12,7 @@ import {
 } from '../modes/survivorAchievements';
 import './SurvivorAchievementCelebration.css';
 
-const AUTO_DISMISS_MS = 2200;
+const BACKDROP_DISMISS_DELAY_MS = 1200;
 
 export default function SurvivorAchievementCelebration() {
   const activeProfileId = useAppSelector(selectActiveProfileId);
@@ -19,6 +20,7 @@ export default function SurvivorAchievementCelebration() {
   const waitingForInput = useAppSelector(selectIsWaitingForInput);
   const game = useAppSelector((state) => state.game);
   const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+  const [backdropDismissId, setBackdropDismissId] = useState<string | null>(null);
   const dismissingRef = useRef<string | null>(null);
 
   const celebration = useMemo(() => {
@@ -33,9 +35,7 @@ export default function SurvivorAchievementCelebration() {
     }
 
     const savedProfile = loadSavedRunProfile(activeProfileId);
-    const candidateDefinitions = Object.values(
-      savedProfile.stats.survivorAchievementsUnlocked,
-    )
+    const candidateDefinitions = Object.values(savedProfile.stats.survivorAchievementsUnlocked)
       .filter((unlock) => !unlock.celebrationSeen && !dismissedIds.includes(unlock.id))
       .map((unlock) => SURVIVOR_ACHIEVEMENTS_BY_ID[unlock.id])
       .filter((achievement): achievement is SurvivorAchievementDefinition => achievement != null);
@@ -52,27 +52,23 @@ export default function SurvivorAchievementCelebration() {
 
   const profileId = activeProfileId ?? '';
   const currentCelebration = celebration;
+  const celebrationId = currentCelebration?.achievement.id ?? null;
+  const backdropDismissEnabled = celebrationId != null && backdropDismissId === celebrationId;
 
   useEffect(() => {
-    if (!currentCelebration || !profileId) return undefined;
+    dismissingRef.current = null;
+    if (!celebrationId) return undefined;
 
     const timer = window.setTimeout(() => {
-      if (dismissingRef.current === currentCelebration.achievement.id) return;
-      dismissingRef.current = currentCelebration.achievement.id;
-      void markSurvivorAchievementCelebrationSeen(profileId, currentCelebration.achievement.id);
-      setDismissedIds((current) =>
-        current.includes(currentCelebration.achievement.id)
-          ? current
-          : [...current, currentCelebration.achievement.id],
-      );
-    }, AUTO_DISMISS_MS);
+      setBackdropDismissId(celebrationId);
+    }, BACKDROP_DISMISS_DELAY_MS);
 
     return () => window.clearTimeout(timer);
-  }, [currentCelebration, profileId]);
+  }, [celebrationId]);
 
   if (!currentCelebration || !profileId) return null;
 
-  const celebrationData = celebration!;
+  const celebrationData = currentCelebration;
   const { display } = celebrationData;
   const unlockDateLabel = display.unlock?.unlockedAt
     ? new Intl.DateTimeFormat(undefined, {
@@ -93,33 +89,91 @@ export default function SurvivorAchievementCelebration() {
     );
   }
 
+  function handleBackdropClick(event: MouseEvent<HTMLDivElement>) {
+    if (event.target !== event.currentTarget || !backdropDismissEnabled) return;
+    dismiss();
+  }
+
   return (
-    <button
-      type="button"
-      className="survivor-celebration"
-      data-tier={display.tier}
-      data-effect={display.effectStyle}
-      aria-label={`Survivor achievement unlocked: ${display.title}. Tap to continue.`}
-      onClick={dismiss}
-    >
-      <div className="survivor-celebration__card">
-        <div className="survivor-celebration__eyebrow">
-          <span className="survivor-celebration__pill">Survivor unlock</span>
-          <span className="survivor-celebration__tier">{display.tierLabel}</span>
+    <AnimatePresence>
+      <motion.div
+        key={celebrationData.achievement.id}
+        className="survivor-celebration"
+        data-tier={display.tier}
+        data-effect={display.effectStyle}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.24, ease: 'easeOut' }}
+        onClick={handleBackdropClick}
+        aria-label={`Survivor achievement unlocked: ${display.title}`}
+      >
+        <div className="survivor-celebration__backdrop" aria-hidden="true">
+          <span className="survivor-celebration__ray survivor-celebration__ray--left" />
+          <span className="survivor-celebration__ray survivor-celebration__ray--right" />
+          <span className="survivor-celebration__glow survivor-celebration__glow--top" />
+          <span className="survivor-celebration__glow survivor-celebration__glow--bottom" />
         </div>
-        <div className="survivor-celebration__body">
-          <p className="survivor-celebration__title">{display.title}</p>
-          <p className="survivor-celebration__subtitle">{display.subtitle}</p>
-          <div className="survivor-celebration__meta">
-            <span>Day {display.day}</span>
-            <span>{display.requirement}</span>
+
+        <motion.section
+          className="survivor-celebration__card"
+          initial={{ opacity: 0, y: 28, scale: 0.96 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 20, scale: 0.98 }}
+          transition={{ duration: 0.28, ease: 'easeOut' }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="survivor-achievement-title"
+        >
+          <div className="survivor-celebration__chrome" aria-hidden="true">
+            <span />
+            <span />
+            <span />
           </div>
-        </div>
-        <div className="survivor-celebration__footer">
-          <span>Unlocked {unlockDateLabel}</span>
-          <span>Tap anywhere to continue</span>
-        </div>
-      </div>
-    </button>
+          <div className="survivor-celebration__eyebrow">
+            <span className="survivor-celebration__pill">Achievement Unlocked</span>
+            <span className="survivor-celebration__tier">{display.tierLabel}</span>
+          </div>
+
+          <div className="survivor-celebration__hero">
+            <p className="survivor-celebration__day">Day {display.day}</p>
+            <h2 id="survivor-achievement-title" className="survivor-celebration__title">
+              {display.title}
+            </h2>
+            <p className="survivor-celebration__subtitle">{display.subtitle}</p>
+          </div>
+
+          <div className="survivor-celebration__meta">
+            <div className="survivor-celebration__meta-block">
+              <span className="survivor-celebration__meta-label">Category</span>
+              <span className="survivor-celebration__meta-value">{display.categoryLabel}</span>
+            </div>
+            <div className="survivor-celebration__meta-block">
+              <span className="survivor-celebration__meta-label">Reached</span>
+              <span className="survivor-celebration__meta-value">
+                Day {display.unlock?.unlockedAtDay ?? display.day}
+              </span>
+            </div>
+            <div className="survivor-celebration__meta-block">
+              <span className="survivor-celebration__meta-label">Unlocked</span>
+              <span className="survivor-celebration__meta-value">{unlockDateLabel}</span>
+            </div>
+          </div>
+
+          <div className="survivor-celebration__footer">
+            <button
+              type="button"
+              className="survivor-celebration__continue"
+              onClick={dismiss}
+            >
+              Continue
+            </button>
+            <p className="survivor-celebration__hint">
+              {backdropDismissEnabled ? 'Tap outside to close.' : 'Take it in for a second.'}
+            </p>
+          </div>
+        </motion.section>
+      </motion.div>
+    </AnimatePresence>
   );
 }

--- a/src/modes/survivorAchievements.test.ts
+++ b/src/modes/survivorAchievements.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   SURVIVOR_ACHIEVEMENTS,
+  buildUnlockedSurvivorAchievementDisplayModels,
   buildSurvivorAchievementDisplayModel,
   getEligibleSurvivorAchievements,
   getNextUnseenSurvivorCelebration,
@@ -64,6 +65,33 @@ describe('survivorAchievements helpers', () => {
     expect(unlocked.title).toBe(secretAchievement!.name);
     expect(unlocked.subtitle).toBe(secretAchievement!.subtitle);
     expect(unlocked.requirement).toBe('Unlocked on Day 404.');
+  });
+
+  it('builds profile cards from unlocked achievements only', () => {
+    const cards = buildUnlockedSurvivorAchievementDisplayModels({
+      'survivor-day-25': {
+        id: 'survivor-day-25',
+        unlockedAt: '2026-07-01T09:30:00.000Z',
+        unlockedAtDay: 25,
+        firstRunId: 'run-1',
+        celebrationSeen: true,
+      },
+      'survivor-anomaly-404': {
+        id: 'survivor-anomaly-404',
+        unlockedAt: '2026-07-02T09:30:00.000Z',
+        unlockedAtDay: 404,
+        firstRunId: 'run-2',
+        celebrationSeen: false,
+      },
+    });
+
+    expect(cards).toHaveLength(2);
+    expect(cards.map((card) => card.id)).toEqual([
+      'survivor-anomaly-404',
+      'survivor-day-25',
+    ]);
+    expect(cards[0].title).toBe('Human Not Found');
+    expect(cards[1].title).toBe('Not a Glitch');
   });
 
   it('does not repeat the celebration once it has been seen', () => {

--- a/src/modes/survivorAchievements.ts
+++ b/src/modes/survivorAchievements.ts
@@ -62,8 +62,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-10',
     day: 10,
-    name: 'First Spar',
-    subtitle: 'Ten days in Survivor Mode is enough to start leaving a mark.',
+    name: 'Signal Detected',
+    subtitle: 'You survived long enough for the system to notice you.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'bronze',
@@ -72,8 +72,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-25',
     day: 25,
-    name: 'Heat Check',
-    subtitle: 'A full month of pressure, and the run is still breathing.',
+    name: 'Not a Glitch',
+    subtitle: 'Twenty-five days in. This is no accident anymore.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'bronze',
@@ -82,8 +82,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-50',
     day: 50,
-    name: 'Halfway Fire',
-    subtitle: 'Fifty days in Survivor Mode with the game still in your hands.',
+    name: 'Half-Century Human',
+    subtitle: 'Fifty days survived against the synthetic house.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'silver',
@@ -92,8 +92,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-100',
     day: 100,
-    name: 'Century Run',
-    subtitle: 'Three digits of Survivor Mode, no flinch required.',
+    name: 'The Human Anomaly',
+    subtitle: 'One hundred days survived. The AI has no clean explanation.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'silver',
@@ -102,8 +102,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-200',
     day: 200,
-    name: 'Pressure Proof',
-    subtitle: 'Two hundred days and the floor is still holding.',
+    name: 'Still Loading',
+    subtitle: 'Two hundred days in, and the exit button is still missing.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'gold',
@@ -112,8 +112,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-300',
     day: 300,
-    name: 'Long Haul',
-    subtitle: 'Survivor Mode becomes a habit somewhere around here.',
+    name: 'Long-Term Problem',
+    subtitle: 'You are no longer a contestant. You are a design flaw.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'gold',
@@ -122,8 +122,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-365',
     day: 365,
-    name: 'Year One',
-    subtitle: 'A full year in Survivor Mode deserves a proper spotlight.',
+    name: 'One Year in the Machine',
+    subtitle: 'Three hundred sixty-five days inside an endless game.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'platinum',
@@ -132,8 +132,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-400',
     day: 400,
-    name: 'Skyline',
-    subtitle: 'The run is starting to look architectural.',
+    name: 'Error Tolerance',
+    subtitle: 'Four hundred days survived. The system has adapted badly.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'platinum',
@@ -142,8 +142,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-500',
     day: 500,
-    name: 'Five Hundred Club',
-    subtitle: 'A half-millennium of Survivor Mode is real commitment.',
+    name: 'Myth of the House',
+    subtitle: 'The AI players are replacing each other around your legend.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'legendary',
@@ -152,8 +152,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-1000',
     day: 1000,
-    name: 'Millennium Survivor',
-    subtitle: 'A four-digit run that belongs on the wall.',
+    name: 'Permanent Error',
+    subtitle: 'One thousand days survived. The system has learned to fear the exception.',
     category: 'milestone',
     visibility: 'visible',
     tier: 'legendary',
@@ -162,8 +162,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-2000',
     day: 2000,
-    name: 'Deep Archive',
-    subtitle: 'Survivor Mode has become part of the profile history.',
+    name: 'Second Millennium',
+    subtitle: 'Two thousand days. The house has rebuilt itself around you.',
     category: 'ultra',
     visibility: 'visible',
     tier: 'mythic',
@@ -172,8 +172,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-3000',
     day: 3000,
-    name: 'Pressure Atlas',
-    subtitle: 'Three thousand days of keeping the lights on.',
+    name: 'Synthetic Folklore',
+    subtitle: 'New robo players enter already knowing your name.',
     category: 'ultra',
     visibility: 'visible',
     tier: 'mythic',
@@ -182,8 +182,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-4000',
     day: 4000,
-    name: 'Signal Tower',
-    subtitle: 'The Survivor profile is now visible from orbit.',
+    name: 'The Endless Resident',
+    subtitle: 'You do not live in the house. The house lives around you.',
     category: 'ultra',
     visibility: 'visible',
     tier: 'mythic',
@@ -192,8 +192,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-5000',
     day: 5000,
-    name: 'Mythic Five',
-    subtitle: 'Five thousand days in Survivor Mode changes the shape of the file.',
+    name: 'Impossible Tenant',
+    subtitle: 'Five thousand days survived. The game has stopped pretending this is normal.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -202,8 +202,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-6000',
     day: 6000,
-    name: 'Mythic Six',
-    subtitle: 'The profile has started collecting weather.',
+    name: 'Machine-Worn Human',
+    subtitle: 'The system is aging faster than you are.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -212,8 +212,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-7000',
     day: 7000,
-    name: 'Mythic Seven',
-    subtitle: 'Seven thousand days of pure stubbornness.',
+    name: 'Beyond Balance',
+    subtitle: 'No simulation was meant to carry you this far.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -222,8 +222,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-8000',
     day: 8000,
-    name: 'Mythic Eight',
-    subtitle: 'By this point, Survivor Mode feels like a second home hub.',
+    name: 'Permanent Occupant',
+    subtitle: 'Eight thousand days. The house has accepted the bug.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -232,8 +232,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-9000',
     day: 9000,
-    name: 'Mythic Nine',
-    subtitle: 'The archive is getting heavier by the day.',
+    name: 'Over 9000',
+    subtitle: 'The survival level is no longer measurable.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -242,8 +242,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-10000',
     day: 10000,
-    name: 'Ten Thousand Days',
-    subtitle: 'An impossible-looking milestone made visible anyway.',
+    name: 'Five-Digit Survivor',
+    subtitle: 'Ten thousand days. You are no longer in Survivor mode. Survivor mode is in you.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -252,8 +252,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-day-100000',
     day: 100000,
-    name: 'Forever Mode',
-    subtitle: 'A myth so large it has to be treated like a landmark.',
+    name: 'The Immortal Exception',
+    subtitle: 'One hundred thousand days. The system ends before you do.',
     category: 'mythic',
     visibility: 'visible',
     tier: 'mythic',
@@ -262,8 +262,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-69',
     day: 69,
-    name: 'Lucky 69',
-    subtitle: 'A suspiciously satisfying anomaly.',
+    name: 'Nice Try, Algorithm',
+    subtitle: 'The system tried to stay serious. You ruined that.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'silver',
@@ -273,7 +273,7 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
     id: 'survivor-anomaly-111',
     day: 111,
     name: 'Triple Signal',
-    subtitle: 'Three ones, no explanation needed.',
+    subtitle: 'Three ones. One human. Zero explanations.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'silver',
@@ -282,8 +282,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-314',
     day: 314,
-    name: 'Pi Day',
-    subtitle: 'A hidden curve in the run.',
+    name: 'Pi in the Machine',
+    subtitle: 'The numbers are irrational. So is your survival.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'gold',
@@ -292,8 +292,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-404',
     day: 404,
-    name: 'Not Found',
-    subtitle: 'The day the signal folded in on itself.',
+    name: 'Human Not Found',
+    subtitle: 'The system searched for your elimination. No result.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'gold',
@@ -302,8 +302,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-444',
     day: 444,
-    name: 'Mirror Wall',
-    subtitle: 'A pattern that looks like it belongs to someone else.',
+    name: 'Synchronized Threat',
+    subtitle: 'The house numbers lined up. Nobody feels safer.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'platinum',
@@ -312,8 +312,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-666',
     day: 666,
-    name: 'Triple Six',
-    subtitle: 'A loud little omen for the Survivor record book.',
+    name: 'Cursed Runtime',
+    subtitle: 'Something unholy is keeping this run alive.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'platinum',
@@ -322,8 +322,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-777',
     day: 777,
-    name: 'Jackpot Seven',
-    subtitle: 'A secret that arrives with extra sparkle.',
+    name: 'Jackpot Survivor',
+    subtitle: 'The house rolled lucky. Unfortunately, so did you.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'legendary',
@@ -332,8 +332,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-888',
     day: 888,
-    name: 'Infinite Loop',
-    subtitle: 'The run seems to know where it is going.',
+    name: 'Infinite Loop Energy',
+    subtitle: 'The symbols repeat. The run refuses to end.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'legendary',
@@ -342,8 +342,8 @@ const SURVIVOR_ACHIEVEMENT_DATA: SurvivorAchievementDefinition[] = [
   {
     id: 'survivor-anomaly-999',
     day: 999,
-    name: 'Almost There',
-    subtitle: 'One breath before the next major wall.',
+    name: 'Almost Permanent',
+    subtitle: 'One day before the line between player and bug disappears.',
     category: 'anomaly',
     visibility: 'secret',
     tier: 'legendary',
@@ -556,4 +556,27 @@ export function buildSurvivorAchievementDisplayModel(
     unlock: null,
     effectStyle: achievement.effectStyle,
   };
+}
+
+export function buildUnlockedSurvivorAchievementDisplayModels(
+  unlocks: SurvivorAchievementUnlockMap,
+): SurvivorAchievementDisplayModel[] {
+  return SURVIVOR_ACHIEVEMENTS
+    .filter((achievement) => unlocks[achievement.id] != null)
+    .map((achievement) =>
+      buildSurvivorAchievementDisplayModel(achievement, unlocks[achievement.id]),
+    )
+    .sort((left, right) => {
+      const rightUnlockDay = right.unlock?.unlockedAtDay ?? right.day;
+      const leftUnlockDay = left.unlock?.unlockedAtDay ?? left.day;
+      if (rightUnlockDay !== leftUnlockDay) return rightUnlockDay - leftUnlockDay;
+
+      const rightUnlockedAt = right.unlock?.unlockedAt ?? '';
+      const leftUnlockedAt = left.unlock?.unlockedAt ?? '';
+      if (rightUnlockedAt !== leftUnlockedAt) {
+        return rightUnlockedAt.localeCompare(leftUnlockedAt);
+      }
+
+      return right.day - left.day;
+    });
 }

--- a/src/screens/Profile/Profile.css
+++ b/src/screens/Profile/Profile.css
@@ -314,6 +314,20 @@
   gap: 10px;
 }
 
+.profile-screen__survivor-empty {
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.profile-screen__survivor-empty-hint {
+  margin: 8px 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .profile-screen__survivor-achievement {
   padding: 12px;
   border-radius: 12px;

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -11,8 +11,7 @@ import { imageIdToDataUrl } from '../../utils/imageDb';
 import { publicOpinionConfig } from '../../publicOpinion/publicOpinionConfig';
 import { normalizeAffinity } from '../../social/affinityUtils';
 import {
-  SURVIVOR_ACHIEVEMENTS,
-  buildSurvivorAchievementDisplayModel,
+  buildUnlockedSurvivorAchievementDisplayModels,
 } from '../../modes/survivorAchievements';
 import type { Phase, Player, StatusPillVariant } from '../../types';
 import './Profile.css';
@@ -497,10 +496,7 @@ export default function Profile() {
   const survivorUnlocks = savedRunProfile?.stats.survivorAchievementsUnlocked ?? {};
   const survivorHighestDay = savedRunProfile?.stats.maxSurvivorDaysSurvived ?? 0;
   const survivorUnlockedCount = Object.keys(survivorUnlocks).length;
-  const survivorTotalCount = SURVIVOR_ACHIEVEMENTS.length;
-  const survivorAchievementCards = SURVIVOR_ACHIEVEMENTS.map((achievement) =>
-    buildSurvivorAchievementDisplayModel(achievement, survivorUnlocks[achievement.id]),
-  );
+  const survivorAchievementCards = buildUnlockedSurvivorAchievementDisplayModels(survivorUnlocks);
 
   const gameInProgress = isGameActive || week > 1 || phase !== 'week_start';
   const goBack = () => {
@@ -816,9 +812,7 @@ export default function Profile() {
               Progress is saved to this profile and carries across Survivor runs.
             </p>
           </div>
-          <div className="profile-screen__survivor-count">
-            {survivorUnlockedCount}/{survivorTotalCount}
-          </div>
+          <div className="profile-screen__survivor-count">{survivorUnlockedCount} unlocked</div>
         </div>
         <div className="profile-screen__survivor-stats">
           <div className="profile-screen__survivor-stat">
@@ -831,13 +825,17 @@ export default function Profile() {
             <span className="profile-screen__survivor-stat-val">{survivorUnlockedCount}</span>
             <span className="profile-screen__survivor-stat-key">Unlocked</span>
           </div>
-          <div className="profile-screen__survivor-stat">
-            <span className="profile-screen__survivor-stat-val">{survivorTotalCount}</span>
-            <span className="profile-screen__survivor-stat-key">Total</span>
-          </div>
         </div>
         <div className="profile-screen__survivor-grid">
-          {survivorAchievementCards.map((achievement) => (
+          {survivorUnlockedCount === 0 ? (
+            <div className="profile-screen__survivor-empty">
+              <p className="profile-screen__empty-text">No Survivor achievements unlocked yet.</p>
+              <p className="profile-screen__survivor-empty-hint">
+                Reach Survivor Day 10 to unlock your first milestone.
+              </p>
+            </div>
+          ) : (
+            survivorAchievementCards.map((achievement) => (
             <article
               key={achievement.id}
               className={[
@@ -856,7 +854,11 @@ export default function Profile() {
               </div>
               <p className="profile-screen__survivor-name">{achievement.title}</p>
               <p className="profile-screen__survivor-subtitle">{achievement.subtitle}</p>
-              <p className="profile-screen__survivor-requirement">{achievement.requirement}</p>
+              <p className="profile-screen__survivor-requirement">
+                {achievement.visibility === 'secret'
+                  ? `Secret Day ${achievement.day}`
+                  : `Day ${achievement.day} milestone`}
+              </p>
               {achievement.isUnlocked && achievement.unlock ? (
                 <p className="profile-screen__survivor-unlocked">
                   Unlocked {formatIsoDate(achievement.unlock.unlockedAt)} · Day{' '}
@@ -864,7 +866,8 @@ export default function Profile() {
                 </p>
               ) : null}
             </article>
-          ))}
+            ))
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## What changed
- updated the Survivor achievement milestone and anomaly copy to the new approved names and subtitles
- changed the profile Survivor section to show only unlocked achievements, with a compact empty state when none are unlocked
- replaced the tiny auto-dismiss Survivor unlock card with a fullscreen blocking celebration overlay that waits for player interaction before being marked seen
- added focused coverage for unlocked-only Survivor profile cards

## Why
Survivor achievements are profile-level progression. The profile should feel earned rather than spoiler-heavy, and the unlock reveal needs to be readable and celebratory instead of disappearing before the player can register it.

## Impact
- profiles now hide locked Survivor achievements entirely
- a fresh profile gets a clean empty state with Day 10 guidance
- unlocked achievements keep their proper secret names once earned
- the Day 10 unlock now appears as a fullscreen reveal with a Continue action and delayed backdrop dismiss
- celebrations still stay Survivor-only and do not replay after dismissal

## Validation
- `npm run lint`
- `npm run test -- survivorAchievements saveStatePersistence`

## Notes
- left unrelated `NavBar` worktree changes untouched and out of this PR