### PR TITLE
[codex] Fix profile photo flow and navigation

### DIFF
--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { avatarVariants } from '../../utils/avatarCase'
+import { getProfilePhotoAvatarId } from '../../utils/avatar'
+import { imageIdToDataUrl } from '../../utils/imageDb'
 import { getBadgesForPlayer } from '../../utils/statusBadges'
 import styles from './HouseguestGrid.module.css'
 
@@ -78,6 +80,7 @@ function formatStat(value: number | null | undefined, options: { decimals?: numb
 }
 
 export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick, roboStats, onHoldPreviewStart, onHoldPreviewEnd, statuses, finalRank, showPermanentBadge = true, layoutId, isEvicting, nominationCeremonyState }: Props) {
+  const profilePhotoId = getProfilePhotoAvatarId(avatarUrl)
   const attemptRef = React.useRef(0)
   const variantsRef = React.useRef<string[] | null>(null)
   const exhaustedRef = React.useRef(false)
@@ -86,6 +89,8 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
   const touchStartPosRef = React.useRef<{ x: number; y: number } | null>(null)
   const isHoldActiveRef = React.useRef(false)
   const [statsOpen, setStatsOpen] = React.useState(false)
+  const [profilePhotoUrl, setProfilePhotoUrl] = React.useState<string | null>(null)
+  const resolvedAvatarUrl = profilePhotoUrl ?? (profilePhotoId ? undefined : avatarUrl)
   const isSurvivorRoboTile = Boolean(roboStats) || Boolean(avatarUrl?.includes('bottts'))
 
   React.useEffect(() => {
@@ -93,6 +98,20 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
     variantsRef.current = null
     exhaustedRef.current = false
   }, [avatarUrl])
+
+  React.useEffect(() => {
+    let cancelled = false
+    setProfilePhotoUrl(null)
+    if (!profilePhotoId) return undefined
+
+    imageIdToDataUrl(profilePhotoId).then((url) => {
+      if (!cancelled) setProfilePhotoUrl(url)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [profilePhotoId])
 
   React.useEffect(
     () => () => {
@@ -287,9 +306,9 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
             </span>
           )}
 
-          {avatarUrl ? (
+          {resolvedAvatarUrl ? (
             <img
-              src={avatarUrl}
+              src={resolvedAvatarUrl}
               alt={name}
               className={styles.avatar}
               onError={handleImgError}

--- a/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -45,9 +45,13 @@ export default function PlayerAvatar({
   showEvictedStyle = true,
 }: PlayerAvatarProps) {
   const { candidates } = useResolvedAvatarSrc(player);
-  const [candidateIdx, setCandidateIdx] = useState(0);
-  const [showFallback, setShowFallback] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  const candidatesKey = candidates.join('\n');
+  const [imageState, setImageState] = useState({
+    candidatesKey,
+    candidateIdx: 0,
+    showFallback: false,
+    loaded: false,
+  });
   const [revived, setRevived] = useState(false);
   const prevStatusRef = useRef(player.status);
 
@@ -66,19 +70,26 @@ export default function PlayerAvatar({
     }
   }, [player.status]);
 
-  useEffect(() => {
-    setCandidateIdx(0);
-    setShowFallback(false);
-    setLoaded(false);
-  }, [candidates]);
-
+  const candidateIdx = imageState.candidatesKey === candidatesKey ? imageState.candidateIdx : 0;
+  const showFallback = imageState.candidatesKey === candidatesKey ? imageState.showFallback : false;
+  const loaded = imageState.candidatesKey === candidatesKey ? imageState.loaded : false;
   const avatarSrc = candidates[candidateIdx] ?? '';
 
   function handleError() {
     if (candidateIdx < candidates.length - 1) {
-      setCandidateIdx((i) => i + 1);
+      setImageState({
+        candidatesKey,
+        candidateIdx: candidateIdx + 1,
+        showFallback: false,
+        loaded: false,
+      });
     } else {
-      setShowFallback(true);
+      setImageState({
+        candidatesKey,
+        candidateIdx,
+        showFallback: true,
+        loaded: false,
+      });
     }
   }
 
@@ -110,7 +121,12 @@ export default function PlayerAvatar({
       src={avatarSrc}
       alt=""
       onError={handleError}
-      onLoad={() => setLoaded(true)}
+      onLoad={() => setImageState({
+        candidatesKey,
+        candidateIdx,
+        showFallback: false,
+        loaded: true,
+      })}
       aria-hidden="true"
     />
   );

--- a/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import type { Player } from '../../types';
-import { resolveAvatarCandidates, isEmoji } from '../../utils/avatar';
+import { isEmoji } from '../../utils/avatar';
+import { useResolvedAvatarSrc } from '../../hooks/useResolvedAvatarSrc';
 import { getRelationshipTone } from './relationshipOutline';
 import { SoundManager } from '../../services/sound/SoundManager';
 import './PlayerAvatar.css';
@@ -43,7 +44,7 @@ export default function PlayerAvatar({
   showRelationshipOutline = true,
   showEvictedStyle = true,
 }: PlayerAvatarProps) {
-  const [candidates] = useState(() => resolveAvatarCandidates(player));
+  const { candidates } = useResolvedAvatarSrc(player);
   const [candidateIdx, setCandidateIdx] = useState(0);
   const [showFallback, setShowFallback] = useState(false);
   const [loaded, setLoaded] = useState(false);
@@ -64,6 +65,12 @@ export default function PlayerAvatar({
       return () => { clearTimeout(startId); clearTimeout(endId); setRevived(false); };
     }
   }, [player.status]);
+
+  useEffect(() => {
+    setCandidateIdx(0);
+    setShowFallback(false);
+    setLoaded(false);
+  }, [candidates]);
 
   const avatarSrc = candidates[candidateIdx] ?? '';
 

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -125,7 +125,7 @@ export default function NavBar() {
       onRulesClick={() => navigate('/rules')}
       onSettingsClick={() => navigate('/settings')}
       onLeaderboardClick={() => navigate('/leaderboard')}
-      onProfileClick={() => navigate('/profile')}
+      onProfileClick={() => navigate('/profile', { state: { from: '/game' } })}
     >
       <ConfirmExitModal
         open={confirmOpen}

--- a/src/components/ui/PlayerAvatar.tsx
+++ b/src/components/ui/PlayerAvatar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Player } from '../../types';
-import { resolveAvatar, getDicebear } from '../../utils/avatar';
+import { getDicebear } from '../../utils/avatar';
 import { useResolvedAvatarSrc } from '../../hooks/useResolvedAvatarSrc';
 import { getBadgesForPlayer } from '../../utils/statusBadges';
 import './PlayerAvatar.css';
@@ -31,13 +31,13 @@ interface PlayerAvatarProps {
 export default function PlayerAvatar({ player, onSelect, size = 'md' }: PlayerAvatarProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const { src: resolvedAvatarSrc } = useResolvedAvatarSrc(player);
-  const [avatarSrc, setAvatarSrc] = useState(() => resolveAvatar(player));
-  const [showEmojiAvatar, setShowEmojiAvatar] = useState(false);
-
-  useEffect(() => {
-    setAvatarSrc(resolvedAvatarSrc);
-    setShowEmojiAvatar(false);
-  }, [resolvedAvatarSrc]);
+  const [avatarState, setAvatarState] = useState({
+    baseSrc: resolvedAvatarSrc,
+    src: resolvedAvatarSrc,
+    showEmojiAvatar: false,
+  });
+  const avatarSrc = avatarState.baseSrc === resolvedAvatarSrc ? avatarState.src : resolvedAvatarSrc;
+  const showEmojiAvatar = avatarState.baseSrc === resolvedAvatarSrc ? avatarState.showEmojiAvatar : false;
 
   function handleClick() {
     if (onSelect) {
@@ -51,10 +51,18 @@ export default function PlayerAvatar({ player, onSelect, size = 'md' }: PlayerAv
     const dicebear = getDicebear(player.name);
     if (avatarSrc !== dicebear) {
       // Step 2: swap to Dicebear
-      setAvatarSrc(dicebear);
+      setAvatarState({
+        baseSrc: resolvedAvatarSrc,
+        src: dicebear,
+        showEmojiAvatar: false,
+      });
     } else {
       // Step 3: Dicebear also failed — show emoji fallback
-      setShowEmojiAvatar(true);
+      setAvatarState({
+        baseSrc: resolvedAvatarSrc,
+        src: avatarSrc,
+        showEmojiAvatar: true,
+      });
     }
   }
 

--- a/src/components/ui/PlayerAvatar.tsx
+++ b/src/components/ui/PlayerAvatar.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Player } from '../../types';
 import { resolveAvatar, getDicebear } from '../../utils/avatar';
+import { useResolvedAvatarSrc } from '../../hooks/useResolvedAvatarSrc';
 import { getBadgesForPlayer } from '../../utils/statusBadges';
 import './PlayerAvatar.css';
 
@@ -29,8 +30,14 @@ interface PlayerAvatarProps {
  */
 export default function PlayerAvatar({ player, onSelect, size = 'md' }: PlayerAvatarProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const { src: resolvedAvatarSrc } = useResolvedAvatarSrc(player);
   const [avatarSrc, setAvatarSrc] = useState(() => resolveAvatar(player));
   const [showEmojiAvatar, setShowEmojiAvatar] = useState(false);
+
+  useEffect(() => {
+    setAvatarSrc(resolvedAvatarSrc);
+    setShowEmojiAvatar(false);
+  }, [resolvedAvatarSrc]);
 
   function handleClick() {
     if (onSelect) {

--- a/src/hooks/useResolvedAvatarSrc.ts
+++ b/src/hooks/useResolvedAvatarSrc.ts
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Player } from '../types';
+import {
+  getProfilePhotoAvatarId,
+  resolveAvatar,
+  resolveAvatarCandidates,
+} from '../utils/avatar';
+import { imageIdToDataUrl } from '../utils/imageDb';
+
+export function useResolvedAvatarSrc(player: Pick<Player, 'id' | 'name' | 'avatar'> & Partial<Pick<Player, 'isUser'>>) {
+  const profilePhotoId = getProfilePhotoAvatarId(player.avatar);
+  const fallbackCandidates = useMemo(
+    () => resolveAvatarCandidates(player),
+    [player.avatar, player.id, player.isUser, player.name],
+  );
+  const [photoSrc, setPhotoSrc] = useState<string | null>(null);
+  const [loadingPhoto, setLoadingPhoto] = useState(Boolean(profilePhotoId));
+
+  useEffect(() => {
+    let cancelled = false;
+    setPhotoSrc(null);
+    setLoadingPhoto(Boolean(profilePhotoId));
+
+    if (!profilePhotoId) return undefined;
+
+    void imageIdToDataUrl(profilePhotoId).then((url) => {
+      if (cancelled) return;
+      setPhotoSrc(url);
+      setLoadingPhoto(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [profilePhotoId]);
+
+  return {
+    src: photoSrc ?? resolveAvatar(player),
+    candidates: photoSrc ? [photoSrc] : fallbackCandidates,
+    isLoadingProfilePhoto: loadingPhoto,
+  };
+}

--- a/src/hooks/useResolvedAvatarSrc.ts
+++ b/src/hooks/useResolvedAvatarSrc.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Player } from '../types';
 import {
   getProfilePhotoAvatarId,
@@ -7,32 +7,33 @@ import {
 } from '../utils/avatar';
 import { imageIdToDataUrl } from '../utils/imageDb';
 
+type PhotoState = {
+  id: string;
+  src: string | null;
+};
+
 export function useResolvedAvatarSrc(player: Pick<Player, 'id' | 'name' | 'avatar'> & Partial<Pick<Player, 'isUser'>>) {
   const profilePhotoId = getProfilePhotoAvatarId(player.avatar);
-  const fallbackCandidates = useMemo(
-    () => resolveAvatarCandidates(player),
-    [player.avatar, player.id, player.isUser, player.name],
-  );
-  const [photoSrc, setPhotoSrc] = useState<string | null>(null);
-  const [loadingPhoto, setLoadingPhoto] = useState(Boolean(profilePhotoId));
+  const fallbackCandidates = resolveAvatarCandidates(player);
+  const [photoState, setPhotoState] = useState<PhotoState | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    setPhotoSrc(null);
-    setLoadingPhoto(Boolean(profilePhotoId));
 
     if (!profilePhotoId) return undefined;
 
     void imageIdToDataUrl(profilePhotoId).then((url) => {
       if (cancelled) return;
-      setPhotoSrc(url);
-      setLoadingPhoto(false);
+      setPhotoState({ id: profilePhotoId, src: url });
     });
 
     return () => {
       cancelled = true;
     };
   }, [profilePhotoId]);
+
+  const photoSrc = photoState?.id === profilePhotoId ? photoState.src : null;
+  const loadingPhoto = Boolean(profilePhotoId && photoState?.id !== profilePhotoId);
 
   return {
     src: photoSrc ?? resolveAvatar(player),

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -166,7 +166,7 @@ function HomeHubAssetLayer({
                     label={label}
                     icon={icon}
                     variant={variant}
-                    onClick={to === '/game' ? onPlay : () => onNavigate(to)}
+                    onClick={to === '/game' ? onPlay : () => onNavigate(to, to === '/profile' ? { state: { from: '/' } } : undefined)}
                   />
                 ))}
           </nav>

--- a/src/screens/Profile/EditProfile.css
+++ b/src/screens/Profile/EditProfile.css
@@ -4,7 +4,7 @@
   padding: 16px;
   max-width: 480px;
   margin: 0 auto;
-  padding-bottom: 40px;
+  padding-bottom: calc(120px + env(safe-area-inset-bottom, 0px));
 }
 
 .edit-profile__title {
@@ -194,7 +194,10 @@
   gap: 10px;
   margin-top: 24px;
   position: sticky;
-  bottom: 16px;
+  bottom: 0;
+  z-index: 5;
+  padding: 12px 0 calc(12px + env(safe-area-inset-bottom, 0px));
+  background: linear-gradient(180deg, rgba(9, 13, 24, 0), #090d18 24%);
 }
 
 .edit-profile__btn {

--- a/src/screens/Profile/EditProfile.tsx
+++ b/src/screens/Profile/EditProfile.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import {
   selectCurrentProfile,
   updateProfile,
   type ProfileBio,
 } from '../../store/profilesSlice';
+import { updateUserPlayerIdentity } from '../../store/gameSlice';
 import { resizeAndCompressImage } from '../../utils/imageUtils';
 import { saveImage, imageIdToDataUrl, deleteImage } from '../../utils/imageDb';
 import './EditProfile.css';
@@ -60,13 +61,17 @@ function CollapsibleSection({
  */
 export default function EditProfile() {
   const navigate = useNavigate();
+  const routeLocation = useLocation();
   const dispatch = useAppDispatch();
   const profile = useAppSelector(selectCurrentProfile);
+  const returnTo = ((routeLocation.state as { from?: string } | null)?.from === '/'
+    ? '/'
+    : '/game');
 
   // Redirect if no profile is active
   useEffect(() => {
-    if (!profile) navigate('/profile-picker', { replace: true });
-  }, [profile, navigate]);
+    if (!profile) navigate('/profile-picker', { replace: true, state: { from: returnTo } });
+  }, [profile, navigate, returnTo]);
 
   // --- Form state ---
   const [name, setName] = useState(profile?.name ?? '');
@@ -202,8 +207,15 @@ export default function EditProfile() {
         bio,
       }),
     );
+    dispatch(
+      updateUserPlayerIdentity({
+        name: name.trim() || profile.name,
+        avatar,
+        photoId,
+      }),
+    );
 
-    navigate('/profile');
+    navigate('/profile', { replace: true, state: { from: returnTo } });
   }
 
   if (!profile) return null;
@@ -460,7 +472,7 @@ export default function EditProfile() {
         <button
           type="button"
           className="edit-profile__btn edit-profile__btn--cancel"
-          onClick={() => navigate(-1)}
+          onClick={() => navigate('/profile', { replace: true, state: { from: returnTo } })}
         >
           Cancel
         </button>

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../store/hooks';
 import {
   selectCurrentProfile,
@@ -454,6 +454,7 @@ function HoldRevealPill({
 
 export default function Profile() {
   const navigate = useNavigate();
+  const location = useLocation();
   const profile = useAppSelector(selectCurrentProfile);
   const isGuest = useAppSelector(selectIsGuest);
 
@@ -499,13 +500,10 @@ export default function Profile() {
   const survivorAchievementCards = buildUnlockedSurvivorAchievementDisplayModels(survivorUnlocks);
 
   const gameInProgress = isGameActive || week > 1 || phase !== 'week_start';
-  const goBack = () => {
-    if (window.history.length > 1) {
-      navigate(-1);
-      return;
-    }
-    navigate('/game');
-  };
+  const returnTo = ((location.state as { from?: string } | null)?.from === '/'
+    ? '/'
+    : '/game');
+  const goBack = () => navigate(returnTo, { replace: true });
 
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
   useEffect(() => {
@@ -626,7 +624,7 @@ export default function Profile() {
             <button
               type="button"
               className="profile-screen__guest-link"
-              onClick={() => navigate('/profile-picker')}
+              onClick={() => navigate('/profile-picker', { state: { from: returnTo } })}
             >
               Create a profile to save progress -&gt;
             </button>
@@ -639,7 +637,7 @@ export default function Profile() {
         <button
           type="button"
           className="profile-screen__switch-btn game-button game-button--secondary"
-          onClick={() => navigate('/profile-picker')}
+          onClick={() => navigate('/profile-picker', { state: { from: returnTo } })}
         >
           Select Profile
         </button>
@@ -656,7 +654,7 @@ export default function Profile() {
         <button
           type="button"
           className="profile-screen__switch-btn game-button game-button--secondary"
-          onClick={() => navigate('/profile-picker')}
+          onClick={() => navigate('/profile-picker', { state: { from: returnTo } })}
           style={{ marginBottom: 12 }}
         >
           Select or Create a Profile
@@ -692,7 +690,7 @@ export default function Profile() {
           <button
             type="button"
             className="profile-screen__icon-btn game-button game-button--menu game-button--ghost"
-            onClick={() => navigate('/profile-edit')}
+            onClick={() => navigate('/profile-edit', { state: { from: returnTo } })}
             aria-label="Edit profile"
           >
             Edit
@@ -700,7 +698,7 @@ export default function Profile() {
           <button
             type="button"
             className="profile-screen__icon-btn game-button game-button--menu game-button--ghost"
-            onClick={() => navigate('/profile-picker')}
+            onClick={() => navigate('/profile-picker', { state: { from: returnTo } })}
             aria-label="Switch profile"
           >
             Switch

--- a/src/screens/ProfilePicker/ProfilePicker.css
+++ b/src/screens/ProfilePicker/ProfilePicker.css
@@ -166,6 +166,78 @@
   color: rgba(255, 255, 255, 0.8);
 }
 
+.profile-picker__create-photo-section {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.profile-picker__create-photo-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.profile-picker__create-photo-img,
+.profile-picker__create-photo-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.05);
+  border: 2px solid rgba(255, 255, 255, 0.12);
+}
+
+.profile-picker__create-photo-img {
+  object-fit: cover;
+}
+
+.profile-picker__create-photo-avatar {
+  font-size: 2.6rem;
+}
+
+.profile-picker__create-photo-btn {
+  position: absolute;
+  right: -5px;
+  bottom: -2px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 0;
+  color: #fff;
+  background: linear-gradient(135deg, #7b5cff, #6fb7ff);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+}
+
+.profile-picker__create-photo-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.profile-picker__create-photo-label {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.profile-picker__create-photo-hint,
+.profile-picker__create-photo-processing {
+  color: rgba(255, 255, 255, 0.46);
+  font-size: 0.74rem;
+}
+
+.profile-picker__create-photo-processing {
+  color: rgba(107, 183, 255, 0.85);
+}
+
 .profile-picker__input {
   width: 100%;
   padding: 9px 12px;

--- a/src/screens/ProfilePicker/ProfilePicker.test.tsx
+++ b/src/screens/ProfilePicker/ProfilePicker.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ProfilePicker from './ProfilePicker';
 
 const mockNavigate = vi.fn();
 const mockDispatch = vi.fn();
+let mockLocationState: { from?: string } | null = null;
 
 const mockState: {
   profiles: {
@@ -35,6 +36,7 @@ const mockState: {
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: mockLocationState }),
 }));
 
 vi.mock('../../store/hooks', () => ({
@@ -54,7 +56,11 @@ vi.mock('../../store/saveStatePersistence', () => ({
 
 vi.mock('../../utils/imageDb', () => ({
   imageIdToDataUrl: vi.fn(() => Promise.resolve(null)),
+  saveImage: vi.fn(() => Promise.resolve()),
   deleteImage: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../utils/imageUtils', () => ({
+  resizeAndCompressImage: vi.fn(),
 }));
 
 vi.mock('../../components/ConfirmExitModal/ConfirmExitModal', () => ({
@@ -65,6 +71,7 @@ describe('ProfilePicker', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
     mockDispatch.mockReset();
+    mockLocationState = null;
     mockState.profiles = {
       profiles: [],
       activeProfileId: null,
@@ -76,7 +83,7 @@ describe('ProfilePicker', () => {
     };
   });
 
-  it('replaces the picker history entry after creating a profile', () => {
+  it('replaces the picker history entry after creating a profile', async () => {
     render(<ProfilePicker />);
 
     fireEvent.click(screen.getByRole('button', { name: /create new profile/i }));
@@ -85,14 +92,17 @@ describe('ProfilePicker', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /create profile/i }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/profile', { replace: true });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/profile', { replace: true, state: { from: '/game' } });
+    });
   });
 
   it('shows a direct way back home from the picker', () => {
+    mockLocationState = { from: '/' };
     render(<ProfilePicker />);
 
     fireEvent.click(screen.getByRole('button', { name: /back to home/i }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 });

--- a/src/screens/ProfilePicker/ProfilePicker.tsx
+++ b/src/screens/ProfilePicker/ProfilePicker.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useRef, type ChangeEvent } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import {
   selectAllProfiles,
@@ -23,8 +23,8 @@ import {
   clearSeasonSnapshot,
 } from '../../store/saveStatePersistence';
 import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal';
-import { imageIdToDataUrl } from '../../utils/imageDb';
-import { deleteImage } from '../../utils/imageDb';
+import { resizeAndCompressImage } from '../../utils/imageUtils';
+import { imageIdToDataUrl, saveImage, deleteImage } from '../../utils/imageDb';
 import './ProfilePicker.css';
 
 const AVATAR_OPTIONS = [
@@ -41,7 +41,11 @@ const AVATAR_OPTIONS = [
  */
 export default function ProfilePicker() {
   const navigate = useNavigate();
+  const location = useLocation();
   const dispatch = useAppDispatch();
+  const returnTo = ((location.state as { from?: string } | null)?.from === '/'
+    ? '/'
+    : '/game');
 
   const profiles = useAppSelector(selectAllProfiles);
   const activeProfileId = useAppSelector(selectActiveProfileId);
@@ -61,6 +65,11 @@ export default function ProfilePicker() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newName, setNewName] = useState('');
   const [newAvatar, setNewAvatar] = useState('🧑');
+  const [newPhotoPreview, setNewPhotoPreview] = useState<string | null>(null);
+  const [newPhotoBlob, setNewPhotoBlob] = useState<Blob | null>(null);
+  const [processingPhoto, setProcessingPhoto] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
 
   // Confirmation for profile switch (current game is active)
   const [pendingSwitchId, setPendingSwitchId] = useState<string | null>(null);
@@ -94,12 +103,20 @@ export default function ProfilePicker() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profiles]);
 
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
   // ── Handlers ────────────────────────────────────────────────────────────────
 
   function handleSelectProfile(id: string) {
     if (id === activeProfileId && !isGuest) {
-      // Already active — just go back
-      navigate(-1);
+      // Already active - return to the profile detail without adding another history entry.
+      navigate('/profile', { replace: true, state: { from: returnTo } });
       return;
     }
     if (isGameActive) {
@@ -127,7 +144,7 @@ export default function ProfilePicker() {
       // No saved season — start fresh immediately.
       const archives = loadSeasonArchives(archiveKeyForProfile(id)) ?? [];
       dispatch(resetGame(archives));
-      navigate('/profile', { replace: true });
+      navigate('/profile', { replace: true, state: { from: returnTo } });
     }
   }
 
@@ -157,7 +174,7 @@ export default function ProfilePicker() {
     clearSeasonSnapshot(saveKey);
     const archives = loadSeasonArchives(archiveKeyForProfile(id)) ?? [];
     dispatch(resetGame(archives));
-    navigate('/profile', { replace: true });
+    navigate('/profile', { replace: true, state: { from: returnTo } });
   }
 
   function handleGuestMode() {
@@ -169,17 +186,21 @@ export default function ProfilePicker() {
   }
 
   function handleHome() {
+    if (returnTo === '/game') {
+      navigate('/game', { replace: true });
+      return;
+    }
     if (isGameActive) {
       setPendingHome(true);
       return;
     }
-    navigate('/');
+    navigate(returnTo, { replace: true });
   }
 
   function commitHome() {
     dispatch(resetGame());
     setPendingHome(false);
-    navigate('/');
+    navigate(returnTo, { replace: true });
   }
 
   function commitGuest() {
@@ -189,15 +210,67 @@ export default function ProfilePicker() {
     navigate('/game', { replace: true });
   }
 
-  function handleCreate() {
+  async function handleCreate() {
     if (!newName.trim() || atLimit) return;
+    let photoId: string | undefined;
+    if (newPhotoBlob) {
+      const randomPart = (() => {
+        try {
+          return crypto.randomUUID();
+        } catch {
+          return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+        }
+      })();
+      photoId = `profile-photo-${randomPart}`;
+      try {
+        await saveImage(photoId, newPhotoBlob);
+      } catch (err) {
+        console.error('Failed to save new profile photo to IndexedDB', err);
+        photoId = undefined;
+      }
+    }
     // A newly created profile has no archives yet.
-    dispatch(createProfile({ name: newName.trim(), avatar: newAvatar }));
+    dispatch(createProfile({ name: newName.trim(), avatar: newAvatar, photoId }));
     dispatch(resetGame([]));
     setShowCreateForm(false);
     setNewName('');
     setNewAvatar('🧑');
-    navigate('/profile', { replace: true });
+    clearNewPhoto();
+    navigate('/profile', { replace: true, state: { from: returnTo } });
+  }
+
+  function clearNewPhoto() {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setNewPhotoPreview(null);
+    setNewPhotoBlob(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
+  async function handleNewPhotoChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    setProcessingPhoto(true);
+    try {
+      const blob = await resizeAndCompressImage(file);
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      const url = URL.createObjectURL(blob);
+      previewUrlRef.current = url;
+      setNewPhotoBlob(blob);
+      setNewPhotoPreview(url);
+    } catch {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      const url = URL.createObjectURL(file);
+      previewUrlRef.current = url;
+      setNewPhotoBlob(file);
+      setNewPhotoPreview(url);
+    } finally {
+      setProcessingPhoto(false);
+    }
   }
 
   function handleDeleteRequest(id: string) {
@@ -237,7 +310,7 @@ export default function ProfilePicker() {
           className="profile-picker__back-btn"
           onClick={handleHome}
         >
-          ← Back to Home
+          {returnTo === '/game' ? '← Back to Game' : '← Back to Home'}
         </button>
       </div>
       <h1 className="profile-picker__title">👤 Profiles</h1>
@@ -321,6 +394,35 @@ export default function ProfilePicker() {
           ) : (
             <div className="profile-picker__create">
               <p className="profile-picker__create-title">New Profile</p>
+              <div className="profile-picker__create-photo-section">
+                <div className="profile-picker__create-photo-wrap">
+                  {newPhotoPreview ? (
+                    <img className="profile-picker__create-photo-img" src={newPhotoPreview} alt="New profile" />
+                  ) : (
+                    <span className="profile-picker__create-photo-avatar">{newAvatar}</span>
+                  )}
+                  <button
+                    type="button"
+                    className="profile-picker__create-photo-btn"
+                    onClick={() => fileInputRef.current?.click()}
+                    aria-label="Upload profile photo"
+                  >
+                    📷
+                  </button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    onChange={handleNewPhotoChange}
+                  />
+                </div>
+                <div className="profile-picker__create-photo-copy">
+                  <span className="profile-picker__create-photo-label">Profile Photo</span>
+                  <span className="profile-picker__create-photo-hint">Upload from your gallery</span>
+                  {processingPhoto && <span className="profile-picker__create-photo-processing">Processing image...</span>}
+                </div>
+              </div>
               <input
                 className="profile-picker__input"
                 type="text"
@@ -348,15 +450,15 @@ export default function ProfilePicker() {
                 <button
                   type="button"
                   className="profile-picker__btn--cancel"
-                  onClick={() => { setShowCreateForm(false); setNewName(''); setNewAvatar('🧑'); }}
+                  onClick={() => { setShowCreateForm(false); setNewName(''); setNewAvatar('🧑'); clearNewPhoto(); }}
                 >
                   Cancel
                 </button>
                 <button
                   type="button"
                   className="profile-picker__btn profile-picker__btn--create"
-                  disabled={!newName.trim()}
-                  onClick={handleCreate}
+                  disabled={!newName.trim() || processingPhoto}
+                  onClick={() => void handleCreate()}
                 >
                   Create Profile
                 </button>

--- a/src/screens/ProfilePicker/ProfilePicker.tsx
+++ b/src/screens/ProfilePicker/ProfilePicker.tsx
@@ -31,6 +31,17 @@ const AVATAR_OPTIONS = [
   '🧑','👱','👩','🧔','👧','🧓','👩‍🦱','🧑‍🦰','🧑‍🦳','🧑‍🦲','👦','👴',
 ];
 
+const SAFE_PREVIEW_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+]);
+
+function isSafePreviewFile(file: File | Blob) {
+  return SAFE_PREVIEW_MIME_TYPES.has(file.type);
+}
+
 /**
  * ProfilePicker — allows the user to select, create, delete profiles or enter
  * guest mode.  Switching profiles (when a game is active) shows a confirmation
@@ -254,6 +265,11 @@ export default function ProfilePicker() {
     if (!file) return;
     e.target.value = '';
 
+    if (!isSafePreviewFile(file)) {
+      clearNewPhoto();
+      return;
+    }
+
     setProcessingPhoto(true);
     try {
       const blob = await resizeAndCompressImage(file);
@@ -264,6 +280,10 @@ export default function ProfilePicker() {
       setNewPhotoPreview(url);
     } catch {
       if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      if (!isSafePreviewFile(file)) {
+        clearNewPhoto();
+        return;
+      }
       const url = URL.createObjectURL(file);
       previewUrlRef.current = url;
       setNewPhotoBlob(file);

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -37,6 +37,7 @@ import { loadActiveProfile, archiveKeyForActiveProfile, loadProfilesState } from
 import { loadSettings } from './settingsSlice';
 import { getConfiguredCastSize, DEFAULT_ROSTER_SIZE } from './settingsHelpers';
 import { pickPhrase, NOMINEE_PLEA_TEMPLATES } from '../utils/juryUtils';
+import { profilePhotoAvatar } from '../utils/avatar';
 import type { SeasonArchive } from './seasonArchive';
 import { loadSeasonArchives } from './archivePersistence';
 import { resolvePublicSaveNominee } from '../publicOpinion/PublicSaveService';
@@ -240,7 +241,7 @@ function buildUserPlayer(): Player {
   return {
     id: 'user',
     name: profile.name,
-    avatar: profile.avatar,
+    avatar: profile.photoId ? profilePhotoAvatar(profile.photoId) : profile.avatar,
     status: 'active',
     isUser: true,
   };
@@ -3066,6 +3067,12 @@ const gameSlice = createSlice({
       state.players = action.payload;
       state.competitionSeasonStateByPlayerId = buildInitialCompetitionSeasonState(action.payload);
     },
+    updateUserPlayerIdentity(state, action: PayloadAction<{ name: string; avatar: string; photoId?: string }>) {
+      const human = state.players.find((player) => player.isUser);
+      if (!human) return;
+      human.name = action.payload.name.trim() || human.name;
+      human.avatar = action.payload.photoId ? profilePhotoAvatar(action.payload.photoId) : action.payload.avatar;
+    },
     /** Reset game state with a fresh random roster. */
     resetGame(state, action: PayloadAction<SeasonArchive[] | undefined>) {
       // Mix Math.random() with Date.now() to derive a fresh 32-bit game seed.
@@ -5189,6 +5196,7 @@ export const {
   clearBlockingFlags,
   archiveSeason,
   replacePlayers,
+  updateUserPlayerIdentity,
   clearSurvivorReplacementTransition,
   resetGame,
   rerollSeed,

--- a/src/store/profilesSlice.ts
+++ b/src/store/profilesSlice.ts
@@ -150,11 +150,11 @@ export function saveProfilesState(state: ProfilesState): void {
  * Return the active profile's name and avatar (for use in gameSlice.buildUserPlayer).
  * Falls back through the legacy userProfile storage, then to the hardcoded default.
  */
-export function loadActiveProfile(): { name: string; avatar: string } {
+export function loadActiveProfile(): { name: string; avatar: string; photoId?: string } {
   const state = loadProfilesState();
   if (!state.isGuest && state.activeProfileId) {
     const profile = state.profiles.find((p) => p.id === state.activeProfileId);
-    if (profile) return { name: profile.name, avatar: profile.avatar };
+    if (profile) return { name: profile.name, avatar: profile.avatar, photoId: profile.photoId };
   }
   // Legacy fallback: read from old userProfile storage key.
   try {
@@ -214,13 +214,14 @@ const profilesSlice = createSlice({
      */
     createProfile(
       state,
-      action: PayloadAction<{ name: string; avatar: string }>,
+      action: PayloadAction<{ name: string; avatar: string; photoId?: string }>,
     ) {
       if (state.profiles.length >= MAX_PROFILES) return;
       const profile: StoredProfile = {
         id: generateId(),
         name: action.payload.name.trim() || 'You',
         avatar: action.payload.avatar || '👤',
+        photoId: action.payload.photoId,
         createdAt: new Date().toISOString(),
       };
       state.profiles.push(profile);

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -5,6 +5,18 @@ import type { Player } from '../types';
 import { getById, findByName } from '../data/houseguests';
 import type { RemotePlayerOverride } from '../remoteConfig/remoteConfigTypes';
 
+const PROFILE_PHOTO_AVATAR_PREFIX = 'profile-photo:';
+
+export function profilePhotoAvatar(photoId: string): string {
+  return `${PROFILE_PHOTO_AVATAR_PREFIX}${photoId}`;
+}
+
+export function getProfilePhotoAvatarId(avatar: string | null | undefined): string | null {
+  if (!avatar?.startsWith(PROFILE_PHOTO_AVATAR_PREFIX)) return null;
+  const id = avatar.slice(PROFILE_PHOTO_AVATAR_PREFIX.length);
+  return id || null;
+}
+
 // ─── Remote override registry ────────────────────────────────────────────────
 
 /**
@@ -113,12 +125,24 @@ function capitalize(s: string): string {
  *
  * For numeric ids with no houseguest match, candidates are: assets/skins/{id}_avatar.webp
  */
-export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'avatar'>): string[] {
+export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'avatar'> & Partial<Pick<Player, 'isUser'>>): string[] {
   const candidates: string[] = [];
+
+  if (getProfilePhotoAvatarId(player.avatar)) {
+    candidates.push(getDicebear(player.name));
+    return candidates;
+  }
+
+  if (player.avatar && (player.avatar.startsWith('data:') || player.avatar.startsWith('blob:'))) {
+    candidates.push(player.avatar);
+    return candidates;
+  }
+
+  const isUserPlayer = player.isUser === true || player.id === 'user';
   const lookupTokens = collectAssetLookupTokens(player);
 
   // Remote config override takes highest priority (if provided for this player id).
-  const hgForRemote = getById(player.id) ?? findByName(player.name);
+  const hgForRemote = isUserPlayer ? undefined : (getById(player.id) ?? findByName(player.name));
   const remoteAvatarUrl = hgForRemote ? _remoteAvatarMap.get(hgForRemote.id) : undefined;
   if (remoteAvatarUrl) {
     candidates.push(remoteAvatarUrl);
@@ -129,12 +153,14 @@ export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'av
     candidates.push(player.avatar);
   }
 
-  const folderAvatar = listAvatarAssetCandidates().find(({ basename }) => {
-    const token = normalizeNameToken(basename.replace(/_avatar$/i, ''));
-    return lookupTokens.includes(token) || lookupTokens.some((target) => token.includes(target) || target.includes(token));
-  });
-  if (folderAvatar) {
-    candidates.push(folderAvatar.source);
+  if (!isUserPlayer) {
+    const folderAvatar = listAvatarAssetCandidates().find(({ basename }) => {
+      const token = normalizeNameToken(basename.replace(/_avatar$/i, ''));
+      return lookupTokens.includes(token) || lookupTokens.some((target) => token.includes(target) || target.includes(token));
+    });
+    if (folderAvatar) {
+      candidates.push(folderAvatar.source);
+    }
   }
 
   const id = player.id;
@@ -142,7 +168,7 @@ export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'av
 
   // Try to resolve a stable houseguest id from the canonical dataset.
   // Match by player.id first (in case it is already a slug), then by player.name.
-  const hg = getById(id) ?? findByName(player.name);
+  const hg = isUserPlayer ? undefined : (getById(id) ?? findByName(player.name));
   if (hg) {
     const hgId = hg.id; // lowercase stable slug, e.g. 'finn'
     const hgIdCap = capitalize(hgId); // e.g. 'Finn'


### PR DESCRIPTION
## Summary
- Add gallery photo upload to the new profile form, using the same resize/compress and IndexedDB storage path as profile editing.
- Carry uploaded profile photos into the active game via a stable `profile-photo:<id>` avatar reference and shared async avatar resolution.
- Make profile picker/detail/edit navigation unidirectional by preserving an explicit source route (`/` or `/game`) instead of relying on history back.
- Reserve space for the edit-profile sticky action bar so Cancel/Save no longer overlap the optional sections.

## Root cause
The create flow could only choose an emoji fallback, while the game user player only received the emoji `avatar` value and lost the stored `photoId`. Avatar rendering then treated the user like a normal houseguest, which could fall through to broken image paths or match built-in cast assets by name. Profile screens also used `navigate(-1)`, so Save/Cancel/Back could bounce through edit/profile routes in confusing loops.

## Validation
- `npm run typecheck`
- `npx vitest run src/screens/ProfilePicker/ProfilePicker.test.tsx src/components/PlayerAvatar/__tests__/PlayerAvatar.test.tsx src/components/HouseguestGrid/__tests__/AvatarTile.test.tsx`
- `npm run build`