### PR TITLE
Add compact bottom controls layout mode

### DIFF
--- a/src/components/GameBottomNav/GameBottomNav.css
+++ b/src/components/GameBottomNav/GameBottomNav.css
@@ -25,10 +25,10 @@
 /* Background SVG fills the nav bar area */
 .game-bottom-nav__shell {
   position: absolute;
-  inset: 0;
+  inset: 0 0 calc(-1 * var(--safe-bottom)) 0;
   z-index: 0;
   width: 100%;
-  height: 100%;
+  height: calc(100% + var(--safe-bottom));
   object-fit: cover;
   opacity: 0.16;
   mix-blend-mode: soft-light;
@@ -101,8 +101,8 @@
 .game-bottom-nav__glyph {
   position: relative;
   z-index: 1;
-  width: 22px;
-  height: 22px;
+  width: var(--game-nav-glyph-size, 22px);
+  height: var(--game-nav-glyph-size, 22px);
   object-fit: contain;
   filter: saturate(0.86) contrast(0.94) brightness(0.97);
   pointer-events: none;
@@ -112,6 +112,7 @@
 .game-bottom-nav__label {
   position: relative;
   z-index: 1;
+  display: var(--game-nav-item-label-display, block);
   font-size: 0.58rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -129,4 +130,23 @@
   outline: 2px solid rgba(255, 255, 255, 0.7);
   outline-offset: -2px;
   border-radius: 6px;
+}
+
+:root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav {
+  margin-bottom: calc(-0.35 * var(--safe-bottom));
+}
+
+:root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav__items {
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+:root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav__item {
+  min-height: 44px;
+  gap: 0;
+  padding: 5px 4px;
+}
+
+:root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav__glyph {
+  --game-nav-glyph-size: 24px;
 }

--- a/src/components/GameBottomNav/__tests__/GameBottomNav.test.tsx
+++ b/src/components/GameBottomNav/__tests__/GameBottomNav.test.tsx
@@ -23,4 +23,15 @@ describe('GameBottomNav', () => {
     expect(screen.queryByRole('button', { name: 'LEADERBOARD' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'PROFILE' })).toBeNull();
   });
+
+  it('keeps accessible names when compact mode hides visual labels', () => {
+    const { container } = render(<GameBottomNav activeTab="home" />);
+
+    expect(screen.getByRole('button', { name: 'HOME' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('button', { name: 'RULES' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'SETTINGS' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'BOARD' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'USER' })).toBeDefined();
+    expect(container.querySelectorAll('.game-bottom-nav__label')).toHaveLength(5);
+  });
 });

--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -4,7 +4,7 @@
   bottom: 2px;
   left: 50%;
   z-index: 100;
-  width: min(80%, 340px);
+  width: min(calc(80% * var(--game-action-dock-scale, 1)), calc(340px * var(--game-action-dock-scale, 1)));
   aspect-ratio: 980 / 220;
   transform: translateX(-50%);
   -webkit-user-select: none;
@@ -14,7 +14,7 @@
 .floating-action-bar__blocked-message {
   position: absolute;
   left: 50%;
-  bottom: clamp(76px, 22vw, 104px);
+  bottom: calc(var(--game-action-dock-height, clamp(56px, 16vw, 76px)) + var(--game-action-dock-gap, 6px) + 12px);
   z-index: 115;
   width: min(88%, 420px);
   transform: translateX(-50%);
@@ -85,6 +85,8 @@
 .dock-hit-area {
   position: absolute;
   display: block;
+  min-width: 44px;
+  min-height: 44px;
   background: transparent;
   border: 0;
   padding: 0;

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -10,18 +10,22 @@ export type GameLayoutSize =
 export type ResponsiveRosterMode = 'normal' | 'compact-small' | 'scroll'
 export type RosterHeaderMode = 'tv-chip' | 'persistent'
 export type SurvivorStandoutLayoutMode = 'full-card' | 'compact-strip' | 'mini-chip'
+export type BottomControlsMode = 'normal' | 'compact'
+
+type GameCssVars = CSSProperties & Record<string, string>
 
 export interface ResponsiveGameLayoutBudget {
   layoutSize: GameLayoutSize
   baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'>
   rosterMode: ResponsiveRosterMode
   rosterHeaderMode: RosterHeaderMode
+  bottomControlsMode: BottomControlsMode
   compactRoster: boolean
   avatarTileSize: number
   rosterGap: number
   tvLogRows: number
   survivorStandoutMode: SurvivorStandoutLayoutMode
-  cssVars: CSSProperties
+  cssVars: GameCssVars
   debugEnabled: boolean
   debugLabel: string
   shellMaxWidth: number
@@ -48,9 +52,13 @@ export interface ResponsiveGameLayoutInput {
 
 const ANDROID_TOP_SAFE_FALLBACK = 24
 const DEFAULT_NAV_HEIGHT = 60
+const COMPACT_NAV_HEIGHT = 46
 const DEFAULT_PHONE_WIDTH = 390
 const DEFAULT_PHONE_HEIGHT = 780
 const DEFAULT_DOCK_RATIO = 220 / 980
+const COMPACT_DOCK_SCALE = 0.9
+const NORMAL_DOCK_GAP = 6
+const COMPACT_DOCK_GAP = 3
 const ROSTER_COLUMNS = 4
 const ROSTER_GAP = 5
 const GAME_INLINE_PADDING = 24
@@ -155,21 +163,25 @@ function buildDebugLabel(input: ResponsiveGameLayoutInput, budget: {
   layoutSize: GameLayoutSize
   baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'>
   rosterMode: ResponsiveRosterMode
+  rosterHeaderMode: RosterHeaderMode
+  bottomControlsMode: BottomControlsMode
   tvLogRows: number
   survivorStandoutMode: SurvivorStandoutLayoutMode
   effectiveSafeTop: number
   dockClearance: number
+  navHeight: number
   rosterMaxHeight: number
 }) {
   return [
     `${Math.round(input.viewportWidth)}x${Math.round(input.viewportHeight)}`,
     `stage ${Math.round(input.stageWidth)}x${Math.round(input.stageHeight)}`,
     `safe ${Math.round(budget.effectiveSafeTop)}/${Math.round(input.safeBottom)}`,
-    `nav ${Math.round(input.navHeight)}`,
+    `nav ${Math.round(budget.navHeight)}`,
     `dock ${Math.round(budget.dockClearance)}`,
+    `controls ${budget.bottomControlsMode}`,
     `tv rows ${budget.tvLogRows}`,
     `standout ${budget.survivorStandoutMode}`,
-    `roster ${budget.baseRosterMode}->${budget.rosterMode} ${Math.round(budget.rosterMaxHeight)}`,
+    `roster ${budget.baseRosterMode}->${budget.rosterMode}/${budget.rosterHeaderMode} ${Math.round(budget.rosterMaxHeight)}`,
     budget.layoutSize,
   ].join(' | ')
 }
@@ -183,10 +195,19 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const effectiveSafeTop = input.isAndroidLike
     ? Math.max(input.safeTop, ANDROID_TOP_SAFE_FALLBACK)
     : input.safeTop
-  const navHeight = input.navHeight || DEFAULT_NAV_HEIGHT
-  void navHeight
+  const measuredNavHeight = input.navHeight || DEFAULT_NAV_HEIGHT + input.safeBottom
+  const normalNavContentHeight = Math.max(DEFAULT_NAV_HEIGHT, measuredNavHeight - input.safeBottom)
+  const compactNavContentHeight = Math.min(normalNavContentHeight, COMPACT_NAV_HEIGHT)
+  const normalNavHeight = normalNavContentHeight + input.safeBottom
+  const compactNavHeight = compactNavContentHeight + input.safeBottom
   const measuredDockHeight = input.dockHeight || estimateDockHeight(stageWidth)
-  const dockClearance = input.hasDock ? measuredDockHeight + 6 : 0
+  const normalDockHeight = input.hasDock ? measuredDockHeight : 0
+  const compactDockHeight = input.hasDock ? Math.max(56, measuredDockHeight * COMPACT_DOCK_SCALE) : 0
+  const normalDockClearance = input.hasDock ? normalDockHeight + NORMAL_DOCK_GAP : 0
+  const compactDockClearance = input.hasDock ? compactDockHeight + COMPACT_DOCK_GAP : 0
+  const measuredStageAndNavHeight = stageHeight + measuredNavHeight
+  const normalStageHeight = Math.max(0, measuredStageAndNavHeight - normalNavHeight)
+  const compactStageHeight = Math.max(0, measuredStageAndNavHeight - compactNavHeight)
   const isTablet = layoutSize === 'tablet-portrait' || layoutSize === 'tablet-landscape'
   const shellMaxWidth = isTablet
     ? (layoutSize === 'tablet-landscape' ? 560 : 520)
@@ -212,9 +233,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     input.playerCount >= 16 &&
     (layoutSize === 'phone-small' || rosterContentWidth < 320)
 
-  const availableAfterTv = Math.max(
+  const normalAvailableAfterTv = Math.max(
     0,
-    stageHeight - dockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
+    normalStageHeight - normalDockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
+  )
+  const compactAvailableAfterTv = Math.max(
+    0,
+    compactStageHeight - compactDockClearance - GAME_VERTICAL_PADDING - GAME_SECTION_GAPS,
   )
   const normalRosterHeight = rosterRows * normalTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
   const compactRosterHeight = rosterRows * compactTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
@@ -227,17 +252,29 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
         : 144
   const minTvHeight = minTvViewportHeight + TV_CHROME_HEIGHT + TV_LOG_ROW_HEIGHT
   const normalWithoutHeader = normalRosterHeight - ROSTER_HEADER_HEIGHT
-  const normalStaticFits =
+  const compactWithoutHeader = compactRosterHeight - ROSTER_HEADER_HEIGHT
+  const normalControlsFullRosterFits =
     !shouldUseCompactBase &&
-    normalWithoutHeader + minTvHeight <= availableAfterTv
+    normalRosterHeight + minTvHeight <= normalAvailableAfterTv
+  const bottomControlsMode: BottomControlsMode = normalControlsFullRosterFits ? 'normal' : 'compact'
+  const availableAfterTv = bottomControlsMode === 'normal'
+    ? normalAvailableAfterTv
+    : compactAvailableAfterTv
+  const selectedNavHeight = bottomControlsMode === 'normal' ? normalNavHeight : compactNavHeight
+  const selectedNavContentHeight = bottomControlsMode === 'normal' ? normalNavContentHeight : compactNavContentHeight
+  const selectedDockHeight = bottomControlsMode === 'normal' ? normalDockHeight : compactDockHeight
+  const dockClearance = bottomControlsMode === 'normal' ? normalDockClearance : compactDockClearance
+  const normalStaticFitsAfterCompactControls =
+    !shouldUseCompactBase &&
+    normalWithoutHeader + minTvHeight <= compactAvailableAfterTv
   const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> =
-    input.userCompactRoster || !normalStaticFits
+    input.userCompactRoster || !normalStaticFitsAfterCompactControls
       ? 'compact-small'
       : 'normal'
   const rosterMode: ResponsiveRosterMode = baseRosterMode
   const baseAvatarTileSize = baseRosterMode === 'compact-small' ? compactTileSize : normalTileSize
   const baseRosterHeight = baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
-  const baseRosterHeightWithoutHeader = baseRosterHeight - ROSTER_HEADER_HEIGHT
+  const baseRosterHeightWithoutHeader = baseRosterMode === 'compact-small' ? compactWithoutHeader : normalWithoutHeader
   const headerFits = baseRosterHeight + minTvHeight <= availableAfterTv
   const rosterHeaderMode: RosterHeaderMode = headerFits ? 'persistent' : 'tv-chip'
   const rosterDisplayHeight = rosterHeaderMode === 'persistent'
@@ -267,10 +304,19 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const rosterMaxHeight = baseRosterHeightWithoutHeader
   const avatarTileSize = baseAvatarTileSize
   const avatarTileSizePx = Math.max(0, Math.floor(avatarTileSize))
+  const actionDockScale = bottomControlsMode === 'normal' ? 1 : COMPACT_DOCK_SCALE
+  const actionDockGap = bottomControlsMode === 'normal' ? NORMAL_DOCK_GAP : COMPACT_DOCK_GAP
+  const navItemLabelDisplay = bottomControlsMode === 'normal' ? 'block' : 'none'
 
   const cssVars = {
     '--game-safe-top': `${roundPx(effectiveSafeTop)}px`,
     '--game-safe-bottom': `${roundPx(input.safeBottom)}px`,
+    '--game-bottom-controls-mode': bottomControlsMode,
+    '--game-action-dock-scale': String(actionDockScale),
+    '--game-action-dock-height': `${roundPx(selectedDockHeight)}px`,
+    '--game-action-dock-gap': `${roundPx(actionDockGap)}px`,
+    '--game-nav-height': `${roundPx(selectedNavContentHeight)}px`,
+    '--game-nav-item-label-display': navItemLabelDisplay,
     '--game-screen-floating-dock-clearance': `${roundPx(dockClearance)}px`,
     '--game-screen-tv-min-height': `${roundPx(tvHeight)}px`,
     '--game-screen-tv-viewport-min-height': `${roundPx(tvViewportHeight)}px`,
@@ -281,16 +327,19 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     '--game-roster-gap': `${ROSTER_GAP}px`,
     '--game-survivor-standout-min-height': `${survivorStandoutHeight}px`,
     '--game-shell-max-width': `${shellMaxWidth}px`,
-  } as CSSProperties
+  } as GameCssVars
 
   const debugLabel = buildDebugLabel(input, {
     layoutSize,
     baseRosterMode,
     rosterMode,
+    rosterHeaderMode,
+    bottomControlsMode,
     tvLogRows,
     survivorStandoutMode,
     effectiveSafeTop,
     dockClearance,
+    navHeight: selectedNavHeight,
     rosterMaxHeight,
   })
   const signature = [
@@ -298,12 +347,14 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     baseRosterMode,
     rosterMode,
     rosterHeaderMode,
+    bottomControlsMode,
     tvLogRows,
     survivorStandoutMode,
     roundPx(tvHeight),
     roundPx(rosterMaxHeight),
     avatarTileSizePx,
     roundPx(dockClearance),
+    roundPx(selectedNavHeight),
     roundPx(effectiveSafeTop),
     shellMaxWidth,
   ].join(':')
@@ -313,6 +364,7 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     baseRosterMode,
     rosterMode,
     rosterHeaderMode,
+    bottomControlsMode,
     compactRoster,
     avatarTileSize: avatarTileSizePx,
     rosterGap: ROSTER_GAP,
@@ -371,7 +423,7 @@ function readViewportInput<TStage extends HTMLElement>(
     stageHeight: stageRect?.height ?? viewportHeight,
     safeTop,
     safeBottom,
-    navHeight: navRect?.height ?? DEFAULT_NAV_HEIGHT,
+    navHeight: navRect?.height ?? DEFAULT_NAV_HEIGHT + safeBottom,
     dockHeight: dockRect?.height ?? 0,
     hasDock: options.hasDock,
     playerCount: options.playerCount,
@@ -449,16 +501,66 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
 
   useEffect(() => {
     const root = document.documentElement
-    const previous = root.style.getPropertyValue('--app-shell-max-width')
+    const cssVars = budget.cssVars
+    const previousShellMaxWidth = root.style.getPropertyValue('--app-shell-max-width')
+    const previousNavHeight = root.style.getPropertyValue('--nav-bar-height')
+    const previousBottomControlsMode = root.style.getPropertyValue('--game-bottom-controls-mode')
+    const previousDockScale = root.style.getPropertyValue('--game-action-dock-scale')
+    const previousDockHeight = root.style.getPropertyValue('--game-action-dock-height')
+    const previousDockGap = root.style.getPropertyValue('--game-action-dock-gap')
+    const previousGameNavHeight = root.style.getPropertyValue('--game-nav-height')
+    const previousNavItemLabelDisplay = root.style.getPropertyValue('--game-nav-item-label-display')
     root.style.setProperty('--app-shell-max-width', `${budget.shellMaxWidth}px`)
+    root.style.setProperty('--nav-bar-height', cssVars['--game-nav-height'])
+    root.style.setProperty('--game-bottom-controls-mode', cssVars['--game-bottom-controls-mode'])
+    root.style.setProperty('--game-action-dock-scale', cssVars['--game-action-dock-scale'])
+    root.style.setProperty('--game-action-dock-height', cssVars['--game-action-dock-height'])
+    root.style.setProperty('--game-action-dock-gap', cssVars['--game-action-dock-gap'])
+    root.style.setProperty('--game-nav-height', cssVars['--game-nav-height'])
+    root.style.setProperty('--game-nav-item-label-display', cssVars['--game-nav-item-label-display'])
     return () => {
-      if (previous) {
-        root.style.setProperty('--app-shell-max-width', previous)
+      if (previousShellMaxWidth) {
+        root.style.setProperty('--app-shell-max-width', previousShellMaxWidth)
       } else {
         root.style.removeProperty('--app-shell-max-width')
       }
+      if (previousNavHeight) {
+        root.style.setProperty('--nav-bar-height', previousNavHeight)
+      } else {
+        root.style.removeProperty('--nav-bar-height')
+      }
+      if (previousBottomControlsMode) {
+        root.style.setProperty('--game-bottom-controls-mode', previousBottomControlsMode)
+      } else {
+        root.style.removeProperty('--game-bottom-controls-mode')
+      }
+      if (previousDockScale) {
+        root.style.setProperty('--game-action-dock-scale', previousDockScale)
+      } else {
+        root.style.removeProperty('--game-action-dock-scale')
+      }
+      if (previousDockHeight) {
+        root.style.setProperty('--game-action-dock-height', previousDockHeight)
+      } else {
+        root.style.removeProperty('--game-action-dock-height')
+      }
+      if (previousDockGap) {
+        root.style.setProperty('--game-action-dock-gap', previousDockGap)
+      } else {
+        root.style.removeProperty('--game-action-dock-gap')
+      }
+      if (previousGameNavHeight) {
+        root.style.setProperty('--game-nav-height', previousGameNavHeight)
+      } else {
+        root.style.removeProperty('--game-nav-height')
+      }
+      if (previousNavItemLabelDisplay) {
+        root.style.setProperty('--game-nav-item-label-display', previousNavItemLabelDisplay)
+      } else {
+        root.style.removeProperty('--game-nav-item-label-display')
+      }
     }
-  }, [budget.shellMaxWidth])
+  }, [budget.cssVars, budget.shellMaxWidth])
 
   return budget
 }

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -41,7 +41,7 @@ describe('responsive game layout budget', () => {
     })
   })
 
-  it('fits an iPhone Pro-like board statically by moving Housemates to the TV chip', () => {
+  it('uses compact bottom controls before compacting an iPhone Pro-like roster', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportHeight: 852,
       stageHeight: 699,
@@ -49,11 +49,16 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.layoutSize).toBe('phone-large')
+    expect(budget.bottomControlsMode).toBe('compact')
     expect(budget.baseRosterMode).toBe('normal')
     expect(budget.rosterMode).toBe('normal')
     expect(budget.rosterHeaderMode).toBe('tv-chip')
     expect(budget.compactRoster).toBe(false)
     expect(budget.cssVars).toMatchObject({
+      '--game-bottom-controls-mode': 'compact',
+      '--game-action-dock-scale': '0.9',
+      '--game-nav-height': '46px',
+      '--game-nav-item-label-display': 'none',
       '--game-roster-board-height': '335px',
     })
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
@@ -89,7 +94,7 @@ describe('responsive game layout budget', () => {
     expect(liveVoteBudget.rosterMode).toBe('normal')
   })
 
-  it('uses a full Housemates row and more log rows on iPhone Pro Max-like screens', () => {
+  it('keeps normal premium controls on iPhone Pro Max-like screens when full roster fits', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 430,
       viewportHeight: 950,
@@ -98,12 +103,17 @@ describe('responsive game layout budget', () => {
       dockHeight: 74,
     }))
 
+    expect(budget.bottomControlsMode).toBe('normal')
     expect(budget.rosterMode).toBe('normal')
     expect(budget.rosterHeaderMode).toBe('persistent')
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(3)
+    expect(budget.cssVars).toMatchObject({
+      '--game-nav-height': '60px',
+      '--game-nav-item-label-display': 'block',
+    })
   })
 
-  it('keeps Pixel 6 Android-style screens on a static normal roster', () => {
+  it('keeps Pixel 6 Android-style screens on a static full roster with protected service row', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 393,
       viewportHeight: 851,
@@ -118,21 +128,23 @@ describe('responsive game layout budget', () => {
     expect(budget.cssVars).toMatchObject({
       '--game-safe-top': '24px',
     })
+    expect(['normal', 'compact']).toContain(budget.bottomControlsMode)
     expect(budget.rosterMode).toBe('normal')
     expect(budget.compactRoster).toBe(false)
-    expect(budget.rosterHeaderMode).toBe('tv-chip')
+    expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
   })
 
-  it('uses compact fallback only on genuinely small static boards', () => {
+  it('tries compact bottom controls before compact roster fallback on small old phones', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 320,
       viewportHeight: 667,
       stageWidth: 320,
-      stageHeight: 620,
+      stageHeight: 560,
       dockHeight: 62,
     }))
 
     expect(budget.layoutSize).toBe('phone-small')
+    expect(budget.bottomControlsMode).toBe('compact')
     expect(budget.rosterMode).toBe('compact-small')
     expect(budget.compactRoster).toBe(true)
     expect(budget.rosterHeaderMode).toBe('tv-chip')


### PR DESCRIPTION
## Summary
- add `bottomControlsMode` to the responsive game layout budget and expose nav/dock sizing CSS variables
- select compact bottom controls before falling back to TV-chip headers or compact rosters
- make the floating action dock and bottom nav consume the compact variables while preserving existing visual language and accessible nav names
- update focused layout and nav accessibility tests for iPhone Pro-like, Pro Max-like, Pixel/Android, and small-phone budgets

## Tests
- Not run locally; implemented directly through GitHub without a local checkout as requested.