### PR TITLE
fix: keep classic spectators from getting stuck in competitions

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -30,6 +30,7 @@ export default function NavBar() {
   const isGameActive = useAppSelector((s) => s.game.status === 'active');
   const pendingChallenge = useAppSelector(selectPendingChallenge);
   const pendingMinigame = useAppSelector((s) => s.game.pendingMinigame);
+  const humanPlayer = useAppSelector((s) => s.game.players.find((player) => player.isUser));
   const gamePhase = useAppSelector((s) => s.game.phase);
   const seasonFinale = useAppSelector((s) => s.game.seasonFinale);
   const battleBack = useAppSelector((s) => s.game.battleBack);
@@ -40,9 +41,13 @@ export default function NavBar() {
   const canPersistActiveRun = !isGuest && Boolean(activeProfileId);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const humanInPendingChallenge =
+    Boolean(pendingChallenge && humanPlayer && pendingChallenge.participants.includes(humanPlayer.id));
+  const humanInPendingMinigame =
+    Boolean(pendingMinigame && humanPlayer && pendingMinigame.participants.includes(humanPlayer.id));
   const isFullScreenFlowActive =
-    Boolean(pendingChallenge) ||
-    Boolean(pendingMinigame) ||
+    humanInPendingChallenge ||
+    humanInPendingMinigame ||
     gamePhase === 'jury' ||
     gamePhase === 'jury_announcement' ||
     gamePhase === 'jury_cinematic' ||

--- a/src/components/layout/__tests__/NavBar.test.tsx
+++ b/src/components/layout/__tests__/NavBar.test.tsx
@@ -9,7 +9,7 @@ import profilesReducer from '../../../store/profilesSlice';
 import type { GameState, MinigameSession } from '../../../types';
 import NavBar from '../NavBar';
 
-function buildPendingChallenge(): PendingChallenge {
+function buildPendingChallenge(participants: string[] = ['user']): PendingChallenge {
   return {
     id: 'challenge-1',
     game: {
@@ -20,16 +20,16 @@ function buildPendingChallenge(): PendingChallenge {
       retired: false,
     } as PendingChallenge['game'],
     seed: 1,
-    participants: ['user'],
+    participants,
     phase: 'rules',
     aiScores: {},
   };
 }
 
-function buildPendingMinigame(): MinigameSession {
+function buildPendingMinigame(participants: string[] = ['user']): MinigameSession {
   return {
     key: 'quickTap',
-    participants: ['user'],
+    participants,
     seed: 1,
     options: { timeLimit: 30 },
     aiScores: {},
@@ -40,7 +40,9 @@ function renderNavBar(
   initialEntry = '/game',
   options: {
     challengePending?: boolean;
+    challengeParticipants?: string[];
     pendingMinigame?: boolean;
+    pendingMinigameParticipants?: string[];
     gameOverrides?: Partial<GameState>;
   } = {},
 ) {
@@ -56,11 +58,11 @@ function renderNavBar(
       game: {
         ...initialGameState,
         status: 'active' as const,
-        ...(options.pendingMinigame ? { pendingMinigame: buildPendingMinigame() } : {}),
+        ...(options.pendingMinigame ? { pendingMinigame: buildPendingMinigame(options.pendingMinigameParticipants) } : {}),
         ...options.gameOverrides,
       },
       challenge: options.challengePending
-        ? { ...initialChallengeState, pending: buildPendingChallenge() }
+        ? { ...initialChallengeState, pending: buildPendingChallenge(options.challengeParticipants) }
         : initialChallengeState,
     },
   });
@@ -92,10 +94,43 @@ describe('NavBar', () => {
     expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
   });
 
+  it('keeps bottom navigation available for an evicted classic spectator during an AI-only challenge', () => {
+    renderNavBar('/game', {
+      challengePending: true,
+      challengeParticipants: ['p1', 'p2'],
+      gameOverrides: {
+        players: [
+          { id: 'user', name: 'You', avatar: '🙂', status: 'evicted', isUser: true },
+          { id: 'p1', name: 'Ari', avatar: '🙂', status: 'active', isUser: false },
+          { id: 'p2', name: 'Bo', avatar: '🙂', status: 'active', isUser: false },
+        ],
+      },
+    });
+
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'HOME' })).toBeDefined();
+  });
+
   it('hides the bottom navigation while a native minigame session is active', () => {
     renderNavBar('/game', { pendingMinigame: true });
 
     expect(screen.queryByRole('navigation', { name: 'Main navigation' })).toBeNull();
+  });
+
+  it('keeps bottom navigation available when a native minigame excludes the evicted user', () => {
+    renderNavBar('/game', {
+      pendingMinigame: true,
+      pendingMinigameParticipants: ['p1', 'p2'],
+      gameOverrides: {
+        players: [
+          { id: 'user', name: 'You', avatar: '🙂', status: 'jury', isUser: true },
+          { id: 'p1', name: 'Ari', avatar: '🙂', status: 'active', isUser: false },
+          { id: 'p2', name: 'Bo', avatar: '🙂', status: 'active', isUser: false },
+        ],
+      },
+    });
+
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeDefined();
   });
 
   it('hides the bottom navigation during the tribunal-style jury sequence', () => {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -60,7 +60,7 @@ import {
   submitCoLohNomination,
   submitPosTieBreak,
 } from '../../store/gameSlice'
-import { startChallenge, selectPendingChallenge, completeChallenge } from '../../store/challengeSlice'
+import { startChallenge, selectPendingChallenge, completeChallenge, type PendingChallenge } from '../../store/challengeSlice'
 import { selectLastSocialReport } from '../../social/socialSlice'
 import { setEnergyBankEntry } from '../../social/socialSlice'
 import { selectSocialSummaryOpen } from '../../store/uiSlice'
@@ -184,6 +184,14 @@ const CONFESSIONAL_TV_PROMPT_MESSAGE =
 const PUBLIC_MODE_STORE_PROMPT =
   'If you want to activate public mode, go to the store in the home hub.'
 const SOCIAL_MODULE_UNAVAILABLE_ANNOUNCEMENT_MS = 3000
+
+function buildAiOnlyChallengeRawResults(challenge: PendingChallenge) {
+  return challenge.participants.map((id) => ({
+    playerId: id,
+    rawValue: challenge.aiScores[id] ?? 0,
+    ...(challenge.aiTiebreakers?.[id] != null ? { tiebreaker: challenge.aiTiebreakers[id] } : {}),
+  }))
+}
 
 type PendingPublicSaveResult = {
   savedId: string
@@ -2612,6 +2620,38 @@ export default function GameScreen() {
   const humanIsChallengeParticipant =
     !!pendingChallenge && !!humanPlayer && pendingChallenge.participants.includes(humanPlayer.id)
   const showMinigameHost = humanIsChallengeParticipant
+  const aiOnlyChallengeResolvedRef = useRef<string | null>(null)
+  useEffect(() => {
+    const isClassicCompetitionPhase =
+      game.mode !== 'survivor' &&
+      (game.phase === 'loh_comp' || game.phase === 'pos_comp')
+    if (
+      !isClassicCompetitionPhase ||
+      !pendingChallenge ||
+      humanIsChallengeParticipant ||
+      pendingChallenge.participants.length === 0 ||
+      aiOnlyChallengeResolvedRef.current === pendingChallenge.id
+    ) {
+      return
+    }
+
+    aiOnlyChallengeResolvedRef.current = pendingChallenge.id
+    const rawResults = buildAiOnlyChallengeRawResults(pendingChallenge)
+    const scoreWinnerId = dispatch(completeChallenge(rawResults)) as string | null
+    const finalWinnerId = scoreWinnerId ?? pendingChallenge.participants[0]
+    const ranked = computeScores(
+      pendingChallenge.game.scoringAdapter,
+      rawResults,
+      pendingChallenge.game.scoringParams ?? {},
+    )
+    const lastNonWinner = [...ranked].reverse().find((result) => result.playerId !== finalWinnerId)
+
+    dispatch(applyMinigameWinner({
+      winnerId: finalWinnerId,
+      lastPlaceId: lastNonWinner?.playerId ?? null,
+      skipSeasonUpdate: true,
+    }))
+  }, [dispatch, game.mode, game.phase, humanIsChallengeParticipant, pendingChallenge])
   /** True whenever a native React LOH/POS minigame overlay should be displayed. */
   const showLohMinigame = !showMinigameHost && humanIsParticipant
   const showPressurePlank = showLohMinigame && pendingMinigame?.key === 'pressurePlank'

--- a/tests/integration/challenge.flow.dispatch.test.tsx
+++ b/tests/integration/challenge.flow.dispatch.test.tsx
@@ -10,7 +10,7 @@
 //     category-only, unique, retired modes).
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { configureStore } from '@reduxjs/toolkit';
@@ -48,6 +48,19 @@ const REDUCERS = {
 
 function makeStore() {
   return configureStore({ reducer: REDUCERS });
+}
+
+function makeStoreWithGame(overrides: Partial<ReturnType<typeof gameReducer>>) {
+  const initialGameState = gameReducer(undefined, { type: '@@INIT' });
+  return configureStore({
+    reducer: REDUCERS,
+    preloadedState: {
+      game: {
+        ...initialGameState,
+        ...overrides,
+      },
+    },
+  });
 }
 
 /** Create a store with custom settings.gameUX.compSelection preloaded. */
@@ -170,6 +183,29 @@ describe('challenge flow – phase transition dispatch', () => {
     const dialogs = screen.getAllByRole('dialog');
     expect(dialogs.length).toBeGreaterThanOrEqual(1);
     expect(dialogs.some((d) => d.classList.contains('minigame-host'))).toBe(true);
+  });
+
+  it('resolves a classic AI-only competition when the human is an evicted spectator', async () => {
+    const store = makeStoreWithGame({
+      status: 'active',
+      phase: 'loh_comp',
+      seed: 42,
+      players: [
+        { id: 'user', name: 'You', avatar: '🙂', status: 'evicted', isUser: true },
+        { id: 'p1', name: 'Ari', avatar: '🙂', status: 'active', isUser: false },
+        { id: 'p2', name: 'Bo', avatar: '🙂', status: 'active', isUser: false },
+      ],
+    });
+
+    renderWithStore(store);
+
+    await waitFor(() => {
+      expect(store.getState().challenge.pending).toBeNull();
+      expect(store.getState().challenge.history).toHaveLength(1);
+    });
+
+    expect(['p1', 'p2']).toContain(store.getState().game.lohId);
+    expect(store.getState().game.phase).toBe('loh_results');
   });
 });
 


### PR DESCRIPTION
## Summary
- Keep the bottom HOME/RULES/etc nav visible when a pending challenge or native minigame does not include the human player.
- Auto-resolve classic LOH/POS AI-only challenges when the human has been evicted/juried and is watching as a spectator, so pendingChallenge cannot strand the game without a minigame UI.
- Add regressions for evicted spectator nav visibility and the classic AI-only challenge completion path.

## Validation
- `git diff --check` passed locally.
- Local npm scripts could not run in this checkout because `tsc`, `eslint`, and `vitest` are not installed; no dependencies were installed locally.