### PR TITLE
[codex] Make Big Spender play in parallel

### DIFF
--- a/src/components/BigSpender/BigSpender.css
+++ b/src/components/BigSpender/BigSpender.css
@@ -1,7 +1,7 @@
 .big-spender {
   min-height: 100dvh;
   display: grid;
-  grid-template-rows: auto auto minmax(0, auto) auto;
+  grid-template-rows: auto auto minmax(0, auto) auto auto;
   gap: 0.65rem;
   padding: calc(env(safe-area-inset-top, 0px) + 0.7rem) 0.75rem calc(env(safe-area-inset-bottom, 0px) + 0.7rem);
   box-sizing: border-box;
@@ -24,6 +24,7 @@
 .big-spender__status-panel,
 .big-spender__players,
 .big-spender__actions,
+.big-spender__broadcasts,
 .big-spender__modal {
   border: 1px solid rgba(213, 226, 255, 0.14);
   background: rgba(7, 12, 20, 0.72);
@@ -111,7 +112,7 @@
   min-height: 0;
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  grid-auto-rows: minmax(4.3rem, 1fr);
+  grid-auto-rows: minmax(5.35rem, 1fr);
   gap: 0.45rem;
 }
 
@@ -123,7 +124,7 @@
   align-content: end;
   justify-items: start;
   min-width: 0;
-  min-height: 4.3rem;
+  min-height: 5.35rem;
   padding: 0.48rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 0.55rem;
@@ -135,6 +136,18 @@
 .big-spender__wallet:disabled {
   cursor: not-allowed;
   opacity: 0.56;
+}
+
+.big-spender__wallet--revealed {
+  justify-items: center;
+  align-content: center;
+  text-align: center;
+  filter: grayscale(0.75) brightness(0.82);
+  animation: big-spender-wallet-reveal 420ms ease-out both;
+}
+
+.big-spender__wallet--bomb {
+  border-color: rgba(255, 91, 91, 0.5);
 }
 
 .big-spender__wallet:focus-visible {
@@ -169,6 +182,27 @@
   position: relative;
   z-index: 1;
   color: rgba(255, 255, 255, 0.76);
+}
+
+.big-spender__wallet-result {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(1rem, 2.7vw, 1.55rem);
+  line-height: 1;
+  color: #fff5c7;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.42);
+}
+
+.big-spender__wallet-opener {
+  position: relative;
+  z-index: 1;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.68rem;
+  font-weight: 900;
+  color: rgba(239, 245, 255, 0.72);
 }
 
 .big-spender__players {
@@ -213,8 +247,15 @@
   place-items: center;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.1);
+  overflow: hidden;
   font-size: 0.72rem;
   font-weight: 900;
+}
+
+.big-spender__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .big-spender__player-copy {
@@ -275,6 +316,24 @@
 .big-spender__actions span {
   color: rgba(235, 242, 255, 0.82);
   font-size: 0.86rem;
+}
+
+.big-spender__action:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.big-spender__broadcasts {
+  display: grid;
+  gap: 0.32rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.75rem;
+}
+
+.big-spender__broadcasts p {
+  color: rgba(239, 245, 255, 0.86);
+  font-size: 0.82rem;
+  line-height: 1.25;
 }
 
 .big-spender__overlay {
@@ -388,7 +447,7 @@
 
   .big-spender__board {
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    grid-auto-rows: 4.15rem;
+    grid-auto-rows: 4.65rem;
   }
 
   .big-spender__players {
@@ -403,5 +462,19 @@
 
   .big-spender__modal-actions {
     grid-template-columns: 1fr;
+  }
+}
+
+@keyframes big-spender-wallet-reveal {
+  0% {
+    transform: scale(0.94) rotateX(12deg);
+  }
+
+  60% {
+    transform: scale(1.03) rotateX(0deg);
+  }
+
+  100% {
+    transform: scale(1);
   }
 }

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -7,14 +7,12 @@ import {
   buildBigSpenderRawResults,
   createInitialBigSpenderState,
   decideAiShouldOpen,
-  finishBigSpenderTurn,
   getAiActionDelayMs,
-  isFunnyAmount,
+  getBigSpenderBoardForPlayer,
   lockBigSpenderPlayer,
   openBigSpenderWallet,
   rankBigSpenderPlayers,
   resolveBigSpenderAdRescue,
-  resolveBigSpenderBonusOffer,
   resolveBigSpenderParticipants,
   type BigSpenderPlayerState,
   type BigSpenderState,
@@ -44,18 +42,26 @@ function getWalletAriaLabel(wallet: BigSpenderWallet) {
   return `Open wallet ${wallet.boardSlotIndex + 1}, generation ${wallet.generationNumber}`;
 }
 
-function getOutcomeCopy(state: BigSpenderState) {
-  const event = state.events.find((entry) => entry.type === 'walletOpened' && entry.outcome);
-  if (!event?.outcome) return 'Pick a wallet. Spend down to zero without finding a bomb.';
-  if (event.outcome.type === 'bomb') return 'Bomb wallet. The room just got expensive.';
-  const amount = event.outcome.amount ?? 0;
-  const funny = isFunnyAmount(amount) ? ' House number hit.' : '';
-  if (amount < 0) return `Spent ${Math.abs(amount)} Eyeoleans.${funny}`;
-  return `Gained ${amount} Eyeoleans.${funny}`;
+function isImageAvatar(avatar?: string) {
+  return Boolean(avatar && (/^(https?:|data:image\/|\/)/.test(avatar) || /\.(avif|jpe?g|png|webp|gif|svg)$/i.test(avatar)));
 }
 
-function chooseAiWallet(state: BigSpenderState, rng: () => number) {
-  const available = state.board.filter((wallet) => wallet.state === 'hidden');
+function getOutcomeCopy(state: BigSpenderState) {
+  const event = state.events.find((entry) => entry.type === 'walletOpened' && entry.outcome);
+  if (!event?.outcome) return 'Pick wallets while the house opens theirs. Lock in whenever you like.';
+  return event.message;
+}
+
+function getWalletResultLabel(wallet: BigSpenderWallet) {
+  if (wallet.state !== 'revealed') return null;
+  if (wallet.outcome.type === 'bomb') return 'Bomb';
+  const amount = wallet.outcome.amount ?? 0;
+  if (amount > 0) return `+${amount}`;
+  return `${amount}`;
+}
+
+function chooseAiWallet(state: BigSpenderState, playerId: string, rng: () => number) {
+  const available = getBigSpenderBoardForPlayer(state, playerId).filter((wallet) => wallet.state === 'hidden');
   return available[Math.floor(rng() * available.length)] ?? available[0] ?? null;
 }
 
@@ -68,79 +74,91 @@ export default function BigSpender(props: GenericMinigameProps) {
   const [state, setState] = useState(() => createInitialBigSpenderState(participants, seed));
   const [resultCommitted, setResultCommitted] = useState(false);
   const aiRngRef = useRef(mulberry32((seed ^ 0x5eedcafe) >>> 0));
-  const aiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const aiTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
 
-  const currentPlayer = useMemo(
-    () => state.players.find((player) => player.playerId === state.currentTurnPlayerId) ?? null,
-    [state.currentTurnPlayerId, state.players],
-  );
   const humanPlayer = useMemo(() => state.players.find((player) => player.isHuman) ?? null, [state.players]);
+  const humanBoard = useMemo(
+    () => humanPlayer ? getBigSpenderBoardForPlayer(state, humanPlayer.playerId) : state.board,
+    [humanPlayer, state],
+  );
+  const playersById = useMemo(() => new Map(state.players.map((player) => [player.playerId, player])), [state.players]);
   const ranking = useMemo(() => rankBigSpenderPlayers(state.players), [state.players]);
   const winner = ranking[0] ?? null;
   const canHumanAct = Boolean(
-    currentPlayer?.isHuman &&
-    currentPlayer.status === 'active' &&
+    humanPlayer &&
+    humanPlayer.status === 'active' &&
     state.status === 'running' &&
-    !state.pendingAdRescue &&
-    !state.pendingBonus &&
-    !state.postWalletLockPlayerId,
-  );
-  const canPostWalletLock = Boolean(
-    humanPlayer && state.postWalletLockPlayerId === humanPlayer.playerId && state.status === 'running',
+    state.pendingAdRescue?.playerId !== humanPlayer.playerId,
   );
 
   useEffect(() => {
-    if (aiTimerRef.current) {
-      clearTimeout(aiTimerRef.current);
-      aiTimerRef.current = null;
+    const timers = aiTimersRef.current;
+    for (const [playerId, timer] of timers) {
+      const player = state.players.find((entry) => entry.playerId === playerId);
+      if (state.status !== 'running' || !player || player.isHuman || player.status !== 'active') {
+        clearTimeout(timer);
+        timers.delete(playerId);
+      }
     }
-    if (state.status !== 'running' || state.pendingAdRescue || state.postWalletLockPlayerId) return;
 
-    if (state.pendingBonus) {
-      const bonusPlayer = state.players.find((player) => player.playerId === state.pendingBonus?.playerId);
-      if (!bonusPlayer || bonusPlayer.isHuman) return;
-      aiTimerRef.current = setTimeout(() => {
+    if (state.status !== 'running') return;
+
+    for (const player of state.players) {
+      if (player.isHuman || player.status !== 'active' || timers.has(player.playerId)) continue;
+      if (!getBigSpenderBoardForPlayer(state, player.playerId).some((wallet) => wallet.state === 'hidden')) continue;
+      const delay = getAiActionDelayMs(state.startingPlayerCount, aiRngRef.current);
+      const timer = setTimeout(() => {
+        aiTimersRef.current.delete(player.playerId);
         setState((previous) => {
-          const actor = previous.players.find((player) => player.playerId === previous.pendingBonus?.playerId);
-          const accept = actor ? decideAiShouldOpen(actor.balance, aiRngRef.current) : false;
-          return resolveBigSpenderBonusOffer(previous, accept);
+          const actor = previous.players.find((entry) => entry.playerId === player.playerId);
+          if (!actor || actor.isHuman || actor.status !== 'active') return previous;
+          const shouldOpen = decideAiShouldOpen(actor.balance, aiRngRef.current);
+          if (!shouldOpen) return lockBigSpenderPlayer(previous, actor.playerId);
+          const wallet = chooseAiWallet(previous, actor.playerId, aiRngRef.current);
+          if (!wallet) return lockBigSpenderPlayer(previous, actor.playerId);
+          return openBigSpenderWallet(previous, actor.playerId, wallet.walletId);
         });
-      }, getAiActionDelayMs(state.startingPlayerCount, aiRngRef.current));
-      return () => {
-        if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
-      };
+      }, delay);
+      timers.set(player.playerId, timer);
     }
+  }, [state]);
 
-    if (!currentPlayer || currentPlayer.isHuman || currentPlayer.status !== 'active') return;
-    const delay = getAiActionDelayMs(state.startingPlayerCount, aiRngRef.current);
-    aiTimerRef.current = setTimeout(() => {
-      setState((previous) => {
-        const actor = previous.players.find((player) => player.playerId === previous.currentTurnPlayerId);
-        if (!actor || actor.isHuman || actor.status !== 'active') return previous;
-        const shouldOpen = decideAiShouldOpen(actor.balance, aiRngRef.current);
-        if (!shouldOpen) return lockBigSpenderPlayer(previous, actor.playerId);
-        const wallet = chooseAiWallet(previous, aiRngRef.current);
-        if (!wallet) return lockBigSpenderPlayer(previous, actor.playerId);
-        return openBigSpenderWallet(previous, actor.playerId, wallet.walletId);
-      });
-    }, delay);
+  useEffect(() => {
     return () => {
-      if (aiTimerRef.current) clearTimeout(aiTimerRef.current);
+      for (const timer of aiTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      aiTimersRef.current.clear();
     };
-  }, [currentPlayer, state]);
+  }, []);
+
+  useEffect(() => {
+    if (state.status !== 'running') return;
+    if (!humanPlayer || humanPlayer.status !== 'active') return;
+    const hasHiddenWallets = humanBoard.some((wallet) => wallet.state === 'hidden');
+    if (hasHiddenWallets) return;
+    setState((previous) => {
+      const actor = previous.players.find((player) => player.playerId === humanPlayer.playerId);
+      if (
+        previous.status !== 'running' ||
+        !actor ||
+        actor.status !== 'active' ||
+        getBigSpenderBoardForPlayer(previous, actor.playerId).some((wallet) => wallet.state === 'hidden')
+      ) {
+        return previous;
+      }
+      return lockBigSpenderPlayer(previous, actor.playerId);
+    });
+  }, [humanBoard, humanPlayer, state.status]);
 
   const openWallet = (walletId: string) => {
-    if (!currentPlayer || !canHumanAct) return;
-    setState((previous) => openBigSpenderWallet(previous, currentPlayer.playerId, walletId));
+    if (!humanPlayer || !canHumanAct) return;
+    setState((previous) => openBigSpenderWallet(previous, humanPlayer.playerId, walletId));
   };
 
   const lockHuman = () => {
     if (!humanPlayer) return;
     setState((previous) => lockBigSpenderPlayer(previous, humanPlayer.playerId));
-  };
-
-  const continueHumanTurn = () => {
-    setState((previous) => finishBigSpenderTurn(previous));
   };
 
   const finish = () => {
@@ -164,8 +182,8 @@ export default function BigSpender(props: GenericMinigameProps) {
 
       <section className="big-spender__status-panel" aria-live="polite">
         <div>
-          <span className="big-spender__eyebrow">Current turn</span>
-          <strong>{currentPlayer?.displayName ?? 'Results'}</strong>
+          <span className="big-spender__eyebrow">Live balance</span>
+          <strong>{humanPlayer ? `${humanPlayer.balance} Eyeoleans` : 'Results'}</strong>
         </div>
         <p>{getOutcomeCopy(state)}</p>
         {humanPlayer && (
@@ -177,20 +195,36 @@ export default function BigSpender(props: GenericMinigameProps) {
 
       <main className="big-spender__table">
         <section className="big-spender__board" aria-label="Wallet board">
-          {state.board.map((wallet) => (
-            <button
-              key={wallet.walletId}
-              type="button"
-              className={`big-spender__wallet big-spender__wallet--color-${wallet.generationColor}`}
-              disabled={!canHumanAct || wallet.state !== 'hidden'}
-              onClick={() => openWallet(wallet.walletId)}
-              aria-label={getWalletAriaLabel(wallet)}
-            >
-              <span className="big-spender__wallet-flap" aria-hidden="true" />
-              <span className="big-spender__wallet-id">{wallet.boardSlotIndex + 1}</span>
-              <span className="big-spender__wallet-generation">G{wallet.generationNumber}</span>
-            </button>
-          ))}
+          {humanBoard.map((wallet) => {
+            const opener = wallet.openedByPlayerId ? playersById.get(wallet.openedByPlayerId) : null;
+            const resultLabel = getWalletResultLabel(wallet);
+            return (
+              <button
+                key={wallet.walletId}
+                type="button"
+                className={[
+                  'big-spender__wallet',
+                  `big-spender__wallet--color-${wallet.generationColor}`,
+                  wallet.state === 'revealed' ? 'big-spender__wallet--revealed' : '',
+                  wallet.outcome.type === 'bomb' && wallet.state === 'revealed' ? 'big-spender__wallet--bomb' : '',
+                ].join(' ')}
+                disabled={!canHumanAct || wallet.state !== 'hidden'}
+                onClick={() => openWallet(wallet.walletId)}
+                aria-label={getWalletAriaLabel(wallet)}
+              >
+                <span className="big-spender__wallet-flap" aria-hidden="true" />
+                <span className="big-spender__wallet-id">{wallet.boardSlotIndex + 1}</span>
+                {resultLabel ? (
+                  <>
+                    <strong className="big-spender__wallet-result">{resultLabel}</strong>
+                    <span className="big-spender__wallet-opener">{opener?.displayName ?? 'Opened'}</span>
+                  </>
+                ) : (
+                  <span className="big-spender__wallet-generation">Tap</span>
+                )}
+              </button>
+            );
+          })}
         </section>
 
         <aside className="big-spender__players" aria-label="Player balances">
@@ -199,12 +233,17 @@ export default function BigSpender(props: GenericMinigameProps) {
               key={player.playerId}
               className={[
                 'big-spender__player',
-                player.currentTurn ? 'big-spender__player--current' : '',
                 player.isHuman ? 'big-spender__player--human' : '',
                 `big-spender__player--${player.status}`,
               ].join(' ')}
             >
-              <span className="big-spender__avatar" aria-hidden="true">{player.avatar || getInitials(player.displayName)}</span>
+              <span className="big-spender__avatar" aria-hidden="true">
+                {isImageAvatar(player.avatar) ? (
+                  <img src={player.avatar} alt="" />
+                ) : (
+                  player.avatar || getInitials(player.displayName)
+                )}
+              </span>
               <div className="big-spender__player-copy">
                 <strong>{player.displayName}</strong>
                 <span>{getPlayerLabel(player)} - {player.walletsOpened} wallets</span>
@@ -219,42 +258,23 @@ export default function BigSpender(props: GenericMinigameProps) {
         </aside>
       </main>
 
-      {canHumanAct && (
+      {state.status === 'running' && (
         <footer className="big-spender__actions">
-          <button type="button" className="big-spender__action big-spender__action--lock" onClick={lockHuman}>
-            Lock
+          <button type="button" className="big-spender__action big-spender__action--lock" onClick={lockHuman} disabled={!canHumanAct}>
+            Lock in
           </button>
-          <span>Open any wallet or lock your balance.</span>
+          <span>{canHumanAct ? 'Open wallets while the house plays live.' : 'Your run is locked.'}</span>
         </footer>
       )}
 
-      {canPostWalletLock && (
-        <div className="big-spender__overlay">
-          <div className="big-spender__modal">
-            <span className="big-spender__eyebrow">Lock window</span>
-            <h2>Keep that balance?</h2>
-            <p>You can lock now, or pass the turn and keep chasing zero next time.</p>
-            <div className="big-spender__modal-actions">
-              <button type="button" onClick={lockHuman}>Lock balance</button>
-              <button type="button" onClick={continueHumanTurn}>Keep playing</button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {state.pendingBonus && humanPlayer?.playerId === state.pendingBonus.playerId && (
-        <div className="big-spender__overlay">
-          <div className="big-spender__modal">
-            <span className="big-spender__eyebrow">Bonus wallet</span>
-            <h2>One more wallet?</h2>
-            <p>The bonus uses normal odds, but cannot trigger another bonus.</p>
-            <div className="big-spender__modal-actions">
-              <button type="button" onClick={() => setState((previous) => resolveBigSpenderBonusOffer(previous, true))}>Open bonus</button>
-              <button type="button" onClick={() => setState((previous) => resolveBigSpenderBonusOffer(previous, false))}>Decline</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <section className="big-spender__broadcasts" aria-label="House broadcasts" aria-live="polite">
+        {state.events
+          .filter((entry) => entry.type === 'walletOpened' || entry.type === 'playerLocked' || entry.type === 'playerBombed' || entry.type === 'playerZeroFinished')
+          .slice(0, 4)
+          .map((entry, index) => (
+            <p key={`${entry.type}-${entry.playerId ?? 'house'}-${index}`}>{entry.message}</p>
+          ))}
+      </section>
 
       {state.pendingAdRescue && humanPlayer?.playerId === state.pendingAdRescue.playerId && (
         <div className="big-spender__overlay">

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -124,32 +124,14 @@ export default function BigSpender(props: GenericMinigameProps) {
   }, [state]);
 
   useEffect(() => {
+    const timers = aiTimersRef.current;
     return () => {
-      for (const timer of aiTimersRef.current.values()) {
+      for (const timer of timers.values()) {
         clearTimeout(timer);
       }
-      aiTimersRef.current.clear();
+      timers.clear();
     };
   }, []);
-
-  useEffect(() => {
-    if (state.status !== 'running') return;
-    if (!humanPlayer || humanPlayer.status !== 'active') return;
-    const hasHiddenWallets = humanBoard.some((wallet) => wallet.state === 'hidden');
-    if (hasHiddenWallets) return;
-    setState((previous) => {
-      const actor = previous.players.find((player) => player.playerId === humanPlayer.playerId);
-      if (
-        previous.status !== 'running' ||
-        !actor ||
-        actor.status !== 'active' ||
-        getBigSpenderBoardForPlayer(previous, actor.playerId).some((wallet) => wallet.state === 'hidden')
-      ) {
-        return previous;
-      }
-      return lockBigSpenderPlayer(previous, actor.playerId);
-    });
-  }, [humanBoard, humanPlayer, state.status]);
 
   const openWallet = (walletId: string) => {
     if (!humanPlayer || !canHumanAct) return;

--- a/src/components/BigSpender/bigSpenderLogic.ts
+++ b/src/components/BigSpender/bigSpenderLogic.ts
@@ -5,13 +5,13 @@ export const BIG_SPENDER_DISPLAY_NAME = 'Big Spender: Broke or Boom';
 
 export const BIG_SPENDER_CONFIG = {
   startingBalance: 1000,
-  boardSize: 24,
+  boardSize: 30,
   outcomeWeights: {
     negative: 81,
     positive: 15,
     bomb: 4,
   },
-  bonusExtraWalletChance: 0.1,
+  bonusExtraWalletChance: 0,
   maxExtraWalletsPerTurn: 1,
   maxAdBombRescues: 2,
 } as const;
@@ -83,6 +83,7 @@ export interface BigSpenderWallet {
   generationColor: number;
   outcome: BigSpenderWalletOutcome;
   state: BigSpenderWalletState;
+  openedByPlayerId: string | null;
 }
 
 export interface BigSpenderPlayerState {
@@ -148,6 +149,7 @@ export interface BigSpenderState {
   currentTurnPlayerId: string | null;
   players: BigSpenderPlayerState[];
   board: BigSpenderWallet[];
+  boardsByPlayerId: Record<string, BigSpenderWallet[]>;
   pendingBonus: BigSpenderPendingBonus | null;
   pendingAdRescue: BigSpenderPendingAdRescue | null;
   postWalletLockPlayerId: string | null;
@@ -177,6 +179,13 @@ function appendEvent(state: BigSpenderState, event: BigSpenderEvent) {
   state.events = [event, ...state.events].slice(0, 16);
 }
 
+function getOutcomeMessage(player: BigSpenderPlayerState, outcome: BigSpenderWalletOutcome) {
+  if (outcome.type === 'bomb') return `Rumors say ${player.displayName} just opened a bomb.`;
+  const amount = outcome.amount ?? 0;
+  if (amount < 0) return `${player.displayName} just opened ${amount} Eyeoleans.`;
+  return `${player.displayName} just found +${amount} Eyeoleans.`;
+}
+
 function nextRandom(state: BigSpenderState) {
   const seed = (state.seed + Math.imul(state.randomCursor + 1, 0x9e3779b1)) >>> 0;
   state.randomCursor += 1;
@@ -199,6 +208,12 @@ function cloneState(state: BigSpenderState): BigSpenderState {
     turnOrder: [...state.turnOrder],
     players: state.players.map((player) => ({ ...player })),
     board: state.board.map((wallet) => ({ ...wallet, outcome: { ...wallet.outcome } })),
+    boardsByPlayerId: Object.fromEntries(
+      Object.entries(state.boardsByPlayerId).map(([playerId, board]) => [
+        playerId,
+        board.map((wallet) => ({ ...wallet, outcome: { ...wallet.outcome } })),
+      ]),
+    ),
     pendingBonus: state.pendingBonus ? { ...state.pendingBonus } : null,
     pendingAdRescue: state.pendingAdRescue ? { ...state.pendingAdRescue } : null,
     events: [...state.events],
@@ -211,10 +226,21 @@ function getPlayerMutable(state: BigSpenderState, playerId: string) {
   return player;
 }
 
-function getWalletMutable(state: BigSpenderState, walletId: string) {
-  const wallet = state.board.find((entry) => entry.walletId === walletId);
+function getBoardMutable(state: BigSpenderState, playerId: string) {
+  const board = state.boardsByPlayerId[playerId];
+  if (!board) throw new Error(`Big Spender board for '${playerId}' not found.`);
+  return board;
+}
+
+function getWalletMutable(state: BigSpenderState, playerId: string, walletId: string) {
+  const wallet = getBoardMutable(state, playerId).find((entry) => entry.walletId === walletId);
   if (!wallet) throw new Error(`Big Spender wallet '${walletId}' not found.`);
   return wallet;
+}
+
+function syncVisibleBoard(state: BigSpenderState) {
+  const humanPlayer = state.players.find((player) => player.isHuman) ?? state.players[0];
+  state.board = humanPlayer ? state.boardsByPlayerId[humanPlayer.playerId] ?? [] : [];
 }
 
 function markTurnFlags(state: BigSpenderState) {
@@ -235,6 +261,12 @@ function nextEligibleTurnIndex(state: BigSpenderState, startIndex: number) {
 }
 
 function completeIfNeeded(state: BigSpenderState) {
+  for (const player of state.players) {
+    const hiddenWallets = (state.boardsByPlayerId[player.playerId] ?? []).some((wallet) => wallet.state === 'hidden');
+    if (player.status === 'active' && player.finalizedAt == null && !hiddenWallets) {
+      finalizePlayer(player, state, 'locked');
+    }
+  }
   const unresolved = state.players.filter((player) => player.status === 'active' && player.finalizedAt == null);
   if (unresolved.length > 0) return state;
   state.status = 'completed';
@@ -243,6 +275,7 @@ function completeIfNeeded(state: BigSpenderState) {
   state.pendingBonus = null;
   state.pendingAdRescue = null;
   markTurnFlags(state);
+  syncVisibleBoard(state);
   appendEvent(state, { type: 'gameCompleted', message: 'All players are finalized.' });
   return state;
 }
@@ -263,30 +296,17 @@ function advanceTurnMutable(state: BigSpenderState) {
   return state;
 }
 
-function createWalletFromRoll(slotIndex: number, generationNumber: number, rng: () => number): BigSpenderWallet {
+function createWalletFromRoll(slotIndex: number, generationNumber: number, playerId: string, rng: () => number): BigSpenderWallet {
   const outcome = pickWalletOutcome(rng);
   return {
-    walletId: `wallet-${slotIndex}-${generationNumber}`,
+    walletId: `${playerId}-wallet-${slotIndex}-${generationNumber}`,
     boardSlotIndex: slotIndex,
     generationNumber,
     generationColor: generationNumber % 6,
     outcome,
     state: 'hidden',
+    openedByPlayerId: null,
   };
-}
-
-function replaceWalletMutable(state: BigSpenderState, wallet: BigSpenderWallet) {
-  const nextWallet = createWalletFromRoll(
-    wallet.boardSlotIndex,
-    wallet.generationNumber + 1,
-    () => nextRandom(state),
-  );
-  state.board = state.board.map((entry) => entry.walletId === wallet.walletId ? nextWallet : entry);
-  appendEvent(state, {
-    type: 'walletReplaced',
-    walletId: nextWallet.walletId,
-    message: `Slot ${nextWallet.boardSlotIndex + 1} refilled.`,
-  });
 }
 
 function finalizePlayer(player: BigSpenderPlayerState, state: BigSpenderState, status: BigSpenderPlayerStatus) {
@@ -296,10 +316,6 @@ function finalizePlayer(player: BigSpenderPlayerState, state: BigSpenderState, s
   if (status === 'locked') player.lockedAt = state.actionOrder;
   if (status === 'zeroFinished') player.zeroFinishedAt = state.actionOrder;
   if (status === 'bombed') player.bombedAt = state.actionOrder;
-}
-
-function shouldPauseForHumanLock(player: BigSpenderPlayerState, state: BigSpenderState, kind: BigSpenderWalletKind) {
-  return kind !== 'bonus' && player.isHuman && player.status === 'active' && state.status === 'running';
 }
 
 function maybeOfferBonus(state: BigSpenderState, player: BigSpenderPlayerState, openedWallet: BigSpenderWallet, options: BigSpenderOpenOptions) {
@@ -341,7 +357,7 @@ function applyOutcomeMutable(
       type: 'walletOpened',
       playerId: player.playerId,
       outcome,
-      message: `${player.displayName} gained ${outcome.amount ?? 0} Eyeoleans.`,
+      message: getOutcomeMessage(player, outcome),
     });
     return;
   }
@@ -353,7 +369,7 @@ function applyOutcomeMutable(
       type: 'walletOpened',
       playerId: player.playerId,
       outcome,
-      message: `${player.displayName} spent ${Math.abs(outcome.amount ?? 0)} Eyeoleans.`,
+      message: getOutcomeMessage(player, outcome),
     });
     if (player.balance === 0) {
       finalizePlayer(player, state, 'zeroFinished');
@@ -371,7 +387,7 @@ function applyOutcomeMutable(
     type: 'walletOpened',
     playerId: player.playerId,
     outcome,
-    message: `${player.displayName} opened a bomb.`,
+    message: getOutcomeMessage(player, outcome),
   });
 }
 
@@ -384,15 +400,11 @@ function markBombedMutable(state: BigSpenderState, player: BigSpenderPlayerState
   });
 }
 
-function finishAfterResolution(state: BigSpenderState, player: BigSpenderPlayerState, kind: BigSpenderWalletKind) {
+function finishAfterResolution(state: BigSpenderState) {
   completeIfNeeded(state);
   if (state.status === 'completed' || state.pendingAdRescue || state.pendingBonus) return state;
-  if (shouldPauseForHumanLock(player, state, kind)) {
-    state.postWalletLockPlayerId = player.playerId;
-    markTurnFlags(state);
-    return state;
-  }
-  return advanceTurnMutable(state);
+  markTurnFlags(state);
+  return state;
 }
 
 export function sumWeights(items: readonly { weight: number }[]) {
@@ -421,6 +433,10 @@ export function pickWalletOutcome(rng: () => number): BigSpenderWalletOutcome {
 
 export function isFunnyAmount(amount: number | null | undefined) {
   return amount != null && BIG_SPENDER_FUNNY_AMOUNTS.has(Math.abs(amount));
+}
+
+export function getBigSpenderBoardForPlayer(state: BigSpenderState, playerId: string) {
+  return state.boardsByPlayerId[playerId] ?? [];
 }
 
 export function resolveBigSpenderParticipants(participants?: BigSpenderParticipant[], participantIds?: string[]) {
@@ -475,22 +491,29 @@ export function createInitialBigSpenderState(
     originalTurnOrderIndex: index,
     currentTurn: false,
   }));
-  const board = Array.from({ length: BIG_SPENDER_CONFIG.boardSize }, (_unused, slotIndex) =>
-    createWalletFromRoll(slotIndex, 1, rng),
+  const boardsByPlayerId = Object.fromEntries(
+    players.map((player) => [
+      player.playerId,
+      Array.from({ length: BIG_SPENDER_CONFIG.boardSize }, (_unused, slotIndex) =>
+        createWalletFromRoll(slotIndex, 1, player.playerId, rng),
+      ),
+    ]),
   );
   const firstPlayerId = players[0]?.playerId ?? null;
+  const humanPlayerId = players.find((player) => player.isHuman)?.playerId ?? firstPlayerId;
   const state: BigSpenderState = {
     gameId: BIG_SPENDER_GAME_ID,
     status: 'running',
     seed,
-    randomCursor: BIG_SPENDER_CONFIG.boardSize + participants.length,
+    randomCursor: BIG_SPENDER_CONFIG.boardSize * participants.length + participants.length,
     actionOrder: 0,
     startingPlayerCount: participants.length,
     turnOrder: players.map((player) => player.playerId),
     currentTurnIndex: 0,
     currentTurnPlayerId: firstPlayerId,
     players,
-    board,
+    board: humanPlayerId ? boardsByPlayerId[humanPlayerId] ?? [] : [],
+    boardsByPlayerId,
     pendingBonus: null,
     pendingAdRescue: null,
     postWalletLockPlayerId: null,
@@ -518,17 +541,18 @@ export function openBigSpenderWallet(
 ) {
   const state = cloneState(previousState);
   if (state.status !== 'running') return state;
-  if (state.pendingAdRescue || state.pendingBonus) return state;
+  if (state.pendingAdRescue?.playerId === playerId || state.pendingBonus?.playerId === playerId) return state;
   const player = getPlayerMutable(state, playerId);
   if (player.status !== 'active' || player.finalizedAt != null) return state;
-  if (state.currentTurnPlayerId !== playerId && kind === 'normal') return state;
 
-  const wallet = getWalletMutable(state, walletId);
+  const wallet = getWalletMutable(state, playerId, walletId);
   if (wallet.state !== 'hidden') return state;
   wallet.state = 'opening';
+  wallet.openedByPlayerId = playerId;
   const outcome = options.forcedOutcome ?? wallet.outcome;
   wallet.outcome = outcome;
   wallet.state = 'revealed';
+  syncVisibleBoard(state);
 
   applyOutcomeMutable(state, player, outcome, kind);
 
@@ -544,15 +568,13 @@ export function openBigSpenderWallet(
       return state;
     }
     markBombedMutable(state, player);
-    replaceWalletMutable(state, wallet);
-    return finishAfterResolution(state, player, kind);
+    return finishAfterResolution(state);
   }
 
-  replaceWalletMutable(state, wallet);
   if (player.status === 'active' && kind === 'normal' && maybeOfferBonus(state, player, wallet, options)) {
     return state;
   }
-  return finishAfterResolution(state, player, kind);
+  return finishAfterResolution(state);
 }
 
 export function resolveBigSpenderBonusOffer(previousState: BigSpenderState, accept: boolean, forcedOutcome?: BigSpenderWalletOutcome) {
@@ -567,13 +589,13 @@ export function resolveBigSpenderBonusOffer(previousState: BigSpenderState, acce
       playerId: pending.playerId,
       message: `${player.displayName} declined the bonus wallet.`,
     });
-    return finishAfterResolution(state, player, 'normal');
+    return finishAfterResolution(state);
   }
 
   const outcome = forcedOutcome ?? pickWalletOutcome(() => nextRandom(state));
   resolveSyntheticWalletMutable(state, player, outcome, 'bonus');
   if (outcome.type === 'bomb') markBombedMutable(state, player);
-  return finishAfterResolution(state, player, 'bonus');
+  return finishAfterResolution(state);
 }
 
 export function resolveBigSpenderAdRescue(
@@ -586,7 +608,6 @@ export function resolveBigSpenderAdRescue(
   if (!pending) return state;
   state.pendingAdRescue = null;
   const player = getPlayerMutable(state, pending.playerId);
-  const wallet = getWalletMutable(state, pending.walletId);
 
   if (decision !== 'completed' || player.status !== 'active') {
     appendEvent(state, {
@@ -595,8 +616,7 @@ export function resolveBigSpenderAdRescue(
       message: `${player.displayName} did not complete the ad save.`,
     });
     markBombedMutable(state, player);
-    replaceWalletMutable(state, wallet);
-    return finishAfterResolution(state, player, 'normal');
+    return finishAfterResolution(state);
   }
 
   player.adBombRescuesUsed += 1;
@@ -608,8 +628,7 @@ export function resolveBigSpenderAdRescue(
   const outcome = forcedSecondChanceOutcome ?? pickWalletOutcome(() => nextRandom(state));
   resolveSyntheticWalletMutable(state, player, outcome, 'secondChance');
   if (outcome.type === 'bomb') markBombedMutable(state, player);
-  replaceWalletMutable(state, wallet);
-  return finishAfterResolution(state, player, 'secondChance');
+  return finishAfterResolution(state);
 }
 
 export function finishBigSpenderTurn(previousState: BigSpenderState) {
@@ -621,14 +640,17 @@ export function lockBigSpenderPlayer(previousState: BigSpenderState, playerId: s
   const state = cloneState(previousState);
   const player = getPlayerMutable(state, playerId);
   if (state.status !== 'running' || player.status !== 'active' || player.finalizedAt != null) return state;
-  if (state.currentTurnPlayerId !== playerId && state.postWalletLockPlayerId !== playerId) return state;
   finalizePlayer(player, state, 'locked');
+  if (state.currentTurnPlayerId === playerId) {
+    state.currentTurnPlayerId = null;
+    markTurnFlags(state);
+  }
   appendEvent(state, {
     type: 'playerLocked',
     playerId,
     message: `${player.displayName} locked at ${player.balance} Eyeoleans.`,
   });
-  return advanceTurnMutable(state);
+  return completeIfNeeded(state);
 }
 
 export function decideAiShouldOpen(balance: number, rng: () => number) {

--- a/tests/unit/big-spender/bigSpenderLogic.test.ts
+++ b/tests/unit/big-spender/bigSpenderLogic.test.ts
@@ -9,6 +9,7 @@ import {
   decideAiShouldOpen,
   finishBigSpenderTurn,
   getAiActionDelayMs,
+  getBigSpenderBoardForPlayer,
   lockBigSpenderPlayer,
   openBigSpenderWallet,
   pickWalletOutcome,
@@ -39,8 +40,8 @@ function setCurrent(state: BigSpenderState, playerId: string) {
   return state;
 }
 
-function firstWallet(state: BigSpenderState) {
-  const wallet = state.board[0];
+function firstWallet(state: BigSpenderState, playerId = 'human') {
+  const wallet = getBigSpenderBoardForPlayer(state, playerId)[0];
   if (!wallet) throw new Error('missing wallet');
   return wallet;
 }
@@ -52,12 +53,14 @@ function player(state: BigSpenderState, playerId: string) {
 }
 
 describe('Big Spender: Broke or Boom logic', () => {
-  it('initializes all players at 1,000 Eyeoleans with a 24-wallet board', () => {
+  it('initializes all players at 1,000 Eyeoleans with private 30-wallet boards', () => {
     const state = makeState();
 
     expect(state.players).toHaveLength(participants.length);
     expect(state.players.every((entry) => entry.balance === BIG_SPENDER_CONFIG.startingBalance)).toBe(true);
-    expect(state.board).toHaveLength(24);
+    expect(state.board).toHaveLength(30);
+    expect(state.players.every((entry) => getBigSpenderBoardForPlayer(state, entry.playerId).length === 30)).toBe(true);
+    expect(firstWallet(state, 'human').walletId).not.toBe(firstWallet(state, 'ai-1').walletId);
     expect(state.currentTurnPlayerId).toBeTruthy();
   });
 
@@ -99,14 +102,16 @@ describe('Big Spender: Broke or Boom logic', () => {
     expect(player(opened, 'human').positiveWalletsOpened).toBe(1);
   });
 
-  it('marks an AI bombed and advances away from that player', () => {
+  it('marks an AI bombed without using the human board', () => {
     const state = setCurrent(makeState(), 'ai-1');
-    const opened = openBigSpenderWallet(state, 'ai-1', firstWallet(state).walletId, 'normal', {
+    const humanWalletId = firstWallet(state, 'human').walletId;
+    const opened = openBigSpenderWallet(state, 'ai-1', firstWallet(state, 'ai-1').walletId, 'normal', {
       forcedOutcome: { type: 'bomb', amount: null },
     });
 
     expect(player(opened, 'ai-1').status).toBe('bombed');
-    expect(opened.currentTurnPlayerId).not.toBe('ai-1');
+    expect(getBigSpenderBoardForPlayer(opened, 'human')[0]?.walletId).toBe(humanWalletId);
+    expect(getBigSpenderBoardForPlayer(opened, 'human')[0]?.state).toBe('hidden');
   });
 
   it('offers ad rescue to an eligible human bomb opening', () => {
@@ -186,18 +191,18 @@ describe('Big Spender: Broke or Boom logic', () => {
     expect(locked.currentTurnPlayerId).not.toBe('human');
   });
 
-  it('replaces opened wallets and keeps the board at 24 slots', () => {
+  it('keeps opened wallets revealed on that player board', () => {
     const state = setCurrent(makeState(), 'ai-1');
-    const wallet = firstWallet(state);
+    const wallet = firstWallet(state, 'ai-1');
     const opened = openBigSpenderWallet(state, 'ai-1', wallet.walletId, 'normal', {
       forcedOutcome: { type: 'negative', amount: -25 },
       suppressBonus: true,
     });
-    const replacement = opened.board.find((entry) => entry.boardSlotIndex === wallet.boardSlotIndex);
+    const openedWallet = getBigSpenderBoardForPlayer(opened, 'ai-1').find((entry) => entry.walletId === wallet.walletId);
 
-    expect(opened.board).toHaveLength(24);
-    expect(replacement?.walletId).not.toBe(wallet.walletId);
-    expect(replacement?.generationNumber).toBe(wallet.generationNumber + 1);
+    expect(getBigSpenderBoardForPlayer(opened, 'ai-1')).toHaveLength(30);
+    expect(openedWallet?.state).toBe('revealed');
+    expect(openedWallet?.openedByPlayerId).toBe('ai-1');
   });
 
   it('offers at most one extra wallet per turn and the extra cannot chain another extra', () => {


### PR DESCRIPTION
## Summary
- Change Big Spender from turn-based play to parallel play.
- Give every player their own private 6x5 wallet board, with the visible grid showing only the human player's board.
- Keep picked wallets revealed and grayed out instead of replacing them.
- Show clear wallet contents on reveal with compact animated result labels.
- Replace the post-wallet lock prompt with an always-available Lock in button.
- Add live broadcast messages for wallet opens, bombs, lock-ins, and zero finishes.
- Fix avatar URLs rendering as text in the player list.

## Notes
AIs now act independently on their own boards every 1-4 seconds while the player keeps interacting with their own board. Opponent scores remain hidden.

## Validation
- `npx vitest run tests/unit/big-spender/bigSpenderLogic.test.ts`
- `npm run typecheck`
- `npm run build`

I attempted a local browser smoke test, but the Vite dev server would not stay alive from this shell session. The production build completed successfully.