### PR TITLE
Redesign Chain of Greed broadcast board flow

### DIFF
--- a/src/components/ChainOfGreed/ChainOfGreed.css
+++ b/src/components/ChainOfGreed/ChainOfGreed.css
@@ -1661,3 +1661,219 @@
     grid-auto-columns: minmax(9.7rem, 58%);
   }
 }
+
+
+/* -- React board composition pass ------------------------------------------ */
+.chain-of-greed__hero-stage {
+  grid-template-rows: auto minmax(5.25rem, auto) minmax(23rem, 1fr) minmax(3.15rem, auto);
+}
+
+.chain-of-greed__score-strip {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.38rem;
+}
+
+.chain-of-greed__score-tile {
+  min-width: 0;
+  min-height: 2.75rem;
+  display: grid;
+  align-content: center;
+  gap: 0.12rem;
+  padding: 0.34rem 0.48rem;
+  border: 1px solid rgba(133, 180, 255, 0.1);
+  border-radius: 0.62rem;
+  background: rgba(2, 8, 18, 0.48);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.018);
+}
+
+.chain-of-greed__score-tile span,
+.chain-of-greed__actor-copy span,
+.chain-of-greed__actor-meter span,
+.chain-of-greed__action-cue span {
+  font-size: 0.55rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(190, 211, 255, 0.68);
+}
+
+.chain-of-greed__score-tile strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8rem;
+  line-height: 1.05;
+  color: rgba(246, 249, 255, 0.96);
+  font-variant-numeric: tabular-nums;
+}
+
+.chain-of-greed__actor-strip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.15rem;
+  padding: 0.25rem 0.35rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.chain-of-greed__actor-token {
+  width: 1.65rem;
+  height: 1.65rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(120, 215, 255, 0.22), rgba(247, 200, 91, 0.16));
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.chain-of-greed__actor-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.02rem;
+}
+
+.chain-of-greed__actor-copy strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.86rem;
+  line-height: 1.1;
+}
+
+.chain-of-greed__actor-meter {
+  min-width: 4.5rem;
+  display: grid;
+  justify-items: end;
+}
+
+.chain-of-greed__actor-meter span {
+  max-width: 6.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(247, 200, 91, 0.86);
+}
+
+.chain-of-greed__ladder-stage {
+  cursor: pointer;
+}
+
+.chain-of-greed__ladder-stage:focus-visible {
+  outline: 2px solid rgba(120, 215, 255, 0.72);
+  outline-offset: 3px;
+}
+
+.chain-of-greed__outcome-slot {
+  width: min(100%, 18.5rem);
+  min-height: 3.25rem;
+  display: grid;
+  place-items: center;
+  align-self: end;
+  margin-top: 0.1rem;
+}
+
+.chain-of-greed__outcome-slot .chain-of-greed__reveal {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.chain-of-greed__outcome-placeholder {
+  width: 100%;
+  min-height: 3rem;
+  display: grid;
+  place-items: center;
+  border: 1px dashed rgba(133, 180, 255, 0.14);
+  border-radius: 0.8rem;
+  color: rgba(207, 222, 255, 0.46);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: rgba(2, 8, 18, 0.28);
+}
+
+.chain-of-greed__action-bar {
+  grid-template-columns: minmax(6.7rem, 0.72fr) minmax(0, 1.6fr);
+}
+
+.chain-of-greed__action-cue {
+  min-width: 0;
+  display: grid;
+  align-content: center;
+  gap: 0.08rem;
+  min-height: 2.45rem;
+  padding: 0 0.58rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.chain-of-greed__action-cue strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.84rem;
+  line-height: 1.05;
+}
+
+.chain-of-greed__action-controls {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.chain-of-greed__action-controls .chain-of-greed__buttons {
+  min-width: 0;
+}
+
+.chain-of-greed__action-controls .chain-of-greed__ai-waiting {
+  min-width: 0;
+}
+
+@media (max-width: 520px) {
+  .chain-of-greed__score-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chain-of-greed__hero-stage {
+    grid-template-rows: auto minmax(5.5rem, auto) minmax(21rem, 1fr) minmax(3.2rem, auto);
+  }
+
+  .chain-of-greed__action-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .chain-of-greed__action-controls {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 380px) {
+  .chain-of-greed__actor-strip {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .chain-of-greed__actor-meter {
+    grid-column: 1 / -1;
+    justify-items: start;
+    min-width: 0;
+  }
+
+  .chain-of-greed__action-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .chain-of-greed__action-info {
+    display: none;
+  }
+}

--- a/src/components/ChainOfGreed/ChainOfGreed.css
+++ b/src/components/ChainOfGreed/ChainOfGreed.css
@@ -1374,3 +1374,290 @@
 .chain-of-greed__action-bar {
   padding-bottom: max(env(safe-area-inset-bottom, 0px), 0.2rem);
 }
+
+
+/* -- Broadcast ladder stability pass --------------------------------------- */
+.chain-of-greed {
+  --chain-panel-blue: #78d7ff;
+  --chain-panel-gold: #f7c85b;
+  --chain-panel-red: #ff6868;
+  background:
+    linear-gradient(180deg, rgba(7, 13, 24, 0.96), rgba(3, 6, 12, 0.98)),
+    radial-gradient(circle at 50% 4%, rgba(88, 169, 255, 0.22), transparent 40%);
+}
+
+.chain-of-greed__shell {
+  max-width: 37rem;
+  gap: 0.55rem;
+}
+
+.chain-of-greed__header {
+  border-radius: 0.8rem;
+  background: linear-gradient(180deg, rgba(12, 22, 39, 0.92), rgba(6, 12, 23, 0.88));
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
+}
+
+.chain-of-greed__hero-stage {
+  grid-template-rows: minmax(4.6rem, auto) minmax(23rem, 1fr) minmax(3.15rem, auto);
+  gap: 0.55rem;
+  min-height: clamp(31rem, 72dvh, 39rem);
+  padding: 0.72rem 0.75rem 0.7rem;
+  border-radius: 1.05rem;
+  background:
+    linear-gradient(180deg, rgba(12, 24, 42, 0.92), rgba(5, 10, 18, 0.96)),
+    radial-gradient(circle at 50% 48%, rgba(94, 190, 255, 0.14), transparent 44%);
+}
+
+.chain-of-greed__hero-meta {
+  align-content: start;
+  min-height: 4.6rem;
+  padding: 0.5rem 0.62rem;
+  border: 1px solid rgba(133, 180, 255, 0.12);
+  border-radius: 0.8rem;
+  background: rgba(2, 8, 18, 0.42);
+}
+
+.chain-of-greed__status-kicker,
+.chain-of-greed__phase-chip {
+  font-size: 0.58rem;
+  letter-spacing: 0.13em;
+}
+
+.chain-of-greed__commentary {
+  min-height: 2.3rem;
+  max-width: 24rem;
+  display: grid;
+  align-items: center;
+  padding: 0.25rem 0.45rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.035);
+  color: rgba(244, 248, 255, 0.92);
+}
+
+.chain-of-greed__stage-core {
+  min-height: 23rem;
+  padding: 0;
+}
+
+.chain-of-greed__ladder-stage {
+  width: min(100%, 22rem);
+  min-height: 23rem;
+  grid-template-rows: minmax(18rem, 1fr) 3.2rem;
+  gap: 0;
+  padding: 0.6rem 0.45rem 0.2rem;
+  border-radius: 0.95rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015));
+  box-shadow: inset 0 0 0 1px rgba(133, 180, 255, 0.08);
+}
+
+.chain-of-greed__ladder-track {
+  height: 100%;
+  min-height: 18rem;
+  padding: 0.8rem 0 0.8rem;
+}
+
+.chain-of-greed__ladder-track::before {
+  top: 1rem;
+  bottom: 1rem;
+  width: 10px;
+  background: linear-gradient(180deg, rgba(255, 104, 104, 0.52), rgba(247, 200, 91, 0.78) 28%, rgba(120, 215, 255, 0.9) 62%, rgba(48, 101, 218, 0.44));
+}
+
+.chain-of-greed__ladder-track::after {
+  top: 1rem;
+  height: 24%;
+  opacity: 0.62;
+}
+
+.chain-of-greed__ladder-node {
+  opacity: 0.32;
+  transition: opacity 180ms ease, filter 180ms ease;
+}
+
+.chain-of-greed__ladder-node--cleared {
+  opacity: 0.68;
+}
+
+.chain-of-greed__ladder-node--next {
+  opacity: 0.9;
+  filter: drop-shadow(0 0 12px rgba(247, 200, 91, 0.2));
+}
+
+.chain-of-greed__ladder-node--active {
+  opacity: 1;
+  filter: drop-shadow(0 0 18px rgba(120, 215, 255, 0.28));
+}
+
+.chain-of-greed__ladder-node--active .chain-of-greed__ladder-dot,
+.chain-of-greed__ladder-node--reference .chain-of-greed__ladder-dot {
+  width: 1.24rem;
+  height: 1.24rem;
+}
+
+.chain-of-greed__ladder-step-copy strong {
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.chain-of-greed__ladder-node:not(.chain-of-greed__ladder-node--active):not(.chain-of-greed__ladder-node--next):not(.chain-of-greed__ladder-node--cleared) .chain-of-greed__ladder-step-copy strong {
+  color: rgba(210, 223, 255, 0.5);
+}
+
+.chain-of-greed__current-anchor-main {
+  min-height: 3.1rem;
+}
+
+.chain-of-greed__number-tag {
+  min-width: 3.8rem;
+  min-height: 2.45rem;
+  border-radius: 0.75rem;
+  font-size: 1.75rem;
+  background: linear-gradient(180deg, rgba(9, 24, 43, 0.96), rgba(21, 54, 88, 0.92));
+  box-shadow: 0 0 0 1px rgba(120, 215, 255, 0.22), 0 16px 28px rgba(0, 0, 0, 0.28);
+}
+
+.chain-of-greed__current-badge {
+  border-radius: 0.45rem;
+  background: rgba(120, 215, 255, 0.16);
+}
+
+.chain-of-greed__reveal {
+  min-width: min(100%, 18rem);
+  min-height: 3rem;
+  border-radius: 0.8rem;
+  padding: 0.48rem 0.85rem;
+  background: rgba(5, 12, 24, 0.82);
+  border: 1px solid rgba(133, 180, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.025);
+}
+
+.chain-of-greed__reveal-comparison {
+  font-size: 1.08rem;
+}
+
+.chain-of-greed__reveal-verdict {
+  color: rgba(232, 241, 255, 0.8);
+}
+
+.chain-of-greed__reveal--success {
+  border-color: rgba(120, 215, 255, 0.34);
+  background: rgba(8, 28, 45, 0.88);
+}
+
+.chain-of-greed__reveal--bank {
+  border-color: rgba(247, 200, 91, 0.42);
+  background: rgba(40, 30, 5, 0.88);
+}
+
+.chain-of-greed__reveal--danger {
+  border-color: rgba(255, 104, 104, 0.38);
+  background: rgba(42, 10, 14, 0.88);
+}
+
+.chain-of-greed__hero-status {
+  min-height: 3.15rem;
+  align-content: center;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid rgba(133, 180, 255, 0.1);
+  border-radius: 0.75rem;
+  background: rgba(2, 8, 18, 0.36);
+}
+
+.chain-of-greed__inline-status {
+  width: 100%;
+  justify-content: space-around;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+}
+
+.chain-of-greed__inline-status span:not(:last-child)::after {
+  content: none;
+}
+
+.chain-of-greed__action-bar {
+  padding: 0.45rem 0.5rem max(env(safe-area-inset-bottom, 0px), 0.45rem);
+  border: 1px solid rgba(133, 180, 255, 0.12);
+  border-radius: 0.85rem;
+  background: rgba(3, 9, 18, 0.72);
+}
+
+.chain-of-greed__buttons {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.chain-of-greed__action,
+.chain-of-greed__continue {
+  min-height: 2.45rem;
+  border-radius: 0.65rem;
+  font-size: 0.82rem;
+}
+
+.chain-of-greed__action--bank:disabled:not(.chain-of-greed__action--spent) {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(238, 244, 255, 0.48);
+  transform: none;
+  box-shadow: none;
+}
+
+.chain-of-greed__ai-waiting {
+  min-height: 2.45rem;
+  padding: 0 0.65rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.chain-of-greed__event-log {
+  min-height: 2.35rem;
+}
+
+.chain-of-greed__log-ticker {
+  min-height: 2.35rem;
+  border: 1px solid rgba(133, 180, 255, 0.1);
+  background: rgba(3, 9, 18, 0.58);
+}
+
+.chain-of-greed__player-rail {
+  grid-auto-columns: minmax(10.5rem, 46%);
+  padding-block: 0.15rem 0.35rem;
+  margin-top: 0;
+}
+
+.chain-of-greed__rail-card {
+  min-height: 2.75rem;
+  border: 1px solid rgba(133, 180, 255, 0.09);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.chain-of-greed__rail-card--current {
+  border-color: rgba(120, 215, 255, 0.42);
+  background: rgba(50, 136, 218, 0.13);
+}
+
+.chain-of-greed__rail-card--human {
+  border-color: rgba(247, 200, 91, 0.28);
+}
+
+.chain-of-greed__vote-card {
+  border: 1px solid rgba(133, 180, 255, 0.12);
+}
+
+@media (max-width: 420px) {
+  .chain-of-greed__hero-stage {
+    min-height: clamp(29rem, 70dvh, 36rem);
+    grid-template-rows: minmax(4.8rem, auto) minmax(21rem, 1fr) minmax(3.2rem, auto);
+  }
+
+  .chain-of-greed__stage-core,
+  .chain-of-greed__ladder-stage {
+    min-height: 21rem;
+  }
+
+  .chain-of-greed__ladder-stage {
+    width: min(100%, 18.5rem);
+  }
+
+  .chain-of-greed__player-rail {
+    grid-auto-columns: minmax(9.7rem, 58%);
+  }
+}

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -1114,6 +1114,27 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
   const isBankUsedThisTurn = Boolean(actionTargetKind && !isBankAvailable(bankedTurn, actionTargetId, actionTargetKind));
   const isBankEmpty = activePot <= 0;
   const isActionLocked = Boolean(pendingTurn);
+  const boardModeLabel = state.phase === 'finalTurn'
+    ? 'Final 2'
+    : state.phase === 'semifinalTurn'
+      ? 'Final 3'
+      : state.phase === 'playerTurn'
+        ? `Round ${state.roundNumber}`
+        : heroPhaseChip;
+  const turnClockLabel = state.phase === 'finalTurn'
+    ? `${Math.min(state.finalTurnIndex + 1, Math.max(state.finalOrder.length, 1))}/${Math.max(state.finalOrder.length, 1)}`
+    : state.phase === 'semifinalTurn'
+      ? `${Math.min(state.semifinalTurnIndex + 1, Math.max(state.semifinalOrder.length, 1))}/${Math.max(state.semifinalOrder.length, 1)}`
+      : state.phase === 'playerTurn'
+        ? `${state.turnsRemaining} turns`
+        : `R${state.roundNumber}`;
+  const actorMetricLabel = currentActor ? playerMetricText(currentActor) : `${activePlayers.length} live`;
+  const scoreStripItems = [
+    { label: 'Players', value: `${activePlayers.length}/${state.startingCount}` },
+    { label: 'Secured', value: state.securedTotal.toLocaleString() },
+    { label: 'Mode', value: boardModeLabel },
+    { label: 'Clock', value: finalSecondsRemaining !== null ? `${finalSecondsRemaining}s` : turnClockLabel },
+  ];
   useEffect(() => {
     if (!bankedTurn) return;
     if (!actionTargetId || !actionTargetKind || bankedTurn.actorId !== actionTargetId || bankedTurn.kind !== actionTargetKind) {
@@ -1220,6 +1241,15 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             }}
             transition={{ duration: 0.34, ease: 'easeOut' }}
           >
+            <div className="chain-of-greed__score-strip" data-testid="chain-score-strip" aria-label="Chain of Greed scoreboard">
+              {scoreStripItems.map((item) => (
+                <div key={item.label} className="chain-of-greed__score-tile">
+                  <span>{item.label}</span>
+                  <strong>{item.value}</strong>
+                </div>
+              ))}
+            </div>
+
             <div className="chain-of-greed__hero-meta">
               <div className="chain-of-greed__hero-topline">
                 <span className="chain-of-greed__status-kicker">{heroKicker}</span>
@@ -1237,8 +1267,20 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                 )}
               </div>
               <p className="chain-of-greed__commentary">{heroCommentary}</p>
+              <div className="chain-of-greed__actor-strip" data-testid="chain-actor-strip">
+                <div className="chain-of-greed__actor-token" aria-hidden="true">
+                  {currentActor?.avatar ?? 'BB'}
+                </div>
+                <div className="chain-of-greed__actor-copy">
+                  <span>{isHumanTurn ? 'You are playing' : currentActor ? 'Now playing' : 'Broadcast board'}</span>
+                  <strong>{currentActor?.name ?? heroPhaseChip}</strong>
+                </div>
+                <div className="chain-of-greed__actor-meter">
+                  <span>{actorMetricLabel}</span>
+                </div>
+              </div>
             </div>
-            <div className="chain-of-greed__stage-core">
+            <div className="chain-of-greed__stage-core" data-testid="chain-broadcast-board">
               <AnimatePresence initial={false}>
                 {lastTurn && heroTone !== 'neutral' && (
                   <motion.div
@@ -1270,11 +1312,19 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                   </motion.aside>
                 )}
               </AnimatePresence>
-              <button
-                type="button"
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label="View full ladder"
                 className="chain-of-greed__ladder-stage"
                 data-testid="chain-ladder-stage"
                 onClick={() => setIsLadderSheetOpen(true)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    setIsLadderSheetOpen(true);
+                  }
+                }}
               >
                 <div className={`chain-of-greed__number-aura chain-of-greed__number-aura--${heroTone}`} aria-hidden="true" />
                 <ol className="chain-of-greed__ladder-track" aria-label="Current chain ladder">
@@ -1337,8 +1387,9 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                     </span>
                   </div>
                 )}
-                <AnimatePresence initial={false}>
-                  {showTurnReveal ? (
+                <div className="chain-of-greed__outcome-slot" data-testid="chain-outcome-slot" aria-live="polite">
+                  <AnimatePresence initial={false}>
+                    {showTurnReveal ? (
                     <motion.div
                       className={`chain-of-greed__reveal chain-of-greed__reveal--${heroTone}`}
                       data-testid="chain-turn-reveal"
@@ -1375,8 +1426,12 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                       Next reveal <strong>{state.revealedNumber}</strong>
                     </motion.div>
                   )}
-                </AnimatePresence>
-              </button>
+                  </AnimatePresence>
+                  {!showTurnReveal && !(state.revealedNumber !== null && state.revealedNumber !== referenceNumber) && (
+                    <div className="chain-of-greed__outcome-placeholder">Awaiting reveal</div>
+                  )}
+                </div>
+              </div>
             </div>
             <div className="chain-of-greed__hero-status">
               <div className="chain-of-greed__inline-status" data-testid="chain-inline-status">
@@ -1403,9 +1458,14 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.24 }}
             >
-              <button
-                type="button"
-                className="chain-of-greed__action-info"
+              <div className="chain-of-greed__action-cue" data-testid="chain-action-cue">
+                <span>{isHumanTurn ? 'Choose move' : 'Watching'}</span>
+                <strong>{currentActor?.name ?? 'House'}</strong>
+              </div>
+              <div className="chain-of-greed__action-controls">
+                <button
+                  type="button"
+                  className="chain-of-greed__action-info"
                 aria-label="Open help"
                 onClick={() => setState((previous) => ({ ...previous, showHelp: !previous.showHelp }))}
               >
@@ -1445,6 +1505,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                   <span>{getAiWaitingText(pendingTurn, isBankUsedThisTurn)}</span>
                 </div>
               )}
+              </div>
             </motion.footer>
           )}
 

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -1315,7 +1315,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
               <div
                 role="button"
                 tabIndex={0}
-                aria-label="View full ladder"
+                aria-label="Open chain ladder board"
                 className="chain-of-greed__ladder-stage"
                 data-testid="chain-ladder-stage"
                 onClick={() => setIsLadderSheetOpen(true)}

--- a/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
+++ b/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
@@ -49,6 +49,12 @@ describe('ChainOfGreed component', () => {
     expect(screen.queryByText(/Bank is safe, but the first correct guess starts the value/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/First correct call starts the climb/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('chain-ladder-stage')).toBeInTheDocument();
+    expect(screen.getByTestId('chain-score-strip')).toHaveTextContent(/Players/i);
+    expect(screen.getByTestId('chain-score-strip')).toHaveTextContent(/Secured/i);
+    expect(screen.getByTestId('chain-actor-strip')).toHaveTextContent(/You/i);
+    expect(screen.getByTestId('chain-broadcast-board')).toBeInTheDocument();
+    expect(screen.getByTestId('chain-outcome-slot')).toHaveTextContent(/Awaiting reveal/i);
+    expect(screen.getByTestId('chain-action-cue')).toHaveTextContent(/Choose move/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Step 0\/8/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Next 50/i);
     expect(screen.getByRole('button', { name: /View full ladder/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Reworks Chain of Greed as a React-structured broadcast board instead of a CSS-only skin.
- Adds a live scoreboard strip, actor strip, keyboard-accessible ladder board, stable outcome slot, and action dock around the higher/lower/bank controls.
- Keeps the existing scoring, AI, voting, banking, and Final 2 timer logic intact while improving the main play surface.
- Adds component assertions for the new board zones so this does not regress back to loose layout-only rendering.

## Notes
- This is still a draft PR so it can be smoke-tested visually before merging.
- The earlier CSS-only ladder pass remains folded into the broader styling pass for now; it can be trimmed further after visual review if desired.

## Validation
- GitHub Actions CI passed on the latest branch head.
- GitHub Actions Lint passed on the latest branch head.
- No local checkout was used, per the earlier GitHub-only constraint.