### PR TITLE
fix: reserve faux TV and static roster layout

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -4,7 +4,7 @@
   flex: 0 0 auto;
   flex-direction: column;
   min-height: 0;
-  padding: 2px 8px 6px;
+  padding: 0 8px;
   overflow: visible;
 }
 

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -1,11 +1,11 @@
 .container {
   position: relative;
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   flex-direction: column;
   min-height: 0;
   padding: 2px 8px 6px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .headerRow {
@@ -58,7 +58,7 @@
   margin: 0;
   padding: 0;
   display: grid;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   min-height: 0;
   gap: var(--game-roster-gap, 5px);
   grid-template-columns: repeat(4, minmax(0, var(--game-avatar-tile-size, 1fr)));
@@ -67,9 +67,9 @@
   justify-content: center;
   justify-items: stretch;
   align-items: start;
-  max-height: min(var(--game-roster-max-height, 480px), var(--grid-available-height, 480px), 100%);
-  overflow: hidden;
-  padding-bottom: 4px;
+  height: var(--game-roster-board-height, auto);
+  max-height: none;
+  overflow: visible;
 }
 
 .slider {
@@ -107,25 +107,18 @@
   transform: none;
 }
 
-.scrollRoster .grid {
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  scroll-padding-block: 8px;
-  padding-right: 2px;
-}
-
-.scrollRoster .grid::-webkit-scrollbar {
-  width: 4px;
-}
-
-.scrollRoster .grid::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.scrollRoster .grid::-webkit-scrollbar-thumb {
-  background: rgba(139, 92, 246, 0.34);
-  border-radius: 999px;
+.container[data-header-mode='tv-chip'] .headerRow {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  opacity: 1;
+  animation: none;
 }
 
 .tile {

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -81,8 +81,8 @@ type Props = {
   compactLayout?: CompactRosterLayout
   /** Responsive budget-selected roster behavior. */
   rosterMode?: 'normal' | 'compact-small' | 'scroll'
-  /** Whether the HOUSEMATES row should stay visible or briefly overlay. */
-  headerMode?: 'transient' | 'persistent'
+  /** Whether the HOUSEMATES row stays above the board or moves into the TV chip. */
+  headerMode?: 'tv-chip' | 'persistent'
   /** Changes when the measured layout budget changes. */
   layoutRevision?: number
   /** Optional alive/total chip shown beside the section heading. */
@@ -123,7 +123,7 @@ export default function HouseguestGrid({
   compact = false,
   compactLayout = 'slider',
   rosterMode = 'normal',
-  headerMode = 'transient',
+  headerMode = 'tv-chip',
   layoutRevision = 0,
   occupancyLabel,
 }: Props) {

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -493,6 +493,29 @@
     linear-gradient(180deg, #0d1320 0%, #060a12 100%);
 }
 
+.tv-zone__occupancy-chip {
+  position: absolute;
+  top: 8px;
+  right: 9px;
+  z-index: 8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(9, 14, 25, 0.72);
+  color: rgba(242, 245, 255, 0.9);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+  font-size: 0.64rem;
+  font-weight: 850;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
 /* ── Bezel brand badge ──────────────────────────────────────────────────────── */
 .tv-zone__bezel-brand {
   position: absolute;
@@ -583,6 +606,13 @@
   }
   .tv-zone__bezel-frame {
     border-width: 2px;
+  }
+  .tv-zone__occupancy-chip {
+    top: 6px;
+    right: 7px;
+    height: 20px;
+    min-width: 40px;
+    font-size: 0.6rem;
   }
 }
 

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -253,6 +253,11 @@ type TvZoneProps = {
   onExternalAnnouncementDismiss?: () => void;
   /** Fallback text shown in the viewport when no fresh event is available and the screen would otherwise go blank. */
   viewportFallbackMessage?: string;
+  /** Compact board occupancy chip shown when the roster header yields space to the board. */
+  occupancyChip?: {
+    label: string;
+    ariaLabel: string;
+  } | null;
 };
 
 /**
@@ -292,6 +297,7 @@ export default function TvZone(props: TvZoneProps) {
     [gameState.tvFeed],
   );
   const mainLogMaxVisible = props.mainLogMaxVisible ?? 2;
+  const occupancyChip = props.occupancyChip ?? null;
 
   const latestEvent = tvVisibleFeed[0];
   const publicSaveRevealActive = Boolean(props.publicSaveReveal);
@@ -894,6 +900,11 @@ export default function TvZone(props: TvZoneProps) {
       {/* ── Bezel + Viewport ────────────────────────────────────────────────── */}
       <div className="tv-zone__bezel">
         <div className="tv-zone__bezel-frame">
+          {occupancyChip && (
+            <span className="tv-zone__occupancy-chip" aria-label={occupancyChip.ariaLabel}>
+              {occupancyChip.label}
+            </span>
+          )}
 
           <div className="tv-zone__viewport" role="region" aria-label="Live game events display" aria-live="polite" aria-atomic="true">
             <p

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -15,7 +15,7 @@
 }
 
 .game-screen:has(.game-control-dock) {
-  padding-bottom: calc(4px + var(--game-screen-floating-dock-clearance));
+  padding-bottom: var(--game-screen-floating-dock-clearance);
 }
 
 .game-screen--compact-roster-balance {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -3045,6 +3045,13 @@ export default function GameScreen() {
     userCompactRosterLayout: settings.gameUX.compactRosterLayout,
   })
   const gameTvLogRows = responsiveGameLayout.tvLogRows
+  const housemateOccupancyLabel = `${alivePlayers.length}/${game.players.length}`
+  const rosterOccupancyChip = responsiveGameLayout.rosterHeaderMode === 'tv-chip'
+    ? {
+        label: housemateOccupancyLabel,
+        ariaLabel: `Housemates ${alivePlayers.length} of ${game.players.length}`,
+      }
+    : null
 
   return (
     <LayoutGroup id="game-layout">
@@ -3081,6 +3088,7 @@ export default function GameScreen() {
           }
           mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
+          occupancyChip={rosterOccupancyChip}
         />
       ) : showDemocraciaResults && democraciaResultDisplay ? (
         <TvZone
@@ -3107,6 +3115,7 @@ export default function GameScreen() {
           }
           mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
+          occupancyChip={rosterOccupancyChip}
         />
       ) : showVoteResults ? (
         <TvZone
@@ -3135,6 +3144,7 @@ export default function GameScreen() {
           }
           mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
+          occupancyChip={rosterOccupancyChip}
         />
       ) : (
         <TvZone
@@ -3163,6 +3173,7 @@ export default function GameScreen() {
           }
           mainLogMaxVisible={gameTvLogRows}
           viewportFallbackMessage={tvViewportFallbackMessage}
+          occupancyChip={rosterOccupancyChip}
         />
       )}
 
@@ -4332,7 +4343,7 @@ export default function GameScreen() {
         rosterMode={responsiveGameLayout.rosterMode}
         headerMode={responsiveGameLayout.rosterHeaderMode}
         layoutRevision={responsiveGameLayout.revision}
-        occupancyLabel={`${alivePlayers.length}/${game.players.length}`}
+        occupancyLabel={housemateOccupancyLabel}
       />
       {previewPlayer && <HouseguestInfoDialog player={previewPlayer} onClose={() => setPreviewPlayer(null)} />}
     </div>

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -9,7 +9,7 @@ export type GameLayoutSize =
   | 'tablet-landscape'
 
 export type ResponsiveRosterMode = 'normal' | 'compact-small' | 'scroll'
-export type RosterHeaderMode = 'transient' | 'persistent'
+export type RosterHeaderMode = 'tv-chip' | 'persistent'
 export type SurvivorStandoutLayoutMode = 'full-card' | 'compact-strip' | 'mini-chip'
 
 export interface ResponsiveGameLayoutBudget {
@@ -56,11 +56,13 @@ const DEFAULT_PHONE_HEIGHT = 780
 const DEFAULT_DOCK_RATIO = 220 / 980
 const ROSTER_COLUMNS = 4
 const ROSTER_GAP = 5
+const GAME_INLINE_PADDING = 24
 const ROSTER_INLINE_PADDING = 16
 const ROSTER_HEADER_HEIGHT = 30
 const GAME_VERTICAL_PADDING = 10
 const GAME_SECTION_GAPS = 12
 const TV_LOG_ROW_HEIGHT = 32
+const TV_CHROME_HEIGHT = 88
 const MAX_PHONE_TV_LOG_ROWS = 5
 const MAX_TABLET_TV_LOG_ROWS = 5
 const SHORT_ROSTER_MAX_PLAYERS = ROSTER_COLUMNS * 2
@@ -139,32 +141,17 @@ function resolveBaseTvLogRows(extraAfterBaseRoster: number, isTablet: boolean) {
 }
 
 function resolveAdaptiveTvLogRows(options: {
-  availableAfterTv: number
-  baseRosterHeight: number
-  baseRows: number
+  extraAfterFeature: number
   isTablet: boolean
   playerCount: number
-  rosterMode: ResponsiveRosterMode
-  survivorStandoutMode: SurvivorStandoutLayoutMode
 }) {
-  if (options.playerCount > SHORT_ROSTER_MAX_PLAYERS || options.rosterMode === 'scroll') {
-    return options.baseRows
-  }
+  const maxRows = options.playerCount <= SHORT_ROSTER_MAX_PLAYERS
+    ? (options.isTablet ? MAX_TABLET_TV_LOG_ROWS : MAX_PHONE_TV_LOG_ROWS)
+    : (options.isTablet ? 4 : 3)
+  const baseRows = resolveBaseTvLogRows(options.extraAfterFeature, options.isTablet)
+  const rowsThatFit = 1 + Math.floor(options.extraAfterFeature / TV_LOG_ROW_HEIGHT)
 
-  const maxRows = options.isTablet ? MAX_TABLET_TV_LOG_ROWS : MAX_PHONE_TV_LOG_ROWS
-  const maxExtraRows = Math.max(0, maxRows - options.baseRows)
-  if (maxExtraRows === 0) return options.baseRows
-
-  const survivorStandoutHeight = getSurvivorStandoutHeight(options.survivorStandoutMode)
-  const reservedHeight =
-    options.baseRosterHeight +
-    options.baseRows * TV_LOG_ROW_HEIGHT +
-    survivorStandoutHeight +
-    SURVIVOR_STANDOUT_GAP_ALLOWANCE
-  const slackAfterFeature = options.availableAfterTv - reservedHeight
-  const extraRows = clamp(Math.floor(slackAfterFeature / TV_LOG_ROW_HEIGHT), 0, maxExtraRows)
-
-  return options.baseRows + extraRows
+  return clamp(Math.max(baseRows, rowsThatFit), 1, maxRows)
 }
 
 function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
@@ -202,95 +189,88 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const navHeight = input.navHeight || DEFAULT_NAV_HEIGHT
   void navHeight
   const measuredDockHeight = input.dockHeight || estimateDockHeight(stageWidth)
-  const dockClearance = input.hasDock ? measuredDockHeight + 8 : 0
+  const dockClearance = input.hasDock ? measuredDockHeight + 6 : 0
   const isTablet = layoutSize === 'tablet-portrait' || layoutSize === 'tablet-landscape'
   const shellMaxWidth = isTablet
     ? (layoutSize === 'tablet-landscape' ? 560 : 520)
     : 480
 
-  const tileWidth = (stageWidth - ROSTER_INLINE_PADDING - ROSTER_GAP * (ROSTER_COLUMNS - 1)) / ROSTER_COLUMNS
-  const normalTileSize = clamp(tileWidth, 64, isTablet ? 128 : 112)
-  const compactTileSize = normalTileSize * 0.72
+  const rosterContentWidth = Math.max(
+    240,
+    stageWidth - GAME_INLINE_PADDING - ROSTER_INLINE_PADDING,
+  )
+  const tileWidth = (rosterContentWidth - ROSTER_GAP * (ROSTER_COLUMNS - 1)) / ROSTER_COLUMNS
+  const normalTileMax = isTablet
+    ? 128
+    : layoutSize === 'phone-large' && (viewportHeight >= 900 || stageWidth >= 420)
+      ? 104
+      : layoutSize === 'phone-large'
+        ? 80
+        : 78
+  const normalTileSize = Math.floor(clamp(tileWidth, 76, normalTileMax))
+  const compactTileSize = Math.floor(clamp(normalTileSize * 0.86, 64, normalTileSize))
   const rosterRows = Math.max(1, Math.ceil(Math.max(input.playerCount, 1) / ROSTER_COLUMNS))
   const shouldUseCompactBase =
     !isTablet &&
     input.playerCount >= 16 &&
-    (layoutSize === 'phone-small' || stageWidth < 370)
-  const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> = input.userCompactRoster || shouldUseCompactBase
-    ? 'compact-small'
-    : 'normal'
+    (layoutSize === 'phone-small' || rosterContentWidth < 320)
 
-  const baseTvHeight = layoutSize === 'phone-small'
-    ? 204
-    : layoutSize === 'phone-medium'
-      ? 232
-      : isTablet
-        ? 292
-        : 258
-  const tvHeight = clamp(
-    stageHeight * (isTablet ? 0.27 : 0.3),
-    baseTvHeight,
-    isTablet ? 336 : 312,
-  )
-  const tvViewportHeight = clamp(tvHeight - 82, 132, isTablet ? 238 : 192)
   const availableAfterTv = Math.max(
     0,
-    stageHeight - tvHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
+    stageHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
   )
   const normalRosterHeight = rosterRows * normalTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
   const compactRosterHeight = rosterRows * compactTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
+  const minTvViewportHeight = layoutSize === 'phone-small'
+    ? 112
+    : layoutSize === 'phone-medium'
+      ? 132
+      : isTablet
+        ? 176
+        : 144
+  const minTvHeight = minTvViewportHeight + TV_CHROME_HEIGHT + TV_LOG_ROW_HEIGHT
+  const normalWithoutHeader = normalRosterHeight - ROSTER_HEADER_HEIGHT
+  const normalStaticFits =
+    !shouldUseCompactBase &&
+    normalWithoutHeader + minTvHeight <= availableAfterTv
+  const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> =
+    input.userCompactRoster || !normalStaticFits
+      ? 'compact-small'
+      : 'normal'
+  const rosterMode: ResponsiveRosterMode = baseRosterMode
   const baseAvatarTileSize = baseRosterMode === 'compact-small' ? compactTileSize : normalTileSize
   const baseRosterHeight = baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
-  const extraAfterBaseRoster = availableAfterTv - baseRosterHeight
-
-  const baseTvLogRows = resolveBaseTvLogRows(extraAfterBaseRoster, isTablet)
-  const preliminaryLogHeight = baseTvLogRows * TV_LOG_ROW_HEIGHT
-  const preliminaryAvailableRosterHeight = Math.max(
-    180,
-    stageHeight - tvHeight - preliminaryLogHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
-  )
-  const preliminaryRosterFits = baseRosterHeight <= preliminaryAvailableRosterHeight
-  const preliminaryRosterMode: ResponsiveRosterMode = preliminaryRosterFits ? baseRosterMode : 'scroll'
-  const preliminarySurvivorStandoutMode = resolveSurvivorStandoutMode({
-    layoutSize,
-    rosterMode: preliminaryRosterMode,
-    extraAfterBaseRoster,
-  })
-  const tvLogRows = resolveAdaptiveTvLogRows({
-    availableAfterTv,
-    baseRosterHeight,
-    baseRows: baseTvLogRows,
-    isTablet,
-    playerCount: input.playerCount,
-    rosterMode: preliminaryRosterMode,
-    survivorStandoutMode: preliminarySurvivorStandoutMode,
-  })
-  const logHeight = tvLogRows * TV_LOG_ROW_HEIGHT
-  const availableRosterHeight = Math.max(
-    180,
-    stageHeight - tvHeight - logHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
-  )
-
-  const baseRosterFits = baseRosterHeight <= availableRosterHeight
-  const rosterMode: ResponsiveRosterMode = baseRosterFits ? baseRosterMode : 'scroll'
+  const baseRosterHeightWithoutHeader = baseRosterHeight - ROSTER_HEADER_HEIGHT
+  const headerFits = baseRosterHeight + minTvHeight <= availableAfterTv
+  const rosterHeaderMode: RosterHeaderMode = headerFits ? 'persistent' : 'tv-chip'
+  const rosterDisplayHeight = rosterHeaderMode === 'persistent'
+    ? baseRosterHeight
+    : baseRosterHeightWithoutHeader
+  const extraAfterMandatory = Math.max(0, availableAfterTv - rosterDisplayHeight - minTvHeight)
   const survivorStandoutMode = resolveSurvivorStandoutMode({
     layoutSize,
     rosterMode,
-    extraAfterBaseRoster,
+    extraAfterBaseRoster: extraAfterMandatory,
   })
   const survivorStandoutHeight = getSurvivorStandoutHeight(survivorStandoutMode)
-
-  const rosterHeaderMode: RosterHeaderMode = baseRosterFits || isTablet || layoutSize === 'phone-large'
-    ? 'persistent'
-    : 'transient'
+  const featureReserve = input.playerCount <= SHORT_ROSTER_MAX_PLAYERS
+    ? survivorStandoutHeight + SURVIVOR_STANDOUT_GAP_ALLOWANCE
+    : 0
+  const extraAfterFeature = Math.max(0, extraAfterMandatory - featureReserve)
+  const tvLogRows = resolveAdaptiveTvLogRows({
+    extraAfterFeature,
+    isTablet,
+    playerCount: input.playerCount,
+  })
+  const extraLogRows = tvLogRows - 1
+  const breathingRoom = clamp(extraAfterFeature - extraLogRows * TV_LOG_ROW_HEIGHT, 0, isTablet ? 36 : 20)
+  const tvHeight = minTvHeight + extraLogRows * TV_LOG_ROW_HEIGHT + breathingRoom
+  const tvViewportHeight = minTvViewportHeight + breathingRoom
   const compactRoster = baseRosterMode === 'compact-small'
   const compactRosterLayout = input.userCompactRoster
     ? input.userCompactRosterLayout
     : 'small'
-  const rosterMaxHeight = Math.max(
-    180,
-    availableRosterHeight - (rosterHeaderMode === 'persistent' ? ROSTER_HEADER_HEIGHT : 0),
-  )
+  const rosterMaxHeight = baseRosterHeightWithoutHeader
   const avatarTileSize = baseAvatarTileSize
   const avatarTileSizePx = Math.max(0, Math.floor(avatarTileSize))
 
@@ -302,6 +282,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     '--game-screen-tv-viewport-min-height': `${roundPx(tvViewportHeight)}px`,
     '--game-tv-log-rows': String(tvLogRows),
     '--game-roster-max-height': `${roundPx(rosterMaxHeight)}px`,
+    '--game-roster-board-height': `${roundPx(baseRosterHeightWithoutHeader)}px`,
     '--game-avatar-tile-size': `${avatarTileSizePx}px`,
     '--game-roster-gap': `${ROSTER_GAP}px`,
     '--game-survivor-standout-min-height': `${survivorStandoutHeight}px`,

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -22,6 +22,11 @@ function makeInput(overrides: Partial<ResponsiveGameLayoutInput> = {}): Responsi
   }
 }
 
+function readCssPx(budget: ReturnType<typeof computeResponsiveGameLayout>, name: string) {
+  const value = (budget.cssVars as Record<string, string>)[name]
+  return Number.parseFloat(value)
+}
+
 describe('responsive game layout budget', () => {
   it('uses a measured Android top-safe fallback when env safe-area is zero', () => {
     const budget = computeResponsiveGameLayout(makeInput({
@@ -52,6 +57,7 @@ describe('responsive game layout budget', () => {
     expect(budget.cssVars).toMatchObject({
       '--game-roster-board-height': '335px',
     })
+    expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
   })
 

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -37,7 +37,7 @@ describe('responsive game layout budget', () => {
     })
   })
 
-  it('keeps the device-bucket roster size before allowing roster scroll on phones', () => {
+  it('fits an iPhone Pro-like board statically by moving Housemates to the TV chip', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportHeight: 852,
       stageHeight: 699,
@@ -46,8 +46,12 @@ describe('responsive game layout budget', () => {
 
     expect(budget.layoutSize).toBe('phone-large')
     expect(budget.baseRosterMode).toBe('normal')
-    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.rosterMode).toBe('normal')
+    expect(budget.rosterHeaderMode).toBe('tv-chip')
     expect(budget.compactRoster).toBe(false)
+    expect(budget.cssVars).toMatchObject({
+      '--game-roster-board-height': '335px',
+    })
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
   })
 
@@ -76,9 +80,11 @@ describe('responsive game layout budget', () => {
     expect(liveVoteBudget.cssVars).toMatchObject({
       '--game-avatar-tile-size': `${dayEndBudget.avatarTileSize}px`,
     })
+    expect(dayEndBudget.rosterMode).toBe('normal')
+    expect(liveVoteBudget.rosterMode).toBe('normal')
   })
 
-  it('spends extra vertical space on more TV log rows before leaving dead space', () => {
+  it('uses a full Housemates row and more log rows on iPhone Pro Max-like screens', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 430,
       viewportHeight: 950,
@@ -90,6 +96,41 @@ describe('responsive game layout budget', () => {
     expect(budget.rosterMode).toBe('normal')
     expect(budget.rosterHeaderMode).toBe('persistent')
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(3)
+  })
+
+  it('keeps Pixel 6 Android-style screens on a static normal roster', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 393,
+      viewportHeight: 851,
+      stageWidth: 393,
+      stageHeight: 700,
+      safeTop: 0,
+      safeBottom: 0,
+      dockHeight: 70,
+      isAndroidLike: true,
+    }))
+
+    expect(budget.cssVars).toMatchObject({
+      '--game-safe-top': '24px',
+    })
+    expect(budget.rosterMode).toBe('normal')
+    expect(budget.compactRoster).toBe(false)
+    expect(budget.rosterHeaderMode).toBe('tv-chip')
+  })
+
+  it('uses compact fallback only on genuinely small static boards', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 320,
+      viewportHeight: 667,
+      stageWidth: 320,
+      stageHeight: 620,
+      dockHeight: 62,
+    }))
+
+    expect(budget.layoutSize).toBe('phone-small')
+    expect(budget.rosterMode).toBe('compact-small')
+    expect(budget.compactRoster).toBe(true)
+    expect(budget.rosterHeaderMode).toBe('tv-chip')
   })
 
   it('classifies tablet landscape and widens the centered game cabinet intentionally', () => {
@@ -104,7 +145,7 @@ describe('responsive game layout budget', () => {
 
     expect(budget.layoutSize).toBe('tablet-landscape')
     expect(budget.shellMaxWidth).toBe(560)
-    expect(budget.rosterHeaderMode).toBe('persistent')
+    expect(budget.rosterMode).not.toBe('scroll')
   })
 
   it('exposes a full Survivor standout mode for medium Android-sized eight-player layouts', () => {

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -77,9 +77,12 @@ describe('safe-area layout styles', () => {
     expect(houseguestGridCss).toContain('grid-template-columns: repeat(4, minmax(0, var(--game-avatar-tile-size, 1fr)));');
     expect(houseguestGridCss).toContain('gap: var(--game-roster-gap, 5px);');
     expect(houseguestGridCss).toContain('width: var(--game-avatar-tile-size, 100%);');
-    expect(houseguestGridCss).toContain('overflow: hidden;');
-    expect(houseguestGridCss).toContain(".scrollRoster .grid { overflow-y: auto;");
+    expect(houseguestGridCss).toContain('height: var(--game-roster-board-height, auto);');
+    expect(houseguestGridCss).toContain('overflow: visible;');
+    expect(houseguestGridCss).not.toContain('.scrollRoster .grid { overflow-y: auto;');
     expect(houseguestGridCss).toContain(".container[data-header-mode='persistent'] .headerRow");
+    expect(houseguestGridCss).toContain(".container[data-header-mode='tv-chip'] .headerRow");
+    expect(gameScreenTsx).toContain('occupancyChip={rosterOccupancyChip}');
     expect(houseguestGridCss).not.toContain('survivorTileSettle');
     expect(gameScreenTsx).toContain('useResponsiveGameLayout');
     expect(gameScreenTsx).toContain('layoutSignal={responsiveGameLayout.revision}');


### PR DESCRIPTION
## Summary
- Switch the measured game layout to a roster-and-TV reserved budget: the full avatar board is static, and the faux TV keeps a stable reserved viewport instead of being squeezed down.
- Collapse the full HOUSEMATES row into a compact TV chip on tight phone layouts before touching the board or TV.
- Remove internal roster scrolling/cropping from the main avatar board and keep normal static roster sizing on iPhone Pro / Pixel-style screens.
- Add/update layout tests for iPhone Pro, iPhone Pro Max, Pixel-style Android, small-phone compact fallback, TV minimum reservation, and no-scroll roster styling.

## Validation
- `git diff --check` passed locally.
- Local npm scripts still cannot run in this checkout because `vitest`, `tsc`, and `eslint` are not installed; no dependencies were installed locally.

This is a follow-up to merged PR #1080 because that PR merged while the faux-TV reservation correction was being applied.