### PR TITLE
[codex] Fix HomeHub full-bleed safe-area regression

### DIFF
--- a/src/hooks/useGameMode.ts
+++ b/src/hooks/useGameMode.ts
@@ -37,7 +37,8 @@ function getNativeStatusBar(): NativeStatusBarLike | null {
  * - requests a screen wake lock so the display stays awake during play
  * - re-requests the wake lock when the tab becomes visible again
  * - attempts to keep the experience portrait-locked when the platform allows it
- * - hides the native Capacitor status bar when the StatusBar plugin exists
+ * - lets the native status bar overlay the WebView before hiding it so
+ *   SafeGameViewport remains the only safe-area layout owner
  */
 export default function useGameMode(): void {
   useEffect(() => {
@@ -127,7 +128,8 @@ export default function useGameMode(): void {
       if (!statusBar || statusBarHidden) return;
 
       try {
-        await statusBar.setOverlaysWebView?.({ overlay: false });
+        // SafeGameViewport owns CSS safe-area layout; native APIs must not resize the WebView.
+        await statusBar.setOverlaysWebView?.({ overlay: true });
         await statusBar.hide?.();
         statusBarHidden = true;
       } catch {

--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -1,6 +1,6 @@
 /* HomeHub — narrower asymmetric buttons, stronger glass look */
 
-/* Shell fills the safe viewport parent */
+/* Shell fills the safe viewport parent; decorative layers intentionally bleed past it. */
 .homehub-shell {
   position: relative;
   width: 100%;
@@ -13,11 +13,13 @@
   justify-content: center;
   padding: 0;
   box-sizing: border-box;
+  isolation: isolate;
 }
 
-/* Master portrait frame */
+/* Master portrait frame for safe interactive content */
 .homehub-frame {
   position: relative;
+  z-index: 2;
   width: 100%;
   max-width: 480px;
   height: 100%;
@@ -30,9 +32,9 @@
   box-sizing: border-box;
 }
 
-/* Full-screen dynamic background */
+/* Full-bleed dynamic background. This is decorative only and covers the physical viewport. */
 .homehub-intro-bg {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background-size: cover;
   background-position: center;
@@ -64,7 +66,7 @@
 /* Foreground content container: centered in the frame */
 .homehub-content {
   position: relative;
-  z-index: 2;
+  z-index: 3;
   width: 100%;
   max-width: 480px;
   min-height: 0;
@@ -139,7 +141,7 @@
 
 /* Remote config overlay — a dark tint layer over the remote background image */
 .homehub-remote-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   background: #000;
   pointer-events: none;

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -447,23 +447,23 @@ export default function HomeHub() {
       )}
 
       <div className="homehub-shell">
-        <div className="homehub-frame">
-          {/* Dynamic background layer */}
+        {/* Decorative background layer: full physical viewport, non-interactive. */}
+        <div
+          className="homehub-intro-bg"
+          style={effectiveBgUrl ? { backgroundImage: `url("${effectiveBgUrl}")` } : undefined}
+          aria-hidden="true"
+        />
+
+        {/* Remote overlay — decorative full-bleed tint over the background image. */}
+        {remoteOverlayOpacity != null && remoteOverlayOpacity > 0 && (
           <div
-            className="homehub-intro-bg"
-            style={effectiveBgUrl ? { backgroundImage: `url("${effectiveBgUrl}")` } : undefined}
+            className="homehub-remote-overlay"
+            style={{ opacity: remoteOverlayOpacity }}
             aria-hidden="true"
           />
+        )}
 
-          {/* Remote overlay — only rendered when the remote config sets an overlayOpacity */}
-          {remoteOverlayOpacity != null && remoteOverlayOpacity > 0 && (
-            <div
-              className="homehub-remote-overlay"
-              style={{ opacity: remoteOverlayOpacity }}
-              aria-hidden="true"
-            />
-          )}
-
+        <div className="homehub-frame">
           <HomeHubAssetLayer
             key={effectiveBgUrl ?? 'default'}
             splashDone={splashDone}

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -72,15 +72,32 @@ describe('safe-area layout styles', () => {
     expect(gameScreenCss).not.toContain('padding: 12px 12px calc(var(--nav-bar-height) + 10px);');
   });
 
-  it('keeps home hub and minigame rules inside their safe viewport parents', () => {
+  it('keeps home hub controls safe-contained while decorative art bleeds full viewport', () => {
+    const homeHubTsx = readFileSync(resolve(process.cwd(), 'src/screens/HomeHub/HomeHub.tsx'), 'utf8');
     const homeHubCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/screens/HomeHub/HomeHub.css'), 'utf8'),
     );
     const minigameRulesCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/MinigameRules/MinigameRules.css'), 'utf8'),
     );
+    const bgIndex = homeHubTsx.indexOf('className="homehub-intro-bg"');
+    const frameIndex = homeHubTsx.indexOf('className="homehub-frame"');
+    const assetLayerIndex = homeHubTsx.indexOf('<HomeHubAssetLayer');
+
+    expect(bgIndex).toBeGreaterThan(-1);
+    expect(frameIndex).toBeGreaterThan(bgIndex);
+    expect(assetLayerIndex).toBeGreaterThan(frameIndex);
+    expect(homeHubTsx).toContain('aria-hidden="true"');
 
     expect(homeHubCss).toContain('.homehub-shell { position: relative; width: 100%; height: 100%;');
+    expect(homeHubCss).toContain('overflow: hidden;');
+    expect(homeHubCss).toContain('.homehub-frame { position: relative; z-index: 2; width: 100%;');
+    expect(homeHubCss).toContain('.homehub-intro-bg { position: fixed; inset: 0;');
+    expect(homeHubCss).toContain('.homehub-remote-overlay { position: fixed; inset: 0;');
+    expect(homeHubCss).toContain('pointer-events: none;');
+    expect(homeHubCss).toContain('.home-hub__buttons { display: flex; flex-direction: column;');
+    expect(homeHubCss).toContain('overflow-y: auto;');
+    expect(homeHubCss).not.toMatch(/\.homehub-(?:shell|frame)\s*\{[^}]*overflow-y:\s*auto/);
     expect(homeHubCss).not.toContain('min-height: 100vh');
     expect(homeHubCss).not.toContain('min-height: 100dvh');
     expect(homeHubCss).not.toContain('margin-top: calc(-1 * var(--app-safe-area-top');
@@ -92,6 +109,19 @@ describe('safe-area layout styles', () => {
     expect(minigameRulesCss).toContain('.minigame-rules-list { margin: 0 0 8px; padding-left: 20px; line-height: 1.6; flex: 1 1 auto;');
     expect(minigameRulesCss).not.toContain('position: fixed;');
     expect(minigameRulesCss).not.toContain('100dvh');
+  });
+
+  it('keeps native status bar policy aligned with CSS-owned safe areas', () => {
+    const useGameModeTs = readFileSync(resolve(process.cwd(), 'src/hooks/useGameMode.ts'), 'utf8');
+    const viewportMetaTs = readFileSync(
+      resolve(process.cwd(), 'src/components/layout/viewportMeta.ts'),
+      'utf8',
+    );
+
+    expect(useGameModeTs).toContain('SafeGameViewport remains the only safe-area layout owner');
+    expect(useGameModeTs).toContain('setOverlaysWebView?.({ overlay: true })');
+    expect(useGameModeTs).not.toContain('setOverlaysWebView?.({ overlay: false })');
+    expect(viewportMetaTs).toContain('viewport-fit=cover');
   });
 
   it('keeps minigames and old fullscreen game roots inside the safe viewport', () => {


### PR DESCRIPTION
## Summary

- Moves the HomeHub decorative background and remote tint into a full-bleed, non-interactive viewport layer.
- Keeps HomeHub buttons and interactive content inside the safe content frame.
- Updates native status-bar handling so Capacitor overlays the WebView instead of resizing it while `SafeGameViewport` owns CSS safe-area layout.
- Adds layout contract coverage for the HomeHub background/content split and native status-bar policy.

## Root Cause

The safe-area cleanup placed the HomeHub decorative background inside the `SafeGameViewport` content rectangle. That kept buttons safe, but it also clipped the background to the safe area, exposing black bands at the physical top and bottom of iPhone screenshots. Native iOS status-bar handling also still requested `overlay: false`, which can resize the WebView while CSS safe-area layout is already applied.

## Validation

- Not run locally because this change was made directly through GitHub without a local checkout.
- GitHub Actions should run on this PR branch and provide the lint/test signal before merge.
