### PR TITLE
[codex] Restrict homebar to the main game screen

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -20,6 +20,7 @@ export default function NavBar() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const reduxStore = useStore<RootState>();
+  const isMainGameRoute = pathname === '/game';
   const isGameOverRoute = pathname.startsWith('/game-over');
   // The homebar should appear as soon as a run is launched from IntroHub, so
   // we key visibility off the run state that resetGame/hydrateGame now mark
@@ -31,7 +32,8 @@ export default function NavBar() {
 
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  if (pathname === '/' || pathname.startsWith('/credits') || (!isGameActive && !isGameOverRoute)) return null;
+  if (!isMainGameRoute && !isGameOverRoute) return null;
+  if (!isGameActive && !isGameOverRoute) return null;
 
   function handleHomeClick() {
     if (!isGameActive) {

--- a/src/components/layout/__tests__/NavBar.test.tsx
+++ b/src/components/layout/__tests__/NavBar.test.tsx
@@ -43,12 +43,10 @@ describe('NavBar', () => {
     expect(screen.queryByRole('button', { name: 'PROFILE' })).toBeNull();
   });
 
-  it('keeps the bottom navigation available on profile routes during an active game', () => {
+  it('hides the bottom navigation on non-game routes even during an active game', () => {
     renderNavBar('/profile');
 
-    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'HOME' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'USER' })).toBeDefined();
+    expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
   });
 
   it('hides the bottom navigation on the credits route', () => {


### PR DESCRIPTION
## What changed
- restrict the bottom homebar so it renders only on the main `/game` screen
- keep the existing game-over exception intact
- update the nav test to assert that profile routes do not show the homebar during an active run

## Why
PR #1063 tied the homebar to any active run, which made it appear on side routes like profile, rules, and other non-main screens. That leaked the action bar into challenge/minigame flows and caused the bugs you flagged.

## Impact
- the homebar stays visible on the main gameplay surface with the faux TV and avatar roster
- the homebar is hidden on non-game routes even when a run is active
- this PR is isolated to the nav visibility fix only and does not include the other work from PR #1064

## Validation
- updated the route visibility test coverage for `NavBar`
- I did not rerun the full local checks from this sandboxed session