### PR TITLE
[codex] Preserve uploaded profile photo in game roster

### DIFF
--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -97,7 +97,7 @@ import SpectatorView from '../../components/ui/SpectatorView'
 import type { SpectatorVariant } from '../../components/ui/SpectatorView'
 import Capitalization from '../../components/Capitalization/Capitalization'
 import Final3Ceremony from '../../components/Final3Ceremony/Final3Ceremony'
-import { resolveAvatar } from '../../utils/avatar'
+import { getProfilePhotoAvatarId, resolveAvatar } from '../../utils/avatar'
 import { pickPhrase, NOMINEE_PLEA_TEMPLATES } from '../../utils/juryUtils'
 import { detectDebugMode } from '../../utils/debugMode'
 import { statusBadgeImageSrc } from '../../utils/statusBadges'
@@ -733,7 +733,7 @@ export default function GameScreen() {
     return {
       id: p.id,
       name: p.name,
-      avatarUrl: resolveAvatar(p),
+      avatarUrl: getProfilePhotoAvatarId(p.avatar) ? p.avatar : resolveAvatar(p),
       statuses,
       finalRank: (p.finalRank ?? null) as 1 | 2 | 3 | null,
       isEvicted,

--- a/src/screens/Houseguests/Houseguests.tsx
+++ b/src/screens/Houseguests/Houseguests.tsx
@@ -4,7 +4,7 @@ import { selectAlivePlayers } from '../../store/gameSlice'
 import HouseguestGrid from '../../components/HouseguestGrid/HouseguestGrid'
 import HouseguestInfoDialog from '../../components/HouseguestGrid/HouseguestInfoDialog'
 import { selectSettings } from '../../store/settingsSlice'
-import { resolveAvatar } from '../../utils/avatar'
+import { getProfilePhotoAvatarId, resolveAvatar } from '../../utils/avatar'
 import type { Player } from '../../types'
 import './Houseguests.css'
 
@@ -38,7 +38,7 @@ export default function Houseguests() {
     return {
       id: p.id,
       name: p.name,
-      avatarUrl: resolveAvatar(p),
+      avatarUrl: getProfilePhotoAvatarId(p.avatar) ? p.avatar : resolveAvatar(p),
       statuses: statusString,
       finalRank: (p.finalRank ?? null) as 1 | 2 | 3 | null,
       isEvicted: p.status === 'evicted' || p.status === 'jury',


### PR DESCRIPTION
## Summary
- Preserve the `profile-photo:<id>` avatar marker when building the main game roster grid.
- Apply the same fix to the Housemates grid.

## Root cause
The previously merged profile-photo flow stored the uploaded image correctly, but the game roster mapped each player through `resolveAvatar(p)` before rendering. For user photos, that converted the profile-photo marker into the Dicebear fallback before `AvatarTile` could load the IndexedDB photo.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/screens/ProfilePicker/ProfilePicker.test.tsx src/components/PlayerAvatar/__tests__/PlayerAvatar.test.tsx src/components/HouseguestGrid/__tests__/AvatarTile.test.tsx`