### PR TITLE
[codex] Add Big Spender minigame

### DIFF
--- a/src/components/BigSpender/BigSpender.css
+++ b/src/components/BigSpender/BigSpender.css
@@ -1,0 +1,415 @@
+.big-spender {
+  min-height: 100dvh;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  padding: calc(env(safe-area-inset-top, 0px) + 0.7rem) 0.75rem calc(env(safe-area-inset-bottom, 0px) + 0.7rem);
+  box-sizing: border-box;
+  color: #f8fbff;
+  background:
+    radial-gradient(circle at 20% 0%, rgba(255, 210, 96, 0.2), transparent 30%),
+    radial-gradient(circle at 84% 18%, rgba(80, 190, 255, 0.18), transparent 28%),
+    linear-gradient(180deg, #111620 0%, #070b12 100%);
+  overflow: hidden;
+}
+
+.big-spender h1,
+.big-spender h2,
+.big-spender p {
+  margin: 0;
+}
+
+.big-spender__header,
+.big-spender__status-panel,
+.big-spender__players,
+.big-spender__actions,
+.big-spender__modal {
+  border: 1px solid rgba(213, 226, 255, 0.14);
+  background: rgba(7, 12, 20, 0.72);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(18px);
+}
+
+.big-spender__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.85rem;
+}
+
+.big-spender__title-block {
+  min-width: 0;
+  display: grid;
+  gap: 0.12rem;
+}
+
+.big-spender__title-block h1 {
+  font-size: clamp(1.15rem, 3.8vw, 1.75rem);
+  line-height: 1.05;
+}
+
+.big-spender__eyebrow,
+.big-spender__timer span,
+.big-spender__save-counter,
+.big-spender__wallet-generation,
+.big-spender__player-copy span {
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: rgba(211, 225, 255, 0.7);
+}
+
+.big-spender__timer {
+  flex: 0 0 auto;
+  min-width: 5.25rem;
+  display: grid;
+  justify-items: end;
+  gap: 0.08rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.big-spender__timer strong {
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.big-spender__status-panel {
+  display: grid;
+  grid-template-columns: minmax(7rem, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4.2rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.8rem;
+}
+
+.big-spender__status-panel > div {
+  min-width: 0;
+  display: grid;
+  gap: 0.1rem;
+}
+
+.big-spender__status-panel strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.big-spender__status-panel p {
+  min-width: 0;
+  color: rgba(239, 245, 255, 0.9);
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.big-spender__save-counter {
+  justify-self: end;
+  padding: 0.28rem 0.46rem;
+  border-radius: 0.45rem;
+  background: rgba(247, 198, 83, 0.14);
+  color: #ffe4a3;
+  white-space: nowrap;
+}
+
+.big-spender__table {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 17rem);
+  gap: 0.65rem;
+}
+
+.big-spender__board {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-auto-rows: minmax(4.3rem, 1fr);
+  gap: 0.45rem;
+}
+
+.big-spender__wallet {
+  appearance: none;
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  align-content: end;
+  justify-items: start;
+  min-width: 0;
+  min-height: 4.3rem;
+  padding: 0.48rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.55rem;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: inset 0 -18px 40px rgba(0, 0, 0, 0.22), 0 10px 20px rgba(0, 0, 0, 0.18);
+}
+
+.big-spender__wallet:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.big-spender__wallet:focus-visible {
+  outline: 2px solid rgba(255, 232, 160, 0.95);
+  outline-offset: 2px;
+}
+
+.big-spender__wallet--color-0 { background: linear-gradient(145deg, #2e7d64, #153d36); }
+.big-spender__wallet--color-1 { background: linear-gradient(145deg, #9f6231, #4a2413); }
+.big-spender__wallet--color-2 { background: linear-gradient(145deg, #315ea3, #172a4c); }
+.big-spender__wallet--color-3 { background: linear-gradient(145deg, #8c3f62, #3f1b2d); }
+.big-spender__wallet--color-4 { background: linear-gradient(145deg, #6b6f33, #303315); }
+.big-spender__wallet--color-5 { background: linear-gradient(145deg, #4e5880, #202638); }
+
+.big-spender__wallet-flap {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 48%;
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.big-spender__wallet-id {
+  position: relative;
+  z-index: 1;
+  font-size: 1.15rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.big-spender__wallet-generation {
+  position: relative;
+  z-index: 1;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.big-spender__players {
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  align-content: start;
+  gap: 0.45rem;
+  padding: 0.55rem;
+  border-radius: 0.8rem;
+}
+
+.big-spender__player {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 3rem;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.55rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.big-spender__player--current {
+  border-color: rgba(100, 198, 255, 0.52);
+  background: rgba(74, 167, 255, 0.12);
+}
+
+.big-spender__player--human {
+  box-shadow: inset 0 0 0 1px rgba(247, 198, 83, 0.18);
+}
+
+.big-spender__player--locked { opacity: 0.82; }
+.big-spender__player--zeroFinished { border-color: rgba(95, 232, 175, 0.4); }
+.big-spender__player--bombed { opacity: 0.5; border-color: rgba(255, 91, 91, 0.35); }
+
+.big-spender__avatar {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.big-spender__player-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.08rem;
+}
+
+.big-spender__player-copy strong,
+.big-spender__player-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.big-spender__player data {
+  font-size: 1rem;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  color: #ffe4a3;
+}
+
+.big-spender__actions {
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.75rem;
+}
+
+.big-spender__action,
+.big-spender__modal button {
+  appearance: none;
+  min-height: 2.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.5rem;
+  padding: 0 0.75rem;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+}
+
+.big-spender__action--lock,
+.big-spender__modal button:first-child {
+  background: linear-gradient(135deg, #e5ad36, #ffe08d);
+  color: #1c1404;
+}
+
+.big-spender__actions span {
+  color: rgba(235, 242, 255, 0.82);
+  font-size: 0.86rem;
+}
+
+.big-spender__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(2, 5, 10, 0.72);
+}
+
+.big-spender__modal {
+  width: min(100%, 28rem);
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.9rem;
+}
+
+.big-spender__modal--danger {
+  border-color: rgba(255, 91, 91, 0.36);
+}
+
+.big-spender__modal--results {
+  max-height: min(80dvh, 36rem);
+}
+
+.big-spender__modal h2 {
+  font-size: 1.35rem;
+}
+
+.big-spender__modal p {
+  color: rgba(235, 242, 255, 0.84);
+  line-height: 1.45;
+}
+
+.big-spender__modal-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+
+.big-spender__modal button:not(:first-child) {
+  background: rgba(255, 255, 255, 0.07);
+  color: #f8fbff;
+}
+
+.big-spender__ranking {
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.big-spender__ranking li {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  gap: 0.1rem 0.55rem;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: 0.55rem;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.big-spender__ranking span {
+  grid-row: span 2;
+  width: 1.6rem;
+  height: 1.6rem;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  font-weight: 900;
+}
+
+.big-spender__ranking strong,
+.big-spender__ranking em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.big-spender__ranking em {
+  font-style: normal;
+  color: rgba(218, 231, 255, 0.78);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 760px) {
+  .big-spender {
+    overflow-y: auto;
+  }
+
+  .big-spender__status-panel {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .big-spender__save-counter {
+    justify-self: start;
+  }
+
+  .big-spender__table {
+    grid-template-columns: 1fr;
+  }
+
+  .big-spender__board {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-auto-rows: 4.15rem;
+  }
+
+  .big-spender__players {
+    max-height: 13.5rem;
+  }
+}
+
+@media (max-width: 390px) {
+  .big-spender__board {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .big-spender__modal-actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { GenericMinigameProps } from '../../minigames/reactComponents';
+import { mulberry32 } from '../../store/rng';
+import {
+  BIG_SPENDER_CONFIG,
+  BIG_SPENDER_DISPLAY_NAME,
+  buildBigSpenderRawResults,
+  createInitialBigSpenderState,
+  decideAiShouldOpen,
+  finalizeBigSpenderByTimeout,
+  finishBigSpenderTurn,
+  getAiActionDelayMs,
+  isFunnyAmount,
+  lockBigSpenderPlayer,
+  openBigSpenderWallet,
+  rankBigSpenderPlayers,
+  resolveBigSpenderAdRescue,
+  resolveBigSpenderBonusOffer,
+  resolveBigSpenderParticipants,
+  type BigSpenderPlayerState,
+  type BigSpenderState,
+  type BigSpenderWallet,
+} from './bigSpenderLogic';
+import './BigSpender.css';
+
+const TICK_MS = 250;
+
+function formatTime(ms: number) {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = String(totalSeconds % 60).padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function getInitials(name: string) {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0])
+    .join('')
+    .toUpperCase() || 'P';
+}
+
+function getPlayerLabel(player: BigSpenderPlayerState) {
+  if (player.status === 'zeroFinished') return 'Zero';
+  if (player.status === 'bombed') return 'Bombed';
+  if (player.status === 'locked') return 'Locked';
+  if (player.finalizedAt != null) return 'Final';
+  return 'Active';
+}
+
+function getWalletAriaLabel(wallet: BigSpenderWallet) {
+  return `Open wallet ${wallet.boardSlotIndex + 1}, generation ${wallet.generationNumber}`;
+}
+
+function getOutcomeCopy(state: BigSpenderState) {
+  const event = state.events.find((entry) => entry.type === 'walletOpened' && entry.outcome);
+  if (!event?.outcome) return 'Pick a wallet. Spend down to zero without finding a bomb.';
+  if (event.outcome.type === 'bomb') return 'Bomb wallet. The room just got expensive.';
+  const amount = event.outcome.amount ?? 0;
+  const funny = isFunnyAmount(amount) ? ' House number hit.' : '';
+  if (amount < 0) return `Spent ${Math.abs(amount)} Eyeoleans.${funny}`;
+  return `Gained ${amount} Eyeoleans.${funny}`;
+}
+
+function chooseAiWallet(state: BigSpenderState, rng: () => number) {
+  const available = state.board.filter((wallet) => wallet.state === 'hidden');
+  return available[Math.floor(rng() * available.length)] ?? available[0] ?? null;
+}
+
+export default function BigSpender(props: GenericMinigameProps) {
+  const participants = useMemo(
+    () => resolveBigSpenderParticipants(props.participants, props.participantIds),
+    [props.participants, props.participantIds],
+  );
+  const seed = props.seed || 73_337;
+  const [state, setState] = useState(() => createInitialBigSpenderState(participants, seed));
+  const [remainingMs, setRemainingMs] = useState(state.timerDurationMs);
+  const [resultCommitted, setResultCommitted] = useState(false);
+  const aiRngRef = useRef(mulberry32((seed ^ 0x5eedcafe) >>> 0));
+  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentPlayer = useMemo(
+    () => state.players.find((player) => player.playerId === state.currentTurnPlayerId) ?? null,
+    [state.currentTurnPlayerId, state.players],
+  );
+  const humanPlayer = useMemo(() => state.players.find((player) => player.isHuman) ?? null, [state.players]);
+  const ranking = useMemo(() => rankBigSpenderPlayers(state.players), [state.players]);
+  const winner = ranking[0] ?? null;
+  const likelyWinningBalance = useMemo(() => {
+    const candidates = state.players.filter((player) => player.status !== 'bombed');
+    return Math.min(...candidates.map((player) => player.balance));
+  }, [state.players]);
+  const canHumanAct = Boolean(
+    currentPlayer?.isHuman &&
+    currentPlayer.status === 'active' &&
+    state.status === 'running' &&
+    !state.pendingAdRescue &&
+    !state.pendingBonus &&
+    !state.postWalletLockPlayerId,
+  );
+  const canPostWalletLock = Boolean(
+    humanPlayer && state.postWalletLockPlayerId === humanPlayer.playerId && state.status === 'running',
+  );
+
+  useEffect(() => {
+    if (state.status !== 'running' || state.timerPaused) return;
+    const timer = setInterval(() => {
+      setRemainingMs((remaining) => {
+        const next = Math.max(0, remaining - TICK_MS);
+        if (next === 0) {
+          setState((previous) => finalizeBigSpenderByTimeout(previous));
+        }
+        return next;
+      });
+    }, TICK_MS);
+    return () => clearInterval(timer);
+  }, [state.status, state.timerPaused]);
+
+  useEffect(() => {
+    if (aiTimerRef.current) {
+      clearTimeout(aiTimerRef.current);
+      aiTimerRef.current = null;
+    }
+    if (state.status !== 'running' || state.pendingAdRescue || state.postWalletLockPlayerId) return;
+
+    if (state.pendingBonus) {
+      const bonusPlayer = state.players.find((player) => player.playerId === state.pendingBonus?.playerId);
+      if (!bonusPlayer || bonusPlayer.isHuman) return;
+      aiTimerRef.current = setTimeout(() => {
+        setState((previous) => {
+          const actor = previous.players.find((player) => player.playerId === previous.pendingBonus?.playerId);
+          const accept = actor ? decideAiShouldOpen(actor.balance, aiRngRef.current, { secondsRemaining: Math.ceil(remainingMs / 1000), likelyWinningBalance }) : false;
+          return resolveBigSpenderBonusOffer(previous, accept);
+        });
+      }, 650);
+      return () => {
+        if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+      };
+    }
+
+    if (!currentPlayer || currentPlayer.isHuman || currentPlayer.status !== 'active') return;
+    const delay = getAiActionDelayMs(state.startingPlayerCount, aiRngRef.current);
+    aiTimerRef.current = setTimeout(() => {
+      setState((previous) => {
+        const actor = previous.players.find((player) => player.playerId === previous.currentTurnPlayerId);
+        if (!actor || actor.isHuman || actor.status !== 'active') return previous;
+        const shouldOpen = decideAiShouldOpen(actor.balance, aiRngRef.current, {
+          secondsRemaining: Math.ceil(remainingMs / 1000),
+          likelyWinningBalance,
+        });
+        if (!shouldOpen) return lockBigSpenderPlayer(previous, actor.playerId);
+        const wallet = chooseAiWallet(previous, aiRngRef.current);
+        if (!wallet) return finalizeBigSpenderByTimeout(previous);
+        return openBigSpenderWallet(previous, actor.playerId, wallet.walletId);
+      });
+    }, delay);
+    return () => {
+      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+    };
+  }, [currentPlayer, likelyWinningBalance, remainingMs, state]);
+
+  const openWallet = (walletId: string) => {
+    if (!currentPlayer || !canHumanAct) return;
+    setState((previous) => openBigSpenderWallet(previous, currentPlayer.playerId, walletId));
+  };
+
+  const lockHuman = () => {
+    if (!humanPlayer) return;
+    setState((previous) => lockBigSpenderPlayer(previous, humanPlayer.playerId));
+  };
+
+  const continueHumanTurn = () => {
+    setState((previous) => finishBigSpenderTurn(previous));
+  };
+
+  const finish = () => {
+    if (resultCommitted || !winner) return;
+    setResultCommitted(true);
+    props.onFinish?.(ranking.length - winner.rank + 1, 0, {
+      authoritativeWinnerId: winner.playerId,
+      rawValue: ranking.length - winner.rank + 1,
+      rawResults: buildBigSpenderRawResults(state.players),
+    });
+  };
+
+  return (
+    <div className="big-spender" data-testid="big-spender-game">
+      <header className="big-spender__header">
+        <div className="big-spender__title-block">
+          <span className="big-spender__eyebrow">Eyeoleans at risk</span>
+          <h1>{BIG_SPENDER_DISPLAY_NAME}</h1>
+        </div>
+        <div className="big-spender__timer" aria-label={`${formatTime(remainingMs)} remaining`}>
+          <span>{state.timerPaused ? 'Paused' : 'Clock'}</span>
+          <strong>{formatTime(remainingMs)}</strong>
+        </div>
+      </header>
+
+      <section className="big-spender__status-panel" aria-live="polite">
+        <div>
+          <span className="big-spender__eyebrow">Current turn</span>
+          <strong>{currentPlayer?.displayName ?? 'Results'}</strong>
+        </div>
+        <p>{getOutcomeCopy(state)}</p>
+        {humanPlayer && (
+          <span className="big-spender__save-counter">
+            Ad saves left: {BIG_SPENDER_CONFIG.maxAdBombRescues - humanPlayer.adBombRescuesUsed}
+          </span>
+        )}
+      </section>
+
+      <main className="big-spender__table">
+        <section className="big-spender__board" aria-label="Wallet board">
+          {state.board.map((wallet) => (
+            <button
+              key={wallet.walletId}
+              type="button"
+              className={`big-spender__wallet big-spender__wallet--color-${wallet.generationColor}`}
+              disabled={!canHumanAct || wallet.state !== 'hidden'}
+              onClick={() => openWallet(wallet.walletId)}
+              aria-label={getWalletAriaLabel(wallet)}
+            >
+              <span className="big-spender__wallet-flap" aria-hidden="true" />
+              <span className="big-spender__wallet-id">{wallet.boardSlotIndex + 1}</span>
+              <span className="big-spender__wallet-generation">G{wallet.generationNumber}</span>
+            </button>
+          ))}
+        </section>
+
+        <aside className="big-spender__players" aria-label="Player balances">
+          {state.players.map((player) => (
+            <article
+              key={player.playerId}
+              className={[
+                'big-spender__player',
+                player.currentTurn ? 'big-spender__player--current' : '',
+                player.isHuman ? 'big-spender__player--human' : '',
+                `big-spender__player--${player.status}`,
+              ].join(' ')}
+            >
+              <span className="big-spender__avatar" aria-hidden="true">{player.avatar || getInitials(player.displayName)}</span>
+              <div className="big-spender__player-copy">
+                <strong>{player.displayName}</strong>
+                <span>{getPlayerLabel(player)} - {player.walletsOpened} wallets</span>
+              </div>
+              <data value={player.balance}>{player.balance}</data>
+            </article>
+          ))}
+        </aside>
+      </main>
+
+      {canHumanAct && (
+        <footer className="big-spender__actions">
+          <button type="button" className="big-spender__action big-spender__action--lock" onClick={lockHuman}>
+            Lock
+          </button>
+          <span>Open any wallet or lock your balance.</span>
+        </footer>
+      )}
+
+      {canPostWalletLock && (
+        <div className="big-spender__overlay">
+          <div className="big-spender__modal">
+            <span className="big-spender__eyebrow">Lock window</span>
+            <h2>Keep that balance?</h2>
+            <p>You can lock now, or pass the turn and keep chasing zero next time.</p>
+            <div className="big-spender__modal-actions">
+              <button type="button" onClick={lockHuman}>Lock balance</button>
+              <button type="button" onClick={continueHumanTurn}>Keep playing</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {state.pendingBonus && humanPlayer?.playerId === state.pendingBonus.playerId && (
+        <div className="big-spender__overlay">
+          <div className="big-spender__modal">
+            <span className="big-spender__eyebrow">Bonus wallet</span>
+            <h2>One more wallet?</h2>
+            <p>The bonus uses normal odds, but cannot trigger another bonus.</p>
+            <div className="big-spender__modal-actions">
+              <button type="button" onClick={() => setState((previous) => resolveBigSpenderBonusOffer(previous, true))}>Open bonus</button>
+              <button type="button" onClick={() => setState((previous) => resolveBigSpenderBonusOffer(previous, false))}>Decline</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {state.pendingAdRescue && humanPlayer?.playerId === state.pendingAdRescue.playerId && (
+        <div className="big-spender__overlay">
+          <div className="big-spender__modal big-spender__modal--danger">
+            <span className="big-spender__eyebrow">Bomb save</span>
+            <h2>Watch an ad for one last wallet?</h2>
+            <p>If the ad completes, the bomb is cancelled and a mandatory Second Chance Wallet opens immediately.</p>
+            <div className="big-spender__modal-actions">
+              <button type="button" onClick={() => setState((previous) => resolveBigSpenderAdRescue(previous, 'completed'))}>Watch ad</button>
+              <button type="button" onClick={() => setState((previous) => resolveBigSpenderAdRescue(previous, 'declined'))}>Skip</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {state.status === 'completed' && (
+        <div className="big-spender__overlay">
+          <div className="big-spender__modal big-spender__modal--results">
+            <span className="big-spender__eyebrow">Final ranking</span>
+            <h2>{winner?.displayName ?? 'Someone'} wins</h2>
+            <ol className="big-spender__ranking">
+              {ranking.map((player) => (
+                <li key={player.playerId}>
+                  <span>{player.rank}</span>
+                  <strong>{player.displayName}</strong>
+                  <em>{player.balance} Eyeoleans - {getPlayerLabel(player)}</em>
+                </li>
+              ))}
+            </ol>
+            <button type="button" onClick={finish} disabled={resultCommitted}>Claim result</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BigSpender/bigSpenderLogic.ts
+++ b/src/components/BigSpender/bigSpenderLogic.ts
@@ -1,0 +1,722 @@
+import { mulberry32 } from '../../store/rng';
+
+export const BIG_SPENDER_GAME_ID = 'big_spender_broke_or_boom';
+export const BIG_SPENDER_DISPLAY_NAME = 'Big Spender: Broke or Boom';
+
+export const BIG_SPENDER_CONFIG = {
+  startingBalance: 1000,
+  boardSize: 24,
+  outcomeWeights: {
+    negative: 81,
+    positive: 15,
+    bomb: 4,
+  },
+  bonusExtraWalletChance: 0.1,
+  maxExtraWalletsPerTurn: 1,
+  maxAdBombRescues: 2,
+} as const;
+
+export const BIG_SPENDER_NEGATIVE_WALLETS = [
+  { amount: -25, weight: 2 },
+  { amount: -37, weight: 2 },
+  { amount: -50, weight: 5 },
+  { amount: -69, weight: 5 },
+  { amount: -75, weight: 5 },
+  { amount: -100, weight: 10 },
+  { amount: -123, weight: 6 },
+  { amount: -150, weight: 12 },
+  { amount: -175, weight: 8 },
+  { amount: -200, weight: 12 },
+  { amount: -222, weight: 6 },
+  { amount: -250, weight: 10 },
+  { amount: -300, weight: 7 },
+  { amount: -333, weight: 4 },
+  { amount: -404, weight: 3 },
+  { amount: -420, weight: 2 },
+  { amount: -666, weight: 1 },
+] as const;
+
+export const BIG_SPENDER_POSITIVE_WALLETS = [
+  { amount: 25, weight: 8 },
+  { amount: 37, weight: 5 },
+  { amount: 50, weight: 13 },
+  { amount: 69, weight: 6 },
+  { amount: 75, weight: 10 },
+  { amount: 100, weight: 15 },
+  { amount: 123, weight: 8 },
+  { amount: 150, weight: 12 },
+  { amount: 175, weight: 6 },
+  { amount: 200, weight: 7 },
+  { amount: 222, weight: 3 },
+  { amount: 250, weight: 3 },
+  { amount: 300, weight: 2 },
+  { amount: 404, weight: 1 },
+  { amount: 666, weight: 1 },
+] as const;
+
+export const BIG_SPENDER_FUNNY_AMOUNTS = new Set([69, 123, 222, 333, 404, 420, 666]);
+
+export type BigSpenderOutcomeType = 'negative' | 'positive' | 'bomb';
+export type BigSpenderWalletKind = 'normal' | 'bonus' | 'secondChance';
+export type BigSpenderWalletState = 'hidden' | 'opening' | 'revealed';
+export type BigSpenderPlayerStatus = 'active' | 'locked' | 'zeroFinished' | 'bombed';
+export type BigSpenderGameStatus = 'running' | 'completed';
+export type BigSpenderAdDecision = 'completed' | 'declined' | 'failed' | 'unavailable';
+
+export interface BigSpenderParticipant {
+  id: string;
+  name: string;
+  isHuman: boolean;
+  avatar?: string;
+  precomputedScore?: number;
+}
+
+export interface BigSpenderWalletOutcome {
+  type: BigSpenderOutcomeType;
+  amount: number | null;
+}
+
+export interface BigSpenderWallet {
+  walletId: string;
+  boardSlotIndex: number;
+  generationNumber: number;
+  generationColor: number;
+  outcome: BigSpenderWalletOutcome;
+  state: BigSpenderWalletState;
+}
+
+export interface BigSpenderPlayerState {
+  playerId: string;
+  displayName: string;
+  isHuman: boolean;
+  avatar?: string;
+  balance: number;
+  status: BigSpenderPlayerStatus;
+  walletsOpened: number;
+  negativeWalletsOpened: number;
+  positiveWalletsOpened: number;
+  bombsOpened: number;
+  bonusWalletsOpened: number;
+  adBombRescuesUsed: number;
+  bombedAt: number | null;
+  lockedAt: number | null;
+  zeroFinishedAt: number | null;
+  finalizedAt: number | null;
+  originalTurnOrderIndex: number;
+  currentTurn: boolean;
+}
+
+export interface BigSpenderPendingBonus {
+  playerId: string;
+  walletId: string;
+}
+
+export interface BigSpenderPendingAdRescue {
+  playerId: string;
+  walletId: string;
+}
+
+export interface BigSpenderEvent {
+  type:
+    | 'walletOpened'
+    | 'walletReplaced'
+    | 'bonusOffered'
+    | 'bonusDeclined'
+    | 'adRescueOffered'
+    | 'adRescueCompleted'
+    | 'adRescueFailed'
+    | 'playerLocked'
+    | 'playerZeroFinished'
+    | 'playerBombed'
+    | 'gameCompleted'
+    | 'turnAdvanced';
+  playerId?: string;
+  walletId?: string;
+  outcome?: BigSpenderWalletOutcome;
+  message: string;
+}
+
+export interface BigSpenderState {
+  gameId: string;
+  status: BigSpenderGameStatus;
+  seed: number;
+  randomCursor: number;
+  actionOrder: number;
+  startingPlayerCount: number;
+  timerDurationMs: number;
+  timerStartedAt: number;
+  timerPaused: boolean;
+  turnOrder: string[];
+  currentTurnIndex: number;
+  currentTurnPlayerId: string | null;
+  players: BigSpenderPlayerState[];
+  board: BigSpenderWallet[];
+  pendingBonus: BigSpenderPendingBonus | null;
+  pendingAdRescue: BigSpenderPendingAdRescue | null;
+  postWalletLockPlayerId: string | null;
+  events: BigSpenderEvent[];
+}
+
+export interface BigSpenderOpenOptions {
+  forcedOutcome?: BigSpenderWalletOutcome;
+  forceBonusOffer?: boolean;
+  suppressBonus?: boolean;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function shuffle<T>(items: T[], rng: () => number) {
+  const copy = [...items];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(rng() * (index + 1));
+    [copy[index], copy[swapIndex]] = [copy[swapIndex], copy[index]];
+  }
+  return copy;
+}
+
+function appendEvent(state: BigSpenderState, event: BigSpenderEvent) {
+  state.events = [event, ...state.events].slice(0, 16);
+}
+
+function nextRandom(state: BigSpenderState) {
+  const seed = (state.seed + Math.imul(state.randomCursor + 1, 0x9e3779b1)) >>> 0;
+  state.randomCursor += 1;
+  return mulberry32(seed)();
+}
+
+function weightedPick<T extends { weight: number }>(items: readonly T[], roll: number): T {
+  const total = sumWeights(items);
+  let target = roll * total;
+  for (const item of items) {
+    target -= item.weight;
+    if (target < 0) return item;
+  }
+  return items[items.length - 1]!;
+}
+
+function cloneState(state: BigSpenderState): BigSpenderState {
+  return {
+    ...state,
+    turnOrder: [...state.turnOrder],
+    players: state.players.map((player) => ({ ...player })),
+    board: state.board.map((wallet) => ({ ...wallet, outcome: { ...wallet.outcome } })),
+    pendingBonus: state.pendingBonus ? { ...state.pendingBonus } : null,
+    pendingAdRescue: state.pendingAdRescue ? { ...state.pendingAdRescue } : null,
+    events: [...state.events],
+  };
+}
+
+function getPlayerMutable(state: BigSpenderState, playerId: string) {
+  const player = state.players.find((entry) => entry.playerId === playerId);
+  if (!player) throw new Error(`Big Spender player '${playerId}' not found.`);
+  return player;
+}
+
+function getWalletMutable(state: BigSpenderState, walletId: string) {
+  const wallet = state.board.find((entry) => entry.walletId === walletId);
+  if (!wallet) throw new Error(`Big Spender wallet '${walletId}' not found.`);
+  return wallet;
+}
+
+function markTurnFlags(state: BigSpenderState) {
+  for (const player of state.players) {
+    player.currentTurn = player.playerId === state.currentTurnPlayerId;
+  }
+}
+
+function nextEligibleTurnIndex(state: BigSpenderState, startIndex: number) {
+  if (state.turnOrder.length === 0) return -1;
+  for (let offset = 0; offset < state.turnOrder.length; offset += 1) {
+    const index = (startIndex + offset) % state.turnOrder.length;
+    const id = state.turnOrder[index];
+    const player = state.players.find((entry) => entry.playerId === id);
+    if (player && player.status === 'active' && player.finalizedAt == null) return index;
+  }
+  return -1;
+}
+
+function completeIfNeeded(state: BigSpenderState) {
+  const unresolved = state.players.filter((player) => player.status === 'active' && player.finalizedAt == null);
+  if (unresolved.length > 0) return state;
+  state.status = 'completed';
+  state.currentTurnPlayerId = null;
+  state.postWalletLockPlayerId = null;
+  state.pendingBonus = null;
+  state.pendingAdRescue = null;
+  markTurnFlags(state);
+  appendEvent(state, { type: 'gameCompleted', message: 'All players are finalized.' });
+  return state;
+}
+
+function advanceTurnMutable(state: BigSpenderState) {
+  state.postWalletLockPlayerId = null;
+  if (state.status === 'completed') return completeIfNeeded(state);
+  const nextIndex = nextEligibleTurnIndex(state, state.currentTurnIndex + 1);
+  if (nextIndex < 0) return completeIfNeeded(state);
+  state.currentTurnIndex = nextIndex;
+  state.currentTurnPlayerId = state.turnOrder[nextIndex] ?? null;
+  markTurnFlags(state);
+  appendEvent(state, {
+    type: 'turnAdvanced',
+    playerId: state.currentTurnPlayerId ?? undefined,
+    message: `${getPlayerMutable(state, state.currentTurnPlayerId ?? '').displayName} is up.`,
+  });
+  return state;
+}
+
+function createWalletFromRoll(slotIndex: number, generationNumber: number, rng: () => number): BigSpenderWallet {
+  const outcome = pickWalletOutcome(rng);
+  return {
+    walletId: `wallet-${slotIndex}-${generationNumber}`,
+    boardSlotIndex: slotIndex,
+    generationNumber,
+    generationColor: generationNumber % 6,
+    outcome,
+    state: 'hidden',
+  };
+}
+
+function replaceWalletMutable(state: BigSpenderState, wallet: BigSpenderWallet) {
+  const nextWallet = createWalletFromRoll(
+    wallet.boardSlotIndex,
+    wallet.generationNumber + 1,
+    () => nextRandom(state),
+  );
+  state.board = state.board.map((entry) => entry.walletId === wallet.walletId ? nextWallet : entry);
+  appendEvent(state, {
+    type: 'walletReplaced',
+    walletId: nextWallet.walletId,
+    message: `Slot ${nextWallet.boardSlotIndex + 1} refilled.`,
+  });
+}
+
+function finalizePlayer(player: BigSpenderPlayerState, state: BigSpenderState, status: BigSpenderPlayerStatus) {
+  state.actionOrder += 1;
+  player.status = status;
+  player.finalizedAt = state.actionOrder;
+  if (status === 'locked') player.lockedAt = state.actionOrder;
+  if (status === 'zeroFinished') player.zeroFinishedAt = state.actionOrder;
+  if (status === 'bombed') player.bombedAt = state.actionOrder;
+}
+
+function shouldPauseForHumanLock(player: BigSpenderPlayerState, state: BigSpenderState, kind: BigSpenderWalletKind) {
+  return kind !== 'bonus' && player.isHuman && player.status === 'active' && state.status === 'running';
+}
+
+function maybeOfferBonus(state: BigSpenderState, player: BigSpenderPlayerState, openedWallet: BigSpenderWallet, options: BigSpenderOpenOptions) {
+  if (options.suppressBonus || state.status !== 'running' || player.status !== 'active') return false;
+  const offered = options.forceBonusOffer ?? nextRandom(state) < BIG_SPENDER_CONFIG.bonusExtraWalletChance;
+  if (!offered) return false;
+  state.pendingBonus = { playerId: player.playerId, walletId: openedWallet.walletId };
+  appendEvent(state, {
+    type: 'bonusOffered',
+    playerId: player.playerId,
+    walletId: openedWallet.walletId,
+    message: `${player.displayName} found a bonus wallet offer.`,
+  });
+  return true;
+}
+
+function resolveSyntheticWalletMutable(
+  state: BigSpenderState,
+  player: BigSpenderPlayerState,
+  outcome: BigSpenderWalletOutcome,
+  kind: BigSpenderWalletKind,
+) {
+  applyOutcomeMutable(state, player, outcome, kind);
+}
+
+function applyOutcomeMutable(
+  state: BigSpenderState,
+  player: BigSpenderPlayerState,
+  outcome: BigSpenderWalletOutcome,
+  kind: BigSpenderWalletKind,
+) {
+  player.walletsOpened += 1;
+  if (kind === 'bonus') player.bonusWalletsOpened += 1;
+
+  if (outcome.type === 'positive') {
+    player.positiveWalletsOpened += 1;
+    player.balance += outcome.amount ?? 0;
+    appendEvent(state, {
+      type: 'walletOpened',
+      playerId: player.playerId,
+      outcome,
+      message: `${player.displayName} gained ${outcome.amount ?? 0} Eyeoleans.`,
+    });
+    return;
+  }
+
+  if (outcome.type === 'negative') {
+    player.negativeWalletsOpened += 1;
+    player.balance = clamp(player.balance + (outcome.amount ?? 0), 0, Number.MAX_SAFE_INTEGER);
+    appendEvent(state, {
+      type: 'walletOpened',
+      playerId: player.playerId,
+      outcome,
+      message: `${player.displayName} spent ${Math.abs(outcome.amount ?? 0)} Eyeoleans.`,
+    });
+    if (player.balance === 0) {
+      finalizePlayer(player, state, 'zeroFinished');
+      appendEvent(state, {
+        type: 'playerZeroFinished',
+        playerId: player.playerId,
+        message: `${player.displayName} hit zero first-class broke.`,
+      });
+    }
+    return;
+  }
+
+  player.bombsOpened += 1;
+  appendEvent(state, {
+    type: 'walletOpened',
+    playerId: player.playerId,
+    outcome,
+    message: `${player.displayName} opened a bomb.`,
+  });
+}
+
+function markBombedMutable(state: BigSpenderState, player: BigSpenderPlayerState) {
+  finalizePlayer(player, state, 'bombed');
+  appendEvent(state, {
+    type: 'playerBombed',
+    playerId: player.playerId,
+    message: `${player.displayName} is bombed out.`,
+  });
+}
+
+function finishAfterResolution(state: BigSpenderState, player: BigSpenderPlayerState, kind: BigSpenderWalletKind) {
+  completeIfNeeded(state);
+  if (state.status === 'completed' || state.pendingAdRescue || state.pendingBonus) return state;
+  if (shouldPauseForHumanLock(player, state, kind)) {
+    state.postWalletLockPlayerId = player.playerId;
+    markTurnFlags(state);
+    return state;
+  }
+  return advanceTurnMutable(state);
+}
+
+export function sumWeights(items: readonly { weight: number }[]) {
+  return items.reduce((total, item) => total + item.weight, 0);
+}
+
+export function getTimerDurationMs(startingPlayerCount: number) {
+  if (startingPlayerCount >= 12) return 240_000;
+  if (startingPlayerCount >= 7) return 210_000;
+  return 180_000;
+}
+
+export function getAiActionDelayMs(startingPlayerCount: number, rng: () => number) {
+  const [min, max] = startingPlayerCount >= 12
+    ? [750, 2500]
+    : startingPlayerCount >= 7
+      ? [1000, 3000]
+      : [1000, 4000];
+  return Math.round(min + rng() * (max - min));
+}
+
+export function pickWalletOutcome(rng: () => number): BigSpenderWalletOutcome {
+  const outcomeType = weightedPick([
+    { type: 'negative' as const, weight: BIG_SPENDER_CONFIG.outcomeWeights.negative },
+    { type: 'positive' as const, weight: BIG_SPENDER_CONFIG.outcomeWeights.positive },
+    { type: 'bomb' as const, weight: BIG_SPENDER_CONFIG.outcomeWeights.bomb },
+  ], rng()).type;
+
+  if (outcomeType === 'bomb') return { type: 'bomb', amount: null };
+  const table = outcomeType === 'negative' ? BIG_SPENDER_NEGATIVE_WALLETS : BIG_SPENDER_POSITIVE_WALLETS;
+  const amount = weightedPick(table, rng()).amount;
+  return { type: outcomeType, amount };
+}
+
+export function isFunnyAmount(amount: number | null | undefined) {
+  return amount != null && BIG_SPENDER_FUNNY_AMOUNTS.has(Math.abs(amount));
+}
+
+export function resolveBigSpenderParticipants(participants?: BigSpenderParticipant[], participantIds?: string[]) {
+  if (participants && participants.length > 0) {
+    return participants.map((participant) => ({
+      id: participant.id,
+      name: participant.name,
+      isHuman: participant.isHuman,
+      avatar: participant.avatar,
+      precomputedScore: participant.precomputedScore ?? 50,
+    }));
+  }
+  const ids = participantIds && participantIds.length > 0
+    ? participantIds
+    : ['human', 'ai-1', 'ai-2', 'ai-3'];
+  return ids.map((id, index) => ({
+    id,
+    name: index === 0 ? 'You' : `AI ${index}`,
+    isHuman: index === 0,
+    avatar: undefined,
+    precomputedScore: Math.max(10, 80 - index * 7),
+  }));
+}
+
+export function createInitialBigSpenderState(
+  participants: BigSpenderParticipant[],
+  seed = Date.now(),
+  now = Date.now(),
+): BigSpenderState {
+  if (participants.length < 2) {
+    throw new Error('Big Spender requires at least 2 players.');
+  }
+  const rng = mulberry32(seed >>> 0);
+  const orderedParticipants = shuffle(participants, rng);
+  const players = orderedParticipants.map((participant, index): BigSpenderPlayerState => ({
+    playerId: participant.id,
+    displayName: participant.name,
+    isHuman: participant.isHuman,
+    avatar: participant.avatar,
+    balance: BIG_SPENDER_CONFIG.startingBalance,
+    status: 'active',
+    walletsOpened: 0,
+    negativeWalletsOpened: 0,
+    positiveWalletsOpened: 0,
+    bombsOpened: 0,
+    bonusWalletsOpened: 0,
+    adBombRescuesUsed: 0,
+    bombedAt: null,
+    lockedAt: null,
+    zeroFinishedAt: null,
+    finalizedAt: null,
+    originalTurnOrderIndex: index,
+    currentTurn: false,
+  }));
+  const board = Array.from({ length: BIG_SPENDER_CONFIG.boardSize }, (_unused, slotIndex) =>
+    createWalletFromRoll(slotIndex, 1, rng),
+  );
+  const firstPlayerId = players[0]?.playerId ?? null;
+  const state: BigSpenderState = {
+    gameId: BIG_SPENDER_GAME_ID,
+    status: 'running',
+    seed,
+    randomCursor: BIG_SPENDER_CONFIG.boardSize + participants.length,
+    actionOrder: 0,
+    startingPlayerCount: participants.length,
+    timerDurationMs: getTimerDurationMs(participants.length),
+    timerStartedAt: now,
+    timerPaused: false,
+    turnOrder: players.map((player) => player.playerId),
+    currentTurnIndex: 0,
+    currentTurnPlayerId: firstPlayerId,
+    players,
+    board,
+    pendingBonus: null,
+    pendingAdRescue: null,
+    postWalletLockPlayerId: null,
+    events: [],
+  };
+  markTurnFlags(state);
+  return state;
+}
+
+export function canOfferAdRescue(state: BigSpenderState, player: BigSpenderPlayerState) {
+  return (
+    player.isHuman &&
+    player.adBombRescuesUsed < BIG_SPENDER_CONFIG.maxAdBombRescues &&
+    player.finalizedAt == null &&
+    state.status === 'running'
+  );
+}
+
+export function openBigSpenderWallet(
+  previousState: BigSpenderState,
+  playerId: string,
+  walletId: string,
+  kind: BigSpenderWalletKind = 'normal',
+  options: BigSpenderOpenOptions = {},
+) {
+  const state = cloneState(previousState);
+  if (state.status !== 'running') return state;
+  if (state.pendingAdRescue || state.pendingBonus) return state;
+  const player = getPlayerMutable(state, playerId);
+  if (player.status !== 'active' || player.finalizedAt != null) return state;
+  if (state.currentTurnPlayerId !== playerId && kind === 'normal') return state;
+
+  const wallet = getWalletMutable(state, walletId);
+  if (wallet.state !== 'hidden') return state;
+  wallet.state = 'opening';
+  const outcome = options.forcedOutcome ?? wallet.outcome;
+  wallet.outcome = outcome;
+  wallet.state = 'revealed';
+
+  applyOutcomeMutable(state, player, outcome, kind);
+
+  if (outcome.type === 'bomb') {
+    if (kind !== 'secondChance' && canOfferAdRescue(state, player)) {
+      state.pendingAdRescue = { playerId: player.playerId, walletId: wallet.walletId };
+      state.timerPaused = true;
+      appendEvent(state, {
+        type: 'adRescueOffered',
+        playerId: player.playerId,
+        walletId: wallet.walletId,
+        message: 'Watch an ad for one last wallet?',
+      });
+      return state;
+    }
+    markBombedMutable(state, player);
+    replaceWalletMutable(state, wallet);
+    return finishAfterResolution(state, player, kind);
+  }
+
+  replaceWalletMutable(state, wallet);
+  if (player.status === 'active' && kind === 'normal' && maybeOfferBonus(state, player, wallet, options)) {
+    return state;
+  }
+  return finishAfterResolution(state, player, kind);
+}
+
+export function resolveBigSpenderBonusOffer(previousState: BigSpenderState, accept: boolean, forcedOutcome?: BigSpenderWalletOutcome) {
+  const state = cloneState(previousState);
+  const pending = state.pendingBonus;
+  if (!pending) return state;
+  state.pendingBonus = null;
+  const player = getPlayerMutable(state, pending.playerId);
+  if (!accept || player.status !== 'active') {
+    appendEvent(state, {
+      type: 'bonusDeclined',
+      playerId: pending.playerId,
+      message: `${player.displayName} declined the bonus wallet.`,
+    });
+    return finishAfterResolution(state, player, 'normal');
+  }
+
+  const outcome = forcedOutcome ?? pickWalletOutcome(() => nextRandom(state));
+  resolveSyntheticWalletMutable(state, player, outcome, 'bonus');
+  if (outcome.type === 'bomb') markBombedMutable(state, player);
+  return finishAfterResolution(state, player, 'bonus');
+}
+
+export function resolveBigSpenderAdRescue(
+  previousState: BigSpenderState,
+  decision: BigSpenderAdDecision,
+  forcedSecondChanceOutcome?: BigSpenderWalletOutcome,
+) {
+  const state = cloneState(previousState);
+  const pending = state.pendingAdRescue;
+  if (!pending) return state;
+  state.pendingAdRescue = null;
+  state.timerPaused = false;
+  const player = getPlayerMutable(state, pending.playerId);
+  const wallet = getWalletMutable(state, pending.walletId);
+
+  if (decision !== 'completed' || player.status !== 'active') {
+    appendEvent(state, {
+      type: 'adRescueFailed',
+      playerId: player.playerId,
+      message: `${player.displayName} did not complete the ad save.`,
+    });
+    markBombedMutable(state, player);
+    replaceWalletMutable(state, wallet);
+    return finishAfterResolution(state, player, 'normal');
+  }
+
+  player.adBombRescuesUsed += 1;
+  appendEvent(state, {
+    type: 'adRescueCompleted',
+    playerId: player.playerId,
+    message: `${player.displayName} earned a second chance wallet.`,
+  });
+  const outcome = forcedSecondChanceOutcome ?? pickWalletOutcome(() => nextRandom(state));
+  resolveSyntheticWalletMutable(state, player, outcome, 'secondChance');
+  if (outcome.type === 'bomb') markBombedMutable(state, player);
+  replaceWalletMutable(state, wallet);
+  return finishAfterResolution(state, player, 'secondChance');
+}
+
+export function finishBigSpenderTurn(previousState: BigSpenderState) {
+  const state = cloneState(previousState);
+  return advanceTurnMutable(state);
+}
+
+export function lockBigSpenderPlayer(previousState: BigSpenderState, playerId: string) {
+  const state = cloneState(previousState);
+  const player = getPlayerMutable(state, playerId);
+  if (state.status !== 'running' || player.status !== 'active' || player.finalizedAt != null) return state;
+  if (state.currentTurnPlayerId !== playerId && state.postWalletLockPlayerId !== playerId) return state;
+  finalizePlayer(player, state, 'locked');
+  appendEvent(state, {
+    type: 'playerLocked',
+    playerId,
+    message: `${player.displayName} locked at ${player.balance} Eyeoleans.`,
+  });
+  return advanceTurnMutable(state);
+}
+
+export function finalizeBigSpenderByTimeout(previousState: BigSpenderState) {
+  const state = cloneState(previousState);
+  for (const player of state.players) {
+    if (player.status === 'active' && player.finalizedAt == null) {
+      state.actionOrder += 1;
+      player.finalizedAt = state.actionOrder;
+    }
+  }
+  state.status = 'completed';
+  state.pendingBonus = null;
+  state.pendingAdRescue = null;
+  state.postWalletLockPlayerId = null;
+  state.currentTurnPlayerId = null;
+  markTurnFlags(state);
+  appendEvent(state, { type: 'gameCompleted', message: 'The clock expired.' });
+  return state;
+}
+
+export function decideAiShouldOpen(balance: number, rng: () => number, options: { secondsRemaining?: number; likelyWinningBalance?: number } = {}) {
+  let openChance = balance >= 701 ? 0.9 : balance >= 401 ? 0.75 : balance >= 151 ? 0.55 : 0.3;
+  if (
+    options.secondsRemaining != null &&
+    options.secondsRemaining <= 30 &&
+    options.likelyWinningBalance != null &&
+    balance > options.likelyWinningBalance
+  ) {
+    openChance = clamp(openChance + 0.18, 0, 0.97);
+  }
+  return rng() < openChance;
+}
+
+export function getNextEligibleBigSpenderPlayer(state: BigSpenderState) {
+  const index = nextEligibleTurnIndex(state, state.currentTurnIndex + 1);
+  return index < 0 ? null : state.players.find((player) => player.playerId === state.turnOrder[index]) ?? null;
+}
+
+export function rankBigSpenderPlayers(players: BigSpenderPlayerState[]) {
+  const zeroFinished = players
+    .filter((player) => player.status === 'zeroFinished')
+    .sort((left, right) => (left.zeroFinishedAt ?? Infinity) - (right.zeroFinishedAt ?? Infinity));
+
+  const nonBombed = players
+    .filter((player) => player.status !== 'zeroFinished' && player.status !== 'bombed')
+    .sort((left, right) => {
+      const balanceDelta = left.balance - right.balance;
+      if (balanceDelta !== 0) return balanceDelta;
+      const walletDelta = right.walletsOpened - left.walletsOpened;
+      if (walletDelta !== 0) return walletDelta;
+      const negativeDelta = right.negativeWalletsOpened - left.negativeWalletsOpened;
+      if (negativeDelta !== 0) return negativeDelta;
+      const finalDelta = (left.lockedAt ?? left.finalizedAt ?? Infinity) - (right.lockedAt ?? right.finalizedAt ?? Infinity);
+      if (finalDelta !== 0) return finalDelta;
+      return left.originalTurnOrderIndex - right.originalTurnOrderIndex;
+    });
+
+  const bombed = players
+    .filter((player) => player.status === 'bombed')
+    .sort((left, right) => {
+      const bombDelta = (right.bombedAt ?? -Infinity) - (left.bombedAt ?? -Infinity);
+      if (bombDelta !== 0) return bombDelta;
+      return left.originalTurnOrderIndex - right.originalTurnOrderIndex;
+    });
+
+  return [...zeroFinished, ...nonBombed, ...bombed].map((player, index) => ({
+    ...player,
+    rank: index + 1,
+  }));
+}
+
+export function buildBigSpenderRawResults(players: BigSpenderPlayerState[]) {
+  const ranked = rankBigSpenderPlayers(players);
+  return Object.fromEntries(ranked.map((player) => [player.playerId, ranked.length - player.rank + 1]));
+}

--- a/src/components/BigSpender/bigSpenderLogic.ts
+++ b/src/components/BigSpender/bigSpenderLogic.ts
@@ -425,7 +425,9 @@ export function pickWalletOutcome(rng: () => number): BigSpenderWalletOutcome {
   ], rng()).type;
 
   if (outcomeType === 'bomb') return { type: 'bomb', amount: null };
-  const table = outcomeType === 'negative' ? BIG_SPENDER_NEGATIVE_WALLETS : BIG_SPENDER_POSITIVE_WALLETS;
+  const table: readonly { amount: number; weight: number }[] = outcomeType === 'negative'
+    ? BIG_SPENDER_NEGATIVE_WALLETS
+    : BIG_SPENDER_POSITIVE_WALLETS;
   const amount = weightedPick(table, rng()).amount;
   return { type: outcomeType, amount };
 }

--- a/src/minigames/reactComponents.ts
+++ b/src/minigames/reactComponents.ts
@@ -50,6 +50,7 @@ import Capitalization from '../components/Capitalization/Capitalization';
 import CodeBreakerComp from '../components/CodeBreakerComp/CodeBreakerComp';
 import GridOfLuck from '../components/GridOfLuck/GridOfLuck';
 import ChainOfGreed from '../components/ChainOfGreed/ChainOfGreed';
+import BigSpender from '../components/BigSpender/BigSpender';
 
 /**
  * Minimal prop contract shared by all generic React minigame components.
@@ -109,6 +110,7 @@ const reactComponents: Record<string, ComponentType<GenericMinigameProps>> = {
   CodeBreaker: CodeBreakerComp as ComponentType<GenericMinigameProps>,
   GridOfLuck: GridOfLuck as ComponentType<GenericMinigameProps>,
   ChainOfGreed: ChainOfGreed as ComponentType<GenericMinigameProps>,
+  BigSpender: BigSpender as ComponentType<GenericMinigameProps>,
 };
 
 export default reactComponents;

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -1213,6 +1213,33 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     retired: false,
   },
 
+  bigSpender: {
+    key: 'bigSpender',
+    title: 'Big Spender: Broke or Boom',
+    description: 'Open wallets, spend down your Eyeoleans, and avoid bombs while racing to the lowest balance.',
+    instructions: [
+      'Every player starts with 1,000 Eyeoleans and takes turns opening wallets from a 24-wallet board.',
+      'Most wallets subtract Eyeoleans, some add Eyeoleans, and a few hide bombs.',
+      'Reach exactly 0 first to take the top spot, or lock your current balance before the risk gets too loud.',
+      'Opened wallets are replaced in the same slot, so the board always stays full.',
+      'Bonus wallets can appear once per turn, but they cannot chain into more bonus wallets.',
+      'If you open a bomb, you may use up to two ad saves for a mandatory Second Chance Wallet.',
+      'Bombed players rank below everyone who survives, even if their balance was low.',
+    ],
+    resultMode: 'placement',
+    metricKind: 'points',
+    metricLabel: 'Placement',
+    timeLimitMs: 0,
+    authoritative: true,
+    scoringAdapter: 'authoritative',
+    implementation: 'react',
+    reactComponentKey: 'BigSpender',
+    legacy: false,
+    weight: 1,
+    category: 'arcade',
+    retired: false,
+  },
+
   chainOfGreed: {
     key: 'chainOfGreed',
     title: 'Chain of Greed',

--- a/tests/unit/big-spender/bigSpenderLogic.test.ts
+++ b/tests/unit/big-spender/bigSpenderLogic.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import { mulberry32 } from '../../../src/store/rng';
+import {
+  BIG_SPENDER_CONFIG,
+  BIG_SPENDER_NEGATIVE_WALLETS,
+  BIG_SPENDER_POSITIVE_WALLETS,
+  canOfferAdRescue,
+  createInitialBigSpenderState,
+  decideAiShouldOpen,
+  finalizeBigSpenderByTimeout,
+  finishBigSpenderTurn,
+  getAiActionDelayMs,
+  getTimerDurationMs,
+  lockBigSpenderPlayer,
+  openBigSpenderWallet,
+  pickWalletOutcome,
+  rankBigSpenderPlayers,
+  resolveBigSpenderAdRescue,
+  resolveBigSpenderBonusOffer,
+  sumWeights,
+  type BigSpenderParticipant,
+  type BigSpenderState,
+} from '../../../src/components/BigSpender/bigSpenderLogic';
+
+const participants: BigSpenderParticipant[] = [
+  { id: 'human', name: 'You', isHuman: true, precomputedScore: 90 },
+  { id: 'ai-1', name: 'Ava', isHuman: false, precomputedScore: 80 },
+  { id: 'ai-2', name: 'Bo', isHuman: false, precomputedScore: 70 },
+  { id: 'ai-3', name: 'Cy', isHuman: false, precomputedScore: 60 },
+];
+
+function makeState(seed = 1234) {
+  return createInitialBigSpenderState(participants, seed, 0);
+}
+
+function setCurrent(state: BigSpenderState, playerId: string) {
+  const index = state.turnOrder.indexOf(playerId);
+  state.currentTurnIndex = index >= 0 ? index : 0;
+  state.currentTurnPlayerId = playerId;
+  state.players = state.players.map((player) => ({ ...player, currentTurn: player.playerId === playerId }));
+  return state;
+}
+
+function firstWallet(state: BigSpenderState) {
+  const wallet = state.board[0];
+  if (!wallet) throw new Error('missing wallet');
+  return wallet;
+}
+
+function player(state: BigSpenderState, playerId: string) {
+  const found = state.players.find((entry) => entry.playerId === playerId);
+  if (!found) throw new Error(`missing player ${playerId}`);
+  return found;
+}
+
+describe('Big Spender: Broke or Boom logic', () => {
+  it('initializes all players at 1,000 Eyeoleans with a 24-wallet board', () => {
+    const state = makeState();
+
+    expect(state.players).toHaveLength(participants.length);
+    expect(state.players.every((entry) => entry.balance === BIG_SPENDER_CONFIG.startingBalance)).toBe(true);
+    expect(state.board).toHaveLength(24);
+    expect(state.currentTurnPlayerId).toBeTruthy();
+  });
+
+  it('uses the configured timer durations for player-count bands', () => {
+    expect(getTimerDurationMs(1)).toBe(180_000);
+    expect(getTimerDurationMs(2)).toBe(180_000);
+    expect(getTimerDurationMs(6)).toBe(180_000);
+    expect(getTimerDurationMs(7)).toBe(210_000);
+    expect(getTimerDurationMs(11)).toBe(210_000);
+    expect(getTimerDurationMs(12)).toBe(240_000);
+  });
+
+  it('declares wallet outcome weights as 81/15/4', () => {
+    expect(BIG_SPENDER_CONFIG.outcomeWeights).toEqual({ negative: 81, positive: 15, bomb: 4 });
+  });
+
+  it('keeps positive and negative amount tables normalized to 100', () => {
+    expect(sumWeights(BIG_SPENDER_NEGATIVE_WALLETS)).toBe(100);
+    expect(sumWeights(BIG_SPENDER_POSITIVE_WALLETS)).toBe(100);
+  });
+
+  it('picks second-chance-compatible primary wallet outcomes', () => {
+    const outcomes = Array.from({ length: 100 }, (_, index) => pickWalletOutcome(mulberry32(index + 99)).type);
+
+    expect(new Set(outcomes)).toEqual(new Set(['negative', 'positive', 'bomb']));
+  });
+
+  it('subtracts negative wallets and clamps at zero', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'negative', amount: -1200 },
+      suppressBonus: true,
+    });
+
+    expect(player(opened, 'human').balance).toBe(0);
+    expect(player(opened, 'human').status).toBe('zeroFinished');
+    expect(player(opened, 'human').negativeWalletsOpened).toBe(1);
+  });
+
+  it('adds positive wallet amounts above the starting balance', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'positive', amount: 666 },
+      suppressBonus: true,
+    });
+
+    expect(player(opened, 'human').balance).toBe(1666);
+    expect(player(opened, 'human').positiveWalletsOpened).toBe(1);
+  });
+
+  it('marks an AI bombed and advances away from that player', () => {
+    const state = setCurrent(makeState(), 'ai-1');
+    const opened = openBigSpenderWallet(state, 'ai-1', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+
+    expect(player(opened, 'ai-1').status).toBe('bombed');
+    expect(opened.currentTurnPlayerId).not.toBe('ai-1');
+  });
+
+  it('offers ad rescue to an eligible human bomb opening', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+
+    expect(opened.pendingAdRescue?.playerId).toBe('human');
+    expect(opened.timerPaused).toBe(true);
+    expect(canOfferAdRescue(opened, player(opened, 'human'))).toBe(true);
+  });
+
+  it('declining or failing ad rescue marks the user as bombed', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+    const declined = resolveBigSpenderAdRescue(opened, 'declined');
+
+    expect(declined.pendingAdRescue).toBeNull();
+    expect(declined.timerPaused).toBe(false);
+    expect(player(declined, 'human').status).toBe('bombed');
+  });
+
+  it('completed ad rescue cancels the original bomb and opens a mandatory Second Chance Wallet', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+    const rescued = resolveBigSpenderAdRescue(opened, 'completed', { type: 'negative', amount: -200 });
+
+    expect(player(rescued, 'human').status).toBe('active');
+    expect(player(rescued, 'human').balance).toBe(800);
+    expect(player(rescued, 'human').adBombRescuesUsed).toBe(1);
+    expect(player(rescued, 'human').walletsOpened).toBe(2);
+  });
+
+  it('does not allow Second Chance Wallets to trigger extra wallets', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+    const rescued = resolveBigSpenderAdRescue(opened, 'completed', { type: 'positive', amount: 100 });
+
+    expect(rescued.pendingBonus).toBeNull();
+    expect(player(rescued, 'human').bonusWalletsOpened).toBe(0);
+  });
+
+  it('bombing inside a Second Chance Wallet bombs the user without another ad rescue', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+    const rescued = resolveBigSpenderAdRescue(opened, 'completed', { type: 'bomb', amount: null });
+
+    expect(player(rescued, 'human').status).toBe('bombed');
+    expect(rescued.pendingAdRescue).toBeNull();
+    expect(player(rescued, 'human').adBombRescuesUsed).toBe(1);
+  });
+
+  it('limits the human to two ad rescues per game', () => {
+    const state = setCurrent(makeState(), 'human');
+    state.players = state.players.map((entry) => entry.playerId === 'human' ? { ...entry, adBombRescuesUsed: 2 } : entry);
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+
+    expect(opened.pendingAdRescue).toBeNull();
+    expect(player(opened, 'human').status).toBe('bombed');
+  });
+
+  it('locks a player and prevents future turns for that player', () => {
+    const state = setCurrent(makeState(), 'human');
+    const locked = lockBigSpenderPlayer(state, 'human');
+
+    expect(player(locked, 'human').status).toBe('locked');
+    expect(player(locked, 'human').finalizedAt).not.toBeNull();
+    expect(locked.currentTurnPlayerId).not.toBe('human');
+  });
+
+  it('replaces opened wallets and keeps the board at 24 slots', () => {
+    const state = setCurrent(makeState(), 'ai-1');
+    const wallet = firstWallet(state);
+    const opened = openBigSpenderWallet(state, 'ai-1', wallet.walletId, 'normal', {
+      forcedOutcome: { type: 'negative', amount: -25 },
+      suppressBonus: true,
+    });
+    const replacement = opened.board.find((entry) => entry.boardSlotIndex === wallet.boardSlotIndex);
+
+    expect(opened.board).toHaveLength(24);
+    expect(replacement?.walletId).not.toBe(wallet.walletId);
+    expect(replacement?.generationNumber).toBe(wallet.generationNumber + 1);
+  });
+
+  it('offers at most one extra wallet per turn and the extra cannot chain another extra', () => {
+    const state = setCurrent(makeState(), 'human');
+    const opened = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'negative', amount: -25 },
+      forceBonusOffer: true,
+    });
+    const bonusResolved = resolveBigSpenderBonusOffer(opened, true, { type: 'positive', amount: 50 });
+
+    expect(opened.pendingBonus?.playerId).toBe('human');
+    expect(player(bonusResolved, 'human').bonusWalletsOpened).toBe(1);
+    expect(bonusResolved.pendingBonus).toBeNull();
+  });
+
+  it('does not force a human action timeout before the global timer expires', () => {
+    const state = setCurrent(makeState(), 'human');
+    const sameTurn = finishBigSpenderTurn({ ...state, postWalletLockPlayerId: null });
+
+    expect(state.timerDurationMs).toBeGreaterThan(0);
+    expect(sameTurn.currentTurnPlayerId).not.toBeNull();
+  });
+
+  it('produces randomized AI action delays in the configured bands', () => {
+    expect(getAiActionDelayMs(2, () => 0)).toBe(1000);
+    expect(getAiActionDelayMs(6, () => 1)).toBe(4000);
+    expect(getAiActionDelayMs(7, () => 0)).toBe(1000);
+    expect(getAiActionDelayMs(11, () => 1)).toBe(3000);
+    expect(getAiActionDelayMs(12, () => 0)).toBe(750);
+    expect(getAiActionDelayMs(16, () => 1)).toBe(2500);
+  });
+
+  it('makes AI more likely to open high balances and cautious at low balances', () => {
+    expect(decideAiShouldOpen(900, () => 0.89)).toBe(true);
+    expect(decideAiShouldOpen(900, () => 0.91)).toBe(false);
+    expect(decideAiShouldOpen(120, () => 0.29)).toBe(true);
+    expect(decideAiShouldOpen(120, () => 0.31)).toBe(false);
+    expect(decideAiShouldOpen(500, () => 0.9, { secondsRemaining: 20, likelyWinningBalance: 100 })).toBe(true);
+  });
+
+  it('ends when all players are finalized and finalizes active players on timeout', () => {
+    let state = makeState();
+    for (const id of [...state.turnOrder]) {
+      state = setCurrent(state, id);
+      state = lockBigSpenderPlayer(state, id);
+    }
+
+    expect(state.status).toBe('completed');
+
+    const timedOut = finalizeBigSpenderByTimeout(makeState());
+    expect(timedOut.status).toBe('completed');
+    expect(timedOut.players.every((entry) => entry.finalizedAt != null)).toBe(true);
+  });
+
+  it('ranks zero finishers, lowest non-zero scores, and bombed players correctly', () => {
+    const state = makeState();
+    const ranked = rankBigSpenderPlayers([
+      { ...player(state, 'ai-1'), status: 'bombed', bombedAt: 5, finalizedAt: 5, balance: 100 },
+      { ...player(state, 'ai-2'), status: 'active', finalizedAt: 4, balance: 40, walletsOpened: 2, negativeWalletsOpened: 2 },
+      { ...player(state, 'human'), status: 'zeroFinished', zeroFinishedAt: 2, finalizedAt: 2, balance: 0 },
+      { ...player(state, 'ai-3'), status: 'locked', lockedAt: 3, finalizedAt: 3, balance: 50 },
+    ]);
+
+    expect(ranked.map((entry) => entry.playerId)).toEqual(['human', 'ai-2', 'ai-3', 'ai-1']);
+  });
+
+  it('uses wallets opened, negative wallets, finalization order, and turn order as deterministic tiebreakers', () => {
+    const state = makeState();
+    const ranked = rankBigSpenderPlayers([
+      { ...player(state, 'human'), balance: 100, walletsOpened: 1, negativeWalletsOpened: 1, finalizedAt: 1 },
+      { ...player(state, 'ai-1'), balance: 100, walletsOpened: 3, negativeWalletsOpened: 1, finalizedAt: 3 },
+      { ...player(state, 'ai-2'), balance: 100, walletsOpened: 3, negativeWalletsOpened: 2, finalizedAt: 4 },
+      { ...player(state, 'ai-3'), balance: 100, walletsOpened: 3, negativeWalletsOpened: 2, finalizedAt: 2 },
+    ]);
+
+    expect(ranked[0]?.playerId).toBe('ai-3');
+    expect(ranked[1]?.playerId).toBe('ai-2');
+    expect(ranked[3]?.playerId).toBe('human');
+  });
+
+  it('ranks later-bombed players above earlier-bombed players when everyone bombs', () => {
+    const state = makeState();
+    const ranked = rankBigSpenderPlayers([
+      { ...player(state, 'human'), status: 'bombed', bombedAt: 1, finalizedAt: 1 },
+      { ...player(state, 'ai-1'), status: 'bombed', bombedAt: 3, finalizedAt: 3 },
+      { ...player(state, 'ai-2'), status: 'bombed', bombedAt: 2, finalizedAt: 2 },
+    ]);
+
+    expect(ranked.map((entry) => entry.playerId)).toEqual(['ai-1', 'ai-2', 'human']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the new **Big Spender: Broke or Boom** minigame as a React-hosted, authoritative placement game.

- Adds a dedicated Big Spender rules engine for seeded wallet generation, weighted outcomes, turn flow, AI choices, bonus wallets, ad bomb rescues, locking, timeout finalization, and final rankings.
- Adds the playable React UI with the 24-wallet board, balance/status rail, lock windows, bonus-wallet prompt, ad-rescue prompt, timer pause state, and final ranking reveal.
- Registers the minigame in the React component map and minigame registry so it appears as an active game.
- Adds focused unit coverage for initialization, timer bands, odds/weight tables, wallet resolution, ad rescue rules, extra-wallet limits, locking, timeout, AI delay/behavior, wallet replacement, and ranking tie-breakers.

## Validation

- `npm run typecheck`
- `npx vitest run tests/unit/big-spender/bigSpenderLogic.test.ts`

Both passed locally in a temporary checkout of `codex/big-spender-broke-or-boom`.