### PR TITLE
Fix classic run reset after self-evict

### DIFF
--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -68,6 +68,7 @@ const HUB_BUTTONS = [
   { to: '/credits',      label: 'Credits',     icon: '🎬', variant: 'secondary_small'  },
 ] as const satisfies ReadonlyArray<{ to: string; label: string; icon: string; variant: GameButtonVariant }>;
 
+type ClassicPrompt = 'resume-or-new' | 'confirm-new' | null;
 type SurvivorPrompt = 'resume-or-new' | 'ended' | 'confirm-new' | null;
 
 function snapshotDay(snapshot: SavedSeasonSnapshot | null | undefined): number | null {
@@ -202,6 +203,7 @@ export default function HomeHub() {
   // an effect on mount.
   const [preloading, setPreloading] = useState(autoStartGame);
   const [playSelectionOpen, setPlaySelectionOpen] = useState(false);
+  const [classicPrompt, setClassicPrompt] = useState<ClassicPrompt>(null);
   const [survivorPrompt, setSurvivorPrompt] = useState<SurvivorPrompt>(null);
   const [survivorRulesOpen, setSurvivorRulesOpen] = useState(false);
   const survivorRulesDismissed = hasSeenSurvivorRules(activeProfileId);
@@ -252,12 +254,29 @@ export default function HomeHub() {
 
   function startClassicRun() {
     if (!isGuest && activeProfileId) {
+      clearSavedRun(activeProfileId, 'classic');
       const archives = loadSeasonArchives(archiveKeyForProfile(activeProfileId)) ?? [];
       dispatch(resetGame(archives));
     } else {
       dispatch(resetGame(undefined));
     }
+    setClassicPrompt(null);
+    setPlaySelectionOpen(false);
     setPreloading(true);
+  }
+
+  function resumeClassicRun() {
+    if (!classicSnapshot) {
+      setClassicPrompt(null);
+      startClassicRun();
+      return;
+    }
+    try {
+      setClassicPrompt(null);
+      hydrateSnapshot(classicSnapshot);
+    } catch {
+      startClassicRun();
+    }
   }
 
   function startSurvivorRun() {
@@ -318,12 +337,8 @@ export default function HomeHub() {
     if (!isGuest && activeProfileId) {
       const snapshot = getSavedRun(activeProfileId, mode);
       if (snapshot?.profileId === activeProfileId) {
-        try {
-          hydrateSnapshot(snapshot);
-          return;
-        } catch {
-          // Bad snapshots fall through to a clean run for the selected mode.
-        }
+        setClassicPrompt('resume-or-new');
+        return;
       }
     }
 
@@ -402,6 +417,28 @@ export default function HomeHub() {
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
       {preloading && <AssetPreloaderOverlay />}
+
+      <ConfirmExitModal
+        open={classicPrompt === 'resume-or-new'}
+        title="Classic Campaign"
+        description="Resume your saved Classic campaign or start over?"
+        confirmLabel="Resume"
+        secondaryLabel="Start New"
+        cancelLabel="Cancel"
+        onConfirm={resumeClassicRun}
+        onSecondary={() => setClassicPrompt('confirm-new')}
+        onCancel={() => setClassicPrompt(null)}
+      />
+
+      <ConfirmExitModal
+        open={classicPrompt === 'confirm-new'}
+        title="Start new Classic campaign?"
+        description="This will replace your saved Classic campaign only. Survivor progress will not be affected."
+        confirmLabel="Start New"
+        cancelLabel="Cancel"
+        onConfirm={startClassicRun}
+        onCancel={() => setClassicPrompt('resume-or-new')}
+      />
 
       <ConfirmExitModal
         open={survivorPrompt === 'resume-or-new'}

--- a/src/screens/SelfEvicted/SelfEvicted.tsx
+++ b/src/screens/SelfEvicted/SelfEvicted.tsx
@@ -1,8 +1,14 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { resetGame } from '../../store/gameSlice';
 import { selectActiveProfileId, selectIsGuest } from '../../store/profilesSlice';
-import { savedStateKeyForProfile, clearSeasonSnapshot } from '../../store/saveStatePersistence';
+import {
+  savedStateKeyForProfile,
+  clearSeasonSnapshot,
+  clearSavedRun,
+} from '../../store/saveStatePersistence';
+import type { GameMode } from '../../modes/modeTypes';
 import './SelfEvicted.css';
 
 /**
@@ -16,13 +22,21 @@ export default function SelfEvicted() {
   const playerName = useAppSelector(
     (s) => s.game.players.find((p) => p.isUser)?.name ?? 'Housemate',
   );
+  const currentMode = useAppSelector((s): GameMode => (s.game.mode === 'survivor' ? 'survivor' : 'classic'));
   const activeProfileId = useAppSelector(selectActiveProfileId);
   const isGuest = useAppSelector(selectIsGuest);
+
+  useEffect(() => {
+    if (isGuest || !activeProfileId) return;
+    clearSavedRun(activeProfileId, currentMode);
+    clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId));
+  }, [activeProfileId, currentMode, isGuest]);
 
   function startNewSeason() {
     // Clear any stale mid-season snapshot so the Play prompt won't offer to
     // resume an outdated save after a self-eviction.
     if (!isGuest && activeProfileId) {
+      clearSavedRun(activeProfileId, currentMode);
       clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId));
     }
     dispatch(resetGame());


### PR DESCRIPTION
## Summary
- add a Classic resume/start-new prompt so players can reset a saved Classic campaign
- clear only the Classic saved run when starting a new Classic campaign
- clear the current saved run as soon as the self-evicted screen loads, so returning home cannot resume a self-evicted Classic save

Fixes #1084.

## Testing
- Not run locally; changes were made directly through the GitHub connector per request.