### PR TITLE
[codex] Hide homebar during fullscreen game flows

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -5,6 +5,8 @@ import './NavBar.css';
 import ConfirmExitModal from '../ConfirmExitModal/ConfirmExitModal';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame } from '../../store/gameSlice';
+import { selectPendingChallenge } from '../../store/challengeSlice';
+import { selectMusicScene } from '../../store/uiSlice';
 import { saveRunSnapshot } from '../../store/saveStatePersistence';
 import type { RootState } from '../../store/store';
 import GameBottomNav, { type NavTab } from '../GameBottomNav/GameBottomNav';
@@ -26,14 +28,32 @@ export default function NavBar() {
   // we key visibility off the run state that resetGame/hydrateGame now mark
   // active immediately.
   const isGameActive = useAppSelector((s) => s.game.status === 'active');
+  const pendingChallenge = useAppSelector(selectPendingChallenge);
+  const pendingMinigame = useAppSelector((s) => s.game.pendingMinigame);
+  const gamePhase = useAppSelector((s) => s.game.phase);
+  const seasonFinale = useAppSelector((s) => s.game.seasonFinale);
+  const battleBack = useAppSelector((s) => s.game.battleBack);
+  const favoritePlayer = useAppSelector((s) => s.game.favoritePlayer);
+  const musicScene = useAppSelector(selectMusicScene);
   const activeProfileId = useAppSelector((s) => s.profiles.activeProfileId);
   const isGuest = useAppSelector((s) => s.profiles.isGuest);
   const canPersistActiveRun = !isGuest && Boolean(activeProfileId);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const isFullScreenFlowActive =
+    Boolean(pendingChallenge) ||
+    Boolean(pendingMinigame) ||
+    gamePhase === 'jury' ||
+    gamePhase === 'jury_announcement' ||
+    gamePhase === 'jury_cinematic' ||
+    Boolean(seasonFinale) ||
+    musicScene !== 'none' ||
+    Boolean(battleBack?.competitionActive) ||
+    Boolean(favoritePlayer?.votingStarted);
 
   if (!isMainGameRoute && !isGameOverRoute) return null;
   if (!isGameActive && !isGameOverRoute) return null;
+  if (!isGameOverRoute && isFullScreenFlowActive) return null;
 
   function handleHomeClick() {
     if (!isGameActive) {

--- a/src/components/layout/__tests__/NavBar.test.tsx
+++ b/src/components/layout/__tests__/NavBar.test.tsx
@@ -4,21 +4,64 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import gameReducer from '../../../store/gameSlice';
+import challengeReducer, { type PendingChallenge } from '../../../store/challengeSlice';
 import profilesReducer from '../../../store/profilesSlice';
+import type { GameState, MinigameSession } from '../../../types';
 import NavBar from '../NavBar';
 
-function renderNavBar(initialEntry = '/game') {
+function buildPendingChallenge(): PendingChallenge {
+  return {
+    id: 'challenge-1',
+    game: {
+      key: 'majority_rules',
+      title: 'Majority Rules',
+      implementation: 'react',
+      reactComponentKey: 'MajorityRules',
+      retired: false,
+    } as PendingChallenge['game'],
+    seed: 1,
+    participants: ['user'],
+    phase: 'rules',
+    aiScores: {},
+  };
+}
+
+function buildPendingMinigame(): MinigameSession {
+  return {
+    key: 'quickTap',
+    participants: ['user'],
+    seed: 1,
+    options: { timeLimit: 30 },
+    aiScores: {},
+  };
+}
+
+function renderNavBar(
+  initialEntry = '/game',
+  options: {
+    challengePending?: boolean;
+    pendingMinigame?: boolean;
+    gameOverrides?: Partial<GameState>;
+  } = {},
+) {
   const initialGameState = gameReducer(undefined, { type: '@@INIT' });
+  const initialChallengeState = challengeReducer(undefined, { type: '@@INIT' });
   const store = configureStore({
     reducer: {
       game: gameReducer,
+      challenge: challengeReducer,
       profiles: profilesReducer,
     },
     preloadedState: {
       game: {
         ...initialGameState,
         status: 'active' as const,
+        ...(options.pendingMinigame ? { pendingMinigame: buildPendingMinigame() } : {}),
+        ...options.gameOverrides,
       },
+      challenge: options.challengePending
+        ? { ...initialChallengeState, pending: buildPendingChallenge() }
+        : initialChallengeState,
     },
   });
 
@@ -43,8 +86,38 @@ describe('NavBar', () => {
     expect(screen.queryByRole('button', { name: 'PROFILE' })).toBeNull();
   });
 
-  it('hides the bottom navigation on non-game routes even during an active game', () => {
-    renderNavBar('/profile');
+  it('hides the bottom navigation while a challenge rules modal is active', () => {
+    renderNavBar('/game', { challengePending: true });
+
+    expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
+  });
+
+  it('hides the bottom navigation while a native minigame session is active', () => {
+    renderNavBar('/game', { pendingMinigame: true });
+
+    expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
+  });
+
+  it('hides the bottom navigation during the tribunal-style jury sequence', () => {
+    renderNavBar('/game', { gameOverrides: { phase: 'jury' as const } });
+
+    expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
+  });
+
+  it('hides the bottom navigation during the season finale recap', () => {
+    renderNavBar('/game', {
+      gameOverrides: {
+        seasonFinale: {
+          phase: 'winnerCinematic',
+          winnerId: 'user',
+          interviewIndex: 0,
+          goodbyeIndex: 0,
+          isChatOpen: false,
+          isLightsOffAnimating: false,
+          publicFavoriteEnabled: false,
+        } as NonNullable<GameState['seasonFinale']>,
+      },
+    });
 
     expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
   });


### PR DESCRIPTION
## What changed
- keep the bottom homebar visible on the normal main game board with the faux TV and roster
- hide it only while the game is in a fullscreen takeover state, including challenge minigames, native minigames, jury/tribunal sequences, and finale recap flows
- restore the bar automatically once those flows end and the board is visible again

## Why
The earlier route-only guard was too broad in one direction and too narrow in another. The bar needs to stay on the main board at all times, but disappear during the fullscreen competition and finale sequences that take over the screen.

## Impact
- normal gameplay keeps the homebar available
- challenge rules modals and minigames no longer leave the homebar visible behind them
- finale/tribunal-style overlays also suppress the bar
- when the player exits a minigame and returns to the board, the bar comes back automatically

## Validation
- updated `NavBar` coverage for challenge, native minigame, tribunal, and finale-recap states
- I did not rerun the full local checks from this sandboxed session