### PR TITLE
fix/restore-full-screen-paint-after-safe-viewport-regression

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -62,6 +62,8 @@
   min-height: 0;
   gap: 5px;
   grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: max-content;
+  align-content: start;
   justify-items: stretch;
   align-items: start;
   max-height: min(var(--grid-available-height, 480px), 100%);
@@ -88,7 +90,6 @@
 .gridItem {
   width: 100%;
   min-width: 0;
-  animation: survivorTileSettle 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .sliderItem {
@@ -295,17 +296,6 @@
 @keyframes crossFadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
-}
-
-@keyframes survivorTileSettle {
-  from {
-    opacity: 0;
-    transform: scale(0.92);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
 }
 
 @keyframes nominationLohGlow {
@@ -579,7 +569,6 @@
     opacity: 0;
   }
 
-  .gridItem,
   .nomination_loh,
   .nomination_danger::before,
   .roboStatsSheet {

--- a/src/components/layout/SafeGameViewport.css
+++ b/src/components/layout/SafeGameViewport.css
@@ -1,14 +1,15 @@
 .safe-game-viewport {
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100dvh;
+  width: auto;
+  height: auto;
   overflow: hidden;
   background: var(--color-bg);
   color: var(--color-text);
   isolation: isolate;
 }
 
+html.homehub-full-bleed-active,
 body.homehub-full-bleed-active {
   background-color: var(--color-bg);
   background-image: var(--homehub-full-bleed-bg, none);

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -216,24 +216,27 @@ export default function HomeHub() {
   const hasEndedSurvivorRecord = !survivorSnapshot && (savedRuns?.stats.maxSurvivorDaysSurvived ?? 0) > 0;
 
   useEffect(() => {
+    const root = document.documentElement;
     const { body } = document;
+    root.classList.add('homehub-full-bleed-active');
     body.classList.add('homehub-full-bleed-active');
 
     if (effectiveBgUrl) {
-      body.style.setProperty('--homehub-full-bleed-bg', `url(${JSON.stringify(effectiveBgUrl)})`);
+      root.style.setProperty('--homehub-full-bleed-bg', `url(${JSON.stringify(effectiveBgUrl)})`);
     } else {
-      body.style.removeProperty('--homehub-full-bleed-bg');
+      root.style.removeProperty('--homehub-full-bleed-bg');
     }
 
-    body.style.setProperty(
+    root.style.setProperty(
       '--homehub-full-bleed-overlay-opacity',
       remoteOverlayOpacity != null && remoteOverlayOpacity > 0 ? String(remoteOverlayOpacity) : '0',
     );
 
     return () => {
+      root.classList.remove('homehub-full-bleed-active');
       body.classList.remove('homehub-full-bleed-active');
-      body.style.removeProperty('--homehub-full-bleed-bg');
-      body.style.removeProperty('--homehub-full-bleed-overlay-opacity');
+      root.style.removeProperty('--homehub-full-bleed-bg');
+      root.style.removeProperty('--homehub-full-bleed-overlay-opacity');
     };
   }, [effectiveBgUrl, remoteOverlayOpacity]);
 

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -33,7 +33,9 @@ describe('safe-area layout styles', () => {
     expect(appShellTsx).toContain('<SafeGameViewport>');
 
     expect(safeViewportCss).toContain('.safe-game-viewport { position: fixed; inset: 0;');
-    expect(safeViewportCss).toContain('height: 100dvh;');
+    expect(safeViewportCss).toContain('width: auto;');
+    expect(safeViewportCss).toContain('height: auto;');
+    expect(safeViewportCss).not.toContain('height: 100dvh;');
     expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');
     expect(safeViewportCss).toContain('body.homehub-full-bleed-active .safe-game-viewport__bleed');
     expect(safeViewportCss).toContain('.safe-game-viewport__content { position: absolute; inset: 0;');
@@ -129,7 +131,10 @@ describe('safe-area layout styles', () => {
     expect(houseguestGridCss).toContain('.headerRow { position: absolute; top: 4px; left: 8px;');
     expect(houseguestGridCss).toContain('animation: houseguestHeaderFlash 2200ms ease forwards;');
     expect(houseguestGridCss).toContain('.grid { list-style: none; margin: 0; padding: 0; display: grid; flex: 1 1 auto; min-height: 0;');
+    expect(houseguestGridCss).toContain('grid-auto-rows: max-content;');
+    expect(houseguestGridCss).toContain('align-content: start;');
     expect(houseguestGridCss).toContain('overflow-y: auto;');
+    expect(houseguestGridCss).not.toContain('survivorTileSettle');
   });
 
   it('keeps home hub controls safe-contained while decorative art is owned by the physical viewport', () => {
@@ -147,6 +152,7 @@ describe('safe-area layout styles', () => {
     const assetLayerIndex = homeHubTsx.indexOf('<HomeHubAssetLayer');
 
     expect(homeHubTsx).toContain("body.classList.add('homehub-full-bleed-active')");
+    expect(homeHubTsx).toContain("root.classList.add('homehub-full-bleed-active')");
     expect(homeHubTsx).toContain("--homehub-full-bleed-bg");
     expect(homeHubTsx).toContain("--homehub-full-bleed-overlay-opacity");
     expect(homeHubTsx).not.toContain('className="homehub-intro-bg"');
@@ -154,6 +160,7 @@ describe('safe-area layout styles', () => {
     expect(frameIndex).toBeGreaterThan(-1);
     expect(assetLayerIndex).toBeGreaterThan(frameIndex);
 
+    expect(safeViewportCss).toContain('html.homehub-full-bleed-active, body.homehub-full-bleed-active');
     expect(safeViewportCss).toContain('body.homehub-full-bleed-active { background-color: var(--color-bg);');
     expect(safeViewportCss).toContain('background-image: var(--homehub-full-bleed-bg, none);');
     expect(safeViewportCss).toContain('.safe-game-viewport__bleed { position: fixed; inset: 0;');


### PR DESCRIPTION
## Summary
- Restore full-screen paint ownership by keeping `SafeGameViewport` fixed to its edges instead of pinning it to `100dvh`.
- Keep HomeHub decorative background available from the document root so the physical viewport background does not fall back to black at the bottom.
- Stabilize Survivor roster layout by preventing stretched grid rows and removing the tile settle animation.
- Keep tests covering the safe viewport paint contract and roster row behavior.

## Verification
- `git diff --check` passed locally.
- `npm run lint`, `npm run typecheck`, and `npm run build` could not run locally because this no-install workspace does not have `eslint` or `tsc` binaries available.