### PR TITLE
fix/post-1070-mobile-layout-regressions

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -465,6 +465,58 @@
   max-height: none;
 }
 
+.compactPrompt {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  left: 8px;
+  z-index: 7;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 10px;
+  background: rgba(8, 13, 24, 0.9);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.compactPromptText {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.94);
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.compactPromptActions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.compactPromptActions button {
+  min-width: 0;
+  min-height: 34px;
+  padding: 6px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: rgba(99, 102, 241, 0.18);
+  color: rgba(255, 255, 255, 0.92);
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1.15;
+  cursor: pointer;
+}
+
+.compactPromptActions button:last-child {
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(226, 232, 240, 0.86);
+}
+
 .roboStatsBackdrop {
   position: fixed;
   inset: 0;
@@ -570,6 +622,16 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 420px) {
+  .compactPromptActions {
+    grid-template-columns: 1fr;
+  }
+
+  .compactPromptActions button {
+    min-height: 32px;
   }
 }
 

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
 import styles from './HouseguestGrid.module.css'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import { clearSurvivorReplacementTransition } from '../../store/gameSlice'
-import type { CompactRosterLayout } from '../../store/settingsSlice'
+import {
+  setGameUX,
+  type CompactRosterLayout,
+  type SupportedCompactRosterLayout,
+} from '../../store/settingsSlice'
 
 const HOUSEMATES_SECTION_TITLE = 'HOUSEMATES'
 
@@ -87,6 +91,37 @@ const MIN_GRID_HEIGHT = 220
 const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
+const NORMAL_GRID_COLUMNS = 4
+const NORMAL_GRID_GAP = 5
+const COMPACT_PROMPT_MIN_TILE_SIZE = 72
+const COMPACT_PROMPT_VERTICAL_BUFFER = 8
+const COMPACT_ROSTER_PROMPT_STORAGE_PREFIX = 'bbmobilenew_compact_roster_prompt_dismissed'
+
+type CompactRosterPromptState = {
+  bucket: string
+} | null
+
+function getViewportSizeBucket(width: number, height: number) {
+  const bucketWidth = Math.max(0, Math.round(width / 80) * 80)
+  const bucketHeight = Math.max(0, Math.round(height / 80) * 80)
+  return `${bucketWidth}x${bucketHeight}`
+}
+
+function isCompactPromptDismissed(bucket: string) {
+  try {
+    return window.localStorage.getItem(`${COMPACT_ROSTER_PROMPT_STORAGE_PREFIX}:${bucket}`) === '1'
+  } catch {
+    return false
+  }
+}
+
+function rememberCompactPromptDismissal(bucket: string) {
+  try {
+    window.localStorage.setItem(`${COMPACT_ROSTER_PROMPT_STORAGE_PREFIX}:${bucket}`, '1')
+  } catch {
+    // localStorage can be unavailable in private browsing or embedded webviews.
+  }
+}
 
 export default function HouseguestGrid({
   houseguests,
@@ -103,6 +138,7 @@ export default function HouseguestGrid({
   const containerRef = useRef<HTMLElement | null>(null)
   const dispatch = useAppDispatch()
   const game = useAppSelector((s) => s.game)
+  const [compactPrompt, setCompactPrompt] = useState<CompactRosterPromptState>(null)
   const survivorReplacementTransition = game.modeSpecific?.kind === 'survivor'
     ? game.modeSpecific.replacementTransition ?? null
     : null
@@ -177,8 +213,10 @@ export default function HouseguestGrid({
     function setAvailableHeight() {
       const visualViewport = window.visualViewport
       const viewportHeight = visualViewport?.height ?? window.innerHeight
+      const viewportWidth = visualViewport?.width ?? window.innerWidth
       const viewportTop = visualViewport?.offsetTop ?? 0
       let listTop = 0
+      let listWidth = 0
       let footerH = DEFAULT_FOOTER_HEIGHT
       let bottomBoundary = viewportTop + viewportHeight - footerH
 
@@ -187,9 +225,15 @@ export default function HouseguestGrid({
 
       if (containerRef.current instanceof HTMLElement) {
         const listEl = containerRef.current.querySelector('ul[role="list"]')
-        listTop = listEl instanceof HTMLElement
-          ? listEl.getBoundingClientRect().top
-          : containerRef.current.getBoundingClientRect().top
+        if (listEl instanceof HTMLElement) {
+          const listRect = listEl.getBoundingClientRect()
+          listTop = listRect.top
+          listWidth = listRect.width
+        } else {
+          const containerRect = containerRef.current.getBoundingClientRect()
+          listTop = containerRect.top
+          listWidth = containerRect.width
+        }
       } else {
         const headerEl = document.querySelector(headerSelector)
         if (headerEl instanceof HTMLElement) {
@@ -214,18 +258,57 @@ export default function HouseguestGrid({
       if (containerRef.current) {
         containerRef.current.style.setProperty('--grid-available-height', `${available}px`)
       }
+
+      const normalRows = Math.ceil(renderedHouseguests.length / NORMAL_GRID_COLUMNS)
+      const measuredTileWidth = listWidth > 0
+        ? (listWidth - NORMAL_GRID_GAP * (NORMAL_GRID_COLUMNS - 1)) / NORMAL_GRID_COLUMNS
+        : COMPACT_PROMPT_MIN_TILE_SIZE
+      const comfortableNormalHeight = Math.ceil(
+        Math.max(COMPACT_PROMPT_MIN_TILE_SIZE, measuredTileWidth) * normalRows
+          + NORMAL_GRID_GAP * Math.max(0, normalRows - 1)
+          + COMPACT_PROMPT_VERTICAL_BUFFER,
+      )
+      const rosterCount = Math.max(gridSize ?? 0, renderedHouseguests.length)
+      const shouldConsiderCompactPrompt =
+        !compact &&
+        rosterCount >= 16 &&
+        renderedHouseguests.length >= 16 &&
+        (game.mode !== 'survivor' || renderedHouseguests.length > 8)
+      const bucket = getViewportSizeBucket(viewportWidth, viewportHeight)
+      const shouldShowPrompt =
+        shouldConsiderCompactPrompt &&
+        available < comfortableNormalHeight &&
+        !isCompactPromptDismissed(bucket)
+
+      setCompactPrompt((current) => {
+        if (!shouldShowPrompt) return current === null ? current : null
+        return current?.bucket === bucket ? current : { bucket }
+      })
     }
 
     setAvailableHeight()
     window.addEventListener('resize', setAvailableHeight)
     window.visualViewport?.addEventListener('resize', setAvailableHeight)
     window.visualViewport?.addEventListener('scroll', setAvailableHeight)
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined' && containerRef.current
+      ? new ResizeObserver(setAvailableHeight)
+      : null
+    if (resizeObserver && containerRef.current) {
+      resizeObserver.observe(containerRef.current)
+      const listEl = containerRef.current.querySelector('ul[role="list"]')
+      if (listEl instanceof HTMLElement) {
+        resizeObserver.observe(listEl)
+      }
+    }
+
     return () => {
       window.removeEventListener('resize', setAvailableHeight)
       window.visualViewport?.removeEventListener('resize', setAvailableHeight)
       window.visualViewport?.removeEventListener('scroll', setAvailableHeight)
+      resizeObserver?.disconnect()
     }
-  }, [headerSelector, footerSelector, overlaySelector])
+  }, [compact, footerSelector, game.mode, gridSize, headerSelector, overlaySelector, renderedHouseguests.length])
 
   const gridSizeClass = gridSize === 16 ? styles.hgGrid16 : gridSize === 12 ? styles.hgGrid12 : ''
   const effectiveCompactLayout = compact ? compactLayout : 'default'
@@ -241,6 +324,18 @@ export default function HouseguestGrid({
   ]
     .filter(Boolean)
     .join(' ')
+
+  function applyCompactPromptChoice(layout: SupportedCompactRosterLayout) {
+    dispatch(setGameUX({ compactRoster: true, compactRosterLayout: layout }))
+    setCompactPrompt(null)
+  }
+
+  function dismissCompactPrompt() {
+    if (compactPrompt) {
+      rememberCompactPromptDismissal(compactPrompt.bucket)
+    }
+    setCompactPrompt(null)
+  }
 
   return (
     <section
@@ -296,6 +391,23 @@ export default function HouseguestGrid({
           </li>
         ))}
       </ul>
+
+      {compactPrompt && (
+        <aside className={styles.compactPrompt} aria-label="Compact roster suggestion">
+          <p className={styles.compactPromptText}>This screen is cramped. Switch to compact roster?</p>
+          <div className={styles.compactPromptActions}>
+            <button type="button" onClick={() => applyCompactPromptChoice('two-rows')}>
+              2 rows of 8 avatars
+            </button>
+            <button type="button" onClick={() => applyCompactPromptChoice('small')}>
+              4x4 smaller avatars
+            </button>
+            <button type="button" onClick={dismissCompactPrompt}>
+              Not now
+            </button>
+          </div>
+        </aside>
+      )}
     </section>
   )
 }

--- a/src/components/layout/SafeGameViewport.css
+++ b/src/components/layout/SafeGameViewport.css
@@ -1,15 +1,21 @@
 .safe-game-viewport {
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100dvh;
   overflow: hidden;
-  background: var(--color-bg);
+  background-color: var(--safe-game-viewport-bg-color, var(--app-physical-bg, var(--color-bg)));
+  background-image: var(--safe-game-viewport-bg-image, none);
+  background-size: cover;
+  background-position: var(--safe-game-viewport-bg-position, center);
+  background-repeat: no-repeat;
   color: var(--color-text);
   isolation: isolate;
 }
 
 body.homehub-full-bleed-active {
+  --app-physical-bg: var(--color-bg);
+  --safe-game-viewport-bg-image: var(--homehub-full-bleed-bg, none);
+  --safe-game-viewport-bleed-bg: var(--homehub-full-bleed-bg, none);
+  --safe-game-viewport-bg-position: center;
   background-color: var(--color-bg);
   background-image: var(--homehub-full-bleed-bg, none);
   background-size: cover;
@@ -21,9 +27,10 @@ body.homehub-full-bleed-active {
   position: fixed;
   inset: 0;
   z-index: 0;
-  background-image: var(--homehub-full-bleed-bg, none);
+  background-color: var(--safe-game-viewport-bg-color, var(--app-physical-bg, var(--color-bg)));
+  background-image: var(--safe-game-viewport-bleed-bg, var(--homehub-full-bleed-bg, none));
   background-size: cover;
-  background-position: center;
+  background-position: var(--safe-game-viewport-bleed-position, var(--safe-game-viewport-bg-position, center));
   background-repeat: no-repeat;
   opacity: 0;
   pointer-events: none;

--- a/src/index.css
+++ b/src/index.css
@@ -84,7 +84,7 @@ html, body {
   margin: 0;
   padding: 0;
   height: 100%;
-  background: var(--color-bg);
+  background: var(--app-physical-bg, var(--color-bg));
   color: var(--color-text);
   /* Prevent pull-to-refresh on mobile */
   overscroll-behavior: none;
@@ -92,6 +92,7 @@ html, body {
 
 #root {
   height: 100%;
+  background: var(--app-physical-bg, var(--color-bg));
 }
 
 html.is-capacitor,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,7 +12,7 @@ import { createHashRouter } from 'react-router-dom';
 import AppShell             from './components/layout/AppShell';
 import RouteErrorBoundary   from './components/RouteErrorBoundary/RouteErrorBoundary';
 import HomeHub              from './screens/HomeHub/HomeHub';
-import GameScreen           from './screens/GameScreen/GameScreen';
+import GameRouteGate        from './routes/GameRouteGate';
 import DiaryRoom            from './screens/DiaryRoom/DiaryRoom';
 import Houseguests          from './screens/Houseguests/Houseguests';
 import Profile              from './screens/Profile/Profile';
@@ -96,22 +96,22 @@ export const router = createHashRouter([
     element: <AppShell />,
     errorElement: <RouteErrorBoundary />,
     children: [
-      { index: true,              element: <HomeHub />      },
-      { path: 'game',             element: <GameScreen />   },
-      { path: 'diary-room',       element: <DiaryRoom />    },
-      { path: 'houseguests',      element: <Houseguests />  },
-      { path: 'profile',          element: <Profile />      },
-      { path: 'profile-edit',     element: <EditProfile />  },
-      { path: 'profile-picker',   element: <ProfilePicker /> },
-      { path: 'leaderboard',      element: <Leaderboard />  },
-      { path: 'credits',          element: <Credits />      },
-      { path: 'week',             element: <Week />         },
-      { path: 'create-player',    element: <CreatePlayer /> },
-      { path: 'game-over',        element: <GameOver />     },
-      { path: 'self-evicted',     element: <SelfEvicted />  },
-      { path: 'rules',            element: <Rules />        },
-      { path: 'public-meter',     element: <PublicMeter />  },
-      { path: 'settings',         element: <Settings />     },
+      { index: true,              element: <HomeHub />        },
+      { path: 'game',             element: <GameRouteGate />  },
+      { path: 'diary-room',       element: <DiaryRoom />      },
+      { path: 'houseguests',      element: <Houseguests />    },
+      { path: 'profile',          element: <Profile />        },
+      { path: 'profile-edit',     element: <EditProfile />    },
+      { path: 'profile-picker',   element: <ProfilePicker />  },
+      { path: 'leaderboard',      element: <Leaderboard />    },
+      { path: 'credits',          element: <Credits />        },
+      { path: 'week',             element: <Week />           },
+      { path: 'create-player',    element: <CreatePlayer />   },
+      { path: 'game-over',        element: <GameOver />       },
+      { path: 'self-evicted',     element: <SelfEvicted />    },
+      { path: 'rules',            element: <Rules />          },
+      { path: 'public-meter',     element: <PublicMeter />    },
+      { path: 'settings',         element: <Settings />       },
       ...(SettingsAdmin != null
         ? [{ path: 'settingsatiste', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> }]
         : []),
@@ -148,7 +148,7 @@ export const router = createHashRouter([
       ...(GameDebug != null
         ? [{ path: 'gamedebug', element: <Suspense fallback={null}><GameDebug /></Suspense> }]
         : []),
-      { path: '*',                element: <NotFound />     },
+      { path: '*',                element: <NotFound />       },
     ],
   },
 ]);

--- a/src/routes/GameRouteGate.tsx
+++ b/src/routes/GameRouteGate.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from 'react-router-dom';
+import GameScreen from '../screens/GameScreen/GameScreen';
+import { useAppSelector } from '../store/hooks';
+
+export default function GameRouteGate() {
+  const isGameActive = useAppSelector((state) => state.game.status === 'active');
+
+  if (!isGameActive) {
+    return <Navigate to="/" replace state={{ blockedRoute: 'game' }} />;
+  }
+
+  return <GameScreen />;
+}

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -29,12 +29,20 @@
   --tv-zone-viewport-min-height: var(--game-screen-tv-viewport-min-height);
 }
 
-body:has(.game-screen-shell) .safe-game-viewport {
+body:has(.game-screen-shell) {
+  --app-physical-bg: var(--color-bg);
+  --safe-game-viewport-bg-image: url('/assets/bb-gameplay-bg.svg');
+  --safe-game-viewport-bleed-bg: url('/assets/bb-gameplay-bg.svg');
+  --safe-game-viewport-bg-position: center top;
   background-color: var(--color-bg);
   background-image: url('/assets/bb-gameplay-bg.svg');
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;
+}
+
+body:has(.game-screen-shell) .safe-game-viewport__bleed {
+  opacity: 1;
 }
 
 /* Gameplay background shell */

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -32,17 +32,12 @@
 body:has(.game-screen-shell) {
   --app-physical-bg: var(--color-bg);
   --safe-game-viewport-bg-image: url('/assets/bb-gameplay-bg.svg');
-  --safe-game-viewport-bleed-bg: url('/assets/bb-gameplay-bg.svg');
   --safe-game-viewport-bg-position: center top;
   background-color: var(--color-bg);
   background-image: url('/assets/bb-gameplay-bg.svg');
   background-size: cover;
   background-position: center top;
   background-repeat: no-repeat;
-}
-
-body:has(.game-screen-shell) .safe-game-viewport__bleed {
-  opacity: 1;
 }
 
 /* Gameplay background shell */

--- a/src/screens/SettingsAdmin/SettingsAdmin.tsx
+++ b/src/screens/SettingsAdmin/SettingsAdmin.tsx
@@ -2,13 +2,14 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
+  normalizeCompactRosterLayout,
   selectSettings,
   setAudio,
   setDisplay,
   setGameUX,
   setSim,
   setVisual,
-  type CompactRosterLayout,
+  type SupportedCompactRosterLayout,
   type ThemePreset,
 } from '../../store/settingsSlice';
 import CompSelection from '../../components/CompSelection';
@@ -67,24 +68,19 @@ const THEME_PRESETS: { id: ThemePreset; label: string; swatch: string }[] = [
 ];
 
 const COMPACT_ROSTER_LAYOUT_OPTIONS: {
-  id: CompactRosterLayout;
+  id: SupportedCompactRosterLayout;
   label: string;
   description: string;
 }[] = [
   {
-    id: 'slider',
-    label: 'Horizontal slider',
-    description: 'Show every avatar in one scrollable row.',
-  },
-  {
-    id: 'small',
-    label: 'Smaller tiles',
-    description: 'Keep the roster grid but shrink each tile to about half size.',
-  },
-  {
     id: 'two-rows',
     label: '2 rows of 8 avatars',
     description: 'Spread the roster across two wide rows.',
+  },
+  {
+    id: 'small',
+    label: '4x4 smaller avatars',
+    description: 'Keep the roster grid but shrink each tile to about half size.',
   },
 ];
 
@@ -152,10 +148,12 @@ export default function SettingsAdmin() {
     const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
     if (meta) {
       meta.content = enableZoom
-        ? 'width=device-width, initial-scale=1.0'
-        : 'width=device-width, initial-scale=1.0, user-scalable=no';
+        ? 'width=device-width, initial-scale=1.0, viewport-fit=cover'
+        : 'width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover';
     }
   }, [enableZoom]);
+
+  const compactRosterLayout = normalizeCompactRosterLayout(settings.gameUX.compactRosterLayout);
 
   return (
     <div className="settings-screen">
@@ -345,7 +343,7 @@ export default function SettingsAdmin() {
               {settings.gameUX.compactRoster && (
                 <div className="settings-choice-group" aria-label="Compact roster layout">
                   {COMPACT_ROSTER_LAYOUT_OPTIONS.map((option) => {
-                    const selected = settings.gameUX.compactRosterLayout === option.id;
+                    const selected = compactRosterLayout === option.id;
                     return (
                       <label
                         key={option.id}
@@ -504,7 +502,7 @@ export default function SettingsAdmin() {
                   aria-label="Morning Shock chance percentage"
                 />
                 <p className="settings-helper-text">
-                  Chance that a Day 3+ morning shock removes an active housemate before the LOH comp starts. Only fires when more than 4 housemates are still alive.
+                  Chance that a Day 3+ morning shock removes an active housemate before the LOH flow begins. Only fires when more than 4 housemates are still alive.
                 </p>
               </div>
             )}

--- a/tests/houseguestGrid.compactPrompt.test.tsx
+++ b/tests/houseguestGrid.compactPrompt.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import gameReducer from '../src/store/gameSlice';
+import settingsReducer from '../src/store/settingsSlice';
+import HouseguestGrid, { type Houseguest } from '../src/components/HouseguestGrid/HouseguestGrid';
+
+vi.mock('../src/components/HouseguestGrid/AvatarTile', () => ({
+  default: ({ name }: { name: string }) => <div>{name}</div>,
+}));
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+      settings: settingsReducer,
+    },
+  });
+}
+
+const houseguests: Houseguest[] = Array.from({ length: 16 }, (_, index) => ({
+  id: `p${index + 1}`,
+  name: `Player ${index + 1}`,
+}));
+
+function renderGrid(store = makeStore()) {
+  render(
+    <Provider store={store}>
+      <HouseguestGrid
+        houseguests={houseguests}
+        footerSelector=".missing-nav"
+        overlaySelector={null}
+        occupancyLabel="16/16"
+      />
+    </Provider>,
+  );
+  return { store };
+}
+
+describe('HouseguestGrid compact roster prompt', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal('innerWidth', 390);
+    vi.stubGlobal('innerHeight', 260);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('prompts for compact roster when the measured 16-player grid is cramped', async () => {
+    const { store } = renderGrid();
+
+    expect(await screen.findByText('This screen is cramped. Switch to compact roster?')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '2 rows of 8 avatars' }));
+
+    expect(store.getState().settings.gameUX.compactRoster).toBe(true);
+    expect(store.getState().settings.gameUX.compactRosterLayout).toBe('two-rows');
+  });
+});

--- a/tests/integration/gameRouteGate.test.tsx
+++ b/tests/integration/gameRouteGate.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import gameReducer from '../../src/store/gameSlice';
+import GameRouteGate from '../../src/routes/GameRouteGate';
+
+vi.mock('../../src/screens/GameScreen/GameScreen', () => ({
+  default: () => <div data-testid="game-screen" />,
+}));
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+    },
+  });
+}
+
+function renderGameRoute(store = makeStore()) {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/game']}>
+        <Routes>
+          <Route path="/" element={<div data-testid="home-hub" />} />
+          <Route path="/game" element={<GameRouteGate />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+  return { store };
+}
+
+describe('GameRouteGate', () => {
+  it('redirects direct /game visits when no active run exists', async () => {
+    renderGameRoute();
+
+    expect(await screen.findByTestId('home-hub')).toBeTruthy();
+    expect(screen.queryByTestId('game-screen')).toBeNull();
+  });
+
+  it('renders the game when an active run exists', async () => {
+    const store = makeStore();
+    store.dispatch({ type: 'game/resetGame' });
+
+    renderGameRoute(store);
+
+    expect(await screen.findByTestId('game-screen')).toBeTruthy();
+    expect(screen.queryByTestId('home-hub')).toBeNull();
+  });
+});

--- a/tests/integration/gameScreen.compactRosterLayout.test.tsx
+++ b/tests/integration/gameScreen.compactRosterLayout.test.tsx
@@ -45,10 +45,10 @@ function renderGameScreen(store: ReturnType<typeof makeStore>) {
 }
 
 describe('GameScreen compact roster balancing', () => {
-  it('expands the tv stack for compact slider mode and requests a taller log feed', () => {
+  it('expands the tv stack for the supported two-row compact mode and requests a taller log feed', () => {
     const store = makeStore()
 
-    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'two-rows' }))
 
     const { container } = renderGameScreen(store)
 
@@ -59,7 +59,7 @@ describe('GameScreen compact roster balancing', () => {
   it('keeps the roster balance active on narrow viewports so the TV log stays visible', () => {
     const store = makeStore()
 
-    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }))
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'small' }))
     vi.stubGlobal('innerWidth', 390)
     vi.stubGlobal('innerHeight', 844)
 

--- a/tests/settings.compactRoster.test.tsx
+++ b/tests/settings.compactRoster.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import Settings from '../src/screens/Settings/Settings';
+import SettingsAdmin from '../src/screens/SettingsAdmin/SettingsAdmin';
 import gameReducer from '../src/store/gameSlice';
 import settingsReducer, { setGameUX } from '../src/store/settingsSlice';
 
@@ -22,6 +23,19 @@ function renderSettings(store = makeStore()) {
       <MemoryRouter initialEntries={['/settings']}>
         <Routes>
           <Route path="/settings" element={<Settings />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+  return { store };
+}
+
+function renderSettingsAdmin(store = makeStore()) {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/settingsatiste']}>
+        <Routes>
+          <Route path="/settingsatiste" element={<SettingsAdmin />} />
         </Routes>
       </MemoryRouter>
     </Provider>,
@@ -50,5 +64,19 @@ describe('Settings compact roster controls', () => {
 
     expect(store.getState().settings.gameUX.compactRosterLayout).toBe('small');
     expect(screen.getByLabelText(/compact roster layout/i)).toHaveValue('small');
+  });
+
+  it('keeps retired horizontal slider out of advanced Settings', () => {
+    const store = makeStore();
+
+    store.dispatch(setGameUX({ compactRoster: true, compactRosterLayout: 'slider' }));
+    renderSettingsAdmin(store);
+    fireEvent.click(screen.getByRole('tab', { name: /game ux/i }));
+
+    expect(screen.queryByText(/horizontal slider/i)).toBeNull();
+    expect(screen.getByText('2 rows of 8 avatars')).toBeTruthy();
+    expect(screen.getByText('4x4 smaller avatars')).toBeTruthy();
+    expect(screen.getByLabelText(/compact roster layout/i)).toBeTruthy();
+    expect(store.getState().settings.gameUX.compactRosterLayout).toBe('small');
   });
 });

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -28,13 +28,18 @@ describe('safe-area layout styles', () => {
     expect(globalCss).toContain('--safe-right: env(safe-area-inset-right, 0px);');
     expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
     expect(globalCss).toContain('--safe-left: env(safe-area-inset-left, 0px);');
+    expect(globalCss).toContain('background: var(--app-physical-bg, var(--color-bg));');
     expect(safeViewportTsx).toContain('export default function SafeGameViewport');
     expect(safeViewportTsx).toContain('safe-game-viewport__bleed');
     expect(appShellTsx).toContain('<SafeGameViewport>');
 
-    expect(safeViewportCss).toContain('.safe-game-viewport { position: fixed; inset: 0;');
-    expect(safeViewportCss).toContain('height: 100dvh;');
+    expect(safeViewportCss).toContain('.safe-game-viewport { position: fixed; inset: 0; overflow: hidden;');
+    expect(safeViewportCss).toContain('background-image: var(--safe-game-viewport-bg-image, none);');
+    expect(safeViewportCss).not.toContain('height: 100dvh;');
+    expect(safeViewportCss).not.toContain('height: 100vh;');
+    expect(safeViewportCss).not.toContain('width: 100vw;');
     expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');
+    expect(safeViewportCss).toContain('background-image: var(--safe-game-viewport-bleed-bg, var(--homehub-full-bleed-bg, none));');
     expect(safeViewportCss).toContain('body.homehub-full-bleed-active .safe-game-viewport__bleed');
     expect(safeViewportCss).toContain('top: var(--safe-top);');
     expect(safeViewportCss).toContain('right: var(--safe-right);');
@@ -97,7 +102,8 @@ describe('safe-area layout styles', () => {
     expect(gameScreenCss).toContain('--game-screen-tv-min-height: clamp(238px, 30svh, 312px);');
     expect(gameScreenCss).toContain('--game-screen-tv-viewport-min-height: clamp(144px, 18svh, 192px);');
     expect(gameScreenCss).toContain('.game-screen > .tv-zone, .game-screen--compact-roster-balance > .tv-zone { flex: 0 0 auto; min-height: var(--game-screen-tv-min-height); --tv-zone-viewport-min-height: var(--game-screen-tv-viewport-min-height); }');
-    expect(gameScreenCss).toContain("body:has(.game-screen-shell) .safe-game-viewport { background-color: var(--color-bg); background-image: url('/assets/bb-gameplay-bg.svg');");
+    expect(gameScreenCss).toContain("body:has(.game-screen-shell) { --app-physical-bg: var(--color-bg); --safe-game-viewport-bg-image: url('/assets/bb-gameplay-bg.svg');");
+    expect(gameScreenCss).not.toContain('body:has(.game-screen-shell) .safe-game-viewport__bleed { opacity: 1;');
     expect(gameScreenCss).not.toContain('.game-screen--compact-roster-balance > .tv-zone { flex: 1 1 auto; min-height: 0; }');
 
     expect(tvZoneCss).toContain('.tv-zone { display: flex; flex: 0 0 auto; flex-direction: column; min-height: var(--tv-zone-min-height, 238px);');
@@ -117,11 +123,15 @@ describe('safe-area layout styles', () => {
 
     expect(houseguestGridTsx).toContain('const headerSignal = occupancyLabel ?? `${renderedHouseguests.length}`');
     expect(houseguestGridTsx).toContain('key={headerSignal}');
+    expect(houseguestGridTsx).toContain('This screen is cramped. Switch to compact roster?');
+    expect(houseguestGridTsx).toContain('new ResizeObserver(setAvailableHeight)');
+    expect(houseguestGridTsx).toContain('COMPACT_ROSTER_PROMPT_STORAGE_PREFIX');
     expect(houseguestGridTsx).not.toContain('setHeaderVisible');
     expect(houseguestGridCss).toContain('.headerRow { position: absolute; top: 4px; left: 8px;');
     expect(houseguestGridCss).toContain('animation: houseguestHeaderFlash 2200ms ease forwards;');
     expect(houseguestGridCss).toContain('.grid { list-style: none; margin: 0; padding: 0; display: grid; flex: 1 1 auto; min-height: 0;');
     expect(houseguestGridCss).toContain('overflow-y: auto;');
+    expect(houseguestGridCss).toContain('.compactPrompt { position: absolute;');
   });
 
   it('keeps home hub controls safe-contained while decorative art is owned by the physical viewport', () => {
@@ -146,8 +156,9 @@ describe('safe-area layout styles', () => {
     expect(frameIndex).toBeGreaterThan(-1);
     expect(assetLayerIndex).toBeGreaterThan(frameIndex);
 
-    expect(safeViewportCss).toContain('body.homehub-full-bleed-active { background-color: var(--color-bg);');
+    expect(safeViewportCss).toContain('body.homehub-full-bleed-active { --app-physical-bg: var(--color-bg);');
     expect(safeViewportCss).toContain('background-image: var(--homehub-full-bleed-bg, none);');
+    expect(safeViewportCss).toContain('--safe-game-viewport-bleed-bg: var(--homehub-full-bleed-bg, none);');
     expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');
     expect(safeViewportCss).toContain('opacity: var(--homehub-full-bleed-overlay-opacity, 0);');
 
@@ -178,11 +189,16 @@ describe('safe-area layout styles', () => {
       resolve(process.cwd(), 'src/components/layout/viewportMeta.ts'),
       'utf8',
     );
+    const settingsAdminTsx = readFileSync(
+      resolve(process.cwd(), 'src/screens/SettingsAdmin/SettingsAdmin.tsx'),
+      'utf8',
+    );
 
     expect(useGameModeTs).toContain('SafeGameViewport remains the only safe-area layout owner');
     expect(useGameModeTs).toContain('setOverlaysWebView?.({ overlay: true })');
     expect(useGameModeTs).not.toContain('setOverlaysWebView?.({ overlay: false })');
     expect(viewportMetaTs).toContain('viewport-fit=cover');
+    expect(settingsAdminTsx).toContain('viewport-fit=cover');
   });
 
   it('keeps minigames and old fullscreen game roots inside the safe viewport', () => {
@@ -199,6 +215,9 @@ describe('safe-area layout styles', () => {
     expect(safeViewportCss).toContain('.minigame-host, .qtr, .qtr-canvas, .pp, .bbl, .td, .snake-root, .spectator-overlay, .pf-overlay, .day-start-shock');
     expect(safeViewportCss).toContain('position: absolute !important;');
     expect(safeViewportCss).toContain('--app-safe-area-top: 0px;');
+    expect(safeViewportCss).toContain('.safe-game-viewport__content .cps-shell { height: 100%; min-height: 0; }');
+    expect(safeViewportCss).toContain('.safe-game-viewport__content .cps-modal, .safe-game-viewport__content .cps-secret-banner { position: absolute; }');
+    expect(safeViewportCss).toContain('.safe-game-viewport__content .cps-secret-banner { top: 1rem; }');
 
     expect(minigameHostCss).toContain('.minigame-host { position: absolute; inset: 0;');
     expect(minigameHostCss).toContain('height: 100%;');


### PR DESCRIPTION
## Summary
- remove the `100dvh` cap from the physical safe viewport paint owner so HomeHub/GameScreen backgrounds can fill the real device screen
- keep interactive content inside `SafeGameViewport` while physical backgrounds paint through root/body/safe viewport fallbacks
- guard direct `/#/game` visits so inactive runs redirect to HomeHub instead of showing board-only/no controls
- add a measured compact-roster prompt for cramped 16-player layouts while preserving the TV/log space priority
- remove the retired horizontal-slider option from advanced settings and preserve `viewport-fit=cover` when settings rewrites the viewport meta

## Tests
- GitHub Actions CI #3818: passed `npm run build`, `npm run lint`, and `npm run typecheck`.
- GitHub Actions Lint #3485: passed `npm run lint:ci`.
- Added/updated focused regression tests for the physical viewport paint contract, direct game route guard, compact roster prompt, supported compact roster layouts, and minigame safe-root contracts.
- The existing PR workflows do not run Vitest directly, and I did not create a local checkout per request.