### PR TITLE
Simplify Chain of Greed board layout

### DIFF
--- a/src/components/ChainOfGreed/ChainOfGreed.css
+++ b/src/components/ChainOfGreed/ChainOfGreed.css
@@ -1877,3 +1877,355 @@
     display: none;
   }
 }
+
+
+/* -- Corrective simplification pass ---------------------------------------- */
+.chain-of-greed__shell {
+  max-width: 43rem;
+  gap: 0.45rem;
+}
+
+.chain-of-greed__header {
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.9rem;
+}
+
+.chain-of-greed__hero-stage {
+  grid-template-rows: minmax(2.3rem, auto) minmax(23.5rem, 1fr) minmax(2.8rem, auto);
+  gap: 0.48rem;
+  min-height: clamp(29rem, 70dvh, 37rem);
+  padding: 0.68rem;
+  border-radius: 1rem;
+}
+
+.chain-of-greed__hero-meta {
+  min-height: 0;
+  padding: 0.35rem 0.45rem;
+  border: 0;
+  background: transparent;
+}
+
+.chain-of-greed__hero-topline {
+  justify-content: space-between;
+}
+
+.chain-of-greed__stage-core {
+  grid-template-columns: minmax(14rem, 1fr) minmax(10rem, 0.72fr);
+  align-items: stretch;
+  justify-items: stretch;
+  gap: 0.65rem;
+  min-height: 23.5rem;
+  padding: 0;
+}
+
+.chain-of-greed__hero-impact,
+.chain-of-greed__side-callout,
+.chain-of-greed__score-strip,
+.chain-of-greed__actor-strip,
+.chain-of-greed__outcome-slot,
+.chain-of-greed__outcome-placeholder,
+.chain-of-greed__action-cue,
+.chain-of-greed__action-controls {
+  display: none;
+}
+
+.chain-of-greed__ladder-stage {
+  width: 100%;
+  min-height: 23.5rem;
+  grid-template-rows: 1fr;
+  padding: 0.65rem 0.45rem;
+  border-radius: 0.9rem;
+  background: rgba(4, 10, 20, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(125, 171, 255, 0.11);
+}
+
+.chain-of-greed__ladder-track {
+  min-height: 20rem;
+  padding: 0.7rem 0 0.55rem;
+}
+
+.chain-of-greed__ladder-track::before {
+  width: 9px;
+  opacity: 0.88;
+  box-shadow: 0 0 18px rgba(107, 200, 255, 0.22);
+}
+
+.chain-of-greed__ladder-track::after {
+  opacity: 0.36;
+}
+
+.chain-of-greed__ladder-node {
+  opacity: 0.24;
+}
+
+.chain-of-greed__ladder-node--cleared {
+  opacity: 0.56;
+}
+
+.chain-of-greed__ladder-node--next {
+  opacity: 0.8;
+}
+
+.chain-of-greed__ladder-node--active,
+.chain-of-greed__ladder-node--reference {
+  opacity: 1;
+}
+
+.chain-of-greed__ladder-step-copy strong {
+  font-size: 0.82rem;
+}
+
+.chain-of-greed__current-cluster {
+  right: 0.2rem;
+}
+
+.chain-of-greed__number-tag {
+  min-width: 3.25rem;
+  min-height: 2.25rem;
+  border-radius: 0.58rem;
+  font-size: 1.55rem;
+}
+
+.chain-of-greed__participant-panel {
+  min-width: 0;
+  min-height: 23.5rem;
+  display: grid;
+  grid-template-rows: auto minmax(5.4rem, auto) auto 1fr;
+  align-content: start;
+  gap: 0.72rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(125, 171, 255, 0.12);
+  border-radius: 0.9rem;
+  background: rgba(4, 10, 20, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.chain-of-greed__participant-panel--success {
+  border-color: rgba(120, 215, 255, 0.24);
+}
+
+.chain-of-greed__participant-panel--bank {
+  border-color: rgba(247, 200, 91, 0.28);
+}
+
+.chain-of-greed__participant-panel--danger {
+  border-color: rgba(255, 104, 104, 0.28);
+}
+
+.chain-of-greed__participant-topline {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.chain-of-greed__participant-avatar {
+  width: 2.15rem;
+  height: 2.15rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(120, 215, 255, 0.14);
+  color: #eef6ff;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.chain-of-greed__participant-name {
+  min-width: 0;
+  display: grid;
+  gap: 0.08rem;
+}
+
+.chain-of-greed__participant-name span,
+.chain-of-greed__participant-status {
+  font-size: 0.64rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(190, 211, 255, 0.72);
+}
+
+.chain-of-greed__participant-name strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1.05rem;
+}
+
+.chain-of-greed__participant-number {
+  min-height: 5.4rem;
+  display: grid;
+  place-items: center;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.045);
+  color: #f7fbff;
+  font-size: clamp(1.9rem, 7vw, 3.1rem);
+  font-weight: 900;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.chain-of-greed__participant-panel--danger .chain-of-greed__participant-number {
+  color: #ffb8b8;
+}
+
+.chain-of-greed__participant-panel--bank .chain-of-greed__participant-number {
+  color: #ffe39a;
+}
+
+.chain-of-greed__participant-status {
+  min-height: 1.2rem;
+  color: rgba(247, 200, 91, 0.88);
+}
+
+.chain-of-greed__participant-detail {
+  min-height: 4.2rem;
+  display: grid;
+  align-items: start;
+  margin: 0;
+  color: rgba(232, 240, 255, 0.82);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.chain-of-greed__hero-status {
+  min-height: 2.75rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.72rem;
+}
+
+.chain-of-greed__action-bar {
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.45rem;
+  padding: 0.45rem 0.5rem max(env(safe-area-inset-bottom, 0px), 0.45rem);
+}
+
+.chain-of-greed__buttons {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.chain-of-greed__action,
+.chain-of-greed__continue {
+  min-height: 2.55rem;
+}
+
+.chain-of-greed__event-log {
+  min-height: 2.2rem;
+}
+
+.chain-of-greed__log-ticker {
+  min-height: 2.2rem;
+  padding: 0.34rem 0.55rem;
+}
+
+.chain-of-greed__player-rail {
+  --rail-card-min-width: 7.75rem;
+  grid-auto-columns: minmax(7.75rem, 9.5rem);
+  gap: 0.38rem;
+  padding-block: 0.08rem 0.25rem;
+}
+
+.chain-of-greed__rail-card {
+  min-height: 2.35rem;
+  gap: 0.34rem;
+  padding: 0.26rem 0.36rem;
+  border-radius: 0.62rem;
+}
+
+.chain-of-greed__rail-avatar {
+  width: 1.55rem;
+  height: 1.55rem;
+  overflow: hidden;
+  flex: 0 0 auto;
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.chain-of-greed__rail-copy {
+  min-width: 0;
+}
+
+.chain-of-greed__rail-copy strong,
+.chain-of-greed__rail-copy span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chain-of-greed__rail-copy strong {
+  font-size: 0.78rem;
+}
+
+.chain-of-greed__rail-copy span {
+  font-size: 0.68rem;
+}
+
+.chain-of-greed__rail-badge {
+  min-width: 1.12rem;
+  height: 1.12rem;
+  border-radius: 0.38rem;
+  font-size: 0.58rem;
+}
+
+@media (max-width: 560px) {
+  .chain-of-greed__shell {
+    max-width: 100%;
+    padding-inline: 0.65rem;
+  }
+
+  .chain-of-greed__hero-stage {
+    grid-template-rows: minmax(2.3rem, auto) minmax(22rem, 1fr) minmax(2.8rem, auto);
+    min-height: clamp(27rem, 68dvh, 35rem);
+  }
+
+  .chain-of-greed__stage-core {
+    grid-template-columns: minmax(11.2rem, 1fr) minmax(8.6rem, 0.8fr);
+    gap: 0.45rem;
+    min-height: 22rem;
+  }
+
+  .chain-of-greed__ladder-stage,
+  .chain-of-greed__participant-panel {
+    min-height: 22rem;
+  }
+
+  .chain-of-greed__participant-panel {
+    padding: 0.62rem;
+    gap: 0.52rem;
+  }
+
+  .chain-of-greed__participant-number {
+    min-height: 4.4rem;
+  }
+
+  .chain-of-greed__participant-detail {
+    font-size: 0.74rem;
+  }
+
+  .chain-of-greed__player-rail {
+    grid-auto-columns: minmax(7.1rem, 8.5rem);
+  }
+}
+
+@media (max-width: 390px) {
+  .chain-of-greed__stage-core {
+    grid-template-columns: minmax(10.2rem, 1fr) minmax(7.8rem, 0.78fr);
+  }
+
+  .chain-of-greed__participant-name strong {
+    font-size: 0.9rem;
+  }
+
+  .chain-of-greed__participant-number {
+    font-size: 1.75rem;
+  }
+}

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -186,7 +186,7 @@ function getPlayerInitials(name: string) {
 function getSafeAvatarDisplay(player: ChainOfGreedPlayerState | null) {
   if (!player) return 'BB';
   const avatar = player.avatar.trim();
-  const looksLikeRawImageText = /profile|photo|image|avatar|https?:|[\/]|[a-f0-9]{8}/i.test(avatar);
+  const looksLikeRawImageText = /profile|photo|image|avatar|https?:|[/]|[a-f0-9]{8}/i.test(avatar);
   if (!avatar || avatar.length > 4 || looksLikeRawImageText) return getPlayerInitials(player.name);
   return avatar;
 }

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -1068,7 +1068,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
   });
   const lastTurn = state.turnHistory[0] ?? null;
   const turnComparisonSymbol = pendingTurn?.choice ? (momentGlyphs[pendingTurn.choice] ?? null) : null;
-  const showTurnReveal = Boolean(pendingTurn && pendingTurn.stage !== 'decision' && (pendingTurn.choice === 'bank' || pendingTurn.resolution.revealedNumber !== null));
   const heroKicker = isHumanTurn
     ? 'YOUR TURN'
     : currentActor

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -176,6 +176,21 @@ function getPlayer(players: ChainOfGreedPlayerState[], id: string | null) {
   return players.find((player) => player.id === id) ?? null;
 }
 
+function getPlayerInitials(name: string) {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  const first = words[0]?.[0] ?? 'P';
+  const second = words.length > 1 ? words[1]?.[0] : words[0]?.[1];
+  return `${first}${second ?? ''}`.toUpperCase();
+}
+
+function getSafeAvatarDisplay(player: ChainOfGreedPlayerState | null) {
+  if (!player) return 'BB';
+  const avatar = player.avatar.trim();
+  const looksLikeRawImageText = /profile|photo|image|avatar|https?:|[\/]|[a-f0-9]{8}/i.test(avatar);
+  if (!avatar || avatar.length > 4 || looksLikeRawImageText) return getPlayerInitials(player.name);
+  return avatar;
+}
+
 function buildIndividualOrder(ids: string[], turnsPerPlayer: number) {
   return Array.from({ length: turnsPerPlayer }, () => ids).flat();
 }
@@ -1114,27 +1129,39 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
   const isBankUsedThisTurn = Boolean(actionTargetKind && !isBankAvailable(bankedTurn, actionTargetId, actionTargetKind));
   const isBankEmpty = activePot <= 0;
   const isActionLocked = Boolean(pendingTurn);
-  const boardModeLabel = state.phase === 'finalTurn'
-    ? 'Final 2'
-    : state.phase === 'semifinalTurn'
-      ? 'Final 3'
-      : state.phase === 'playerTurn'
-        ? `Round ${state.roundNumber}`
-        : heroPhaseChip;
-  const turnClockLabel = state.phase === 'finalTurn'
-    ? `${Math.min(state.finalTurnIndex + 1, Math.max(state.finalOrder.length, 1))}/${Math.max(state.finalOrder.length, 1)}`
-    : state.phase === 'semifinalTurn'
-      ? `${Math.min(state.semifinalTurnIndex + 1, Math.max(state.semifinalOrder.length, 1))}/${Math.max(state.semifinalOrder.length, 1)}`
-      : state.phase === 'playerTurn'
-        ? `${state.turnsRemaining} turns`
-        : `R${state.roundNumber}`;
-  const actorMetricLabel = currentActor ? playerMetricText(currentActor) : `${activePlayers.length} live`;
-  const scoreStripItems = [
-    { label: 'Players', value: `${activePlayers.length}/${state.startingCount}` },
-    { label: 'Secured', value: state.securedTotal.toLocaleString() },
-    { label: 'Mode', value: boardModeLabel },
-    { label: 'Clock', value: finalSecondsRemaining !== null ? `${finalSecondsRemaining}s` : turnClockLabel },
-  ];
+  const panelActor = pendingTurn ? getPlayer(state.players, pendingTurn.actorId) : currentActor;
+  const panelActorName = panelActor?.name ?? pendingTurn?.actorName ?? heroPhaseChip;
+  const panelAvatar = getSafeAvatarDisplay(panelActor);
+  const panelModeLabel = pendingTurn
+    ? getActionVerb(pendingTurn.choice)
+    : isHumanTurn
+      ? 'YOUR TURN'
+      : currentActor
+        ? 'READING THE BOARD'
+        : heroKicker;
+  const panelNumberLabel = pendingTurn
+    && pendingTurn.choice !== 'bank'
+    && pendingTurn.stage !== 'decision'
+    && pendingTurn.resolution.revealedNumber !== null
+    ? `${pendingTurn.referenceNumber} ${turnComparisonSymbol ?? ''} ${pendingTurn.resolution.revealedNumber}`
+    : `${referenceNumber}`;
+  const panelStatusText = pendingTurn
+    ? pendingTurn.stage === 'decision'
+      ? 'LOCKED IN'
+      : pendingTurn.verdictText.toUpperCase()
+    : isHumanTurn
+      ? 'Choose move'
+      : currentActor
+        ? 'Reading the board'
+        : heroCommentary;
+  const panelDetailText = pendingTurn
+    ? pendingTurn.stage === 'decision'
+      ? `Pot ${currentPotLabel} - Next ${nextRewardValueLabel}`
+      : pendingTurn.choice === 'bank'
+        ? `+${Math.max(pendingTurn.resolution.securedDelta, pendingTurn.resolution.individualDelta).toLocaleString()} secured - Current ${pendingTurn.resolution.updatedChain.referenceNumber}`
+        : pendingTurn.consequenceText
+    : `Pot ${currentPotLabel} - Next ${nextRewardValueLabel}`;
+  const panelTone = pendingTurn ? pendingTurn.tone : heroTone;
   useEffect(() => {
     if (!bankedTurn) return;
     if (!actionTargetId || !actionTargetKind || bankedTurn.actorId !== actionTargetId || bankedTurn.kind !== actionTargetKind) {
@@ -1179,7 +1206,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             data-testid={`chain-player-${player.id}`}
             ref={(element) => { playerCardRefs.current[player.id] = element; }}
           >
-            <div className="chain-of-greed__rail-avatar">{player.avatar}</div>
+            <div className="chain-of-greed__rail-avatar">{getSafeAvatarDisplay(player)}</div>
             <div className="chain-of-greed__rail-copy">
               <strong>{player.name}</strong>
               <span>{playerMetricText(player)}</span>
@@ -1241,15 +1268,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             }}
             transition={{ duration: 0.34, ease: 'easeOut' }}
           >
-            <div className="chain-of-greed__score-strip" data-testid="chain-score-strip" aria-label="Chain of Greed scoreboard">
-              {scoreStripItems.map((item) => (
-                <div key={item.label} className="chain-of-greed__score-tile">
-                  <span>{item.label}</span>
-                  <strong>{item.value}</strong>
-                </div>
-              ))}
-            </div>
-
             <div className="chain-of-greed__hero-meta">
               <div className="chain-of-greed__hero-topline">
                 <span className="chain-of-greed__status-kicker">{heroKicker}</span>
@@ -1266,19 +1284,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                   <span className="chain-of-greed__phase-chip">{heroPhaseChip}</span>
                 )}
               </div>
-              <p className="chain-of-greed__commentary">{heroCommentary}</p>
-              <div className="chain-of-greed__actor-strip" data-testid="chain-actor-strip">
-                <div className="chain-of-greed__actor-token" aria-hidden="true">
-                  {currentActor?.avatar ?? 'BB'}
-                </div>
-                <div className="chain-of-greed__actor-copy">
-                  <span>{isHumanTurn ? 'You are playing' : currentActor ? 'Now playing' : 'Broadcast board'}</span>
-                  <strong>{currentActor?.name ?? heroPhaseChip}</strong>
-                </div>
-                <div className="chain-of-greed__actor-meter">
-                  <span>{actorMetricLabel}</span>
-                </div>
-              </div>
             </div>
             <div className="chain-of-greed__stage-core" data-testid="chain-broadcast-board">
               <AnimatePresence initial={false}>
@@ -1292,24 +1297,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.55, ease: 'easeOut' }}
                   />
-                )}
-              </AnimatePresence>
-              {/* Left-side callout: temporary turn messages that must NOT overlay the ladder spine */}
-              <AnimatePresence>
-                {pendingTurn && pendingTurn.stage !== 'decision' && (
-                  <motion.aside
-                    className={`chain-of-greed__side-callout chain-of-greed__side-callout--${pendingTurn.tone}`}
-                    aria-live="polite"
-                    initial={{ opacity: 0, x: -12 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: -8 }}
-                    transition={{ duration: 0.22 }}
-                  >
-                    <span className="chain-of-greed__side-callout-text">{pendingTurn.verdictText}</span>
-                    {(pendingTurn.stage === 'consequence' || pendingTurn.stage === 'ladderUpdate' || pendingTurn.stage === 'settle') && (
-                      <span className="chain-of-greed__side-callout-sub">{pendingTurn.consequenceText}</span>
-                    )}
-                  </motion.aside>
                 )}
               </AnimatePresence>
               <div
@@ -1387,51 +1374,22 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                     </span>
                   </div>
                 )}
-                <div className="chain-of-greed__outcome-slot" data-testid="chain-outcome-slot" aria-live="polite">
-                  <AnimatePresence initial={false}>
-                    {showTurnReveal ? (
-                    <motion.div
-                      className={`chain-of-greed__reveal chain-of-greed__reveal--${heroTone}`}
-                      data-testid="chain-turn-reveal"
-                      initial={{ opacity: 0, y: 8 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -8 }}
-                    >
-                      {pendingTurn?.choice === 'bank' ? (
-                        <>
-                          <span className="chain-of-greed__reveal-comparison">
-                            <strong>{Math.max(pendingTurn.resolution.securedDelta, pendingTurn.resolution.individualDelta).toLocaleString()}</strong>
-                            <span>{turnComparisonSymbol}</span>
-                          </span>
-                          <span className="chain-of-greed__reveal-verdict">{pendingTurn.verdictText}</span>
-                        </>
-                      ) : (
-                        <>
-                          <span className="chain-of-greed__reveal-comparison">
-                            <strong>{pendingTurn?.referenceNumber}</strong>
-                            <span>{turnComparisonSymbol}</span>
-                            <strong>{pendingTurn?.resolution.revealedNumber}</strong>
-                          </span>
-                          <span className="chain-of-greed__reveal-verdict">{pendingTurn?.verdictText}</span>
-                        </>
-                      )}
-                    </motion.div>
-                  ) : state.revealedNumber !== null && state.revealedNumber !== referenceNumber && (
-                    <motion.div
-                      className={`chain-of-greed__reveal chain-of-greed__reveal--${heroTone}`}
-                      initial={{ opacity: 0, y: 8 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -8 }}
-                    >
-                      Next reveal <strong>{state.revealedNumber}</strong>
-                    </motion.div>
-                  )}
-                  </AnimatePresence>
-                  {!showTurnReveal && !(state.revealedNumber !== null && state.revealedNumber !== referenceNumber) && (
-                    <div className="chain-of-greed__outcome-placeholder">Awaiting reveal</div>
-                  )}
-                </div>
               </div>
+              <aside className={[
+                'chain-of-greed__participant-panel',
+                `chain-of-greed__participant-panel--${panelTone}`,
+              ].filter(Boolean).join(' ')} data-testid="chain-participant-panel" aria-live="polite">
+                <div className="chain-of-greed__participant-topline">
+                  <span className="chain-of-greed__participant-avatar" aria-hidden="true">{panelAvatar}</span>
+                  <div className="chain-of-greed__participant-name">
+                    <span>{panelModeLabel}</span>
+                    <strong>{panelActorName}</strong>
+                  </div>
+                </div>
+                <div className="chain-of-greed__participant-number">{panelNumberLabel}</div>
+                <div className="chain-of-greed__participant-status">{panelStatusText}</div>
+                <p className="chain-of-greed__participant-detail">{panelDetailText}</p>
+              </aside>
             </div>
             <div className="chain-of-greed__hero-status">
               <div className="chain-of-greed__inline-status" data-testid="chain-inline-status">
@@ -1458,12 +1416,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.24 }}
             >
-              <div className="chain-of-greed__action-cue" data-testid="chain-action-cue">
-                <span>{isHumanTurn ? 'Choose move' : 'Watching'}</span>
-                <strong>{currentActor?.name ?? 'House'}</strong>
-              </div>
-              <div className="chain-of-greed__action-controls">
-                <button
+              <button
                   type="button"
                   className="chain-of-greed__action-info"
                 aria-label="Open help"
@@ -1505,7 +1458,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                   <span>{getAiWaitingText(pendingTurn, isBankUsedThisTurn)}</span>
                 </div>
               )}
-              </div>
             </motion.footer>
           )}
 

--- a/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
+++ b/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
@@ -49,12 +49,13 @@ describe('ChainOfGreed component', () => {
     expect(screen.queryByText(/Bank is safe, but the first correct guess starts the value/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/First correct call starts the climb/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('chain-ladder-stage')).toBeInTheDocument();
-    expect(screen.getByTestId('chain-score-strip')).toHaveTextContent(/Players/i);
-    expect(screen.getByTestId('chain-score-strip')).toHaveTextContent(/Secured/i);
-    expect(screen.getByTestId('chain-actor-strip')).toHaveTextContent(/You/i);
+    expect(screen.queryByTestId('chain-score-strip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('chain-outcome-slot')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('chain-action-cue')).not.toBeInTheDocument();
     expect(screen.getByTestId('chain-broadcast-board')).toBeInTheDocument();
-    expect(screen.getByTestId('chain-outcome-slot')).toHaveTextContent(/Awaiting reveal/i);
-    expect(screen.getByTestId('chain-action-cue')).toHaveTextContent(/Choose move/i);
+    const participantPanel = screen.getByTestId('chain-participant-panel');
+    expect(participantPanel).toHaveTextContent(/You/i);
+    expect(participantPanel).toHaveTextContent(/Choose move/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Step 0\/8/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Next 50/i);
     expect(screen.getByRole('button', { name: /View full ladder/i })).toBeInTheDocument();
@@ -116,6 +117,23 @@ describe('ChainOfGreed component', () => {
     expect(screen.getAllByText('Max').length).toBeGreaterThan(0);
   });
 
+  it('falls back to initials instead of rendering raw profile image text', () => {
+    vi.useFakeTimers();
+    const imageTextParticipants = [
+      { ...participants[0], name: 'Ate Three', avatar: 'profile photo:photo-d34feb7a-7c42-4864-a8e2-23fa285c69af-1783205172715' },
+      ...participants.slice(1),
+    ];
+
+    render(<ChainOfGreed participants={imageTextParticipants} seed={42} onFinish={() => {}} />);
+
+    act(() => {
+      vi.advanceTimersByTime(950);
+    });
+
+    expect(screen.queryByText(/profile photo/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/photo-d34/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('chain-participant-panel')).toHaveTextContent(/AT/i);
+  });
   it('keeps banking unavailable until the chain has a pot', () => {
     vi.useFakeTimers();
     render(<ChainOfGreed participants={participants} seed={42} onFinish={() => {}} />);


### PR DESCRIPTION
## Summary
- Corrects the previous Chain of Greed redesign by removing dashboard-like clutter from the live screen.
- Re-centers the experience on one vertical ladder plus one fixed participant/info panel.
- Removes the four-card score grid, actor strip, outcome placeholder box, action cue, and floating side result callout.
- Compacts the player rail and adds avatar fallback handling so raw profile-photo filenames do not render in the UI.
- Updates component tests for the simplified layout and avatar fallback behavior.

## Validation
- GitHub Actions CI passed on `e1f8525`.
- GitHub Actions Lint passed on `e1f8525`.
- No local checkout was used; edits were made directly through GitHub per the earlier constraint.