### PR TITLE
fix: harden ceremony animation targets

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -60,10 +60,11 @@
   display: grid;
   flex: 1 1 auto;
   min-height: 0;
-  gap: 5px;
-  grid-template-columns: repeat(4, 1fr);
+  gap: var(--game-roster-gap, 5px);
+  grid-template-columns: repeat(4, minmax(0, var(--game-avatar-tile-size, 1fr)));
   grid-auto-rows: max-content;
   align-content: start;
+  justify-content: center;
   justify-items: stretch;
   align-items: start;
   max-height: min(var(--game-roster-max-height, 480px), var(--grid-available-height, 480px), 100%);
@@ -86,7 +87,8 @@
 
 
 .gridItem {
-  width: 100%;
+  width: var(--game-avatar-tile-size, 100%);
+  max-width: 100%;
   min-width: 0;
 }
 
@@ -407,7 +409,7 @@
 /* 12-tile and 16-tile grid layouts (both use 4 columns) */
 .hgGrid12,
 .hgGrid16 {
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, var(--game-avatar-tile-size, 1fr)));
 }
 
 /* Inactive/placeholder tile */
@@ -448,7 +450,7 @@
 }
 
 .compact .grid {
-  gap: 3px;
+  gap: var(--game-roster-gap, 5px);
 }
 
 .compact .avatarWrap {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -149,6 +149,7 @@ import {
 } from './gameScreenPersistence'
 import { requestFavoriteAudienceSurge } from './favoriteAudienceSurgeRequest'
 import { useResponsiveGameLayout } from './useResponsiveGameLayout'
+import { getCeremonyTileRect } from './ceremonyTileMeasurement'
 import {
   BATTLE_BACK_ANNOUNCEMENT_SEQUENCE,
   advanceBattleBackAnnouncementStep,
@@ -410,24 +411,10 @@ export default function GameScreen() {
     FEATURE_SPECTATOR_REACT && game.cfg?.enableSpectatorReact !== false
 
   // ── Tile position lookup for CeremonyOverlay ──────────────────────────────
-  // Queries a `data-player-id` attribute on the houseguest grid's <li> items so
-  // we can get a bounding rect without needing to pass refs through render.
+  // Queries the houseguest grid's data-player-id items and centers only scroll
+  // roster targets before measurement, keeping normal/compact rosters fixed.
   const getTileRect = useCallback((playerId: string): DOMRect | null => {
-    // CSS.escape may be unavailable in some environments (jsdom); fall back to
-    // a simple attribute selector when it isn't defined.
-    const escaped = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(playerId) : playerId
-    const el = document.querySelector<HTMLElement>(`[data-player-id="${escaped}"]`)
-    if (!el) return null
-    const scrollRoot = el.closest<HTMLElement>('[data-roster-scroll="true"]')
-    if (scrollRoot) {
-      const tileRect = el.getBoundingClientRect()
-      const scrollRect = scrollRoot.getBoundingClientRect()
-      if (tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom) {
-        el.scrollIntoView({ block: 'center', inline: 'nearest' })
-      }
-    }
-    const rect = el.getBoundingClientRect()
-    return rect.width > 0 || rect.height > 0 ? rect : null
+    return getCeremonyTileRect(playerId)
   }, [])
 
   // ── CeremonyOverlay — deferred LOH / POS winner commit ─────────────────
@@ -1201,6 +1188,7 @@ export default function GameScreen() {
   // plays, showing the 🛡️ badge landing on the saved nominee's tile.
   const [pendingSaveCeremony, setPendingSaveCeremony] = useState<{
     tiles: CeremonyTile[]
+    resolveTiles: () => CeremonyTile[]
     caption: string
     subtitle?: string
     savedId: string
@@ -1252,10 +1240,33 @@ export default function GameScreen() {
         glowTone: 'success' as const,
       },
     ]
+    const resolveTiles = (): CeremonyTile[] => {
+      const currentSavedRect = getTileRect(id)
+      const currentHolderRect = game.posWinnerId ? getTileRect(game.posWinnerId) : null
+      const currentSourceIsDistinctHolder =
+        currentHolderRect != null && game.posWinnerId != null && game.posWinnerId !== id
+
+      return [
+        ...(currentSourceIsDistinctHolder
+          ? [{
+              rect: currentHolderRect,
+              glowTone: 'gold' as const,
+            }]
+          : []),
+        {
+          rect: currentSavedRect,
+          badge: 'ðŸ›¡ï¸',
+          badgeStart: currentSourceIsDistinctHolder && currentHolderRect ? currentHolderRect : 'center',
+          badgeLabel: `${savedPlayer.name} saved by veto`,
+          glowTone: 'success' as const,
+        },
+      ]
+    }
 
     pendingSaveDispatchRef.current = () => dispatch(submitSaveAction)
     setPendingSaveCeremony({
       tiles,
+      resolveTiles,
       caption: `${savedPlayer.name} has been saved!`,
       subtitle: saveSubtitle,
       savedId: id,
@@ -1299,6 +1310,7 @@ export default function GameScreen() {
   // tile to the replacement nominee's tile.
   const [pendingReplacementCeremony, setPendingReplacementCeremony] = useState<{
     tiles: CeremonyTile[]
+    resolveTiles: () => CeremonyTile[]
     caption: string
     subtitle?: string
     replacementId: string
@@ -1352,10 +1364,33 @@ export default function GameScreen() {
         glowTone: 'danger' as const,
       },
     ]
+    const resolveTiles = (): CeremonyTile[] => {
+      const currentReplacementRect = getTileRect(id)
+      const currentSourceRect = sourceId ? getTileRect(sourceId) : null
+      const currentSourceIsDistinct = currentSourceRect != null && sourceId != null && sourceId !== id
+
+      return [
+        ...(currentSourceIsDistinct
+          ? [{
+              rect: currentSourceRect,
+              glowTone: 'gold' as const,
+            }]
+          : []),
+        {
+          rect: currentReplacementRect,
+          badge: 'â“',
+          badgeImageSrc: NOMINATION_BADGE_SRC,
+          badgeStart: currentSourceIsDistinct && currentSourceRect ? currentSourceRect : 'center',
+          badgeLabel: `${replacementPlayer.name} named backup nominee`,
+          glowTone: 'danger' as const,
+        },
+      ]
+    }
 
     pendingReplacementDispatchRef.current = onCommit
     setPendingReplacementCeremony({
       tiles,
+      resolveTiles,
       caption: `${replacementPlayer.name} is the backup nominee!`,
       subtitle: replacementSubtitle,
       replacementId: id,
@@ -3830,7 +3865,9 @@ export default function GameScreen() {
       {/* ── CeremonyOverlay — Replacement nominee (human LOH deferred) ──── */}
       {pendingReplacementCeremony && (
         <CeremonyOverlay
-          tiles={pendingReplacementCeremony.tiles}
+          tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
+          resolveTiles={pendingReplacementCeremony.resolveTiles}
           caption={pendingReplacementCeremony.caption}
           subtitle={pendingReplacementCeremony.subtitle}
           onDone={handleReplacementCeremonyDone}
@@ -3898,7 +3935,9 @@ export default function GameScreen() {
       {/* ── CeremonyOverlay — POS save ceremony (human POS holder) ────── */}
       {showSaveCeremony && pendingSaveCeremony && (
         <CeremonyOverlay
-          tiles={pendingSaveCeremony.tiles}
+          tiles={[]}
+          layoutSignal={responsiveGameLayout.revision}
+          resolveTiles={pendingSaveCeremony.resolveTiles}
           caption={pendingSaveCeremony.caption}
           subtitle={pendingSaveCeremony.subtitle}
           onDone={handleSaveCeremonyDone}

--- a/src/screens/GameScreen/ceremonyTileMeasurement.ts
+++ b/src/screens/GameScreen/ceremonyTileMeasurement.ts
@@ -1,0 +1,29 @@
+export const ROSTER_SCROLL_SELECTOR = '[data-roster-scroll="true"]'
+
+function escapePlayerIdForAttributeSelector(playerId: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(playerId)
+  }
+
+  return playerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+export function getCeremonyTileRect(playerId: string, root: ParentNode = document): DOMRect | null {
+  const escaped = escapePlayerIdForAttributeSelector(playerId)
+  const el = root.querySelector<HTMLElement>(`[data-player-id="${escaped}"]`)
+  if (!el) return null
+
+  const scrollRoot = el.closest<HTMLElement>(ROSTER_SCROLL_SELECTOR)
+  if (scrollRoot) {
+    const tileRect = el.getBoundingClientRect()
+    const scrollRect = scrollRoot.getBoundingClientRect()
+    const isOutsideVisibleRoster = tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom
+
+    if (isOutsideVisibleRoster && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'center', inline: 'nearest' })
+    }
+  }
+
+  const rect = el.getBoundingClientRect()
+  return rect.width > 0 || rect.height > 0 ? rect : null
+}

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -13,10 +13,13 @@ export type RosterHeaderMode = 'transient' | 'persistent'
 
 export interface ResponsiveGameLayoutBudget {
   layoutSize: GameLayoutSize
+  baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'>
   rosterMode: ResponsiveRosterMode
   rosterHeaderMode: RosterHeaderMode
   compactRoster: boolean
   compactRosterLayout: CompactRosterLayout
+  avatarTileSize: number
+  rosterGap: number
   tvLogRows: number
   cssVars: CSSProperties
   debugEnabled: boolean
@@ -86,6 +89,7 @@ function resolveLayoutSize(width: number, height: number): GameLayoutSize {
 
 function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
   layoutSize: GameLayoutSize
+  baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'>
   rosterMode: ResponsiveRosterMode
   tvLogRows: number
   effectiveSafeTop: number
@@ -99,7 +103,7 @@ function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
     `nav ${Math.round(input.navHeight)}`,
     `dock ${Math.round(budget.dockClearance)}`,
     `tv rows ${budget.tvLogRows}`,
-    `roster ${budget.rosterMode} ${Math.round(budget.rosterMaxHeight)}`,
+    `roster ${budget.baseRosterMode}->${budget.rosterMode} ${Math.round(budget.rosterMaxHeight)}`,
     budget.layoutSize,
   ].join(' | ')
 }
@@ -126,6 +130,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const normalTileSize = clamp(tileWidth, 64, isTablet ? 128 : 112)
   const compactTileSize = normalTileSize * 0.72
   const rosterRows = Math.max(1, Math.ceil(Math.max(input.playerCount, 1) / ROSTER_COLUMNS))
+  const shouldUseCompactBase =
+    !isTablet &&
+    input.playerCount >= 16 &&
+    (layoutSize === 'phone-small' || stageWidth < 370)
+  const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> = input.userCompactRoster || shouldUseCompactBase
+    ? 'compact-small'
+    : 'normal'
 
   const baseTvHeight = layoutSize === 'phone-small'
     ? 204
@@ -146,11 +157,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   )
   const normalRosterHeight = rosterRows * normalTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
   const compactRosterHeight = rosterRows * compactTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
-  const extraAfterNormalRoster = availableAfterTv - normalRosterHeight
+  const baseAvatarTileSize = baseRosterMode === 'compact-small' ? compactTileSize : normalTileSize
+  const baseRosterHeight = baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
+  const extraAfterBaseRoster = availableAfterTv - baseRosterHeight
 
-  const tvLogRows = extraAfterNormalRoster >= 96 || isTablet
-    ? (isTablet && extraAfterNormalRoster >= 160 ? 4 : 3)
-    : extraAfterNormalRoster >= 36
+  const tvLogRows = extraAfterBaseRoster >= 96 || isTablet
+    ? (isTablet && extraAfterBaseRoster >= 160 ? 4 : 3)
+    : extraAfterBaseRoster >= 36
       ? 2
       : 1
   const logHeight = tvLogRows * 32
@@ -159,20 +172,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     stageHeight - tvHeight - logHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
   )
 
-  const normalFits = normalRosterHeight <= availableRosterHeight
-  const compactFits = compactRosterHeight <= availableRosterHeight
-  const rosterMode: ResponsiveRosterMode = input.userCompactRoster
-    ? 'compact-small'
-    : normalFits
-      ? 'normal'
-      : compactFits
-        ? 'compact-small'
-        : 'scroll'
+  const baseRosterFits = baseRosterHeight <= availableRosterHeight
+  const rosterMode: ResponsiveRosterMode = baseRosterFits ? baseRosterMode : 'scroll'
 
-  const rosterHeaderMode: RosterHeaderMode = normalFits || isTablet || layoutSize === 'phone-large'
+  const rosterHeaderMode: RosterHeaderMode = baseRosterFits || isTablet || layoutSize === 'phone-large'
     ? 'persistent'
     : 'transient'
-  const compactRoster = input.userCompactRoster || rosterMode === 'compact-small'
+  const compactRoster = baseRosterMode === 'compact-small'
   const compactRosterLayout = input.userCompactRoster
     ? input.userCompactRosterLayout
     : 'small'
@@ -180,7 +186,8 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     180,
     availableRosterHeight - (rosterHeaderMode === 'persistent' ? ROSTER_HEADER_HEIGHT : 0),
   )
-  const avatarTileSize = rosterMode === 'compact-small' ? compactTileSize : normalTileSize
+  const avatarTileSize = baseAvatarTileSize
+  const avatarTileSizePx = Math.max(0, Math.floor(avatarTileSize))
 
   const cssVars = {
     '--game-safe-top': `${roundPx(effectiveSafeTop)}px`,
@@ -190,12 +197,14 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     '--game-screen-tv-viewport-min-height': `${roundPx(tvViewportHeight)}px`,
     '--game-tv-log-rows': String(tvLogRows),
     '--game-roster-max-height': `${roundPx(rosterMaxHeight)}px`,
-    '--game-avatar-tile-size': `${roundPx(avatarTileSize)}px`,
+    '--game-avatar-tile-size': `${avatarTileSizePx}px`,
+    '--game-roster-gap': `${ROSTER_GAP}px`,
     '--game-shell-max-width': `${shellMaxWidth}px`,
   } as CSSProperties
 
   const debugLabel = buildDebugLabel(input, {
     layoutSize,
+    baseRosterMode,
     rosterMode,
     tvLogRows,
     effectiveSafeTop,
@@ -204,11 +213,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   })
   const signature = [
     layoutSize,
+    baseRosterMode,
     rosterMode,
     rosterHeaderMode,
     tvLogRows,
     roundPx(tvHeight),
     roundPx(rosterMaxHeight),
+    avatarTileSizePx,
     roundPx(dockClearance),
     roundPx(effectiveSafeTop),
     shellMaxWidth,
@@ -216,10 +227,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
 
   return {
     layoutSize,
+    baseRosterMode,
     rosterMode,
     rosterHeaderMode,
     compactRoster,
     compactRosterLayout,
+    avatarTileSize: avatarTileSizePx,
+    rosterGap: ROSTER_GAP,
     tvLogRows,
     cssVars,
     debugEnabled: input.debugEnabled === true,

--- a/tests/unit/gameScreen/animationHardening.contract.test.ts
+++ b/tests/unit/gameScreen/animationHardening.contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function gameScreenSource() {
+  return readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.tsx'), 'utf8')
+}
+
+describe('GameScreen ceremony animation contracts', () => {
+  it('re-measures LOH/POS winner, nomination, replacement, save, and public-save targets', () => {
+    const source = gameScreenSource()
+
+    expect(source).toContain('measureA: () => getTileRect(finalWinnerId)')
+    expect(source).toContain('measureA={pendingWinnerCeremony.measureA}')
+    expect(source).toContain('layoutSignal={responsiveGameLayout.revision}')
+    expect(source).toContain('resolveTiles={pendingReplacementCeremony.resolveTiles}')
+    expect(source).toContain('resolveTiles={pendingSaveCeremony.resolveTiles}')
+    expect(source).toContain("badgeMotion: 'extract' as const")
+    expect(source).toContain('const nomCeremonyTileIds = showNomAnim ? nomAnimPlayers.map((p) => p.id) : []')
+    expect(source).toContain('resolveTiles={() => {')
+  })
+
+  it('keeps eviction/spotlight animation tied to stable avatar tile layout ids', () => {
+    const source = gameScreenSource()
+
+    expect(source).toContain('layoutId: `avatar-tile-${p.id}`')
+    expect(source).toContain('isEvicting: (showEvictionSplash && pendingEvictionPlayer?.id === p.id)')
+    expect(source).toContain('layoutId={`avatar-tile-${pendingEvictionPlayer.id}`}')
+  })
+})

--- a/tests/unit/gameScreen/ceremonyTileMeasurement.test.ts
+++ b/tests/unit/gameScreen/ceremonyTileMeasurement.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getCeremonyTileRect } from '../../../src/screens/GameScreen/ceremonyTileMeasurement'
+
+function rect(top: number, height: number, width = 80) {
+  return new DOMRect(10, top, width, height)
+}
+
+function mountRoster({
+  rosterMode,
+  tileRect = rect(20, 80),
+  scrollRect = rect(0, 320, 360),
+}: {
+  rosterMode: 'normal' | 'compact-small' | 'scroll'
+  tileRect?: DOMRect
+  scrollRect?: DOMRect
+}) {
+  const section = document.createElement('section')
+  section.dataset.rosterMode = rosterMode
+  const list = document.createElement('ul')
+  if (rosterMode === 'scroll') {
+    list.dataset.rosterScroll = 'true'
+  }
+  const item = document.createElement('li')
+  item.dataset.playerId = 'p4'
+  item.getBoundingClientRect = vi.fn(() => tileRect)
+  item.scrollIntoView = vi.fn()
+  list.getBoundingClientRect = vi.fn(() => scrollRect)
+  list.append(item)
+  section.append(list)
+  document.body.append(section)
+
+  return { item, list, section }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('getCeremonyTileRect', () => {
+  it('measures normal roster tiles without scrolling the roster', () => {
+    const { item } = mountRoster({ rosterMode: 'normal' })
+
+    const measured = getCeremonyTileRect('p4')
+
+    expect(measured?.width).toBe(80)
+    expect(item.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('measures compact roster tiles without changing their position', () => {
+    const { item } = mountRoster({ rosterMode: 'compact-small' })
+
+    const measured = getCeremonyTileRect('p4')
+
+    expect(measured?.height).toBe(80)
+    expect(item.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('centers an offscreen target only when the roster is internally scrollable', () => {
+    const { item } = mountRoster({
+      rosterMode: 'scroll',
+      tileRect: rect(420, 80),
+      scrollRect: rect(0, 320, 360),
+    })
+
+    const measured = getCeremonyTileRect('p4')
+
+    expect(measured?.top).toBe(420)
+    expect(item.scrollIntoView).toHaveBeenCalledWith({ block: 'center', inline: 'nearest' })
+  })
+
+  it('returns null for missing or zero-size targets', () => {
+    expect(getCeremonyTileRect('missing')).toBeNull()
+
+    mountRoster({ rosterMode: 'normal', tileRect: rect(20, 0, 0) })
+    expect(getCeremonyTileRect('p4')).toBeNull()
+  })
+})

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -37,7 +37,7 @@ describe('responsive game layout budget', () => {
     })
   })
 
-  it('tries a fixed compact roster before allowing roster scroll on phones', () => {
+  it('keeps the device-bucket roster size before allowing roster scroll on phones', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportHeight: 852,
       stageHeight: 699,
@@ -45,9 +45,37 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.layoutSize).toBe('phone-large')
-    expect(budget.rosterMode).toBe('compact-small')
-    expect(budget.compactRoster).toBe(true)
+    expect(budget.baseRosterMode).toBe('normal')
+    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.compactRoster).toBe(false)
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does not change avatar tile size when transient vertical budget changes', () => {
+    const dayEndBudget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 852,
+      stageWidth: 393,
+      stageHeight: 760,
+      playerCount: 16,
+    }))
+    const liveVoteBudget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 852,
+      stageWidth: 393,
+      stageHeight: 700,
+      playerCount: 16,
+    }))
+
+    expect(dayEndBudget.layoutSize).toBe(liveVoteBudget.layoutSize)
+    expect(dayEndBudget.baseRosterMode).toBe(liveVoteBudget.baseRosterMode)
+    expect(dayEndBudget.avatarTileSize).toBe(liveVoteBudget.avatarTileSize)
+    expect(dayEndBudget.cssVars).toMatchObject({
+      '--game-avatar-tile-size': `${dayEndBudget.avatarTileSize}px`,
+    })
+    expect(liveVoteBudget.cssVars).toMatchObject({
+      '--game-avatar-tile-size': `${dayEndBudget.avatarTileSize}px`,
+    })
   })
 
   it('spends extra vertical space on more TV log rows before leaving dead space', () => {

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -74,6 +74,9 @@ describe('safe-area layout styles', () => {
     expect(gameScreenCss).not.toContain('.safe-game-viewport');
     expect(houseguestGridCss).toContain('grid-auto-rows: max-content;');
     expect(houseguestGridCss).toContain('align-content: start;');
+    expect(houseguestGridCss).toContain('grid-template-columns: repeat(4, minmax(0, var(--game-avatar-tile-size, 1fr)));');
+    expect(houseguestGridCss).toContain('gap: var(--game-roster-gap, 5px);');
+    expect(houseguestGridCss).toContain('width: var(--game-avatar-tile-size, 100%);');
     expect(houseguestGridCss).toContain('overflow: hidden;');
     expect(houseguestGridCss).toContain(".scrollRoster .grid { overflow-y: auto;");
     expect(houseguestGridCss).toContain(".container[data-header-mode='persistent'] .headerRow");


### PR DESCRIPTION
## Summary
- Add a shared ceremony tile measurement helper that only scrolls targets into view when the roster is explicitly in internal scroll mode.
- Re-measure human POS save and human replacement nominee ceremony targets through `CeremonyOverlay` resolvers and the responsive layout signal.
- Stabilize avatar tile sizing so transient phase/log/vote-panel height changes do not resize the roster; tight height now enables roster scrolling while preserving the base device-bucket tile size.
- Add regression coverage for normal/compact/scroll target measurement, ceremony animation contracts, responsive tile-size stability, and fixed grid rhythm.

## Validation
- `git diff --check` passed.
- `npm run test -- tests/unit/gameScreen/ceremonyTileMeasurement.test.ts tests/unit/gameScreen/animationHardening.contract.test.ts tests/unit/layout/responsiveGameLayout.test.ts tests/unit/layout/safeArea.styles.test.ts` could not run locally because this checkout has no installed `vitest` binary.
- `npm run typecheck` could not run locally because this checkout has no installed `tsc` binary.
- `npm run lint` could not run locally because this checkout has no installed `eslint` binary.

No dependencies were installed locally.