### PR TITLE
Compact Chain of Greed and add LOH final

### DIFF
--- a/src/components/ChainOfGreed/ChainOfGreed.css
+++ b/src/components/ChainOfGreed/ChainOfGreed.css
@@ -2229,3 +2229,99 @@
     font-size: 1.75rem;
   }
 }
+
+
+/* -- Extra compact LOH final pass ------------------------------------------ */
+.chain-of-greed__hero-stage {
+  grid-template-rows: minmax(24.5rem, 1fr) minmax(2.55rem, auto);
+  min-height: clamp(27rem, 68dvh, 35.5rem);
+  gap: 0.4rem;
+}
+
+.chain-of-greed__hero-meta,
+.chain-of-greed__event-log,
+.chain-of-greed__action-info {
+  display: none;
+}
+
+.chain-of-greed__stage-core {
+  min-height: 24.5rem;
+}
+
+.chain-of-greed__ladder-stage,
+.chain-of-greed__participant-panel {
+  min-height: 24.5rem;
+}
+
+.chain-of-greed__participant-panel {
+  grid-template-rows: auto minmax(4.7rem, auto) auto auto minmax(0, 1fr);
+  gap: 0.55rem;
+  padding: 0.72rem;
+}
+
+.chain-of-greed__participant-detail {
+  min-height: 2.55rem;
+}
+
+.chain-of-greed__participant-log {
+  min-height: 3.1rem;
+  display: grid;
+  align-content: start;
+  gap: 0.18rem;
+  padding-top: 0.52rem;
+  border-top: 1px solid rgba(125, 171, 255, 0.12);
+}
+
+.chain-of-greed__participant-log span {
+  font-size: 0.58rem;
+  font-weight: 900;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: rgba(190, 211, 255, 0.62);
+}
+
+.chain-of-greed__participant-log strong {
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  color: rgba(238, 244, 255, 0.88);
+  font-size: 0.74rem;
+  line-height: 1.28;
+}
+
+.chain-of-greed__action-bar {
+  grid-template-columns: 1fr;
+  padding: 0.38rem 0.45rem max(env(safe-area-inset-bottom, 0px), 0.38rem);
+}
+
+.chain-of-greed__buttons {
+  gap: 0.38rem;
+}
+
+.chain-of-greed__action,
+.chain-of-greed__continue {
+  min-height: 2.4rem;
+}
+
+.chain-of-greed__player-rail {
+  padding-block: 0.02rem 0.18rem;
+}
+
+@media (max-width: 560px) {
+  .chain-of-greed__hero-stage {
+    grid-template-rows: minmax(23.5rem, 1fr) minmax(2.55rem, auto);
+    min-height: clamp(26rem, 66dvh, 34rem);
+  }
+
+  .chain-of-greed__stage-core,
+  .chain-of-greed__ladder-stage,
+  .chain-of-greed__participant-panel {
+    min-height: 23.5rem;
+  }
+
+  .chain-of-greed__participant-detail {
+    min-height: 2.25rem;
+  }
+}

--- a/src/components/ChainOfGreed/ChainOfGreed.tsx
+++ b/src/components/ChainOfGreed/ChainOfGreed.tsx
@@ -16,6 +16,7 @@ import {
   formatInfluence,
   getStandardRoundEliminationCount,
   getStandardRoundTurnCap,
+  rankFinalPlayersByScore,
   rankPlayersByScore,
   resolveChainAction,
   resolveChainOfGreedParticipants,
@@ -154,6 +155,8 @@ const FAST_FINAL_BANK_PIPELINE_DURATIONS: Record<TurnPipelineStage, number> = {
   ladderUpdate: 120,
   settle: 120,
 };
+
+const STANDARD_ROUND_COUNT = 5;
 
 function emitSoundCue(cue: string) {
   if (typeof window === 'undefined') return;
@@ -362,7 +365,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
   const [pendingTurn, setPendingTurn] = useState<PendingTurnPipeline | null>(null);
   const [bankedTurn, setBankedTurn] = useState<{ actorId: string; kind: TurnPhaseKind } | null>(null);
   const [isResultCommitted, setIsResultCommitted] = useState(false);
-  const [logExpanded, setLogExpanded] = useState(false);
   const [finalSecondsRemaining, setFinalSecondsRemaining] = useState<number | null>(null);
   const [finalDetailExpanded, setFinalDetailExpanded] = useState(false);
   const rngRef = useRef(createChainOfGreedRng(props.seed));
@@ -554,7 +556,11 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
           latestMoment: getLatestMoment(turn.choice, turn.resolution),
           ...(turn.kind === 'semifinal'
             ? { semifinalScore: nextScore }
-            : { finalScore: nextScore }),
+            : {
+              finalScore: nextScore,
+              finalWrongGuesses: player.finalWrongGuesses + (turn.resolution.wasCorrect === false ? 1 : 0),
+              finalBanks: player.finalBanks + (turn.choice === 'bank' ? 1 : 0),
+            }),
         };
       });
       const nextHistory: ChainOfGreedTurnRecord[] = [turn.historyEntry, ...previous.turnHistory].slice(0, 10);
@@ -745,11 +751,13 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
   function startFinal() {
     const finalists = getActivePlayers(state.players);
     const ids = finalists.map((player) => player.id);
-    // Timed final: each player gets one 30-second window (not interleaved turns)
     const chains = Object.fromEntries(ids.map((id) => [id, createInitialChainState(rngRef.current.rng)]));
     const scores = Object.fromEntries(ids.map((id) => [id, 0]));
+    const nextPlayers = state.players.map((player) => ids.includes(player.id)
+      ? { ...player, finalScore: 0, finalWrongGuesses: 0, finalBanks: 0, latestMoment: null }
+      : player);
     const firstPlayerId = ids[0] ?? null;
-    const firstPlayer = getPlayer(state.players, firstPlayerId);
+    const firstPlayer = getPlayer(nextPlayers, firstPlayerId);
     const firstIsHuman = Boolean(firstPlayer?.isHuman);
     setPendingTurn(null);
     setBankedTurn(null);
@@ -757,16 +765,17 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
     setState((previous) => ({
       ...previous,
       phase: 'finalTurn',
+      players: nextPlayers,
+      roundNumber: STANDARD_ROUND_COUNT + 1,
       finalOrder: ids,
       finalTurnIndex: 0,
       finalScores: scores,
       finalChains: chains,
       finalTieBreak: null,
-      // Only start a real-time timer for human players; AI windows are simulated instantly
       finalTimerExpiry: firstIsHuman ? Date.now() + FINAL_ROUND_DURATION_MS : null,
       finalTimerPausedRemaining: null,
-      statusText: '30-second Final. Bank as much as possible.',
-      helperText: nextHelper(FINAL_HELPERS),
+      statusText: 'Round 6 Final. Bank the highest individual score.',
+      helperText: 'Ties use fewer mistakes, then fewer banks.',
       revealedNumber: chains[firstPlayerId ?? '']?.referenceNumber ?? Object.values(chains)[0]?.referenceNumber ?? null,
     }));
   }
@@ -777,7 +786,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
     setState((previous) => {
       const nextTurnIndex = previous.finalTurnIndex + 1;
       if (nextTurnIndex >= previous.finalOrder.length) {
-        const ranking = rankPlayersByScore(previous.finalScores, previous.players, rngRef.current.rng);
+        const ranking = rankFinalPlayersByScore(previous.finalScores, previous.players, rngRef.current.rng);
         emitSoundCue('winner-stinger');
         return {
           ...previous,
@@ -813,6 +822,8 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
     const rng = rngRef.current.rng;
     let chain = startChain;
     let score = startScore;
+    let mistakes = 0;
+    let banks = 0;
     const simTurns = 6 + Math.floor(rng() * 7); // 6–12 representative turns for AI final simulation
     let bankAvailableForSim = true;
     for (let i = 0; i < simTurns; i++) {
@@ -827,6 +838,8 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
       });
       const resolution = resolveChainAction(choice, chain, rng);
       score += resolution.individualDelta;
+      mistakes += resolution.wasCorrect === false ? 1 : 0;
+      banks += choice === 'bank' ? 1 : 0;
       chain = resolution.updatedChain;
       bankAvailableForSim = choice !== 'bank';
     }
@@ -834,7 +847,14 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
       const nextScores = { ...previous.finalScores, [aiPlayer.id]: score };
       const nextChains = { ...previous.finalChains, [aiPlayer.id]: chain };
       const nextPlayers = previous.players.map((player) =>
-        player.id === aiPlayer.id ? { ...player, finalScore: score } : player,
+        player.id === aiPlayer.id
+          ? {
+            ...player,
+            finalScore: score,
+            finalWrongGuesses: player.finalWrongGuesses + mistakes,
+            finalBanks: player.finalBanks + banks,
+          }
+          : player,
       );
       return { ...previous, players: nextPlayers, finalScores: nextScores, finalChains: nextChains };
     });
@@ -843,10 +863,10 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
 
   function continueAfterElimination() {
     const remaining = getActivePlayers(state.players);
-    if (remaining.length === 2) {
+    if (state.roundNumber >= STANDARD_ROUND_COUNT || remaining.length <= 2) {
       setPhase('finalIntro', {
-        statusText: 'Two players remain. Final showdown.',
-        helperText: 'Winner claims everything.',
+        statusText: `Round ${STANDARD_ROUND_COUNT + 1}: LOH final.`,
+        helperText: 'Every active player gets one 30-second chain.',
       });
       return;
     }
@@ -1161,6 +1181,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
         : pendingTurn.consequenceText
     : `Pot ${currentPotLabel} - Next ${nextRewardValueLabel}`;
   const panelTone = pendingTurn ? pendingTurn.tone : heroTone;
+  const participantLogText = lastTurn?.message ?? 'Live feed - no turns yet';
   useEffect(() => {
     if (!bankedTurn) return;
     if (!actionTargetId || !actionTargetKind || bankedTurn.actorId !== actionTargetId || bankedTurn.kind !== actionTargetKind) {
@@ -1267,23 +1288,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             }}
             transition={{ duration: 0.34, ease: 'easeOut' }}
           >
-            <div className="chain-of-greed__hero-meta">
-              <div className="chain-of-greed__hero-topline">
-                <span className="chain-of-greed__status-kicker">{heroKicker}</span>
-                {state.phase === 'playerTurn' ? (
-                  <button
-                    type="button"
-                    className="chain-of-greed__phase-chip chain-of-greed__phase-chip--info"
-                    aria-label="View full ladder"
-                    onClick={() => setIsLadderSheetOpen(true)}
-                  >
-                    <span className="chain-of-greed__phase-chip-icon" aria-hidden="true">ℹ️</span>
-                  </button>
-                ) : (
-                  <span className="chain-of-greed__phase-chip">{heroPhaseChip}</span>
-                )}
-              </div>
-            </div>
             <div className="chain-of-greed__stage-core" data-testid="chain-broadcast-board">
               <AnimatePresence initial={false}>
                 {lastTurn && heroTone !== 'neutral' && (
@@ -1388,6 +1392,10 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
                 <div className="chain-of-greed__participant-number">{panelNumberLabel}</div>
                 <div className="chain-of-greed__participant-status">{panelStatusText}</div>
                 <p className="chain-of-greed__participant-detail">{panelDetailText}</p>
+                <div className="chain-of-greed__participant-log" data-testid="chain-participant-log">
+                  <span>Log</span>
+                  <strong>{participantLogText}</strong>
+                </div>
               </aside>
             </div>
             <div className="chain-of-greed__hero-status">
@@ -1415,14 +1423,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.24 }}
             >
-              <button
-                  type="button"
-                  className="chain-of-greed__action-info"
-                aria-label="Open help"
-                onClick={() => setState((previous) => ({ ...previous, showHelp: !previous.showHelp }))}
-              >
-                <span aria-hidden="true">ℹ️</span>
-              </button>
               {isHumanTurn ? (
                 <div className="chain-of-greed__buttons">
                   <button
@@ -1460,37 +1460,6 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             </motion.footer>
           )}
 
-          <div className="chain-of-greed__event-log" data-testid="chain-event-log">
-            {state.turnHistory.length === 0 ? (
-              <div className="chain-of-greed__log-ticker">
-                <span className="chain-of-greed__log-ticker-text">Live feed — no turns yet</span>
-              </div>
-            ) : (
-              <div className="chain-of-greed__log-ticker">
-                <span className="chain-of-greed__log-ticker-actor">{state.turnHistory[0]?.actorName}</span>
-                <span className="chain-of-greed__log-ticker-text">{state.turnHistory[0]?.message}</span>
-                {state.turnHistory.length > 1 && (
-                  <button
-                    type="button"
-                    className="chain-of-greed__log-expand"
-                    aria-expanded={logExpanded}
-                    onClick={() => setLogExpanded((prev) => !prev)}
-                  >
-                    {logExpanded ? '▲' : `+${state.turnHistory.length - 1}`}
-                  </button>
-                )}
-                {logExpanded && (
-                  <ol className="chain-of-greed__log-history">
-                    {state.turnHistory.slice(1).map((entry, index) => (
-                      <li key={`${entry.actorId}-${index}-${entry.referenceNumber}-${entry.choice}`}>
-                        <strong>{entry.actorName}</strong> — {entry.message}
-                      </li>
-                    ))}
-                  </ol>
-                )}
-              </div>
-            )}
-          </div>
 
           {playerRail}
         </main>
@@ -1570,9 +1539,9 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
               <li>Guess higher or lower to grow the chain from 50 up to 1300.</li>
               <li>Bank secures the active pot, keeps the reference number, and resets the chain.</li>
               <li>A wrong guess destroys only the active pot. Equal numbers count as a miss.</li>
-              <li>Standard rounds end with weakest-link votes until 2 players remain.</li>
-              <li>Final 2 uses individual timed scoring. Only the winner claims the secured influence total.</li>
-              <li>Only the final winner claims the secured influence total. Everyone else gets 0.</li>
+              <li>There are five standard rounds, each ending with weakest-link votes.</li>
+              <li>Round 6 is the LOH final: every active player gets 30 seconds to build an individual chain.</li>
+              <li>Highest final score becomes LOH. Ties use fewer final mistakes, then fewer final banks.</li>
             </ul>
             <button type="button" className="chain-of-greed__continue" onClick={() => setState((previous) => ({ ...previous, showHelp: false }))}>Close Help</button>
           </div>
@@ -1688,7 +1657,7 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
             )}
             {!(humanPlayer && state.eliminatedThisStep.includes(humanPlayer.id)) && (
               <button type="button" className="chain-of-greed__continue" onClick={continueAfterElimination}>
-                {getActivePlayers(state.players).length === 2 ? 'Continue to Final' : `Continue to Round ${state.roundNumber + 1}`}
+                {state.roundNumber >= STANDARD_ROUND_COUNT || getActivePlayers(state.players).length <= 2 ? 'Continue to Final' : `Continue to Round ${state.roundNumber + 1}`}
               </button>
             )}
           </div>
@@ -1730,9 +1699,9 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
       {state.phase === 'finalIntro' && (
         <div className="chain-of-greed__overlay">
           <div className="chain-of-greed__modal chain-of-greed__modal--hero">
-            <div className="chain-of-greed__eyebrow">Final 2: 30-Second Showdown</div>
-            <h2>30 seconds each. Bank as much as possible.</h2>
-            <p>Each finalist gets 30 seconds to build and bank. Whoever banks more wins {formatInfluence(state.securedTotal)}.</p>
+            <div className="chain-of-greed__eyebrow">Round 6: LOH Final</div>
+            <h2>30 seconds each. Highest chain score wins.</h2>
+            <p>Every active player gets one timed chain. Ties use fewer mistakes, then fewer banks.</p>
             <button type="button" className="chain-of-greed__continue" onClick={startFinal}>Start Final</button>
           </div>
         </div>
@@ -1742,8 +1711,8 @@ export default function ChainOfGreed(props: GenericMinigameProps) {
         <div className="chain-of-greed__overlay">
           <div className="chain-of-greed__modal chain-of-greed__modal--hero">
             <div className="chain-of-greed__eyebrow">Winner</div>
-            <h2>{winner?.name ?? 'A finalist'} claims {formatInfluence(state.securedTotal)}</h2>
-            <p>All other players leave with nothing.</p>
+            <h2>{winner?.name ?? 'A finalist'} becomes LOH</h2>
+            <p>Highest final score wins. Ties use fewer mistakes, then fewer banks.</p>
             <div className="chain-of-greed__summary-grid">
               {Object.entries(state.finalScores).map(([id, score]) => (
                 <div key={id}><span>{getPlayer(state.players, id)?.name ?? id}</span><strong>{score}</strong></div>

--- a/src/components/ChainOfGreed/chainOfGreedLogic.ts
+++ b/src/components/ChainOfGreed/chainOfGreedLogic.ts
@@ -49,6 +49,8 @@ export interface ChainOfGreedPlayerState extends ChainOfGreedResolvedParticipant
   voteCount: number;
   semifinalScore: number;
   finalScore: number;
+  finalWrongGuesses: number;
+  finalBanks: number;
   turnsTakenThisRound: number;
   personality: ChainOfGreedPersonality;
   lastRoundPerformance: number;
@@ -191,6 +193,8 @@ export function createChainOfGreedPlayers(
       voteCount: 0,
       semifinalScore: 0,
       finalScore: 0,
+      finalWrongGuesses: 0,
+      finalBanks: 0,
       turnsTakenThisRound: 0,
       personality: {
         aggression,
@@ -659,6 +663,56 @@ export function rankPlayersByScore(scores: Record<string, number>, players: Chai
       type: 'duel' as const,
       message: 'Scores were tied, so sudden death decided it.',
       transcript: duel.transcript,
+    },
+  };
+}
+
+export function rankFinalPlayersByScore(scores: Record<string, number>, players: ChainOfGreedPlayerState[], rng: () => number) {
+  const contenders = players.filter((player) => !player.isEliminated);
+  const compareFinalists = (left: ChainOfGreedPlayerState, right: ChainOfGreedPlayerState) => {
+    const scoreDelta = (scores[right.id] ?? 0) - (scores[left.id] ?? 0);
+    if (scoreDelta !== 0) return scoreDelta;
+    const mistakeDelta = left.finalWrongGuesses - right.finalWrongGuesses;
+    if (mistakeDelta !== 0) return mistakeDelta;
+    return left.finalBanks - right.finalBanks;
+  };
+  const sorted = [...contenders].sort(compareFinalists);
+  const top = sorted[0];
+  if (!top) return { ordered: sorted, tieBreak: null as ChainOfGreedTieBreakInfo | null };
+
+  const scoreTied = sorted.filter((player) => (scores[player.id] ?? 0) === (scores[top.id] ?? 0));
+  if (scoreTied.length <= 1) return { ordered: sorted, tieBreak: null as ChainOfGreedTieBreakInfo | null };
+
+  const statBest = scoreTied[0]!;
+  const fullyTied = scoreTied.filter((player) =>
+    player.finalWrongGuesses === statBest.finalWrongGuesses && player.finalBanks === statBest.finalBanks,
+  );
+  if (fullyTied.length <= 1) {
+    return {
+      ordered: sorted,
+      tieBreak: {
+        type: 'stats' as const,
+        message: 'Final score tied. Fewer mistakes, then fewer banks decided the LOH.',
+        transcript: scoreTied.map((player) => `${player.name}: score ${scores[player.id] ?? 0}, mistakes ${player.finalWrongGuesses}, banks ${player.finalBanks}`),
+      },
+    };
+  }
+
+  const duel = resolveSuddenDeathDuel(fullyTied, rng);
+  const duelOrderedIds = duel.orderedIds;
+  const ordered = [
+    ...duelOrderedIds.map((id) => sorted.find((player) => player.id === id)!).filter(Boolean),
+    ...sorted.filter((player) => !duelOrderedIds.includes(player.id)),
+  ];
+  return {
+    ordered,
+    tieBreak: {
+      type: 'duel' as const,
+      message: 'Final score, mistakes, and banks were tied; sudden death decided the LOH.',
+      transcript: [
+        ...fullyTied.map((player) => `${player.name}: score ${scores[player.id] ?? 0}, mistakes ${player.finalWrongGuesses}, banks ${player.finalBanks}`),
+        ...duel.transcript,
+      ],
     },
   };
 }

--- a/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
+++ b/tests/unit/chain-of-greed/ChainOfGreed.component.test.tsx
@@ -1,7 +1,11 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ChainOfGreed from '../../../src/components/ChainOfGreed/ChainOfGreed';
-import { CHAIN_TURN_PIPELINE_DURATIONS } from '../../../src/components/ChainOfGreed/chainOfGreedLogic';
+import {
+  CHAIN_TURN_PIPELINE_DURATIONS,
+  rankFinalPlayersByScore,
+  type ChainOfGreedPlayerState,
+} from '../../../src/components/ChainOfGreed/chainOfGreedLogic';
 
 const TURN_PIPELINE_MS = Object.values(CHAIN_TURN_PIPELINE_DURATIONS).reduce((total, value) => total + value, 0);
 
@@ -52,13 +56,16 @@ describe('ChainOfGreed component', () => {
     expect(screen.queryByTestId('chain-score-strip')).not.toBeInTheDocument();
     expect(screen.queryByTestId('chain-outcome-slot')).not.toBeInTheDocument();
     expect(screen.queryByTestId('chain-action-cue')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('chain-event-log')).not.toBeInTheDocument();
     expect(screen.getByTestId('chain-broadcast-board')).toBeInTheDocument();
     const participantPanel = screen.getByTestId('chain-participant-panel');
     expect(participantPanel).toHaveTextContent(/You/i);
     expect(participantPanel).toHaveTextContent(/Choose move/i);
+    expect(screen.getByTestId('chain-participant-log')).toHaveTextContent(/Live feed/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Step 0\/8/i);
     expect(screen.getByTestId('chain-inline-status')).toHaveTextContent(/Next 50/i);
-    expect(screen.getByRole('button', { name: /View full ladder/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /View full ladder/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open chain ladder board' })).toBeInTheDocument();
     expect(screen.getByLabelText('Current chain ladder')).toBeInTheDocument();
     const ladderStage = screen.getByTestId('chain-ladder-stage');
     const higherButton = screen.getByRole('button', { name: 'Higher' });
@@ -68,7 +75,7 @@ describe('ChainOfGreed component', () => {
     expect(higherButton.compareDocumentPosition(playerRail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByTestId('chain-current-anchor')).toBeInTheDocument();
     expect(screen.queryByText(/Current pot 0/i)).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Open help' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Open help' })).toHaveLength(1);
     expect(screen.getAllByText('Max').length).toBeGreaterThan(0);
     expect(screen.getByTestId('chain-ladder-stage')).not.toHaveTextContent(/Next\s+Next/i);
     expect(screen.queryByText(/Step 0\/8 • Pot 0 • Next 50/i)).not.toBeInTheDocument();
@@ -94,13 +101,15 @@ describe('ChainOfGreed component', () => {
     expect(screen.queryByText(/is reading the board/i)).not.toBeInTheDocument();
   });
 
-  it('shows a reusable help overlay with the bank and equal-number rules', () => {
+  it('shows a reusable help overlay with the bank, equal-number, and LOH final rules', () => {
     render(<ChainOfGreed participants={participants} seed={7} onFinish={() => {}} />);
 
     fireEvent.click(screen.getByRole('button', { name: /open help/i }));
 
     expect(screen.getByText(/Bank secures the active pot/i)).toBeInTheDocument();
     expect(screen.getByText(/Equal numbers count as a miss/i)).toBeInTheDocument();
+    expect(screen.getByText(/five standard rounds/i)).toBeInTheDocument();
+    expect(screen.getByText(/Round 6 is the LOH final/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Close Help' }));
     expect(screen.queryByText(/Bank secures the active pot/i)).not.toBeInTheDocument();
   });
@@ -112,7 +121,7 @@ describe('ChainOfGreed component', () => {
       expect(screen.getByRole('button', { name: 'Higher' })).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /View full ladder/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open chain ladder board' }));
     expect(screen.getByText('Chain rewards')).toBeInTheDocument();
     expect(screen.getAllByText('Max').length).toBeGreaterThan(0);
   });
@@ -134,6 +143,43 @@ describe('ChainOfGreed component', () => {
     expect(screen.queryByText(/photo-d34/i)).not.toBeInTheDocument();
     expect(screen.getByTestId('chain-participant-panel')).toHaveTextContent(/AT/i);
   });
+
+  it('breaks final score ties by fewer mistakes, then fewer banks', () => {
+    const makePlayer = (id: string, finalWrongGuesses: number, finalBanks: number) => ({
+      ...participants[0],
+      id,
+      name: id.toUpperCase(),
+      avatar: id,
+      isHuman: false,
+      isEliminated: false,
+      totalContribution: 0,
+      roundContribution: 0,
+      roundCorrectGuesses: 0,
+      roundWrongGuesses: 0,
+      roundBanks: 0,
+      roundBusts: 0,
+      totalCorrectGuesses: 0,
+      totalWrongGuesses: 0,
+      totalBanks: 0,
+      totalBusts: 0,
+      voteCount: 0,
+      semifinalScore: 0,
+      finalScore: 500,
+      finalWrongGuesses,
+      finalBanks,
+      turnsTakenThisRound: 0,
+      personality: { aggression: 0.5, caution: 0.5, volatility: 0.5, social: 0.5 },
+      lastRoundPerformance: 0,
+      latestMoment: null,
+    }) as ChainOfGreedPlayerState;
+
+    const players = [makePlayer('a', 1, 0), makePlayer('b', 0, 2), makePlayer('c', 0, 1)];
+    const ranking = rankFinalPlayersByScore({ a: 500, b: 500, c: 500 }, players, () => 0.5);
+
+    expect(ranking.ordered.map((player) => player.id)).toEqual(['c', 'b', 'a']);
+    expect(ranking.tieBreak?.message).toMatch(/Fewer mistakes/i);
+  });
+
   it('keeps banking unavailable until the chain has a pot', () => {
     vi.useFakeTimers();
     render(<ChainOfGreed participants={participants} seed={42} onFinish={() => {}} />);


### PR DESCRIPTION
## Summary
- Tightens the Chain of Greed live board by removing the redundant top turn row, action info button, and standalone event-log row.
- Moves the live turn log into the right participant panel under the pot/next detail.
- Adds the new five-standard-round structure: after round 5, remaining active players enter the Round 6 LOH final.
- Tracks final-only mistakes and banks for tie resolution: highest final score wins, then fewer mistakes, then fewer banks.
- Updates help/rules text and component tests for the compact layout and LOH final tie rule.

## Validation
- GitHub Actions Lint passed on `8cf41b9`.
- GitHub Actions CI passed on `8cf41b9`.
- No local checkout was used; edits were made directly through GitHub/browser/API paths.