### PR TITLE
[codex] add Survivor standout module

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -100,8 +100,13 @@ function resolveSurvivorStandoutMode(options: {
   compact: boolean
   compactLayout: CompactRosterLayout
   rosterMode: 'normal' | 'compact-small' | 'scroll'
+  viewportWidth: number
+  viewportHeight: number
 }): SurvivorStandoutMode {
-  if (options.rosterMode === 'scroll') return 'mini-chip'
+  if (options.rosterMode === 'scroll' || options.viewportHeight < 700 || options.viewportWidth < 360) {
+    return 'mini-chip'
+  }
+  if (options.viewportWidth >= 720) return 'full-card'
   if (options.compact && options.compactLayout === 'slider') return 'mini-chip'
   if (options.compact || options.rosterMode === 'compact-small') return 'compact-strip'
   return 'full-card'
@@ -125,7 +130,7 @@ export default function HouseguestGrid({
   const containerRef = useRef<HTMLElement | null>(null)
   const dispatch = useAppDispatch()
   const game = useAppSelector((s) => s.game)
-  const challengeHistory = useAppSelector((s) => s.challenge.history)
+  const challengeHistory = useAppSelector((s) => s.challenge?.history ?? [])
   const survivorReplacementTransition = game.modeSpecific?.kind === 'survivor'
     ? game.modeSpecific.replacementTransition ?? null
     : null
@@ -188,7 +193,16 @@ export default function HouseguestGrid({
     () => (showSurvivorStandout ? selectSurvivorStandout(game, challengeHistory) : null),
     [challengeHistory, game, showSurvivorStandout],
   )
-  const survivorStandoutMode = resolveSurvivorStandoutMode({ compact, compactLayout, rosterMode })
+  const visualViewport = typeof window === 'undefined' ? undefined : window.visualViewport
+  const viewportWidth = visualViewport?.width ?? (typeof window === 'undefined' ? 0 : window.innerWidth)
+  const viewportHeight = visualViewport?.height ?? (typeof window === 'undefined' ? 0 : window.innerHeight)
+  const survivorStandoutMode = resolveSurvivorStandoutMode({
+    compact,
+    compactLayout,
+    rosterMode,
+    viewportWidth,
+    viewportHeight,
+  })
 
   useEffect(() => {
     if (survivorReplacementTransition === null) return undefined

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react'
 import AvatarTile from './AvatarTile'
 import StatusPill from '../ui/StatusPill'
+import SurvivorStandoutCard from '../SurvivorStandout/SurvivorStandoutCard'
 import styles from './HouseguestGrid.module.css'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import { clearSurvivorReplacementTransition } from '../../store/gameSlice'
 import type { CompactRosterLayout } from '../../store/settingsSlice'
+import { selectSurvivorStandout, type SurvivorStandoutMode } from '../../modes/survivorStandout'
 
 const HOUSEMATES_SECTION_TITLE = 'HOUSEMATES'
 
@@ -94,6 +96,17 @@ const DEFAULT_FOOTER_HEIGHT = 60
 /** Extra vertical margin subtracted from available height */
 const GRID_VERTICAL_MARGIN = 4
 
+function resolveSurvivorStandoutMode(options: {
+  compact: boolean
+  compactLayout: CompactRosterLayout
+  rosterMode: 'normal' | 'compact-small' | 'scroll'
+}): SurvivorStandoutMode {
+  if (options.rosterMode === 'scroll') return 'mini-chip'
+  if (options.compact && options.compactLayout === 'slider') return 'mini-chip'
+  if (options.compact || options.rosterMode === 'compact-small') return 'compact-strip'
+  return 'full-card'
+}
+
 export default function HouseguestGrid({
   houseguests,
   showCountInHeader = false,
@@ -112,6 +125,7 @@ export default function HouseguestGrid({
   const containerRef = useRef<HTMLElement | null>(null)
   const dispatch = useAppDispatch()
   const game = useAppSelector((s) => s.game)
+  const challengeHistory = useAppSelector((s) => s.challenge.history)
   const survivorReplacementTransition = game.modeSpecific?.kind === 'survivor'
     ? game.modeSpecific.replacementTransition ?? null
     : null
@@ -169,6 +183,12 @@ export default function HouseguestGrid({
     ))
   }, [game.mode, game.players, game.week, houseguests, survivorReplacementTransition])
   const headerSignal = occupancyLabel ?? `${renderedHouseguests.length}`
+  const showSurvivorStandout = game.mode === 'survivor' && overlaySelector === '.game-control-dock'
+  const survivorStandout = useMemo(
+    () => (showSurvivorStandout ? selectSurvivorStandout(game, challengeHistory) : null),
+    [challengeHistory, game, showSurvivorStandout],
+  )
+  const survivorStandoutMode = resolveSurvivorStandoutMode({ compact, compactLayout, rosterMode })
 
   useEffect(() => {
     if (survivorReplacementTransition === null) return undefined
@@ -312,6 +332,9 @@ export default function HouseguestGrid({
           </li>
         ))}
       </ul>
+      {survivorStandout && (
+        <SurvivorStandoutCard standout={survivorStandout} mode={survivorStandoutMode} />
+      )}
     </section>
   )
 }

--- a/src/components/SurvivorStandout/SurvivorStandoutCard.css
+++ b/src/components/SurvivorStandout/SurvivorStandoutCard.css
@@ -1,0 +1,184 @@
+.survivor-standout {
+  flex: 0 0 auto;
+  width: min(100%, 420px);
+  margin: 6px auto 0;
+  color: #f8fafc;
+}
+
+.survivor-standout__body {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 74px;
+  padding: 8px 10px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(34, 197, 94, 0.18), transparent 38%),
+    linear-gradient(135deg, rgba(8, 13, 22, 0.86), rgba(19, 28, 42, 0.78));
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.survivor-standout__body:disabled {
+  cursor: default;
+}
+
+.survivor-standout__body:not(:disabled) {
+  cursor: pointer;
+}
+
+.survivor-standout__body:not(:disabled):focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.72);
+  outline-offset: 2px;
+}
+
+.survivor-standout__avatar-wrap {
+  width: 46px;
+  height: 46px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(250, 204, 21, 0.34);
+  background: rgba(15, 23, 42, 0.82);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.survivor-standout__avatar {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.survivor-standout__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.survivor-standout__eyebrow {
+  color: rgba(187, 247, 208, 0.82);
+  font-size: 0.64rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.survivor-standout__title {
+  overflow: hidden;
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 900;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.survivor-standout__subtitle {
+  overflow: hidden;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.74rem;
+  font-weight: 650;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.survivor-standout__stats {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 6px;
+}
+
+.survivor-standout__stats span {
+  display: flex;
+  min-width: 42px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  padding: 6px 7px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.survivor-standout__stats strong {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.survivor-standout__stats small {
+  color: rgba(203, 213, 225, 0.74);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.survivor-standout--compact-strip .survivor-standout__body {
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  min-height: 48px;
+  padding: 6px 8px;
+}
+
+.survivor-standout--compact-strip .survivor-standout__avatar-wrap {
+  width: 34px;
+  height: 34px;
+}
+
+.survivor-standout--compact-strip .survivor-standout__eyebrow,
+.survivor-standout--mini-chip .survivor-standout__eyebrow,
+.survivor-standout--mini-chip .survivor-standout__avatar-wrap,
+.survivor-standout--mini-chip .survivor-standout__stats {
+  display: none;
+}
+
+.survivor-standout--compact-strip .survivor-standout__stats span:not(:first-child) {
+  display: none;
+}
+
+.survivor-standout--mini-chip {
+  width: 100%;
+  margin-top: 4px;
+}
+
+.survivor-standout--mini-chip .survivor-standout__body {
+  display: block;
+  min-height: 0;
+  padding: 6px 9px;
+  border-radius: 999px;
+}
+
+.survivor-standout--mini-chip .survivor-standout__copy {
+  display: block;
+}
+
+.survivor-standout--mini-chip .survivor-standout__title,
+.survivor-standout--mini-chip .survivor-standout__subtitle {
+  display: inline;
+  font-size: 0.72rem;
+  line-height: 1.2;
+}
+
+.survivor-standout--mini-chip .survivor-standout__title::after {
+  content: ' - ';
+  color: rgba(226, 232, 240, 0.72);
+  font-weight: 700;
+}
+
+@media (max-width: 360px), (max-height: 700px) {
+  .survivor-standout__stats span:not(:first-child) {
+    display: none;
+  }
+}

--- a/src/components/SurvivorStandout/SurvivorStandoutCard.tsx
+++ b/src/components/SurvivorStandout/SurvivorStandoutCard.tsx
@@ -1,0 +1,78 @@
+import { resolveAvatar } from '../../utils/avatar';
+import type { SurvivorStandoutMode, SurvivorStandoutResult } from '../../modes/survivorStandout';
+import './SurvivorStandoutCard.css';
+
+type Props = {
+  standout: SurvivorStandoutResult;
+  mode: SurvivorStandoutMode;
+  onPlayerClick?: (playerId: string) => void;
+};
+
+function formatAveragePlacement(value: number | null) {
+  if (value === null) return null;
+  return value % 1 === 0 ? String(value) : value.toFixed(1);
+}
+
+function formatTiedNames(standout: SurvivorStandoutResult) {
+  const names = standout.tiedPlayers.map((row) => row.player.name);
+  if (names.length <= 3) return names.join(', ');
+  return `${names.slice(0, 3).join(', ')} +${names.length - 3}`;
+}
+
+export default function SurvivorStandoutCard({ standout, mode, onPlayerClick }: Props) {
+  if (standout.status === 'unavailable') return null;
+
+  const primary = standout.status === 'leader' ? standout.leader : standout.tiedPlayers[0];
+  if (!primary) return null;
+
+  const tied = standout.status === 'tied';
+  const averagePlacement = formatAveragePlacement(primary.averagePlacement);
+  const wins = primary.lohWins + primary.posWins;
+  const title = tied ? 'Leaders tied' : primary.player.name;
+  const subtitle = tied ? formatTiedNames(standout) : `${primary.daysInGame} days in game`;
+  const ariaLabel = tied
+    ? `Survivor leaders tied: ${formatTiedNames(standout)}`
+    : `Current Survivor leader: ${primary.player.name}, ${primary.daysInGame} days in game`;
+
+  return (
+    <section
+      className={`survivor-standout survivor-standout--${mode}`}
+      aria-label={ariaLabel}
+      data-survivor-standout-mode={mode}
+    >
+      <button
+        type="button"
+        className="survivor-standout__body"
+        onClick={() => onPlayerClick?.(primary.player.id)}
+        disabled={!onPlayerClick || tied}
+      >
+        <span className="survivor-standout__avatar-wrap" aria-hidden="true">
+          <img className="survivor-standout__avatar" src={resolveAvatar(primary.player)} alt="" />
+        </span>
+        <span className="survivor-standout__copy">
+          <span className="survivor-standout__eyebrow">Survivor Standout</span>
+          <strong className="survivor-standout__title">{title}</strong>
+          <span className="survivor-standout__subtitle">{subtitle}</span>
+        </span>
+        <span className="survivor-standout__stats" aria-hidden="true">
+          <span>
+            <strong>{primary.daysInGame}</strong>
+            <small>days</small>
+          </span>
+          {averagePlacement && (
+            <span>
+              <strong>{averagePlacement}</strong>
+              <small>avg rank</small>
+            </span>
+          )}
+          {wins > 0 && (
+            <span>
+              <strong>{wins}</strong>
+              <small>wins</small>
+            </span>
+          )}
+        </span>
+      </button>
+    </section>
+  );
+}

--- a/src/modes/survivorStandout.ts
+++ b/src/modes/survivorStandout.ts
@@ -1,0 +1,162 @@
+import type { ChallengeRun } from '../store/challengeSlice';
+import type { GameState, Player } from '../types';
+
+export type SurvivorStandoutMode = 'full-card' | 'compact-strip' | 'mini-chip';
+export type SurvivorStandoutTieBreaker = 'days' | 'averagePlacement';
+
+export type SurvivorStandoutPlayer = {
+  player: Player;
+  daysInGame: number;
+  averagePlacement: number | null;
+  placementCount: number;
+  lohWins: number;
+  posWins: number;
+};
+
+export type SurvivorStandoutResult =
+  | {
+      status: 'leader';
+      leader: SurvivorStandoutPlayer;
+      tiedPlayers: SurvivorStandoutPlayer[];
+      tieBreaker: SurvivorStandoutTieBreaker;
+      currentDay: number;
+    }
+  | {
+      status: 'tied';
+      leader: null;
+      tiedPlayers: SurvivorStandoutPlayer[];
+      tieBreaker: SurvivorStandoutTieBreaker;
+      currentDay: number;
+    }
+  | {
+      status: 'unavailable';
+      leader: null;
+      tiedPlayers: [];
+      tieBreaker: 'days';
+      currentDay: number;
+    };
+
+function isAliveSurvivorPlayer(player: Player) {
+  return player.status !== 'evicted' && player.status !== 'jury';
+}
+
+function getCurrentSurvivorDay(game: GameState) {
+  const survivorDay = game.modeSpecific?.kind === 'survivor'
+    ? game.modeSpecific.currentDay
+    : undefined;
+  return Math.max(1, survivorDay ?? game.week ?? 1);
+}
+
+function getDaysInGame(player: Player, currentDay: number) {
+  return Math.max(1, currentDay - (player.survivorEntryDay ?? 1) + 1);
+}
+
+function buildAveragePlacementByPlayerId(
+  history: ChallengeRun[],
+  playerIds: Set<string>,
+): Map<string, { total: number; count: number }> {
+  const placements = new Map<string, { total: number; count: number }>();
+
+  history.forEach((run) => {
+    const scoreEntries = Object.entries(run.canonicalScores ?? {})
+      .filter(([playerId]) => playerIds.has(playerId) && run.participants.includes(playerId))
+      .sort((a, b) => b[1] - a[1]);
+
+    if (scoreEntries.length === 0) return;
+
+    let rank = 0;
+    let seen = 0;
+    let previousScore: number | null = null;
+    scoreEntries.forEach(([playerId, score]) => {
+      seen += 1;
+      if (previousScore === null || score !== previousScore) {
+        rank = seen;
+        previousScore = score;
+      }
+      const current = placements.get(playerId) ?? { total: 0, count: 0 };
+      placements.set(playerId, {
+        total: current.total + rank,
+        count: current.count + 1,
+      });
+    });
+  });
+
+  return placements;
+}
+
+export function selectSurvivorStandout(
+  game: GameState,
+  challengeHistory: ChallengeRun[] = [],
+): SurvivorStandoutResult | null {
+  if (game.mode !== 'survivor') return null;
+
+  const currentDay = getCurrentSurvivorDay(game);
+  const alivePlayers = game.players.filter(isAliveSurvivorPlayer);
+  if (alivePlayers.length === 0) {
+    return {
+      status: 'unavailable',
+      leader: null,
+      tiedPlayers: [],
+      tieBreaker: 'days',
+      currentDay,
+    };
+  }
+
+  const aliveIds = new Set(alivePlayers.map((player) => player.id));
+  const averagePlacements = buildAveragePlacementByPlayerId(challengeHistory, aliveIds);
+  const rows = alivePlayers.map((player): SurvivorStandoutPlayer => {
+    const placement = averagePlacements.get(player.id);
+    return {
+      player,
+      daysInGame: getDaysInGame(player, currentDay),
+      averagePlacement: placement && placement.count > 0 ? placement.total / placement.count : null,
+      placementCount: placement?.count ?? 0,
+      lohWins: player.stats?.lohWins ?? 0,
+      posWins: player.stats?.posWins ?? 0,
+    };
+  });
+
+  const bestDays = Math.max(...rows.map((row) => row.daysInGame));
+  const dayLeaders = rows.filter((row) => row.daysInGame === bestDays);
+  if (dayLeaders.length === 1) {
+    return {
+      status: 'leader',
+      leader: dayLeaders[0],
+      tiedPlayers: dayLeaders,
+      tieBreaker: 'days',
+      currentDay,
+    };
+  }
+
+  const everyDayLeaderHasPlacement = dayLeaders.every((row) => row.averagePlacement !== null);
+  if (everyDayLeaderHasPlacement) {
+    const bestAveragePlacement = Math.min(
+      ...dayLeaders.map((row) => row.averagePlacement ?? Number.POSITIVE_INFINITY),
+    );
+    const averageLeaders = dayLeaders.filter((row) => row.averagePlacement === bestAveragePlacement);
+    if (averageLeaders.length === 1) {
+      return {
+        status: 'leader',
+        leader: averageLeaders[0],
+        tiedPlayers: averageLeaders,
+        tieBreaker: 'averagePlacement',
+        currentDay,
+      };
+    }
+    return {
+      status: 'tied',
+      leader: null,
+      tiedPlayers: averageLeaders,
+      tieBreaker: 'averagePlacement',
+      currentDay,
+    };
+  }
+
+  return {
+    status: 'tied',
+    leader: null,
+    tiedPlayers: dayLeaders,
+    tieBreaker: 'days',
+    currentDay,
+  };
+}

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -10,6 +10,7 @@ export type GameLayoutSize =
 
 export type ResponsiveRosterMode = 'normal' | 'compact-small' | 'scroll'
 export type RosterHeaderMode = 'transient' | 'persistent'
+export type SurvivorStandoutLayoutMode = 'full-card' | 'compact-strip' | 'mini-chip'
 
 export interface ResponsiveGameLayoutBudget {
   layoutSize: GameLayoutSize
@@ -21,6 +22,7 @@ export interface ResponsiveGameLayoutBudget {
   avatarTileSize: number
   rosterGap: number
   tvLogRows: number
+  survivorStandoutMode: SurvivorStandoutLayoutMode
   cssVars: CSSProperties
   debugEnabled: boolean
   debugLabel: string
@@ -58,6 +60,11 @@ const ROSTER_INLINE_PADDING = 16
 const ROSTER_HEADER_HEIGHT = 30
 const GAME_VERTICAL_PADDING = 10
 const GAME_SECTION_GAPS = 12
+const SURVIVOR_FULL_STANDOUT_MIN_SPACE = 72
+const SURVIVOR_COMPACT_STANDOUT_MIN_SPACE = 34
+const SURVIVOR_FULL_STANDOUT_HEIGHT = 74
+const SURVIVOR_COMPACT_STANDOUT_HEIGHT = 48
+const SURVIVOR_MINI_STANDOUT_HEIGHT = 28
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value))
@@ -87,11 +94,44 @@ function resolveLayoutSize(width: number, height: number): GameLayoutSize {
   return 'phone-large'
 }
 
+function resolveSurvivorStandoutMode(options: {
+  layoutSize: GameLayoutSize
+  rosterMode: ResponsiveRosterMode
+  extraAfterBaseRoster: number
+}): SurvivorStandoutLayoutMode {
+  if (options.rosterMode === 'scroll' || options.layoutSize === 'phone-small') {
+    return 'mini-chip'
+  }
+  if (options.layoutSize === 'tablet-portrait' || options.layoutSize === 'tablet-landscape') {
+    return 'full-card'
+  }
+  if (options.extraAfterBaseRoster >= SURVIVOR_FULL_STANDOUT_MIN_SPACE) {
+    return 'full-card'
+  }
+  if (options.extraAfterBaseRoster >= SURVIVOR_COMPACT_STANDOUT_MIN_SPACE) {
+    return 'compact-strip'
+  }
+  return 'mini-chip'
+}
+
+function getSurvivorStandoutHeight(mode: SurvivorStandoutLayoutMode) {
+  switch (mode) {
+    case 'full-card':
+      return SURVIVOR_FULL_STANDOUT_HEIGHT
+    case 'compact-strip':
+      return SURVIVOR_COMPACT_STANDOUT_HEIGHT
+    case 'mini-chip':
+    default:
+      return SURVIVOR_MINI_STANDOUT_HEIGHT
+  }
+}
+
 function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
   layoutSize: GameLayoutSize
   baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'>
   rosterMode: ResponsiveRosterMode
   tvLogRows: number
+  survivorStandoutMode: SurvivorStandoutLayoutMode
   effectiveSafeTop: number
   dockClearance: number
   rosterMaxHeight: number
@@ -103,6 +143,7 @@ function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
     `nav ${Math.round(input.navHeight)}`,
     `dock ${Math.round(budget.dockClearance)}`,
     `tv rows ${budget.tvLogRows}`,
+    `standout ${budget.survivorStandoutMode}`,
     `roster ${budget.baseRosterMode}->${budget.rosterMode} ${Math.round(budget.rosterMaxHeight)}`,
     budget.layoutSize,
   ].join(' | ')
@@ -174,6 +215,12 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
 
   const baseRosterFits = baseRosterHeight <= availableRosterHeight
   const rosterMode: ResponsiveRosterMode = baseRosterFits ? baseRosterMode : 'scroll'
+  const survivorStandoutMode = resolveSurvivorStandoutMode({
+    layoutSize,
+    rosterMode,
+    extraAfterBaseRoster,
+  })
+  const survivorStandoutHeight = getSurvivorStandoutHeight(survivorStandoutMode)
 
   const rosterHeaderMode: RosterHeaderMode = baseRosterFits || isTablet || layoutSize === 'phone-large'
     ? 'persistent'
@@ -199,6 +246,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     '--game-roster-max-height': `${roundPx(rosterMaxHeight)}px`,
     '--game-avatar-tile-size': `${avatarTileSizePx}px`,
     '--game-roster-gap': `${ROSTER_GAP}px`,
+    '--game-survivor-standout-min-height': `${survivorStandoutHeight}px`,
     '--game-shell-max-width': `${shellMaxWidth}px`,
   } as CSSProperties
 
@@ -207,6 +255,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     baseRosterMode,
     rosterMode,
     tvLogRows,
+    survivorStandoutMode,
     effectiveSafeTop,
     dockClearance,
     rosterMaxHeight,
@@ -217,6 +266,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     rosterMode,
     rosterHeaderMode,
     tvLogRows,
+    survivorStandoutMode,
     roundPx(tvHeight),
     roundPx(rosterMaxHeight),
     avatarTileSizePx,
@@ -235,6 +285,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     avatarTileSize: avatarTileSizePx,
     rosterGap: ROSTER_GAP,
     tvLogRows,
+    survivorStandoutMode,
     cssVars,
     debugEnabled: input.debugEnabled === true,
     debugLabel,

--- a/tests/survivorStandout.test.ts
+++ b/tests/survivorStandout.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { selectSurvivorStandout } from '../src/modes/survivorStandout';
+import type { ChallengeRun } from '../src/store/challengeSlice';
+import type { GameState, Player } from '../src/types';
+
+function player(
+  id: string,
+  options: Partial<Player> & { survivorEntryDay?: number } = {},
+): Player {
+  return {
+    id,
+    name: id.toUpperCase(),
+    avatar: 'avatar.png',
+    status: 'active',
+    stats: { lohWins: 0, posWins: 0, timesNominated: 0 },
+    survivorEntryDay: 1,
+    ...options,
+  } as Player;
+}
+
+function survivorGame(players: Player[], currentDay = 10): GameState {
+  return {
+    mode: 'survivor',
+    modeSpecific: {
+      kind: 'survivor',
+      currentDay,
+      totalRoboContestantsEvicted: 0,
+      bestDayReached: currentDay,
+      startingCastSize: 8,
+      nextRoboIndex: 8,
+      competitionRotation: { usedKeys: [], round: 1 },
+    },
+    week: currentDay,
+    players,
+  } as unknown as GameState;
+}
+
+function run(scores: Record<string, number>, participants = Object.keys(scores)): ChallengeRun {
+  return {
+    id: 'run',
+    gameKey: 'quickTap',
+    seed: 1,
+    participants,
+    rawScores: scores,
+    canonicalScores: scores,
+    winnerId: participants[0] ?? '',
+    timestamp: 1,
+    authoritative: false,
+  };
+}
+
+describe('selectSurvivorStandout', () => {
+  it('selects the only player with the most days survived', () => {
+    const result = selectSurvivorStandout(survivorGame([
+      player('a', { survivorEntryDay: 1 }),
+      player('b', { survivorEntryDay: 3 }),
+    ], 7));
+
+    expect(result?.status).toBe('leader');
+    expect(result?.leader?.player.id).toBe('a');
+    expect(result?.leader?.daysInGame).toBe(7);
+    expect(result?.tieBreaker).toBe('days');
+  });
+
+  it('uses lower average competition placement to break a days tie when history is available', () => {
+    const result = selectSurvivorStandout(
+      survivorGame([player('a'), player('b')], 4),
+      [run({ a: 80, b: 100 })],
+    );
+
+    expect(result?.status).toBe('leader');
+    expect(result?.leader?.player.id).toBe('b');
+    expect(result?.leader?.averagePlacement).toBe(1);
+    expect(result?.tieBreaker).toBe('averagePlacement');
+  });
+
+  it('returns a tied state when days and average placement remain tied', () => {
+    const result = selectSurvivorStandout(
+      survivorGame([player('a'), player('b')], 4),
+      [
+        run({ a: 100, b: 80 }),
+        run({ a: 80, b: 100 }),
+      ],
+    );
+
+    expect(result?.status).toBe('tied');
+    expect(result?.tiedPlayers.map((row) => row.player.id)).toEqual(['a', 'b']);
+    expect(result?.tieBreaker).toBe('averagePlacement');
+  });
+
+  it('does not fabricate average rankings when no reliable placement history exists', () => {
+    const result = selectSurvivorStandout(survivorGame([player('a'), player('b')], 4));
+
+    expect(result?.status).toBe('tied');
+    expect(result?.tiedPlayers.map((row) => row.averagePlacement)).toEqual([null, null]);
+    expect(result?.tieBreaker).toBe('days');
+  });
+
+  it('excludes eliminated players from the standout ranking', () => {
+    const result = selectSurvivorStandout(survivorGame([
+      player('a', { survivorEntryDay: 1, status: 'evicted' }),
+      player('b', { survivorEntryDay: 4 }),
+    ], 8));
+
+    expect(result?.status).toBe('leader');
+    expect(result?.leader?.player.id).toBe('b');
+  });
+
+  it('returns null outside Survivor mode', () => {
+    const result = selectSurvivorStandout({ mode: 'classic', players: [player('a')] } as unknown as GameState);
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -106,4 +106,74 @@ describe('responsive game layout budget', () => {
     expect(budget.shellMaxWidth).toBe(560)
     expect(budget.rosterHeaderMode).toBe('persistent')
   })
+
+  it('exposes a full Survivor standout mode for medium Android-sized eight-player layouts', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 851,
+      stageWidth: 393,
+      stageHeight: 851,
+      safeTop: 0,
+      safeBottom: 0,
+      navHeight: 60,
+      dockHeight: 76,
+      playerCount: 8,
+      isAndroidLike: true,
+    }))
+
+    expect(budget.survivorStandoutMode).toBe('full-card')
+    expect(budget.cssVars).toMatchObject({
+      '--game-survivor-standout-min-height': '74px',
+    })
+  })
+
+  it('collapses the Survivor standout on small phones instead of dropping it', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 340,
+      viewportHeight: 660,
+      stageWidth: 340,
+      stageHeight: 660,
+      navHeight: 60,
+      dockHeight: 76,
+      playerCount: 8,
+    }))
+
+    expect(budget.survivorStandoutMode).toBe('mini-chip')
+  })
+
+  it('uses the richer Survivor standout treatment on tablet budgets', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 820,
+      viewportHeight: 1080,
+      stageWidth: 520,
+      stageHeight: 980,
+      dockHeight: 0,
+      hasDock: false,
+      playerCount: 8,
+    }))
+
+    expect(budget.survivorStandoutMode).toBe('full-card')
+  })
+
+  it('keeps Survivor avatar tile size stable across transient dock budget changes', () => {
+    const calm = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 851,
+      stageWidth: 393,
+      stageHeight: 851,
+      dockHeight: 76,
+      playerCount: 8,
+    }))
+    const crowded = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 851,
+      stageWidth: 393,
+      stageHeight: 851,
+      dockHeight: 140,
+      playerCount: 8,
+    }))
+
+    expect(crowded.avatarTileSize).toBe(calm.avatarTileSize)
+    expect(crowded.rosterGap).toBe(calm.rosterGap)
+  })
 })


### PR DESCRIPTION
## Summary
- Adds a read-only Survivor standout selector that ranks alive Survivor players by days in game, then by real challenge-history average placement only when all tied candidates have reliable placement data.
- Adds a Survivor Standout UI module with full-card, compact-strip, and mini-chip presentations below the GameScreen roster path.
- Extends the responsive GameScreen layout budget with `survivorStandoutMode` and tests Pixel-like, small-phone, tablet, and stable-avatar sizing cases.

## Notes
- Classic mode is not ranked by the selector and the roster render path is gated to Survivor plus the active game-screen dock context.
- Average rankings are omitted when challenge history does not contain reliable placement data for the tied candidates.

## Validation
- Added unit tests for Survivor leader selection, tie handling, missing placement data, eliminated-player exclusion, and classic-mode null behavior.
- Added responsive layout budget tests for medium Android, small phone, tablet, and avatar size stability.
- Not run locally: this was implemented directly through GitHub without creating a local checkout, per request.