### PR TITLE
feat/measured-responsive-game-layout-budget

### DIFF
--- a/src/components/CeremonyOverlay/CeremonyOverlay.tsx
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.tsx
@@ -70,6 +70,8 @@ export interface CeremonyOverlayProps {
    * during the render phase (e.g. first paint).
    */
   resolveTiles?: () => CeremonyTile[];
+  /** Changes when the surrounding layout budget changes and tile rects should be refreshed. */
+  layoutSignal?: string | number;
 }
 
 /** Badge animation phases with timing (ms from overlay mount) */
@@ -169,6 +171,7 @@ export default function CeremonyOverlay({
   showDim = true,
   showCaption = true,
   resolveTiles,
+  layoutSignal,
 }: CeremonyOverlayProps) {
   const [visible, setVisible] = useState(true);
   const [badgePhase, setBadgePhase] = useState<BadgePhase>('hidden');
@@ -229,13 +232,13 @@ export default function CeremonyOverlay({
     return id;
   }, []);
 
-  // Resolve tiles lazily on mount when resolveTiles is provided.
+  // Resolve tiles lazily and refresh them when the measured layout changes.
   useEffect(() => {
-    if (resolveTiles && resolvedTiles === null) {
+    if (resolveTiles) {
       setResolvedTiles(resolveTiles());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [layoutSignal]);
 
   // Headless fallback: fire onDone immediately
   useEffect(() => {

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -66,7 +66,7 @@
   align-content: start;
   justify-items: stretch;
   align-items: start;
-  max-height: min(var(--grid-available-height, 480px), 100%);
+  max-height: min(var(--game-roster-max-height, 480px), var(--grid-available-height, 480px), 100%);
   overflow: hidden;
   padding-bottom: 4px;
 }
@@ -94,6 +94,36 @@
   flex: 0 0 min(84px, calc(25vw - 10px));
   min-width: 0;
   scroll-snap-align: start;
+}
+
+.container[data-header-mode='persistent'] .headerRow {
+  position: static;
+  max-width: 100%;
+  margin: 0 0 5px;
+  animation: none;
+  opacity: 1;
+  transform: none;
+}
+
+.scrollRoster .grid {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-block: 8px;
+  padding-right: 2px;
+}
+
+.scrollRoster .grid::-webkit-scrollbar {
+  width: 4px;
+}
+
+.scrollRoster .grid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollRoster .grid::-webkit-scrollbar-thumb {
+  background: rgba(139, 92, 246, 0.34);
+  border-radius: 999px;
 }
 
 .tile {
@@ -439,7 +469,7 @@
 
 .compactSmall .tile,
 .compactSmall .hgTileInactive {
-  width: var(--compact-small-tile-width, 50%);
+  width: min(100%, var(--game-avatar-tile-size, var(--compact-small-tile-width, 50%)));
   margin-inline: auto;
 }
 

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -77,6 +77,12 @@ type Props = {
   compact?: boolean
   /** Optional compact roster presentation chosen in Settings. */
   compactLayout?: CompactRosterLayout
+  /** Responsive budget-selected roster behavior. */
+  rosterMode?: 'normal' | 'compact-small' | 'scroll'
+  /** Whether the HOUSEMATES row should stay visible or briefly overlay. */
+  headerMode?: 'transient' | 'persistent'
+  /** Changes when the measured layout budget changes. */
+  layoutRevision?: number
   /** Optional alive/total chip shown beside the section heading. */
   occupancyLabel?: string
 }
@@ -98,6 +104,9 @@ export default function HouseguestGrid({
   placeholderCount = 0,
   compact = false,
   compactLayout = 'slider',
+  rosterMode = 'normal',
+  headerMode = 'transient',
+  layoutRevision = 0,
   occupancyLabel,
 }: Props) {
   const containerRef = useRef<HTMLElement | null>(null)
@@ -225,7 +234,7 @@ export default function HouseguestGrid({
       window.visualViewport?.removeEventListener('resize', setAvailableHeight)
       window.visualViewport?.removeEventListener('scroll', setAvailableHeight)
     }
-  }, [headerSelector, footerSelector, overlaySelector])
+  }, [headerSelector, footerSelector, layoutRevision, overlaySelector])
 
   const gridSizeClass = gridSize === 16 ? styles.hgGrid16 : gridSize === 12 ? styles.hgGrid12 : ''
   const effectiveCompactLayout = compact ? compactLayout : 'default'
@@ -238,6 +247,7 @@ export default function HouseguestGrid({
     compact ? styles.compact : '',
     effectiveCompactLayout === 'small' ? styles.compactSmall : '',
     effectiveCompactLayout === 'two-rows' ? styles.compactTwoRows : '',
+    rosterMode === 'scroll' ? styles.scrollRoster : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -248,6 +258,8 @@ export default function HouseguestGrid({
       className={sectionClassName}
       aria-labelledby="houseguests-heading"
       data-compact-layout={effectiveCompactLayout}
+      data-roster-mode={rosterMode}
+      data-header-mode={headerMode}
     >
       <div key={headerSignal} className={styles.headerRow} aria-live="polite">
         <h3 id="houseguests-heading" className={styles.header}>
@@ -260,7 +272,11 @@ export default function HouseguestGrid({
         )}
       </div>
 
-      <ul className={listClassName} role="list">
+      <ul
+        className={listClassName}
+        role="list"
+        data-roster-scroll={rosterMode === 'scroll' ? 'true' : undefined}
+      >
         {renderedHouseguests.map((hg) => {
           const resolvedRoboStats = hg.roboStats ?? survivorRoboStatsById.get(String(hg.id))
           return (

--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   width: 100%;
   height: 100dvh;
-  max-width: 480px;
+  max-width: var(--app-shell-max-width, 480px);
   margin: 0 auto;
   background: var(--color-bg);
   position: relative;

--- a/src/index.css
+++ b/src/index.css
@@ -94,9 +94,12 @@ html, body {
   height: 100%;
 }
 
-html.is-capacitor,
-html.is-chrome-android {
+html.is-capacitor {
   --app-safe-area-top-fallback: 16px;
+}
+
+html.is-chrome-android {
+  --app-safe-area-top-fallback: 24px;
 }
 
 /* ── Base elements ────────────────────────────────────────────────────────── */

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -37,6 +37,19 @@ body:has(.game-screen-shell) .app-shell {
   background-repeat: no-repeat;
 }
 
+body:has(.game-screen-shell) {
+  background-color: var(--color-bg);
+  background-image: url('/assets/bb-gameplay-bg.svg');
+  background-size: cover;
+  background-position: center top;
+  background-repeat: no-repeat;
+}
+
+.game-screen[data-layout-size='tablet-portrait'],
+.game-screen[data-layout-size='tablet-landscape'] {
+  padding-inline: 14px;
+}
+
 /* Gameplay background shell */
 .game-screen-shell {
   background-image: url('/assets/bb-gameplay-bg.svg');
@@ -217,6 +230,21 @@ body:has(.game-screen-shell) .app-shell {
 .game-screen__vote-breakdown-actions {
   display: flex;
   justify-content: center;
+}
+
+.game-screen__layout-debug {
+  position: absolute;
+  right: 8px;
+  bottom: calc(var(--game-screen-floating-dock-clearance) + 10px);
+  z-index: 9100;
+  max-width: calc(100% - 16px);
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(5, 8, 14, 0.82);
+  color: rgba(240, 246, 255, 0.92);
+  font-size: 10px;
+  line-height: 1.3;
+  pointer-events: none;
 }
 
 

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -148,6 +148,7 @@ import {
   usePersistedPromptDate,
 } from './gameScreenPersistence'
 import { requestFavoriteAudienceSurge } from './favoriteAudienceSurgeRequest'
+import { useResponsiveGameLayout } from './useResponsiveGameLayout'
 import {
   BATTLE_BACK_ANNOUNCEMENT_SEQUENCE,
   advanceBattleBackAnnouncementStep,
@@ -300,6 +301,7 @@ function buildDoubleEvictionPostVoteAnnouncement(options: {
 export default function GameScreen() {
   const dispatch = useAppDispatch()
   const store = useStore<RootState>()
+  const gameScreenRef = useRef<HTMLDivElement | null>(null)
   const storeRef = useRef(store)
   useEffect(() => {
     storeRef.current = store
@@ -416,6 +418,14 @@ export default function GameScreen() {
     const escaped = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(playerId) : playerId
     const el = document.querySelector<HTMLElement>(`[data-player-id="${escaped}"]`)
     if (!el) return null
+    const scrollRoot = el.closest<HTMLElement>('[data-roster-scroll="true"]')
+    if (scrollRoot) {
+      const tileRect = el.getBoundingClientRect()
+      const scrollRect = scrollRoot.getBoundingClientRect()
+      if (tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom) {
+        el.scrollIntoView({ block: 'center', inline: 'nearest' })
+      }
+    }
     const rect = el.getBoundingClientRect()
     return rect.width > 0 || rect.height > 0 ? rect : null
   }, [])
@@ -2951,9 +2961,6 @@ export default function GameScreen() {
     spectatorF3Active ||
     spectatorLegacyActive
 
-  const expandsTvForCompactRoster = settings.gameUX.compactRoster
-  const compactRosterLogRows = expandsTvForCompactRoster ? 6 : 2
-
   // ── Viewport fallback message for blank-TV states ────────────────────────
   // Provides a meaningful holding message during states where no fresh TV event
   // is available: after dismissing the live_eviction announcement during
@@ -2996,10 +3003,24 @@ export default function GameScreen() {
     })
   }
 
+  const responsiveGameLayout = useResponsiveGameLayout(gameScreenRef, {
+    hasDock: showGameControlDock,
+    playerCount: game.players.length,
+    userCompactRoster: settings.gameUX.compactRoster,
+    userCompactRosterLayout: settings.gameUX.compactRosterLayout,
+  })
+  const gameTvLogRows = responsiveGameLayout.tvLogRows
+
   return (
     <LayoutGroup id="game-layout">
     <div
-      className={`game-screen game-screen-shell${expandsTvForCompactRoster ? ' game-screen--compact-roster-balance' : ''}`}
+      ref={gameScreenRef}
+      className={`game-screen game-screen-shell${responsiveGameLayout.compactRoster ? ' game-screen--compact-roster-balance' : ''}`}
+      style={responsiveGameLayout.cssVars}
+      data-layout-size={responsiveGameLayout.layoutSize}
+      data-roster-mode={responsiveGameLayout.rosterMode}
+      data-roster-header={responsiveGameLayout.rosterHeaderMode}
+      data-layout-revision={responsiveGameLayout.revision}
     >
       {showPublicSaveReveal && publicSaveWinnerId ? (
         <TvZone
@@ -3023,7 +3044,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showDemocraciaResults && democraciaResultDisplay ? (
@@ -3049,7 +3070,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : showVoteResults ? (
@@ -3077,7 +3098,7 @@ export default function GameScreen() {
               ? () => setPublicMeterUnavailableAnnouncement(null)
               : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       ) : (
@@ -3105,12 +3126,18 @@ export default function GameScreen() {
                   ? handlePublicSaveResultDismiss
                   : handlePreAdAnnouncementDismiss
           }
-          mainLogMaxVisible={compactRosterLogRows}
+          mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
         />
       )}
 
       {/* ── Outgoing LOH ineligibility warning ──────────────────────────── */}
+      {responsiveGameLayout.debugEnabled && (
+        <output className="game-screen__layout-debug" aria-live="polite">
+          {responsiveGameLayout.debugLabel}
+        </output>
+      )}
+
       {showOutgoingHohWarning && (
         <div
           className="tv-binary-modal"
@@ -3162,6 +3189,7 @@ export default function GameScreen() {
       {shouldShowNominationCeremony && (
         <CeremonyOverlay
           tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
           resolveTiles={() => {
             const lohId = lohCeremonyTileId
             if (!lohId) return []
@@ -3780,6 +3808,7 @@ export default function GameScreen() {
       {showAdvanceHohCeremony && game.lohId && (
         <CeremonyOverlay
           tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
           resolveTiles={() => {
             const winnerId = game.lohId!
             const winnerPlayer = game.players.find((p) => p.id === winnerId)
@@ -3815,6 +3844,7 @@ export default function GameScreen() {
       {showAiReplacementAnim && game.nomineeIds.length > 0 && (
         <CeremonyOverlay
           tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
           resolveTiles={() => {
             const replacementId = game.nomineeIds[game.nomineeIds.length - 1]
             const sourceId = game.specialVeto?.activeType === 'diamond' ? game.posWinnerId : game.lohId
@@ -3848,6 +3878,7 @@ export default function GameScreen() {
       {showPublicSaveCeremony && pendingPublicSaveResult && (
         <CeremonyOverlay
           tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
           resolveTiles={() => [{
             rect: getTileRect(pendingPublicSaveResult.savedId),
             badge: '❓',
@@ -4257,8 +4288,11 @@ export default function GameScreen() {
         headerSelector=".tv-zone"
         footerSelector=".nav-bar"
         overlaySelector=".game-control-dock"
-        compact={settings.gameUX.compactRoster}
-        compactLayout={settings.gameUX.compactRosterLayout}
+        compact={responsiveGameLayout.compactRoster}
+        compactLayout={responsiveGameLayout.compactRosterLayout}
+        rosterMode={responsiveGameLayout.rosterMode}
+        headerMode={responsiveGameLayout.rosterHeaderMode}
+        layoutRevision={responsiveGameLayout.revision}
         occupancyLabel={`${alivePlayers.length}/${game.players.length}`}
       />
       {previewPlayer && <HouseguestInfoDialog player={previewPlayer} onClose={() => setPreviewPlayer(null)} />}

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type RefObject } from 'react'
+import type { CompactRosterLayout } from '../../store/settingsSlice'
+
+export type GameLayoutSize =
+  | 'phone-small'
+  | 'phone-medium'
+  | 'phone-large'
+  | 'tablet-portrait'
+  | 'tablet-landscape'
+
+export type ResponsiveRosterMode = 'normal' | 'compact-small' | 'scroll'
+export type RosterHeaderMode = 'transient' | 'persistent'
+
+export interface ResponsiveGameLayoutBudget {
+  layoutSize: GameLayoutSize
+  rosterMode: ResponsiveRosterMode
+  rosterHeaderMode: RosterHeaderMode
+  compactRoster: boolean
+  compactRosterLayout: CompactRosterLayout
+  tvLogRows: number
+  cssVars: CSSProperties
+  debugEnabled: boolean
+  debugLabel: string
+  shellMaxWidth: number
+  revision: number
+  signature: string
+}
+
+export interface ResponsiveGameLayoutInput {
+  viewportWidth: number
+  viewportHeight: number
+  stageWidth: number
+  stageHeight: number
+  safeTop: number
+  safeBottom: number
+  navHeight: number
+  dockHeight: number
+  hasDock: boolean
+  playerCount: number
+  userCompactRoster: boolean
+  userCompactRosterLayout: CompactRosterLayout
+  isAndroidLike?: boolean
+  debugEnabled?: boolean
+  revision?: number
+}
+
+const ANDROID_TOP_SAFE_FALLBACK = 24
+const DEFAULT_NAV_HEIGHT = 60
+const DEFAULT_PHONE_WIDTH = 390
+const DEFAULT_PHONE_HEIGHT = 780
+const DEFAULT_DOCK_RATIO = 220 / 980
+const ROSTER_COLUMNS = 4
+const ROSTER_GAP = 5
+const ROSTER_INLINE_PADDING = 16
+const ROSTER_HEADER_HEIGHT = 30
+const GAME_VERTICAL_PADDING = 10
+const GAME_SECTION_GAPS = 12
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function roundPx(value: number) {
+  return Math.max(0, Math.round(value))
+}
+
+function readPx(value: string | null | undefined) {
+  if (!value) return 0
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function estimateDockHeight(stageWidth: number) {
+  const dockWidth = Math.min(stageWidth * 0.8, 340)
+  return dockWidth * DEFAULT_DOCK_RATIO
+}
+
+function resolveLayoutSize(width: number, height: number): GameLayoutSize {
+  if (width >= 720) {
+    return width > height ? 'tablet-landscape' : 'tablet-portrait'
+  }
+  if (height < 700 || width < 360) return 'phone-small'
+  if (height < 840) return 'phone-medium'
+  return 'phone-large'
+}
+
+function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
+  layoutSize: GameLayoutSize
+  rosterMode: ResponsiveRosterMode
+  tvLogRows: number
+  effectiveSafeTop: number
+  dockClearance: number
+  rosterMaxHeight: number
+}) {
+  return [
+    `${Math.round(input.viewportWidth)}x${Math.round(input.viewportHeight)}`,
+    `stage ${Math.round(input.stageWidth)}x${Math.round(input.stageHeight)}`,
+    `safe ${Math.round(budget.effectiveSafeTop)}/${Math.round(input.safeBottom)}`,
+    `nav ${Math.round(input.navHeight)}`,
+    `dock ${Math.round(budget.dockClearance)}`,
+    `tv rows ${budget.tvLogRows}`,
+    `roster ${budget.rosterMode} ${Math.round(budget.rosterMaxHeight)}`,
+    budget.layoutSize,
+  ].join(' | ')
+}
+
+export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): ResponsiveGameLayoutBudget {
+  const viewportWidth = input.viewportWidth || input.stageWidth || DEFAULT_PHONE_WIDTH
+  const viewportHeight = input.viewportHeight || input.stageHeight || DEFAULT_PHONE_HEIGHT
+  const stageWidth = input.stageWidth || Math.min(viewportWidth, DEFAULT_PHONE_WIDTH)
+  const stageHeight = input.stageHeight || viewportHeight
+  const layoutSize = resolveLayoutSize(viewportWidth, viewportHeight)
+  const effectiveSafeTop = input.isAndroidLike
+    ? Math.max(input.safeTop, ANDROID_TOP_SAFE_FALLBACK)
+    : input.safeTop
+  const navHeight = input.navHeight || DEFAULT_NAV_HEIGHT
+  const measuredDockHeight = input.dockHeight || estimateDockHeight(stageWidth)
+  const dockClearance = input.hasDock ? measuredDockHeight + 8 : 0
+  const isTablet = layoutSize === 'tablet-portrait' || layoutSize === 'tablet-landscape'
+  const shellMaxWidth = isTablet
+    ? (layoutSize === 'tablet-landscape' ? 560 : 520)
+    : 480
+
+  const tileWidth = (stageWidth - ROSTER_INLINE_PADDING - ROSTER_GAP * (ROSTER_COLUMNS - 1)) / ROSTER_COLUMNS
+  const normalTileSize = clamp(tileWidth, 64, isTablet ? 128 : 112)
+  const compactTileSize = normalTileSize * 0.72
+  const rosterRows = Math.max(1, Math.ceil(Math.max(input.playerCount, 1) / ROSTER_COLUMNS))
+
+  const baseTvHeight = layoutSize === 'phone-small'
+    ? 204
+    : layoutSize === 'phone-medium'
+      ? 232
+      : isTablet
+        ? 292
+        : 258
+  const tvHeight = clamp(
+    stageHeight * (isTablet ? 0.27 : 0.3),
+    baseTvHeight,
+    isTablet ? 336 : 312,
+  )
+  const tvViewportHeight = clamp(tvHeight - 82, 132, isTablet ? 238 : 192)
+  const availableAfterTv = Math.max(
+    0,
+    stageHeight - tvHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
+  )
+  const normalRosterHeight = rosterRows * normalTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
+  const compactRosterHeight = rosterRows * compactTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
+  const extraAfterNormalRoster = availableAfterTv - normalRosterHeight
+
+  const tvLogRows = extraAfterNormalRoster >= 96 || isTablet
+    ? (isTablet && extraAfterNormalRoster >= 160 ? 4 : 3)
+    : extraAfterNormalRoster >= 36
+      ? 2
+      : 1
+  const logHeight = tvLogRows * 32
+  const availableRosterHeight = Math.max(
+    180,
+    stageHeight - tvHeight - logHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
+  )
+
+  const normalFits = normalRosterHeight <= availableRosterHeight
+  const compactFits = compactRosterHeight <= availableRosterHeight
+  const rosterMode: ResponsiveRosterMode = input.userCompactRoster
+    ? 'compact-small'
+    : normalFits
+      ? 'normal'
+      : compactFits
+        ? 'compact-small'
+        : 'scroll'
+
+  const rosterHeaderMode: RosterHeaderMode = normalFits || isTablet || layoutSize === 'phone-large'
+    ? 'persistent'
+    : 'transient'
+  const compactRoster = input.userCompactRoster || rosterMode === 'compact-small'
+  const compactRosterLayout = input.userCompactRoster
+    ? input.userCompactRosterLayout
+    : 'small'
+  const rosterMaxHeight = Math.max(
+    180,
+    availableRosterHeight - (rosterHeaderMode === 'persistent' ? ROSTER_HEADER_HEIGHT : 0),
+  )
+  const avatarTileSize = rosterMode === 'compact-small' ? compactTileSize : normalTileSize
+
+  const cssVars = {
+    '--game-safe-top': `${roundPx(effectiveSafeTop)}px`,
+    '--game-safe-bottom': `${roundPx(input.safeBottom)}px`,
+    '--game-screen-floating-dock-clearance': `${roundPx(dockClearance)}px`,
+    '--game-screen-tv-min-height': `${roundPx(tvHeight)}px`,
+    '--game-screen-tv-viewport-min-height': `${roundPx(tvViewportHeight)}px`,
+    '--game-tv-log-rows': String(tvLogRows),
+    '--game-roster-max-height': `${roundPx(rosterMaxHeight)}px`,
+    '--game-avatar-tile-size': `${roundPx(avatarTileSize)}px`,
+    '--game-shell-max-width': `${shellMaxWidth}px`,
+  } as CSSProperties
+
+  const debugLabel = buildDebugLabel(input, {
+    layoutSize,
+    rosterMode,
+    tvLogRows,
+    effectiveSafeTop,
+    dockClearance,
+    rosterMaxHeight,
+  })
+  const signature = [
+    layoutSize,
+    rosterMode,
+    rosterHeaderMode,
+    tvLogRows,
+    roundPx(tvHeight),
+    roundPx(rosterMaxHeight),
+    roundPx(dockClearance),
+    roundPx(effectiveSafeTop),
+    shellMaxWidth,
+  ].join(':')
+
+  return {
+    layoutSize,
+    rosterMode,
+    rosterHeaderMode,
+    compactRoster,
+    compactRosterLayout,
+    tvLogRows,
+    cssVars,
+    debugEnabled: input.debugEnabled === true,
+    debugLabel,
+    shellMaxWidth,
+    revision: input.revision ?? 0,
+    signature,
+  }
+}
+
+function isLayoutDebugEnabled() {
+  if (typeof window === 'undefined') return false
+  const params = new URLSearchParams(window.location.search)
+  if (params.has('debugLayout')) return true
+  try {
+    return window.localStorage.getItem('bbmobile:debugLayout') === '1'
+  } catch {
+    return false
+  }
+}
+
+function readViewportInput<TStage extends HTMLElement>(
+  stageRef: RefObject<TStage | null>,
+  options: {
+    hasDock: boolean
+    playerCount: number
+    userCompactRoster: boolean
+    userCompactRosterLayout: CompactRosterLayout
+  },
+  revision: number,
+): ResponsiveGameLayoutInput {
+  const visualViewport = window.visualViewport
+  const viewportWidth = visualViewport?.width ?? window.innerWidth
+  const viewportHeight = visualViewport?.height ?? window.innerHeight
+  const stageRect = stageRef.current?.getBoundingClientRect()
+  const navRect = document.querySelector<HTMLElement>('.nav-bar')?.getBoundingClientRect()
+  const dockRect = document.querySelector<HTMLElement>('.game-control-dock')?.getBoundingClientRect()
+  const rootStyle = getComputedStyle(document.documentElement)
+  const safeTop = Math.max(
+    readPx(rootStyle.getPropertyValue('--safe-top')),
+    readPx(rootStyle.getPropertyValue('--app-safe-area-top')),
+  )
+  const safeBottom = Math.max(
+    readPx(rootStyle.getPropertyValue('--safe-bottom')),
+    readPx(rootStyle.getPropertyValue('--safe-area-inset-bottom')),
+  )
+  const isAndroidLike = document.documentElement.classList.contains('is-chrome-android')
+
+  return {
+    viewportWidth,
+    viewportHeight,
+    stageWidth: stageRect?.width ?? Math.min(viewportWidth, DEFAULT_PHONE_WIDTH),
+    stageHeight: stageRect?.height ?? viewportHeight,
+    safeTop,
+    safeBottom,
+    navHeight: navRect?.height ?? DEFAULT_NAV_HEIGHT,
+    dockHeight: dockRect?.height ?? 0,
+    hasDock: options.hasDock,
+    playerCount: options.playerCount,
+    userCompactRoster: options.userCompactRoster,
+    userCompactRosterLayout: options.userCompactRosterLayout,
+    isAndroidLike,
+    debugEnabled: isLayoutDebugEnabled(),
+    revision,
+  }
+}
+
+export function useResponsiveGameLayout<TStage extends HTMLElement>(
+  stageRef: RefObject<TStage | null>,
+  options: {
+    hasDock: boolean
+    playerCount: number
+    userCompactRoster: boolean
+    userCompactRosterLayout: CompactRosterLayout
+  },
+) {
+  const revisionRef = useRef(0)
+  const {
+    hasDock,
+    playerCount,
+    userCompactRoster,
+    userCompactRosterLayout,
+  } = options
+  const [budget, setBudget] = useState<ResponsiveGameLayoutBudget>(() =>
+    computeResponsiveGameLayout({
+      viewportWidth: DEFAULT_PHONE_WIDTH,
+      viewportHeight: DEFAULT_PHONE_HEIGHT,
+      stageWidth: DEFAULT_PHONE_WIDTH,
+      stageHeight: DEFAULT_PHONE_HEIGHT,
+      safeTop: 0,
+      safeBottom: 0,
+      navHeight: DEFAULT_NAV_HEIGHT,
+      dockHeight: 0,
+      hasDock,
+      playerCount,
+      userCompactRoster,
+      userCompactRosterLayout,
+      revision: 0,
+    }))
+
+  const measure = useCallback(() => {
+    revisionRef.current += 1
+    const next = computeResponsiveGameLayout(readViewportInput(stageRef, {
+      hasDock,
+      playerCount,
+      userCompactRoster,
+      userCompactRosterLayout,
+    }, revisionRef.current))
+    setBudget((prev) => (prev.signature === next.signature && prev.debugLabel === next.debugLabel ? prev : next))
+  }, [hasDock, playerCount, stageRef, userCompactRoster, userCompactRosterLayout])
+
+  useEffect(() => {
+    measure()
+    window.addEventListener('resize', measure)
+    window.visualViewport?.addEventListener('resize', measure)
+    window.visualViewport?.addEventListener('scroll', measure)
+
+    const observed = [
+      stageRef.current,
+      document.querySelector<HTMLElement>('.nav-bar'),
+      document.querySelector<HTMLElement>('.game-control-dock'),
+    ].filter((el): el is HTMLElement => el instanceof HTMLElement)
+    let resizeObserver: ResizeObserver | null = null
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(measure)
+      observed.forEach((el) => resizeObserver?.observe(el))
+    }
+
+    return () => {
+      window.removeEventListener('resize', measure)
+      window.visualViewport?.removeEventListener('resize', measure)
+      window.visualViewport?.removeEventListener('scroll', measure)
+      resizeObserver?.disconnect()
+    }
+  }, [measure, stageRef])
+
+  useEffect(() => {
+    const root = document.documentElement
+    const previous = root.style.getPropertyValue('--app-shell-max-width')
+    root.style.setProperty('--app-shell-max-width', `${budget.shellMaxWidth}px`)
+    return () => {
+      if (previous) {
+        root.style.setProperty('--app-shell-max-width', previous)
+      } else {
+        root.style.removeProperty('--app-shell-max-width')
+      }
+    }
+  }, [budget.shellMaxWidth])
+
+  return budget
+}

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -114,6 +114,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     ? Math.max(input.safeTop, ANDROID_TOP_SAFE_FALLBACK)
     : input.safeTop
   const navHeight = input.navHeight || DEFAULT_NAV_HEIGHT
+  void navHeight
   const measuredDockHeight = input.dockHeight || estimateDockHeight(stageWidth)
   const dockClearance = input.hasDock ? measuredDockHeight + 8 : 0
   const isTablet = layoutSize === 'tablet-portrait' || layoutSize === 'tablet-landscape'

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeResponsiveGameLayout,
+  type ResponsiveGameLayoutInput,
+} from '../../../src/screens/GameScreen/useResponsiveGameLayout'
+
+function makeInput(overrides: Partial<ResponsiveGameLayoutInput> = {}): ResponsiveGameLayoutInput {
+  return {
+    viewportWidth: 393,
+    viewportHeight: 852,
+    stageWidth: 393,
+    stageHeight: 750,
+    safeTop: 0,
+    safeBottom: 34,
+    navHeight: 94,
+    dockHeight: 70,
+    hasDock: true,
+    playerCount: 16,
+    userCompactRoster: false,
+    userCompactRosterLayout: 'small',
+    ...overrides,
+  }
+}
+
+describe('responsive game layout budget', () => {
+  it('uses a measured Android top-safe fallback when env safe-area is zero', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportHeight: 800,
+      stageHeight: 700,
+      safeTop: 0,
+      safeBottom: 0,
+      isAndroidLike: true,
+    }))
+
+    expect(budget.cssVars).toMatchObject({
+      '--game-safe-top': '24px',
+    })
+  })
+
+  it('tries a fixed compact roster before allowing roster scroll on phones', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportHeight: 852,
+      stageHeight: 699,
+      playerCount: 16,
+    }))
+
+    expect(budget.layoutSize).toBe('phone-large')
+    expect(budget.rosterMode).toBe('compact-small')
+    expect(budget.compactRoster).toBe(true)
+    expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
+  })
+
+  it('spends extra vertical space on more TV log rows before leaving dead space', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 430,
+      viewportHeight: 950,
+      stageWidth: 430,
+      stageHeight: 900,
+      dockHeight: 74,
+    }))
+
+    expect(budget.rosterMode).toBe('normal')
+    expect(budget.rosterHeaderMode).toBe('persistent')
+    expect(budget.tvLogRows).toBeGreaterThanOrEqual(3)
+  })
+
+  it('classifies tablet landscape and widens the centered game cabinet intentionally', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 1024,
+      viewportHeight: 768,
+      stageWidth: 560,
+      stageHeight: 650,
+      safeBottom: 20,
+      dockHeight: 76,
+    }))
+
+    expect(budget.layoutSize).toBe('tablet-landscape')
+    expect(budget.shellMaxWidth).toBe(560)
+    expect(budget.rosterHeaderMode).toBe('persistent')
+  })
+})

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -19,10 +19,12 @@ describe('safe-area layout styles', () => {
 
     expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);');
     expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
+    expect(globalCss).toContain('html.is-chrome-android { --app-safe-area-top-fallback: 24px; }');
     expect(existsSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.tsx'))).toBe(false);
     expect(existsSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'))).toBe(false);
     expect(appShellTsx).not.toContain('SafeGameViewport');
     expect(appShellCss).toContain('height: 100dvh;');
+    expect(appShellCss).toContain('max-width: var(--app-shell-max-width, 480px);');
     expect(appShellCss).toContain('margin: 0 auto;');
     expect(appShellCss).toContain('padding-top: var(--app-safe-area-top);');
     expect(appShellCss).toContain('padding-right: var(--safe-right);');
@@ -56,8 +58,13 @@ describe('safe-area layout styles', () => {
     const gameScreenCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.css'), 'utf8'),
     );
+    const gameScreenTsx = readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.tsx'), 'utf8');
     const houseguestGridCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/HouseguestGrid/HouseguestGrid.module.css'), 'utf8'),
+    );
+    const ceremonyOverlayTsx = readFileSync(
+      resolve(process.cwd(), 'src/components/CeremonyOverlay/CeremonyOverlay.tsx'),
+      'utf8',
     );
     const tvLogCss = normalizeCss(
       readFileSync(resolve(process.cwd(), 'src/components/TVLog/TVLog.css'), 'utf8'),
@@ -68,8 +75,12 @@ describe('safe-area layout styles', () => {
     expect(houseguestGridCss).toContain('grid-auto-rows: max-content;');
     expect(houseguestGridCss).toContain('align-content: start;');
     expect(houseguestGridCss).toContain('overflow: hidden;');
-    expect(houseguestGridCss).not.toContain('overflow-y: auto;');
+    expect(houseguestGridCss).toContain(".scrollRoster .grid { overflow-y: auto;");
+    expect(houseguestGridCss).toContain(".container[data-header-mode='persistent'] .headerRow");
     expect(houseguestGridCss).not.toContain('survivorTileSettle');
+    expect(gameScreenTsx).toContain('useResponsiveGameLayout');
+    expect(gameScreenTsx).toContain('layoutSignal={responsiveGameLayout.revision}');
+    expect(ceremonyOverlayTsx).toContain('layoutSignal?: string | number;');
     expect(tvLogCss).toContain('overflow-y: auto;');
     expect(tvLogCss).toContain('@media (max-width: 480px) and (max-height: 900px)');
     expect(tvLogCss).toContain('max-height: var(--tv-log-item-h);');


### PR DESCRIPTION
## Summary
- Adds a measured responsive game layout budget instead of hardcoded device-model patches.
- Adds conservative Android top safe fallback for Chrome/Android-style service row overlap when CSS env safe-area is zero.
- Adapts TV log rows, roster header visibility, compact roster fallback, and tablet cabinet width from measured space.
- Keeps roster scroll as an explicit last-resort mode and scrolls/re-measures animation targets when layout changes.

## Validation
- `git diff --check` passed.
- `npm run typecheck` could not run locally because `tsc` is not installed in this workspace.
- `npm run lint` could not run locally because `eslint` is not installed in this workspace.
- `npm run build` could not run locally because `tsc`/`vite` are not installed in this workspace.

No dependencies were installed.