### PR TITLE
fix: minigame responsive safety audit

### DIFF
--- a/src/components/BullseyeBlitz/BullseyeBlitz.css
+++ b/src/components/BullseyeBlitz/BullseyeBlitz.css
@@ -8,7 +8,12 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.88);
-  padding: 16px;
+  box-sizing: border-box;
+  padding:
+    max(16px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 16px));
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -17,9 +22,7 @@
 .bbl__card {
   width: 100%;
   max-width: 460px;
-  /* Fallback first; prefer dynamic viewport units when supported. */
-  max-height: calc(100vh - 32px);
-  max-height: calc(100dvh - 32px);
+  max-height: 100%;
   margin-block: auto;
   background: var(--color-surface, #1e1e2e);
   border: 1px solid rgba(255, 255, 255, 0.1);

--- a/src/components/GlassBridgeComp/GlassBridgeComp.css
+++ b/src/components/GlassBridgeComp/GlassBridgeComp.css
@@ -784,6 +784,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
+  padding:
+    max(16px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 16px));
   animation: gb-fadein 0.26s ease;
 }
 
@@ -794,10 +800,13 @@
   padding: 2.1rem 1.35rem 1.5rem;
   width: 90%;
   max-width: 360px;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1.1rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 18px 50px rgba(0, 0, 0, 0.45),

--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -85,6 +85,8 @@
 .minigame-host-playing > .td,
 .minigame-host-playing > .bbl,
 .minigame-host-playing > .tbg,
+.minigame-host-playing > .glass-bridge,
+.minigame-host-playing > .bb-blitz,
 .minigame-host-playing > .snake-root {
   box-sizing: border-box;
 }
@@ -154,6 +156,21 @@
 
 .minigame-host-playing > .tbg .tbg__card {
   max-height: calc(100% - var(--minigame-stage-top-padding) - var(--minigame-safe-padding-bottom));
+}
+
+.minigame-host-playing > .glass-bridge,
+.minigame-host-playing > .bb-blitz {
+  height: 100%;
+  min-height: 0;
+  max-height: 100%;
+  padding:
+    var(--minigame-stage-top-padding)
+    var(--minigame-safe-padding-right)
+    var(--minigame-safe-padding-bottom)
+    var(--minigame-safe-padding-left);
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .minigame-host-playing > .snake-root {
@@ -446,8 +463,8 @@
 
 .minigame-host-close-btn {
   position: absolute;
-  top: 12px;
-  right: 14px;
+  top: max(12px, calc(var(--minigame-safe-top) + 12px));
+  right: max(14px, calc(var(--minigame-safe-right) + 14px));
   z-index: 9600;
   width: 36px;
   height: 36px;

--- a/src/components/MinigameRules/MinigameRules.css
+++ b/src/components/MinigameRules/MinigameRules.css
@@ -97,6 +97,7 @@
 
 .minigame-rules-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   margin-top: 20px;
   justify-content: center;
@@ -104,7 +105,8 @@
 }
 
 .minigame-rules-btn-start {
-  flex: 1;
+  flex: 1 1 160px;
+  min-width: 0;
   max-width: 200px;
   padding: 12px 24px;
   background: #e94560;

--- a/src/components/PressurePlank/PressurePlank.css
+++ b/src/components/PressurePlank/PressurePlank.css
@@ -10,6 +10,12 @@
   background: radial-gradient(120% 120% at 50% 0%, #050b1c, #0a1428);
   z-index: 500;
   overflow: hidden;
+  box-sizing: border-box;
+  padding:
+    max(12px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 12px));
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   color: #e2eeff;
 }
@@ -42,7 +48,7 @@
   align-items: center;
   gap: 0;
   padding: 0 16px 20px;
-  max-height: 100vh;
+  max-height: 100%;
   overflow-y: auto;
 }
 

--- a/src/components/QuickTapRace/QuickTapRace.css
+++ b/src/components/QuickTapRace/QuickTapRace.css
@@ -8,10 +8,12 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.85);
+  box-sizing: border-box;
   padding:
-    calc(16px + var(--safe-top))
-    16px
-    calc(16px + var(--safe-bottom));
+    max(16px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 16px))
+    max(16px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 16px));
   transition: background 0.3s ease;
 }
 
@@ -25,18 +27,19 @@
 .qtr__card {
   width: 100%;
   max-width: 440px;
+  max-height: 100%;
   background: var(--color-surface, #1e1e2e);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 24px;
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .qtr__card--canvas {
   max-width: min(1120px, 100%);
-  max-height: calc(100vh - 32px - var(--safe-top) - var(--safe-bottom));
-  max-height: calc(100dvh - 32px - var(--safe-top) - var(--safe-bottom));
+  max-height: min(760px, 100%);
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -746,11 +749,15 @@
 
 @media (max-width: 640px) {
   .qtr {
-    padding: 10px;
+    padding:
+      max(10px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 10px))
+      max(10px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 10px))
+      max(10px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 10px))
+      max(10px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 10px));
   }
 
   .qtr__card--canvas {
-    max-height: calc(100dvh - 20px);
+    max-height: 100%;
     border-radius: 18px;
   }
 

--- a/src/components/TravelingDots/TravelingDots.css
+++ b/src/components/TravelingDots/TravelingDots.css
@@ -8,17 +8,24 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.88);
-  padding: 12px;
+  box-sizing: border-box;
+  padding:
+    max(12px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-bottom, var(--safe-bottom, 0px)) + 12px))
+    max(12px, calc(var(--minigame-safe-left, var(--safe-left, 0px)) + 12px));
 }
 
 /* ── Card ──────────────────────────────────────────────────────────────────── */
 .td__card {
   width: 100%;
   max-width: 460px;
+  max-height: 100%;
   background: var(--color-surface, #1e1e2e);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 24px;
-  overflow: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
   display: flex;
   flex-direction: column;

--- a/src/minigames/LegacyMinigameWrapper.tsx
+++ b/src/minigames/LegacyMinigameWrapper.tsx
@@ -177,8 +177,8 @@ export default function LegacyMinigameWrapper({ game, options = {}, onComplete, 
         aria-label="Quit minigame"
         style={{
           position: 'absolute',
-          top: 8,
-          right: 8,
+          top: 'max(8px, calc(var(--minigame-safe-top, var(--safe-top, 0px)) + 8px))',
+          right: 'max(8px, calc(var(--minigame-safe-right, var(--safe-right, 0px)) + 8px))',
           zIndex: 10,
           background: 'rgba(0,0,0,0.6)',
           color: '#fff',

--- a/src/minigames/quickTapRace/QuickTapRaceCanvasGame.css
+++ b/src/minigames/quickTapRace/QuickTapRaceCanvasGame.css
@@ -8,11 +8,12 @@
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.85);
+  box-sizing: border-box;
   padding:
-    max(12px, env(safe-area-inset-top))
-    max(12px, env(safe-area-inset-right))
-    max(12px, env(safe-area-inset-bottom))
-    max(12px, env(safe-area-inset-left));
+    max(12px, calc(var(--minigame-safe-top, var(--safe-top, env(safe-area-inset-top, 0px))) + 12px))
+    max(12px, calc(var(--minigame-safe-right, var(--safe-right, env(safe-area-inset-right, 0px))) + 12px))
+    max(12px, calc(var(--minigame-safe-bottom, var(--safe-bottom, env(safe-area-inset-bottom, 0px))) + 12px))
+    max(12px, calc(var(--minigame-safe-left, var(--safe-left, env(safe-area-inset-left, 0px))) + 12px));
   min-height: 100dvh;
   transition: background 0.3s ease;
 }
@@ -27,7 +28,7 @@
 .qtr-canvas__card {
   width: 100%;
   max-width: 440px;
-  max-height: min(760px, calc(100dvh - 24px));
+  max-height: min(760px, 100%);
   background: var(--color-surface, #1e1e2e);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 24px;

--- a/tests/unit/minigameResponsiveSafety.styles.test.ts
+++ b/tests/unit/minigameResponsiveSafety.styles.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readCss(path: string) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+function getRule(css: string, selector: string) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`));
+  expect(match, `Expected CSS rule for ${selector}`).toBeTruthy();
+  return match?.[1] ?? '';
+}
+
+describe('minigame responsive safe-stage styles', () => {
+  it('keeps the shared rules modal safe and internally scrollable', () => {
+    const css = readCss('src/components/MinigameRules/MinigameRules.css');
+
+    expect(getRule(css, '.minigame-rules-overlay')).toContain('var(--minigame-safe-padding-top');
+    expect(getRule(css, '.minigame-rules-overlay')).toContain('var(--minigame-safe-padding-bottom');
+    expect(getRule(css, '.minigame-rules-modal')).toContain('max-height: 100%;');
+    expect(getRule(css, '.minigame-rules-list')).toContain('overflow-y: auto;');
+    expect(getRule(css, '.minigame-rules-actions')).toContain('flex-wrap: wrap;');
+  });
+
+  it('applies safe-stage padding to hosted legacy-style roots and close affordances', () => {
+    const css = readCss('src/components/MinigameHost/MinigameHost.css');
+
+    expect(css).toContain('.minigame-host-playing > .glass-bridge');
+    expect(css).toContain('.minigame-host-playing > .bb-blitz');
+    expect(css).toContain('var(--minigame-stage-top-padding)');
+    expect(css).toContain('var(--minigame-safe-padding-bottom)');
+
+    const closeRule = getRule(css, '.minigame-host-close-btn');
+    expect(closeRule).toContain('calc(var(--minigame-safe-top) + 12px)');
+    expect(closeRule).toContain('calc(var(--minigame-safe-right) + 14px)');
+  });
+
+  it('preserves safe padding on qtr overlays at normal and phone breakpoints', () => {
+    const qtrCss = readCss('src/components/QuickTapRace/QuickTapRace.css');
+    const qtrCanvasCss = readCss('src/minigames/quickTapRace/QuickTapRaceCanvasGame.css');
+
+    expect(getRule(qtrCss, '.qtr')).toContain('var(--minigame-safe-top');
+    expect(getRule(qtrCss, '.qtr')).toContain('var(--minigame-safe-bottom');
+    expect(qtrCss).not.toContain('padding: 10px;');
+    expect(getRule(qtrCss, '.qtr__card--canvas')).toContain('max-height: min(760px, 100%);');
+
+    expect(getRule(qtrCanvasCss, '.qtr-canvas')).toContain('var(--minigame-safe-top');
+    expect(getRule(qtrCanvasCss, '.qtr-canvas')).toContain('var(--minigame-safe-bottom');
+    expect(getRule(qtrCanvasCss, '.qtr-canvas__card')).toContain('max-height: min(760px, 100%);');
+  });
+
+  it('keeps representative fixed React minigame overlays inside safe rows', () => {
+    const checks = [
+      ['src/components/BullseyeBlitz/BullseyeBlitz.css', '.bbl', '.bbl__card'],
+      ['src/components/TravelingDots/TravelingDots.css', '.td', '.td__card'],
+      ['src/components/PressurePlank/PressurePlank.css', '.pp', '.pp__card'],
+    ] as const;
+
+    for (const [path, rootSelector, cardSelector] of checks) {
+      const css = readCss(path);
+      expect(getRule(css, rootSelector)).toContain('var(--minigame-safe-top');
+      expect(getRule(css, rootSelector)).toContain('var(--minigame-safe-bottom');
+      expect(getRule(css, rootSelector)).toContain('box-sizing: border-box;');
+      expect(getRule(css, cardSelector)).toContain('max-height: 100%;');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep shared minigame rules/results surfaces safe and scrollable
- protect qtr/native, canvas qtr, Bullseye, Traveling Dots, Pressure Plank, Glass Bridge, Biography-style hosted roots, and legacy quit controls from iOS service/home rows
- add a CSS contract test for minigame safe-stage behavior

## Validation
- git diff --check
- npm run test -- tests/unit/minigameResponsiveSafety.styles.test.ts (blocked locally: vitest is not installed in this workspace)
- npm run typecheck (blocked locally: tsc is not installed in this workspace)
- npm run lint (blocked locally: eslint is not installed in this workspace)