### PR TITLE
[codex] Fix full-bleed safe-area and mobile game layout

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -1,30 +1,32 @@
 .container {
   position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
   padding: 2px 8px 6px;
+  overflow: hidden;
 }
 
 .headerRow {
-  display: flex;
+  position: absolute;
+  top: 4px;
+  left: 8px;
+  z-index: 6;
+  display: inline-flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
-  max-height: 32px;
-  margin-bottom: 8px;
-  overflow: hidden;
-  transition: max-height 180ms ease, margin-bottom 180ms ease, opacity 180ms ease, transform 180ms ease;
-}
-
-.headerRowVisible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.headerRowHidden {
-  max-height: 0;
-  margin-bottom: 0;
-  opacity: 0;
+  gap: 8px;
+  max-width: calc(100% - 16px);
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(10, 15, 26, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.34);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   pointer-events: none;
-  transform: translateY(-4px);
+  animation: houseguestHeaderFlash 2200ms ease forwards;
 }
 .header {
   font-size: 13px;
@@ -40,17 +42,32 @@
   margin-left: 6px;
 }
 
+@keyframes houseguestHeaderFlash {
+  0%, 68% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
 .grid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
+  flex: 1 1 auto;
+  min-height: 0;
   gap: 5px;
   grid-template-columns: repeat(4, 1fr);
   justify-items: stretch;
   align-items: start;
-  max-height: var(--grid-available-height, 480px);
-  overflow: hidden;
+  max-height: min(var(--grid-available-height, 480px), 100%);
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
   padding-bottom: 4px;
 }
 
@@ -59,6 +76,8 @@
   margin: 0;
   padding: 0 0 4px;
   display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
   gap: 5px;
   overflow-x: auto;
   overflow-y: hidden;
@@ -556,7 +575,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .headerRow {
-    transition: none;
+    animation: none;
+    opacity: 0;
   }
 
   .gridItem,

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -1,5 +1,6 @@
 .container {
-  padding: 4px 8px 6px;
+  position: relative;
+  padding: 2px 8px 6px;
 }
 
 .headerRow {
@@ -7,7 +8,23 @@
   align-items: center;
   justify-content: flex-start;
   gap: 12px;
-  margin-bottom: 10px;
+  max-height: 32px;
+  margin-bottom: 8px;
+  overflow: hidden;
+  transition: max-height 180ms ease, margin-bottom 180ms ease, opacity 180ms ease, transform 180ms ease;
+}
+
+.headerRowVisible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.headerRowHidden {
+  max-height: 0;
+  margin-bottom: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
 }
 .header {
   font-size: 13px;
@@ -390,7 +407,7 @@
 
 /* ── Compact mode ────────────────────────────────────────────────────────── */
 .compact {
-  padding: 4px 4px 2px;
+  padding: 2px 4px;
 }
 
 .compact .grid {
@@ -538,6 +555,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .headerRow {
+    transition: none;
+  }
+
   .gridItem,
   .nomination_loh,
   .nomination_danger::before,

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
@@ -87,10 +87,6 @@ const MIN_GRID_HEIGHT = 220
 const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
-/** Initial header flash lets players orient without permanently spending a row. */
-const HEADER_INITIAL_FLASH_MS = 1400
-/** Count changes deserve a slightly longer flash because the roster state changed. */
-const HEADER_CHANGE_FLASH_MS = 2200
 
 export default function HouseguestGrid({
   houseguests,
@@ -164,20 +160,6 @@ export default function HouseguestGrid({
     ))
   }, [game.mode, game.players, game.week, houseguests, survivorReplacementTransition])
   const headerSignal = occupancyLabel ?? `${renderedHouseguests.length}`
-  const [headerVisible, setHeaderVisible] = useState(true)
-  const previousHeaderSignalRef = useRef(headerSignal)
-
-  useEffect(() => {
-    const changed = previousHeaderSignalRef.current !== headerSignal
-    previousHeaderSignalRef.current = headerSignal
-    setHeaderVisible(true)
-
-    const timer = window.setTimeout(
-      () => setHeaderVisible(false),
-      changed ? HEADER_CHANGE_FLASH_MS : HEADER_INITIAL_FLASH_MS,
-    )
-    return () => window.clearTimeout(timer)
-  }, [headerSignal])
 
   useEffect(() => {
     if (survivorReplacementTransition === null) return undefined
@@ -243,7 +225,7 @@ export default function HouseguestGrid({
       window.visualViewport?.removeEventListener('resize', setAvailableHeight)
       window.visualViewport?.removeEventListener('scroll', setAvailableHeight)
     }
-  }, [headerSelector, footerSelector, overlaySelector, headerVisible])
+  }, [headerSelector, footerSelector, overlaySelector])
 
   const gridSizeClass = gridSize === 16 ? styles.hgGrid16 : gridSize === 12 ? styles.hgGrid12 : ''
   const effectiveCompactLayout = compact ? compactLayout : 'default'
@@ -259,12 +241,6 @@ export default function HouseguestGrid({
   ]
     .filter(Boolean)
     .join(' ')
-  const headerRowClassName = [
-    styles.headerRow,
-    headerVisible ? styles.headerRowVisible : styles.headerRowHidden,
-  ]
-    .filter(Boolean)
-    .join(' ')
 
   return (
     <section
@@ -273,7 +249,7 @@ export default function HouseguestGrid({
       aria-labelledby="houseguests-heading"
       data-compact-layout={effectiveCompactLayout}
     >
-      <div className={headerRowClassName} aria-live="polite">
+      <div key={headerSignal} className={styles.headerRow} aria-live="polite">
         <h3 id="houseguests-heading" className={styles.header}>
           {HOUSEMATES_SECTION_TITLE}
           {showCountInHeader && <span className={styles.count}> ({renderedHouseguests.length})</span>}

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
@@ -87,6 +87,10 @@ const MIN_GRID_HEIGHT = 220
 const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
+/** Initial header flash lets players orient without permanently spending a row. */
+const HEADER_INITIAL_FLASH_MS = 1400
+/** Count changes deserve a slightly longer flash because the roster state changed. */
+const HEADER_CHANGE_FLASH_MS = 2200
 
 export default function HouseguestGrid({
   houseguests,
@@ -159,6 +163,21 @@ export default function HouseguestGrid({
         : houseguest
     ))
   }, [game.mode, game.players, game.week, houseguests, survivorReplacementTransition])
+  const headerSignal = occupancyLabel ?? `${renderedHouseguests.length}`
+  const [headerVisible, setHeaderVisible] = useState(true)
+  const previousHeaderSignalRef = useRef(headerSignal)
+
+  useEffect(() => {
+    const changed = previousHeaderSignalRef.current !== headerSignal
+    previousHeaderSignalRef.current = headerSignal
+    setHeaderVisible(true)
+
+    const timer = window.setTimeout(
+      () => setHeaderVisible(false),
+      changed ? HEADER_CHANGE_FLASH_MS : HEADER_INITIAL_FLASH_MS,
+    )
+    return () => window.clearTimeout(timer)
+  }, [headerSignal])
 
   useEffect(() => {
     if (survivorReplacementTransition === null) return undefined
@@ -224,7 +243,7 @@ export default function HouseguestGrid({
       window.visualViewport?.removeEventListener('resize', setAvailableHeight)
       window.visualViewport?.removeEventListener('scroll', setAvailableHeight)
     }
-  }, [headerSelector, footerSelector, overlaySelector])
+  }, [headerSelector, footerSelector, overlaySelector, headerVisible])
 
   const gridSizeClass = gridSize === 16 ? styles.hgGrid16 : gridSize === 12 ? styles.hgGrid12 : ''
   const effectiveCompactLayout = compact ? compactLayout : 'default'
@@ -240,6 +259,12 @@ export default function HouseguestGrid({
   ]
     .filter(Boolean)
     .join(' ')
+  const headerRowClassName = [
+    styles.headerRow,
+    headerVisible ? styles.headerRowVisible : styles.headerRowHidden,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <section
@@ -248,7 +273,7 @@ export default function HouseguestGrid({
       aria-labelledby="houseguests-heading"
       data-compact-layout={effectiveCompactLayout}
     >
-      <div className={styles.headerRow}>
+      <div className={headerRowClassName} aria-live="polite">
         <h3 id="houseguests-heading" className={styles.header}>
           {HOUSEMATES_SECTION_TITLE}
           {showCountInHeader && <span className={styles.count}> ({renderedHouseguests.length})</span>}

--- a/src/components/TVLog/TVLog.css
+++ b/src/components/TVLog/TVLog.css
@@ -6,18 +6,22 @@
      --tv-log-max-vis  : number of rows visible before scroll (default 3)
                          max-height is calculated as calc(var(--tv-log-item-h) * var(--tv-log-max-vis))
 
-   Both variables can be overridden on a parent element to adapt the log to
-   different screen sizes without touching the component code.
+   The log always reserves one row and can grow to three rows as viewport space
+   allows. Older entries remain reachable through the internal scroller.
    ───────────────────────────────────────────────────────────────────────────── */
 
 .tv-log {
   --tv-log-item-h: 36px;
   --tv-log-max-vis: 3;
 
+  flex: 0 0 auto;
   list-style: none;
   margin: 0;
   padding: 0;
+  min-height: var(--tv-log-item-h);
   max-height: calc(var(--tv-log-item-h) * var(--tv-log-max-vis));
+  max-height: clamp(var(--tv-log-item-h), 10vh, calc(var(--tv-log-item-h) * var(--tv-log-max-vis)));
+  max-height: clamp(var(--tv-log-item-h), 10svh, calc(var(--tv-log-item-h) * var(--tv-log-max-vis)));
   overflow-y: auto;
   overscroll-behavior: contain;
   border-top: 1px solid rgba(255, 255, 255, 0.05);
@@ -56,6 +60,15 @@
   background: rgba(255, 255, 255, 0.04);
 }
 
+.tv-log__item--empty {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.tv-log__item--empty:hover {
+  background: transparent;
+}
+
 /* Expanded items grow to show full text */
 .tv-log__item--expanded {
   align-items: flex-start;
@@ -69,6 +82,12 @@
   color: var(--color-text, #f1f5f9);
   background: rgba(99, 102, 241, 0.06);
   animation: tvLogItemIn 0.3s ease;
+}
+
+.tv-log__item--empty:first-child {
+  color: var(--color-text-muted, #9ca3af);
+  background: transparent;
+  animation: none;
 }
 
 @keyframes tvLogItemIn {
@@ -104,13 +123,8 @@
     --tv-log-item-h: 32px;
   }
 
-  .tv-log[data-mobile-two-line='true'] {
-    max-height: calc((0.78rem * 1.4 * 2) + 12px);
-  }
-
   .tv-log[data-mobile-two-line='true'] .tv-log__item {
     align-items: flex-start;
-    min-height: 0;
     padding: 6px 12px;
   }
 

--- a/src/components/TVLog/TVLog.tsx
+++ b/src/components/TVLog/TVLog.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 import type { TvEvent } from '../../types';
 import { tease } from '../../utils/tvLogTemplates';
 import './TVLog.css';
+
+const MAX_ADAPTIVE_VISIBLE_ROWS = 3;
 
 const TYPE_ICONS: Record<TvEvent['type'], string> = {
   game: '🎮',
@@ -17,18 +19,19 @@ export interface TVLogProps {
   /**
    * Text currently displayed in the main TV viewport.
    * When the first entry's text matches this value it is suppressed from the
-   * log to avoid showing a duplicate row.
+   * log to avoid showing a duplicate row when older rows remain available.
    */
   mainTVMessage?: string;
   /**
    * Maximum number of rows visible before the list scrolls.
-   * Exposed as the `--tv-log-max-vis` CSS variable on the root element.
+   * The mobile layout always allows up to three adaptive rows so the log never
+   * disappears entirely when screen space is tight.
    * @default 3
    */
   maxVisible?: number;
   /**
-   * When enabled, small screens collapse the feed to a two-line viewport so the
-   * TV area can stay taller while older messages remain reachable via scroll.
+   * When enabled, small screens clamp each collapsed feed entry to two text
+   * lines while older messages remain reachable via scroll.
    */
   mobileTwoLineMode?: boolean;
 }
@@ -37,30 +40,28 @@ export interface TVLogProps {
  * TVLog — a compact, scrollable event-log strip.
  *
  * Features:
- *   - Duplicate suppression: hides the first entry when it matches the main TV message.
- *   - Shows `maxVisible` (default 3) rows; older entries are accessible via scroll.
+ *   - Duplicate suppression: hides the first entry when it matches the main TV message and older entries remain.
+ *   - Reserves at least one visible row; grows up to three rows when the viewport has room.
  *   - Teaser truncation: long lines are clipped to 60 chars; tap/click to expand.
- *   - Optional mobile two-line mode that reduces the visible feed height on phones.
+ *   - Optional mobile two-line mode that clamps row copy without hiding the log.
  */
 export default function TVLog({
   entries,
   mainTVMessage,
-  maxVisible = 3,
+  maxVisible = MAX_ADAPTIVE_VISIBLE_ROWS,
   mobileTwoLineMode = false,
 }: TVLogProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
-  const isSurvivorLog = entries.some((event) => event.meta?.mode === 'survivor');
-  const effectiveMaxVisible = isSurvivorLog ? Math.max(maxVisible, 5) : maxVisible;
-  const effectiveMobileTwoLineMode = isSurvivorLog ? false : mobileTwoLineMode;
+  const effectiveMaxVisible = Math.max(MAX_ADAPTIVE_VISIBLE_ROWS, maxVisible);
 
-  // Suppress the first entry when its text duplicates the main viewport message.
-  const visible = useMemo(
-    () =>
-      mainTVMessage
-        ? entries.filter((ev, i) => !(i === 0 && ev.text === mainTVMessage))
-        : entries,
-    [entries, mainTVMessage],
-  );
+  // Suppress the first entry only when older rows remain, so the log never
+  // collapses to an empty strip just because the main TV repeats the newest row.
+  const visible = useMemo(() => {
+    if (!mainTVMessage || entries.length <= 1) return entries;
+
+    const [latestEntry, ...olderEntries] = entries;
+    return latestEntry.text === mainTVMessage ? olderEntries : entries;
+  }, [entries, mainTVMessage]);
 
   function toggleExpand(id: string) {
     setExpandedIds((prev) => {
@@ -78,10 +79,16 @@ export default function TVLog({
     <ul
       className="tv-log"
       data-testid="tv-feed"
-      data-mobile-two-line={effectiveMobileTwoLineMode ? 'true' : undefined}
-      style={{ '--tv-log-max-vis': effectiveMaxVisible } as React.CSSProperties}
+      data-mobile-two-line={mobileTwoLineMode ? 'true' : undefined}
+      style={{ '--tv-log-max-vis': effectiveMaxVisible } as CSSProperties}
       aria-label="Game event log"
     >
+      {visible.length === 0 && (
+        <li className="tv-log__item tv-log__item--empty" aria-hidden="true">
+          <span className="tv-log__icon" aria-hidden="true">•</span>
+          <span className="tv-log__text">Game log</span>
+        </li>
+      )}
       {visible.map((ev) => {
         const isExpanded = expandedIds.has(ev.id);
         const displayText = isExpanded ? ev.text : tease(ev.text);

--- a/src/components/layout/SafeGameViewport.css
+++ b/src/components/layout/SafeGameViewport.css
@@ -120,6 +120,25 @@ body.homehub-full-bleed-active .safe-game-viewport__bleed {
   right: 1rem;
 }
 
+/* Crystal Path's own CSS predates the safe viewport. Keep it scoped to the safe minigame host. */
+.safe-game-viewport__content .cps-shell {
+  height: 100%;
+  min-height: 0;
+}
+
+.safe-game-viewport__content .cps-modal,
+.safe-game-viewport__content .cps-secret-banner {
+  position: absolute;
+}
+
+.safe-game-viewport__content .cps-secret-banner {
+  top: 1rem;
+}
+
+.safe-game-viewport__content .cps-complete {
+  min-height: 100%;
+}
+
 .safe-game-viewport--debug::before {
   content: '';
   position: fixed;

--- a/src/components/layout/SafeGameViewport.css
+++ b/src/components/layout/SafeGameViewport.css
@@ -6,6 +6,56 @@
   overflow: hidden;
   background: var(--color-bg);
   color: var(--color-text);
+  isolation: isolate;
+}
+
+body.homehub-full-bleed-active {
+  background-color: var(--color-bg);
+  background-image: var(--homehub-full-bleed-bg, none);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.safe-game-viewport__bleed {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background-image: var(--homehub-full-bleed-bg, none);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 300ms ease, transform 350ms ease;
+}
+
+.safe-game-viewport__bleed::before {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  height: 72%;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.80) 0%,
+    rgba(0, 0, 0, 0.50) 32%,
+    rgba(0, 0, 0, 0.18) 62%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+.safe-game-viewport__bleed::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: #000;
+  opacity: var(--homehub-full-bleed-overlay-opacity, 0);
+  pointer-events: none;
+}
+
+body.homehub-full-bleed-active .safe-game-viewport__bleed {
+  opacity: 1;
 }
 
 .safe-game-viewport__content {
@@ -14,6 +64,7 @@
   right: var(--safe-right);
   bottom: var(--safe-bottom);
   left: var(--safe-left);
+  z-index: 1;
   display: flex;
   justify-content: center;
   min-width: 0;

--- a/src/components/layout/SafeGameViewport.tsx
+++ b/src/components/layout/SafeGameViewport.tsx
@@ -36,6 +36,7 @@ export default function SafeGameViewport({ children, className = '', debug }: Sa
 
   return (
     <div className={classes} data-safe-game-viewport="outer">
+      <div className="safe-game-viewport__bleed" aria-hidden="true" />
       <div className="safe-game-viewport__content" data-safe-game-viewport="content">
         {children}
       </div>

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -5,7 +5,9 @@
 
 .tv-zone {
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
+  min-height: var(--tv-zone-min-height, 238px);
   border-radius: 16px;
   overflow: hidden;
   border: 1px solid rgba(99, 102, 241, 0.2);
@@ -148,8 +150,8 @@
   --tv-reflection-x: 18%;
   --tv-reflection-y: 12%;
   position: relative;
-  flex: 1 1 0;
-  min-height: 192px; /* ~20% larger than original 160px — constant, not dynamic */
+  flex: 1 0 auto;
+  min-height: var(--tv-zone-viewport-min-height, 192px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -417,6 +419,10 @@
 
 /* ── Responsive ────────────────────────────────────────────────────────────── */
 @media (max-width: 480px) {
+  .tv-zone {
+    min-height: var(--tv-zone-min-height, 238px);
+  }
+
   .tv-zone__head {
     gap: 5px;
     padding: 6px 10px;
@@ -442,7 +448,7 @@
   }
 
   .tv-zone__viewport {
-    min-height: 144px;
+    min-height: var(--tv-zone-viewport-min-height, 144px);
     padding: 18px 14px;
   }
   .tv-zone__now {
@@ -458,6 +464,7 @@
   display: flex;
   flex: 1 1 auto;
   align-items: stretch;
+  min-height: 0;
   padding: 8px 10px 4px;
   background:
     radial-gradient(circle at 50% 0%, rgba(99, 102, 241, 0.18), rgba(99, 102, 241, 0) 48%),
@@ -468,6 +475,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-height: 0;
   position: relative;
   border-radius: 10px;
   border: 3px solid #1a1a2e;

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -1,6 +1,8 @@
 /* GameScreen */
 .game-screen {
   --game-screen-floating-dock-clearance: clamp(64px, 18vw, 88px);
+  --game-screen-tv-min-height: clamp(238px, 30svh, 312px);
+  --game-screen-tv-viewport-min-height: clamp(144px, 18svh, 192px);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -20,9 +22,19 @@
   box-sizing: border-box;
 }
 
+.game-screen > .tv-zone,
 .game-screen--compact-roster-balance > .tv-zone {
-  flex: 1 1 auto;
-  min-height: 0;
+  flex: 0 0 auto;
+  min-height: var(--game-screen-tv-min-height);
+  --tv-zone-viewport-min-height: var(--game-screen-tv-viewport-min-height);
+}
+
+body:has(.game-screen-shell) .safe-game-viewport {
+  background-color: var(--color-bg);
+  background-image: url('/assets/bb-gameplay-bg.svg');
+  background-size: cover;
+  background-position: center top;
+  background-repeat: no-repeat;
 }
 
 /* Gameplay background shell */

--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -1,6 +1,6 @@
 /* HomeHub — narrower asymmetric buttons, stronger glass look */
 
-/* Shell fills the safe viewport parent; decorative layers intentionally bleed past it. */
+/* Shell fills the safe viewport parent; decorative art is painted by SafeGameViewport. */
 .homehub-shell {
   position: relative;
   width: 100%;
@@ -13,7 +13,6 @@
   justify-content: center;
   padding: 0;
   box-sizing: border-box;
-  isolation: isolate;
 }
 
 /* Master portrait frame for safe interactive content */
@@ -30,37 +29,6 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-}
-
-/* Full-bleed dynamic background. This is decorative only and covers the physical viewport. */
-.homehub-intro-bg {
-  position: fixed;
-  inset: 0;
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  z-index: 0;
-  transition: opacity 300ms ease, transform 350ms ease;
-  pointer-events: none;
-}
-
-/* Bottom scrim gradient — deepens behind the button stack so text/icons
-   remain legible against any background image */
-.homehub-intro-bg::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 72%;
-  background: linear-gradient(
-    to top,
-    rgba(0, 0, 0, 0.80) 0%,
-    rgba(0, 0, 0, 0.50) 32%,
-    rgba(0, 0, 0, 0.18) 62%,
-    transparent 100%
-  );
-  pointer-events: none;
 }
 
 /* Foreground content container: centered in the frame */
@@ -137,15 +105,6 @@
 @media (max-width: 420px) {
   .home-hub__title { font-size: 1.8rem; }
   .home-hub { padding-bottom: 24px; }
-}
-
-/* Remote config overlay — a dark tint layer over the remote background image */
-.homehub-remote-overlay {
-  position: fixed;
-  inset: 0;
-  background: #000;
-  pointer-events: none;
-  z-index: 1;
 }
 
 .homehub-resume-modal {

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -216,6 +216,28 @@ export default function HomeHub() {
   const hasEndedSurvivorRecord = !survivorSnapshot && (savedRuns?.stats.maxSurvivorDaysSurvived ?? 0) > 0;
 
   useEffect(() => {
+    const { body } = document;
+    body.classList.add('homehub-full-bleed-active');
+
+    if (effectiveBgUrl) {
+      body.style.setProperty('--homehub-full-bleed-bg', `url(${JSON.stringify(effectiveBgUrl)})`);
+    } else {
+      body.style.removeProperty('--homehub-full-bleed-bg');
+    }
+
+    body.style.setProperty(
+      '--homehub-full-bleed-overlay-opacity',
+      remoteOverlayOpacity != null && remoteOverlayOpacity > 0 ? String(remoteOverlayOpacity) : '0',
+    );
+
+    return () => {
+      body.classList.remove('homehub-full-bleed-active');
+      body.style.removeProperty('--homehub-full-bleed-bg');
+      body.style.removeProperty('--homehub-full-bleed-overlay-opacity');
+    };
+  }, [effectiveBgUrl, remoteOverlayOpacity]);
+
+  useEffect(() => {
     const gameWindow = window as Window & { game?: Record<string, unknown> };
     gameWindow.game = gameWindow.game ?? {};
     // Legacy IntroHub/achievements scripts still read from window.game, so keep
@@ -447,22 +469,6 @@ export default function HomeHub() {
       )}
 
       <div className="homehub-shell">
-        {/* Decorative background layer: full physical viewport, non-interactive. */}
-        <div
-          className="homehub-intro-bg"
-          style={effectiveBgUrl ? { backgroundImage: `url("${effectiveBgUrl}")` } : undefined}
-          aria-hidden="true"
-        />
-
-        {/* Remote overlay — decorative full-bleed tint over the background image. */}
-        {remoteOverlayOpacity != null && remoteOverlayOpacity > 0 && (
-          <div
-            className="homehub-remote-overlay"
-            style={{ opacity: remoteOverlayOpacity }}
-            aria-hidden="true"
-          />
-        )}
-
         <div className="homehub-frame">
           <HomeHubAssetLayer
             key={effectiveBgUrl ?? 'default'}

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -29,10 +29,13 @@ describe('safe-area layout styles', () => {
     expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
     expect(globalCss).toContain('--safe-left: env(safe-area-inset-left, 0px);');
     expect(safeViewportTsx).toContain('export default function SafeGameViewport');
+    expect(safeViewportTsx).toContain('safe-game-viewport__bleed');
     expect(appShellTsx).toContain('<SafeGameViewport>');
 
     expect(safeViewportCss).toContain('.safe-game-viewport { position: fixed; inset: 0;');
     expect(safeViewportCss).toContain('height: 100dvh;');
+    expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');
+    expect(safeViewportCss).toContain('body.homehub-full-bleed-active .safe-game-viewport__bleed');
     expect(safeViewportCss).toContain('top: var(--safe-top);');
     expect(safeViewportCss).toContain('right: var(--safe-right);');
     expect(safeViewportCss).toContain('bottom: var(--safe-bottom);');
@@ -72,7 +75,10 @@ describe('safe-area layout styles', () => {
     expect(gameScreenCss).not.toContain('padding: 12px 12px calc(var(--nav-bar-height) + 10px);');
   });
 
-  it('keeps home hub controls safe-contained while decorative art bleeds full viewport', () => {
+  it('keeps home hub controls safe-contained while decorative art is owned by the physical viewport', () => {
+    const safeViewportCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'), 'utf8'),
+    );
     const homeHubTsx = readFileSync(resolve(process.cwd(), 'src/screens/HomeHub/HomeHub.tsx'), 'utf8');
     const homeHubCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/screens/HomeHub/HomeHub.css'), 'utf8'),
@@ -80,23 +86,29 @@ describe('safe-area layout styles', () => {
     const minigameRulesCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/MinigameRules/MinigameRules.css'), 'utf8'),
     );
-    const bgIndex = homeHubTsx.indexOf('className="homehub-intro-bg"');
     const frameIndex = homeHubTsx.indexOf('className="homehub-frame"');
     const assetLayerIndex = homeHubTsx.indexOf('<HomeHubAssetLayer');
 
-    expect(bgIndex).toBeGreaterThan(-1);
-    expect(frameIndex).toBeGreaterThan(bgIndex);
+    expect(homeHubTsx).toContain("body.classList.add('homehub-full-bleed-active')");
+    expect(homeHubTsx).toContain("--homehub-full-bleed-bg");
+    expect(homeHubTsx).toContain("--homehub-full-bleed-overlay-opacity");
+    expect(homeHubTsx).not.toContain('className="homehub-intro-bg"');
+    expect(homeHubTsx).not.toContain('className="homehub-remote-overlay"');
+    expect(frameIndex).toBeGreaterThan(-1);
     expect(assetLayerIndex).toBeGreaterThan(frameIndex);
-    expect(homeHubTsx).toContain('aria-hidden="true"');
+
+    expect(safeViewportCss).toContain('body.homehub-full-bleed-active { background-color: var(--color-bg);');
+    expect(safeViewportCss).toContain('background-image: var(--homehub-full-bleed-bg, none);');
+    expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');
+    expect(safeViewportCss).toContain('opacity: var(--homehub-full-bleed-overlay-opacity, 0);');
 
     expect(homeHubCss).toContain('.homehub-shell { position: relative; width: 100%; height: 100%;');
     expect(homeHubCss).toContain('overflow: hidden;');
     expect(homeHubCss).toContain('.homehub-frame { position: relative; z-index: 2; width: 100%;');
-    expect(homeHubCss).toContain('.homehub-intro-bg { position: fixed; inset: 0;');
-    expect(homeHubCss).toContain('.homehub-remote-overlay { position: fixed; inset: 0;');
-    expect(homeHubCss).toContain('pointer-events: none;');
     expect(homeHubCss).toContain('.home-hub__buttons { display: flex; flex-direction: column;');
     expect(homeHubCss).toContain('overflow-y: auto;');
+    expect(homeHubCss).not.toContain('.homehub-intro-bg');
+    expect(homeHubCss).not.toContain('.homehub-remote-overlay');
     expect(homeHubCss).not.toMatch(/\.homehub-(?:shell|frame)\s*\{[^}]*overflow-y:\s*auto/);
     expect(homeHubCss).not.toContain('min-height: 100vh');
     expect(homeHubCss).not.toContain('min-height: 100dvh');

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -75,6 +75,55 @@ describe('safe-area layout styles', () => {
     expect(gameScreenCss).not.toContain('padding: 12px 12px calc(var(--nav-bar-height) + 10px);');
   });
 
+  it('keeps gameplay safe bands painted while TV and log keep their own space', () => {
+    const gameScreenCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.css'), 'utf8'),
+    );
+    const tvZoneCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/ui/TvZone.css'), 'utf8'),
+    );
+    const tvLogTsx = readFileSync(resolve(process.cwd(), 'src/components/TVLog/TVLog.tsx'), 'utf8');
+    const tvLogCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/TVLog/TVLog.css'), 'utf8'),
+    );
+    const houseguestGridTsx = readFileSync(
+      resolve(process.cwd(), 'src/components/HouseguestGrid/HouseguestGrid.tsx'),
+      'utf8',
+    );
+    const houseguestGridCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/components/HouseguestGrid/HouseguestGrid.module.css'), 'utf8'),
+    );
+
+    expect(gameScreenCss).toContain('--game-screen-tv-min-height: clamp(238px, 30svh, 312px);');
+    expect(gameScreenCss).toContain('--game-screen-tv-viewport-min-height: clamp(144px, 18svh, 192px);');
+    expect(gameScreenCss).toContain('.game-screen > .tv-zone, .game-screen--compact-roster-balance > .tv-zone { flex: 0 0 auto; min-height: var(--game-screen-tv-min-height); --tv-zone-viewport-min-height: var(--game-screen-tv-viewport-min-height); }');
+    expect(gameScreenCss).toContain("body:has(.game-screen-shell) .safe-game-viewport { background-color: var(--color-bg); background-image: url('/assets/bb-gameplay-bg.svg');");
+    expect(gameScreenCss).not.toContain('.game-screen--compact-roster-balance > .tv-zone { flex: 1 1 auto; min-height: 0; }');
+
+    expect(tvZoneCss).toContain('.tv-zone { display: flex; flex: 0 0 auto; flex-direction: column; min-height: var(--tv-zone-min-height, 238px);');
+    expect(tvZoneCss).toContain('flex: 1 0 auto; min-height: var(--tv-zone-viewport-min-height, 192px); display: flex;');
+    expect(tvZoneCss).toContain('.tv-zone__bezel { display: flex; flex: 1 1 auto; align-items: stretch; min-height: 0;');
+    expect(tvZoneCss).not.toContain('.tv-zone { flex: 1 1 auto;');
+
+    expect(tvLogTsx).toContain('const MAX_ADAPTIVE_VISIBLE_ROWS = 3;');
+    expect(tvLogTsx).toContain('entries.length <= 1');
+    expect(tvLogTsx).toContain('visible.length === 0');
+    expect(tvLogTsx).toContain("'--tv-log-max-vis': effectiveMaxVisible");
+    expect(tvLogCss).toContain('.tv-log { --tv-log-item-h: 36px; --tv-log-max-vis: 3; flex: 0 0 auto;');
+    expect(tvLogCss).toContain('min-height: var(--tv-log-item-h);');
+    expect(tvLogCss).toContain('max-height: clamp(var(--tv-log-item-h), 10svh, calc(var(--tv-log-item-h) * var(--tv-log-max-vis)));');
+    expect(tvLogCss).toContain('overflow-y: auto;');
+    expect(tvLogCss).not.toContain('display: none;');
+
+    expect(houseguestGridTsx).toContain('const headerSignal = occupancyLabel ?? `${renderedHouseguests.length}`');
+    expect(houseguestGridTsx).toContain('key={headerSignal}');
+    expect(houseguestGridTsx).not.toContain('setHeaderVisible');
+    expect(houseguestGridCss).toContain('.headerRow { position: absolute; top: 4px; left: 8px;');
+    expect(houseguestGridCss).toContain('animation: houseguestHeaderFlash 2200ms ease forwards;');
+    expect(houseguestGridCss).toContain('.grid { list-style: none; margin: 0; padding: 0; display: grid; flex: 1 1 auto; min-height: 0;');
+    expect(houseguestGridCss).toContain('overflow-y: auto;');
+  });
+
   it('keeps home hub controls safe-contained while decorative art is owned by the physical viewport', () => {
     const safeViewportCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'), 'utf8'),


### PR DESCRIPTION
## Summary

- Adds a dedicated `SafeGameViewport` bleed layer so decorative art can paint the physical viewport while interactive content stays inside the safe rectangle.
- Routes HomeHub art through viewport-owned CSS variables and removes the local safe-contained background nodes.
- Paints the gameplay safe bands with the gameplay background so the bottom reserved device strip no longer appears as a dead black gap.
- Keeps the faux TV stack from being flex-squashed, and keeps the TV log present as at least one scrollable row that can grow up to three rows when space allows.
- Converts the `HOUSEMATES 16/16` row into a brief overlay on count changes so it does not permanently consume vertical space.
- Keeps Crystal Path scoped to the safe minigame host so its shell, modal, secret banner, and completion panel do not use the raw physical viewport over the iOS service row.
- Extends regression coverage for HomeHub bleed ownership, status-bar/safe-area ownership, gameplay TV/log sizing, roster header behavior, and bottom nav/dock safe-area contracts.

## Validation

- GitHub Actions passed on the latest PR commit: Lint #3483 and CI #3816.
- Source-level Crystal Path check: the game mounts inside `.minigame-host`, which is inside `SafeGameViewport` content; the follow-up commit also scopes Crystal Path viewport/fixed-style UI to that safe host.
- Not run locally because this work is being done directly through GitHub without a local checkout, per request.
