### PR TITLE
Add tablet landscape layout strategy

### DIFF
--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -1,5 +1,9 @@
 /* GameScreen */
 .game-screen {
+  --game-cabinet-max-width: var(--game-shell-max-width, 480px);
+  --game-cabinet-max-height: 100%;
+  --game-layout-columns: 1fr;
+  --game-panel-gap: 0px;
   --game-screen-floating-dock-clearance: clamp(56px, 16vw, 76px);
   --game-screen-tv-min-height: clamp(238px, 30svh, 312px);
   --game-screen-tv-viewport-min-height: clamp(144px, 18svh, 192px);
@@ -12,6 +16,7 @@
   min-height: 0;
   padding: 4px 12px 6px;
   overflow: hidden;
+  box-sizing: border-box;
 }
 
 .game-screen:has(.game-control-dock) {
@@ -47,7 +52,75 @@ body:has(.game-screen-shell) {
 
 .game-screen[data-layout-size='tablet-portrait'],
 .game-screen[data-layout-size='tablet-landscape'] {
+  width: min(100%, var(--game-cabinet-max-width));
+  max-width: var(--game-cabinet-max-width);
+  max-height: var(--game-cabinet-max-height);
+  margin: 0 auto;
   padding-inline: 14px;
+}
+
+.game-screen[data-layout-size='tablet-portrait'] {
+  gap: 8px;
+  padding: 8px 16px 10px;
+}
+
+.game-screen[data-layout-size='tablet-landscape'] {
+  display: grid;
+  grid-template-columns: var(--game-layout-columns, minmax(0, 1fr));
+  grid-template-rows: minmax(0, 1fr);
+  grid-template-areas: 'tv roster';
+  align-items: stretch;
+  gap: var(--game-panel-gap, 16px);
+  padding: 10px 18px calc(var(--game-screen-floating-dock-clearance) + 10px);
+}
+
+.game-screen[data-layout-size='tablet-landscape'] > .tv-zone {
+  grid-area: tv;
+  flex: initial;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: min(100%, var(--game-screen-tv-min-height));
+  --tv-zone-min-height: min(100%, var(--game-screen-tv-min-height));
+  --tv-zone-viewport-min-height: min(30svh, var(--game-screen-tv-viewport-min-height));
+}
+
+.game-screen[data-layout-size='tablet-landscape'] > section[aria-labelledby='houseguests-heading'] {
+  grid-area: roster;
+  align-self: stretch;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  padding: 12px;
+  border: 1px solid rgba(129, 140, 248, 0.18);
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(99, 102, 241, 0.14), rgba(99, 102, 241, 0) 42%),
+    linear-gradient(180deg, rgba(14, 20, 34, 0.86), rgba(7, 11, 20, 0.9));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 10px 28px rgba(0, 0, 0, 0.34);
+  overflow: visible;
+}
+
+.game-screen[data-layout-size='tablet-landscape'] > section[aria-labelledby='houseguests-heading'] > ul[role='list'] {
+  flex: 0 0 auto;
+}
+
+.game-screen[data-layout-size='tablet-landscape'] .tv-log {
+  max-height: min(30svh, calc(var(--tv-log-item-h) * var(--tv-log-max-vis)));
+}
+
+@media (max-height: 700px) and (min-width: 720px) and (orientation: landscape) {
+  .game-screen[data-layout-size='tablet-landscape'] {
+    padding-top: 8px;
+    padding-inline: 14px;
+  }
+
+  .game-screen[data-layout-size='tablet-landscape'] > section[aria-labelledby='houseguests-heading'] {
+    padding: 10px;
+  }
 }
 
 /* Gameplay background shell */

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -69,7 +69,7 @@ const GAME_SECTION_GAPS = 12
 const TV_LOG_ROW_HEIGHT = 32
 const TV_CHROME_HEIGHT = 88
 const MAX_PHONE_TV_LOG_ROWS = 5
-const MAX_TABLET_TV_LOG_ROWS = 5
+const MAX_TABLET_TV_LOG_ROWS = 6
 const SHORT_ROSTER_MAX_PLAYERS = ROSTER_COLUMNS * 2
 const SURVIVOR_STANDOUT_GAP_ALLOWANCE = 10
 const SURVIVOR_FULL_STANDOUT_MIN_SPACE = 72
@@ -152,7 +152,7 @@ function resolveAdaptiveTvLogRows(options: {
 }) {
   const maxRows = options.playerCount <= SHORT_ROSTER_MAX_PLAYERS
     ? (options.isTablet ? MAX_TABLET_TV_LOG_ROWS : MAX_PHONE_TV_LOG_ROWS)
-    : (options.isTablet ? 4 : 3)
+    : (options.isTablet ? 5 : 3)
   const baseRows = resolveBaseTvLogRows(options.extraAfterFeature, options.isTablet)
   const rowsThatFit = 1 + Math.floor(options.extraAfterFeature / TV_LOG_ROW_HEIGHT)
 
@@ -209,22 +209,36 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const normalStageHeight = Math.max(0, measuredStageAndNavHeight - normalNavHeight)
   const compactStageHeight = Math.max(0, measuredStageAndNavHeight - compactNavHeight)
   const isTablet = layoutSize === 'tablet-portrait' || layoutSize === 'tablet-landscape'
-  const shellMaxWidth = isTablet
-    ? (layoutSize === 'tablet-landscape' ? 560 : 520)
-    : 480
+  const shellMaxWidth = layoutSize === 'tablet-landscape'
+    ? roundPx(clamp(viewportWidth - 48, 900, 1100))
+    : layoutSize === 'tablet-portrait'
+      ? 620
+      : 480
+  const cabinetMaxHeight = Math.max(0, viewportHeight - effectiveSafeTop - input.safeBottom)
+  const panelGap = layoutSize === 'tablet-landscape'
+    ? roundPx(clamp(viewportWidth * 0.018, 12, 20))
+    : 0
+  const layoutColumns = layoutSize === 'tablet-landscape'
+    ? 'minmax(0, 1.05fr) minmax(360px, 0.95fr)'
+    : '1fr'
+  const rosterStageWidth = layoutSize === 'tablet-landscape'
+    ? clamp(stageWidth * 0.44, 400, 520)
+    : stageWidth
 
   const rosterContentWidth = Math.max(
     240,
-    stageWidth - GAME_INLINE_PADDING - ROSTER_INLINE_PADDING,
+    rosterStageWidth - GAME_INLINE_PADDING - ROSTER_INLINE_PADDING,
   )
   const tileWidth = (rosterContentWidth - ROSTER_GAP * (ROSTER_COLUMNS - 1)) / ROSTER_COLUMNS
-  const normalTileMax = isTablet
-    ? 128
-    : layoutSize === 'phone-large' && (viewportHeight >= 900 || stageWidth >= 420)
-      ? 104
-      : layoutSize === 'phone-large'
-        ? 80
-        : 78
+  const normalTileMax = layoutSize === 'tablet-landscape'
+    ? 112
+    : isTablet
+      ? 128
+      : layoutSize === 'phone-large' && (viewportHeight >= 900 || stageWidth >= 420)
+        ? 104
+        : layoutSize === 'phone-large'
+          ? 80
+          : 78
   const normalTileSize = Math.floor(clamp(tileWidth, 76, normalTileMax))
   const compactTileSize = Math.floor(clamp(normalTileSize * 0.86, 64, normalTileSize))
   const rosterRows = Math.max(1, Math.ceil(Math.max(input.playerCount, 1) / ROSTER_COLUMNS))
@@ -256,7 +270,11 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const normalControlsFullRosterFits =
     !shouldUseCompactBase &&
     normalRosterHeight + minTvHeight <= normalAvailableAfterTv
-  const bottomControlsMode: BottomControlsMode = normalControlsFullRosterFits ? 'normal' : 'compact'
+  const bottomControlsMode: BottomControlsMode = isTablet
+    ? 'normal'
+    : normalControlsFullRosterFits
+      ? 'normal'
+      : 'compact'
   const availableAfterTv = bottomControlsMode === 'normal'
     ? normalAvailableAfterTv
     : compactAvailableAfterTv
@@ -267,8 +285,9 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const normalStaticFitsAfterCompactControls =
     !shouldUseCompactBase &&
     normalWithoutHeader + minTvHeight <= compactAvailableAfterTv
-  const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> =
-    input.userCompactRoster || !normalStaticFitsAfterCompactControls
+  const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> = isTablet
+    ? 'normal'
+    : input.userCompactRoster || !normalStaticFitsAfterCompactControls
       ? 'compact-small'
       : 'normal'
   const rosterMode: ResponsiveRosterMode = baseRosterMode
@@ -276,7 +295,11 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const baseRosterHeight = baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
   const baseRosterHeightWithoutHeader = baseRosterMode === 'compact-small' ? compactWithoutHeader : normalWithoutHeader
   const headerFits = baseRosterHeight + minTvHeight <= availableAfterTv
-  const rosterHeaderMode: RosterHeaderMode = headerFits ? 'persistent' : 'tv-chip'
+  const rosterHeaderMode: RosterHeaderMode = isTablet
+    ? 'persistent'
+    : headerFits
+      ? 'persistent'
+      : 'tv-chip'
   const rosterDisplayHeight = rosterHeaderMode === 'persistent'
     ? baseRosterHeight
     : baseRosterHeightWithoutHeader
@@ -291,11 +314,13 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     ? survivorStandoutHeight + SURVIVOR_STANDOUT_GAP_ALLOWANCE
     : 0
   const extraAfterFeature = Math.max(0, extraAfterMandatory - featureReserve)
-  const tvLogRows = resolveAdaptiveTvLogRows({
-    extraAfterFeature,
-    isTablet,
-    playerCount: input.playerCount,
-  })
+  const tvLogRows = layoutSize === 'tablet-landscape'
+    ? (input.playerCount <= SHORT_ROSTER_MAX_PLAYERS ? MAX_TABLET_TV_LOG_ROWS : 5)
+    : resolveAdaptiveTvLogRows({
+        extraAfterFeature,
+        isTablet,
+        playerCount: input.playerCount,
+      })
   const extraLogRows = tvLogRows - 1
   const breathingRoom = clamp(extraAfterFeature - extraLogRows * TV_LOG_ROW_HEIGHT, 0, isTablet ? 36 : 20)
   const tvHeight = minTvHeight + extraLogRows * TV_LOG_ROW_HEIGHT + breathingRoom
@@ -327,6 +352,10 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     '--game-roster-gap': `${ROSTER_GAP}px`,
     '--game-survivor-standout-min-height': `${survivorStandoutHeight}px`,
     '--game-shell-max-width': `${shellMaxWidth}px`,
+    '--game-cabinet-max-width': `${shellMaxWidth}px`,
+    '--game-cabinet-max-height': `${roundPx(cabinetMaxHeight)}px`,
+    '--game-layout-columns': layoutColumns,
+    '--game-panel-gap': `${panelGap}px`,
   } as GameCssVars
 
   const debugLabel = buildDebugLabel(input, {
@@ -357,6 +386,9 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
     roundPx(selectedNavHeight),
     roundPx(effectiveSafeTop),
     shellMaxWidth,
+    roundPx(cabinetMaxHeight),
+    panelGap,
+    layoutColumns,
   ].join(':')
 
   return {

--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -1,5 +1,9 @@
 /* HomeHub — narrower asymmetric buttons, stronger glass look */
 
+body:has(.homehub-shell) .app-shell {
+  background: var(--color-bg, #050813);
+}
+
 /* Shell fills the viewport; HomeHub owns its own decorative paint. */
 .homehub-shell {
   position: relative;
@@ -135,6 +139,62 @@
 @media (max-width: 420px) {
   .home-hub__title { font-size: 1.8rem; }
   .home-hub { padding-bottom: 28px; }
+}
+
+@media (min-width: 720px) and (orientation: portrait) {
+  .homehub-frame {
+    width: min(100vw, 620px);
+  }
+
+  .homehub-content {
+    max-width: 520px;
+  }
+}
+
+@media (min-width: 720px) and (orientation: landscape) {
+  body:has(.homehub-shell) .app-shell {
+    max-width: 100%;
+  }
+
+  .homehub-frame {
+    width: 100vw;
+    max-width: none;
+  }
+
+  .homehub-content {
+    width: min(100%, 520px);
+    max-width: 520px;
+  }
+
+  .homehub-frame #intro-hub {
+    --hub-chip-top-offset: 18px;
+    --hub-chip-left-offset: 18px;
+    --hub-chip-right-offset: 18px;
+    position: absolute;
+    inset: auto;
+    top: 50%;
+    left: 50%;
+    width: min(calc(100% - 96px), 760px);
+    height: min(calc(100% - var(--app-safe-area-top, 0px) - var(--safe-bottom, 0px) - 28px), 560px);
+    min-height: 360px;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+
+  .homehub-frame #intro-hub .hub-chip--bottom-left,
+  .homehub-frame #intro-hub .hub-chip--bottom-right {
+    bottom: 18px;
+  }
+
+  .homehub-frame #intro-hub .hub-chip--bottom-left-2,
+  .homehub-frame #intro-hub .hub-chip--bottom-right-2 {
+    bottom: 70px;
+  }
+
+  .homehub-frame #intro-hub .hub-chip--bottom-left-3,
+  .homehub-frame #intro-hub .hub-chip--bottom-right-3 {
+    bottom: 122px;
+  }
 }
 
 .homehub-resume-modal {

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -154,15 +154,47 @@ describe('responsive game layout budget', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 1024,
       viewportHeight: 768,
-      stageWidth: 560,
+      stageWidth: 976,
       stageHeight: 650,
       safeBottom: 20,
       dockHeight: 76,
     }))
 
     expect(budget.layoutSize).toBe('tablet-landscape')
-    expect(budget.shellMaxWidth).toBe(560)
+    expect(budget.shellMaxWidth).toBe(976)
+    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.baseRosterMode).toBe('normal')
     expect(budget.rosterMode).not.toBe('scroll')
+    expect(budget.rosterHeaderMode).toBe('persistent')
+    expect(budget.compactRoster).toBe(false)
+    expect(budget.avatarTileSize).toBeLessThanOrEqual(112)
+    expect(budget.tvLogRows).toBe(5)
+    expect(budget.cssVars).toMatchObject({
+      '--game-bottom-controls-mode': 'normal',
+      '--game-action-dock-scale': '1',
+      '--game-nav-item-label-display': 'block',
+      '--game-cabinet-max-width': '976px',
+      '--game-layout-columns': 'minmax(0, 1.05fr) minmax(360px, 0.95fr)',
+    })
+    expect(readCssPx(budget, '--game-panel-gap')).toBeGreaterThan(0)
+  })
+
+  it('does not apply user compact roster preferences to tablet landscape', () => {
+    const budget = computeResponsiveGameLayout(makeInput({
+      viewportWidth: 1180,
+      viewportHeight: 820,
+      stageWidth: 1100,
+      stageHeight: 700,
+      safeBottom: 20,
+      dockHeight: 80,
+      userCompactRoster: true,
+    }))
+
+    expect(budget.layoutSize).toBe('tablet-landscape')
+    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.rosterMode).toBe('normal')
+    expect(budget.compactRoster).toBe(false)
+    expect(budget.shellMaxWidth).toBe(1100)
   })
 
   it('exposes a full Survivor standout mode for medium Android-sized eight-player layouts', () => {
@@ -205,7 +237,7 @@ describe('responsive game layout budget', () => {
     const budget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 820,
       viewportHeight: 1080,
-      stageWidth: 520,
+      stageWidth: 620,
       stageHeight: 980,
       dockHeight: 0,
       hasDock: false,

--- a/tests/unit/layout/tabletLandscape.styles.test.ts
+++ b/tests/unit/layout/tabletLandscape.styles.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function normalizeCss(css: string) {
+  return css.replace(/\s+/g, ' ').trim()
+}
+
+describe('tablet and landscape layout styles', () => {
+  it('uses a two-panel GameScreen cabinet for tablet landscape', () => {
+    const gameScreenCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/screens/GameScreen/GameScreen.css'), 'utf8'),
+    )
+
+    expect(gameScreenCss).toContain(".game-screen[data-layout-size='tablet-landscape'] { display: grid;")
+    expect(gameScreenCss).toContain("grid-template-areas: 'tv roster';")
+    expect(gameScreenCss).toContain('grid-template-columns: var(--game-layout-columns, minmax(0, 1fr));')
+    expect(gameScreenCss).toContain(".game-screen[data-layout-size='tablet-landscape'] > .tv-zone")
+    expect(gameScreenCss).toContain(".game-screen[data-layout-size='tablet-landscape'] > section[aria-labelledby='houseguests-heading']")
+    expect(gameScreenCss).toContain('max-height: min(30svh, calc(var(--tv-log-item-h) * var(--tv-log-max-vis)));')
+  })
+
+  it('keeps HomeHub chips relative to the cabinet on tablet landscape', () => {
+    const homeHubCss = normalizeCss(
+      readFileSync(resolve(process.cwd(), 'src/screens/HomeHub/HomeHub.css'), 'utf8'),
+    )
+
+    expect(homeHubCss).toContain('@media (min-width: 720px) and (orientation: landscape)')
+    expect(homeHubCss).toContain('body:has(.homehub-shell) .app-shell { max-width: 100%; }')
+    expect(homeHubCss).toContain('.homehub-frame #intro-hub { --hub-chip-top-offset: 18px;')
+    expect(homeHubCss).toContain('width: min(calc(100% - 96px), 760px);')
+    expect(homeHubCss).toContain('transform: translate(-50%, -50%);')
+    expect(homeHubCss).toContain('.homehub-frame #intro-hub .hub-chip--bottom-left')
+  })
+})


### PR DESCRIPTION
## Summary
- widen the measured tablet cabinet budget and expose tablet layout CSS variables for cabinet width, height, columns, and panel gap
- give tablet landscape GameScreen a two-panel layout with TV/log on the left and a static roster panel on the right
- keep tablet controls in the normal mode instead of falling into compact phone controls
- anchor HomeHub side chips to a centered cabinet frame on tablet landscape while allowing the background to fill the screen
- add responsive budget and CSS contract tests for the new tablet landscape behavior

## Testing
- Not run locally: this PR was created directly through GitHub as requested, without a local checkout.
- Visual screenshots not generated for the same reason.