### PR TITLE
Fix iOS HomeHub background first paint

### DIFF
--- a/src/components/KolequantSplash/KolequantSplash.tsx
+++ b/src/components/KolequantSplash/KolequantSplash.tsx
@@ -50,8 +50,6 @@ export default function KolequantSplash({
   const progressLabel = status ?? activeMessages[messageIndex];
 
   useEffect(() => {
-    setMinimumElapsed(false);
-    setExiting(false);
     exitStartedRef.current = false;
     const timer = window.setTimeout(() => setMinimumElapsed(true), duration);
     return () => window.clearTimeout(timer);
@@ -69,9 +67,18 @@ export default function KolequantSplash({
     if (!ready || !minimumElapsed || exitStartedRef.current) return;
 
     exitStartedRef.current = true;
-    setExiting(true);
-    const timer = window.setTimeout(() => onFinish?.(), EXIT_MS);
-    return () => window.clearTimeout(timer);
+    let finishTimer: number | undefined;
+    const exitTimer = window.setTimeout(() => {
+      setExiting(true);
+      finishTimer = window.setTimeout(() => onFinish?.(), EXIT_MS);
+    }, 0);
+
+    return () => {
+      window.clearTimeout(exitTimer);
+      if (finishTimer != null) {
+        window.clearTimeout(finishTimer);
+      }
+    };
   }, [minimumElapsed, onFinish, ready]);
 
   const splashStyle = {

--- a/src/hooks/useBackgroundTheme.ts
+++ b/src/hooks/useBackgroundTheme.ts
@@ -25,14 +25,21 @@ interface UseBackgroundThemeOptions {
   attachToRoot?: boolean;
 }
 
+function resolveInitialBackground(): BackgroundState {
+  const fallbackKey = getBinaryFallbackKey(new Date());
+  const fallbackAsset = resolveSkinAsset(fallbackKey);
+
+  return {
+    url: fallbackAsset.url,
+    key: fallbackAsset.key,
+    reason: 'fallback:initial-render',
+  };
+}
+
 export default function useBackgroundTheme(
   opts: UseBackgroundThemeOptions = {},
 ): BackgroundState {
-  const [state, setState] = useState<BackgroundState>({
-    url: null,
-    key: null,
-    reason: null,
-  });
+  const [state, setState] = useState<BackgroundState>(() => resolveInitialBackground());
 
   const { attachToRoot } = opts;
 

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -209,13 +209,13 @@ export default function HomeHub() {
   );
   // Remote background takes priority over weather/time-of-day background.
   const effectiveBgUrl = introHubBgUrl ?? remoteBgUrl ?? bgUrl;
-  const [splashDone, setSplashDone] = useState(() => hasSeenHomeHubSplashForGame(gameId));
   const [splashExitRequested, setSplashExitRequested] = useState(false);
   const [hubAssetState, setHubAssetState] = useState<HubAssetState>({
     ready: false,
     progress: 0,
     status: 'Opening the house doors.',
   });
+  const splashDone = hasSeenHomeHubSplashForGame(gameId) || (splashExitRequested && hubAssetState.ready);
   // Seed preloading from transient route state so "Start New Season" can
   // reuse the existing Play → preloader → /game flow without setting state in
   // an effect on mount.
@@ -439,13 +439,12 @@ export default function HomeHub() {
   }
 
   useEffect(() => {
-    if (splashDone || !splashExitRequested || !hubAssetState.ready) {
+    if (!splashDone) {
       return;
     }
 
     markHomeHubSplashSeenForGame(gameId);
-    setSplashDone(true);
-  }, [gameId, hubAssetState.ready, splashDone, splashExitRequested]);
+  }, [gameId, splashDone]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- seed `useBackgroundTheme` with an immediate bundled day/night fallback instead of starting with `null`
- keep the existing async weather/location background resolution so the themed image can replace the fallback once ready

## Why
On iOS, HomeHub could render the buttons before any background URL existed. The later CSS background swap was fragile and sometimes did not visibly paint until navigating away and back. This makes the first render already include a valid bundled background image.

## Testing
- Not run locally; change was applied through the GitHub connector without a local checkout per request.