### PR TITLE
[codex] Refine Vault Verdict presentation

### DIFF
--- a/src/components/VaultVerdict/VaultVerdict.css
+++ b/src/components/VaultVerdict/VaultVerdict.css
@@ -2,39 +2,56 @@
   min-height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: calc(var(--minigame-safe-top, 0px) + 16px) 16px calc(var(--minigame-safe-bottom, 0px) + 18px);
+  padding: calc(var(--minigame-safe-top, 0px) + 14px) 14px calc(var(--minigame-safe-bottom, 0px) + 16px);
   background:
-    radial-gradient(circle at 50% 30%, rgba(0, 229, 255, 0.22), transparent 28%),
-    linear-gradient(135deg, #081018 0%, #16061c 46%, #101013 100%);
-  color: #f7fbff;
+    radial-gradient(circle at 50% -10%, rgba(54, 202, 214, 0.2), transparent 34%),
+    radial-gradient(circle at 8% 16%, rgba(226, 79, 126, 0.14), transparent 22%),
+    linear-gradient(135deg, #091114 0%, #111820 48%, #090b10 100%);
+  color: #eef8f7;
 }
 
 .vault-verdict__stage {
-  position: relative;
-  z-index: 1;
   display: grid;
-  gap: 14px;
-  max-width: 1240px;
+  gap: 12px;
+  max-width: 1180px;
   margin: 0 auto;
 }
 
 .vault-verdict__header {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: minmax(170px, auto) minmax(280px, 1fr) minmax(112px, auto);
+  gap: 10px;
+  align-items: stretch;
+}
+
+.vault-verdict__brand,
+.vault-verdict__timer,
+.vault-verdict__broadcast-row,
+.vault-verdict__event-panel,
+.vault-verdict__board,
+.vault-verdict__result-hero,
+.vault-verdict__result-list article,
+.vault-verdict__amount-panel {
+  border: 1px solid rgba(174, 242, 238, 0.18);
+  border-radius: 8px;
+  background: rgba(7, 14, 18, 0.78);
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.26);
+  backdrop-filter: blur(18px);
+}
+
+.vault-verdict__brand {
+  padding: 12px 14px;
 }
 
 .vault-verdict__eyebrow,
-.vault-verdict__offer span,
-.vault-verdict__my-vault span,
-.vault-verdict__round-panel span,
-.vault-verdict__result-hero span {
+.vault-verdict__event-topline span,
+.vault-verdict__result-hero span,
+.vault-verdict__amount-header span {
   display: block;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #93f4ff;
+  color: #74e3df;
 }
 
 .vault-verdict h1,
@@ -44,105 +61,170 @@
 }
 
 .vault-verdict h1 {
-  font-size: clamp(2rem, 4vw, 4rem);
+  margin-top: 3px;
+  font-size: clamp(1.65rem, 3.2vw, 3.3rem);
   line-height: 0.95;
+  letter-spacing: 0;
   text-transform: uppercase;
-  color: #fff2b0;
-  text-shadow: 0 0 24px rgba(255, 223, 112, 0.34);
+  color: #f5f0d0;
 }
 
-.vault-verdict__timer,
-.vault-verdict__my-vault,
-.vault-verdict__round-panel,
-.vault-verdict__offer,
-.vault-verdict__broadcast,
-.vault-verdict__ladder,
-.vault-verdict__result-hero,
-.vault-verdict__result-list article {
-  border: 1px solid rgba(147, 244, 255, 0.24);
-  border-radius: 8px;
-  background: rgba(4, 10, 16, 0.74);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.22);
+.vault-verdict__broadcast-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  gap: 5px 10px;
+  align-content: center;
+  padding: 10px 12px;
+  overflow: hidden;
+}
+
+.vault-verdict__broadcast-row > span {
+  align-self: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(116, 227, 223, 0.12);
+  color: #74e3df;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.vault-verdict__broadcast-row > strong {
+  min-width: 0;
+  align-self: center;
+  overflow: hidden;
+  color: #f5f0d0;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vault-verdict__broadcast-chips {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.vault-verdict__broadcast-chips em {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 160px;
+  padding: 3px 7px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.055);
+  color: rgba(238, 248, 247, 0.74);
+  font-size: 0.72rem;
+  font-style: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .vault-verdict__timer {
+  display: grid;
+  align-content: center;
   padding: 10px 14px;
   text-align: right;
 }
 
-.vault-verdict__timer span,
-.vault-verdict__timer strong {
-  display: block;
-}
-
 .vault-verdict__timer span {
-  font-size: 0.75rem;
-  color: rgba(247, 251, 255, 0.72);
+  color: rgba(238, 248, 247, 0.64);
+  font-size: 0.72rem;
 }
 
 .vault-verdict__timer strong {
-  font-size: 1.45rem;
-  color: #fff2b0;
+  color: #f5f0d0;
+  font-size: 1.35rem;
 }
 
 .vault-verdict__game-grid {
   display: grid;
-  grid-template-columns: minmax(430px, 1fr) minmax(220px, 0.42fr) minmax(150px, 0.24fr) minmax(240px, 0.34fr);
-  gap: 14px;
-  align-items: start;
+  grid-template-columns: minmax(430px, 1fr) minmax(300px, 0.42fr);
+  gap: 12px;
+  align-items: stretch;
 }
 
 .vault-verdict__board {
   position: relative;
   min-height: 650px;
-  border-radius: 8px;
   overflow: hidden;
   background:
-    radial-gradient(circle at center, rgba(255, 242, 176, 0.24), transparent 10%),
-    radial-gradient(circle at center, rgba(147, 244, 255, 0.18), transparent 35%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015));
-  border: 1px solid rgba(255, 242, 176, 0.22);
+    linear-gradient(rgba(116, 227, 223, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(116, 227, 223, 0.08) 1px, transparent 1px),
+    radial-gradient(circle at center, rgba(116, 227, 223, 0.16), transparent 39%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.012));
+  background-size: 44px 44px, 44px 44px, auto, auto;
 }
 
-.vault-verdict__eye {
+.vault-verdict__board::before,
+.vault-verdict__board::after {
+  content: '';
+  position: absolute;
+  inset: 12%;
+  border: 1px solid rgba(116, 227, 223, 0.12);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.vault-verdict__board::after {
+  inset: 24%;
+  border-color: rgba(245, 240, 208, 0.14);
+}
+
+.vault-verdict__iris-core {
   position: absolute;
   inset: 50% auto auto 50%;
-  width: 190px;
-  height: 118px;
+  width: 210px;
+  min-height: 118px;
   transform: translate(-50%, -50%);
   display: grid;
   place-items: center;
-  border-radius: 50%;
-  background: radial-gradient(circle, #fff7cf 0 18%, #00d8ff 19% 34%, rgba(255, 255, 255, 0.08) 35% 100%);
-  border: 1px solid rgba(255, 242, 176, 0.58);
-  box-shadow: 0 0 52px rgba(0, 216, 255, 0.42);
+  gap: 4px;
+  padding: 16px;
+  border: 1px solid rgba(245, 240, 208, 0.28);
+  border-radius: 8px;
+  background: linear-gradient(145deg, rgba(245, 240, 208, 0.14), rgba(116, 227, 223, 0.1));
+  text-align: center;
   text-transform: uppercase;
-  font-size: 0.72rem;
+}
+
+.vault-verdict__iris-core span {
+  color: rgba(238, 248, 247, 0.72);
+  font-size: 0.74rem;
   letter-spacing: 0.16em;
-  color: #091018;
-  font-weight: 800;
+}
+
+.vault-verdict__iris-core strong {
+  color: #f5f0d0;
+  font-size: 1.7rem;
 }
 
 .vault-verdict__pod {
   position: absolute;
   inset: 50% auto auto 50%;
-  width: 82px;
-  height: 82px;
-  margin: -41px 0 0 -41px;
+  width: 76px;
+  height: 76px;
+  margin: -38px 0 0 -38px;
   display: grid;
   place-items: center;
+  border: 1px solid rgba(116, 227, 223, 0.32);
   border-radius: 50%;
-  border: 1px solid rgba(147, 244, 255, 0.45);
-  background: radial-gradient(circle at 35% 30%, #f9fdff, #2de2ff 30%, #143342 72%, #070c12);
-  color: #fff;
+  background:
+    radial-gradient(circle at 50% 32%, rgba(255, 255, 255, 0.18), transparent 24%),
+    linear-gradient(145deg, #18313a, #091116);
+  color: #eef8f7;
   cursor: pointer;
-  transition: filter 160ms ease, opacity 160ms ease, box-shadow 160ms ease;
-  box-shadow: 0 0 24px rgba(45, 226, 255, 0.22);
+  transition: border-color 160ms ease, filter 160ms ease, opacity 160ms ease, transform 160ms ease;
 }
 
 .vault-verdict__pod:hover:not(:disabled) {
+  border-color: rgba(245, 240, 208, 0.64);
   filter: brightness(1.16);
-  box-shadow: 0 0 34px rgba(255, 242, 176, 0.4);
 }
 
 .vault-verdict__pod:disabled {
@@ -150,68 +232,127 @@
 }
 
 .vault-verdict__pod span {
+  font-size: 1.05rem;
   font-weight: 900;
-  font-size: 1.2rem;
 }
 
 .vault-verdict__pod strong {
+  padding: 0 5px;
   font-size: 0.68rem;
-  padding: 0 4px;
+  line-height: 1.05;
   word-break: break-word;
 }
 
 .vault-verdict__pod--personal {
-  opacity: 0.22;
+  border-color: rgba(245, 240, 208, 0.42);
+  background: linear-gradient(145deg, rgba(245, 240, 208, 0.16), rgba(34, 55, 63, 0.82));
+  opacity: 0.42;
 }
 
 .vault-verdict__pod--opened {
-  animation: vault-pop 360ms ease both;
-  background: radial-gradient(circle, #fff2b0, #ff4f8f 58%, #220813);
+  animation: vault-pop 260ms ease both;
+  border-color: rgba(226, 79, 126, 0.46);
+  background: linear-gradient(145deg, rgba(226, 79, 126, 0.9), rgba(44, 14, 28, 0.94));
 }
 
 .vault-verdict__pod--dramatic {
-  box-shadow: 0 0 36px rgba(255, 79, 143, 0.74), 0 0 70px rgba(255, 242, 176, 0.3);
+  box-shadow: 0 0 30px rgba(226, 79, 126, 0.5);
 }
 
 .vault-verdict__pod--remainingFinalWallVault {
-  background: radial-gradient(circle, #3d4b55, #101820);
-  color: rgba(255, 255, 255, 0.7);
+  background: linear-gradient(145deg, #343d44, #11171c);
+  color: rgba(238, 248, 247, 0.62);
 }
 
-.vault-verdict__side {
+.vault-verdict__event-panel {
   display: grid;
+  align-content: start;
   gap: 14px;
+  padding: 18px;
 }
 
-.vault-verdict__my-vault,
-.vault-verdict__round-panel,
-.vault-verdict__offer {
-  padding: 14px;
+.vault-verdict__event-panel.is-live {
+  border-color: rgba(245, 240, 208, 0.42);
+  box-shadow: 0 20px 52px rgba(0, 0, 0, 0.34), 0 0 34px rgba(245, 240, 208, 0.12);
 }
 
-.vault-verdict__my-vault strong,
-.vault-verdict__round-panel strong,
-.vault-verdict__offer strong {
-  display: block;
-  margin-top: 6px;
-  font-size: clamp(1.3rem, 3vw, 2rem);
-  line-height: 1;
-  color: #fff2b0;
+.vault-verdict__event-topline,
+.vault-verdict__amount-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
-.vault-verdict small {
-  color: rgba(247, 251, 255, 0.68);
+.vault-verdict__event-panel > strong {
+  color: #f5f0d0;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 0.94;
 }
 
-.vault-verdict__offer.is-live {
-  border-color: rgba(255, 242, 176, 0.54);
-  animation: offer-pulse 1.8s ease-in-out infinite;
+.vault-verdict__event-panel p {
+  color: rgba(238, 248, 247, 0.78);
+  font-size: 0.98rem;
+  line-height: 1.42;
+}
+
+.vault-verdict__info-button,
+.vault-verdict__amount-header button {
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(116, 227, 223, 0.28);
+  border-radius: 50%;
+  background: rgba(116, 227, 223, 0.1);
+  color: #f5f0d0;
+  cursor: pointer;
+  font-weight: 900;
+}
+
+.vault-verdict__event-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.vault-verdict__event-stats div,
+.vault-verdict__recent-values span {
+  min-width: 0;
+  padding: 9px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.vault-verdict__event-stats dt {
+  color: rgba(238, 248, 247, 0.56);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.vault-verdict__event-stats dd {
+  margin: 3px 0 0;
+  color: #eef8f7;
+  font-size: 0.95rem;
+  font-weight: 900;
+}
+
+.vault-verdict__recent-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.vault-verdict__recent-values span {
+  color: rgba(238, 248, 247, 0.78);
+  font-size: 0.86rem;
+  font-weight: 800;
 }
 
 .vault-verdict__actions {
   display: grid;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 4px;
 }
 
 .vault-verdict button {
@@ -220,106 +361,66 @@
 
 .vault-verdict__actions button,
 .vault-verdict__commit {
+  min-height: 44px;
   border: 0;
   border-radius: 6px;
   padding: 12px 14px;
-  font-weight: 900;
-  color: #081018;
-  background: #fff2b0;
+  color: #071014;
+  background: #f5f0d0;
   cursor: pointer;
+  font-weight: 900;
 }
 
 .vault-verdict__actions button:nth-child(2) {
-  background: #93f4ff;
+  background: #74e3df;
 }
 
 .vault-verdict__actions button:disabled,
 .vault-verdict__commit:disabled {
-  opacity: 0.42;
+  opacity: 0.38;
   cursor: default;
 }
 
-.vault-verdict__ladder {
+.vault-verdict__amount-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
   display: grid;
-  gap: 4px;
-  padding: 10px;
+  place-items: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.58);
 }
 
-.vault-verdict__ladder span {
-  display: block;
-  padding: 6px 8px;
-  border-radius: 5px;
+.vault-verdict__amount-panel {
+  width: min(520px, 100%);
+  padding: 16px;
+}
+
+.vault-verdict__amount-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.vault-verdict__amount-grid span {
+  padding: 8px 10px;
+  border-radius: 6px;
   background: rgba(255, 255, 255, 0.06);
-  color: #fff7cf;
-  font-size: 0.78rem;
+  color: #f5f0d0;
+  font-weight: 800;
   text-align: right;
 }
 
-.vault-verdict__ladder span.is-opened {
-  color: rgba(247, 251, 255, 0.38);
+.vault-verdict__amount-grid span.is-opened {
+  color: rgba(238, 248, 247, 0.34);
   text-decoration: line-through;
-  background: rgba(255, 79, 143, 0.14);
-}
-
-.vault-verdict__broadcast {
-  display: grid;
-  gap: 12px;
-  padding: 14px;
-}
-
-.vault-verdict__broadcast h2 {
-  font-size: 1rem;
-  color: #fff2b0;
-}
-
-.vault-verdict__feed {
-  display: grid;
-  gap: 8px;
-}
-
-.vault-verdict__feed p {
-  padding: 9px 10px;
-  border-radius: 6px;
-  background: rgba(147, 244, 255, 0.09);
-  color: rgba(247, 251, 255, 0.88);
-  font-size: 0.85rem;
-  animation: feed-in 220ms ease both;
-}
-
-.vault-verdict__booths {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.vault-verdict__booths div {
-  min-width: 0;
-  padding: 8px;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.055);
-}
-
-.vault-verdict__booths span,
-.vault-verdict__booths strong {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.vault-verdict__booths span {
-  color: rgba(247, 251, 255, 0.68);
-  font-size: 0.76rem;
-}
-
-.vault-verdict__booths strong {
-  color: #93f4ff;
-  font-size: 0.84rem;
+  background: rgba(226, 79, 126, 0.13);
 }
 
 .vault-verdict__results {
   display: grid;
-  gap: 14px;
+  gap: 12px;
 }
 
 .vault-verdict__result-hero {
@@ -328,17 +429,17 @@
 
 .vault-verdict__result-hero h2 {
   margin-top: 4px;
+  color: #f5f0d0;
   font-size: clamp(1.7rem, 4vw, 3.1rem);
-  color: #fff2b0;
 }
 
 .vault-verdict__result-hero p {
   margin-top: 8px;
-  color: rgba(247, 251, 255, 0.82);
+  color: rgba(238, 248, 247, 0.8);
 }
 
 .vault-verdict__missed {
-  color: #93f4ff;
+  color: #74e3df;
 }
 
 .vault-verdict__result-list {
@@ -355,11 +456,11 @@
 }
 
 .vault-verdict__result-list article.is-human {
-  border-color: rgba(255, 242, 176, 0.64);
+  border-color: rgba(245, 240, 208, 0.48);
 }
 
 .vault-verdict__result-list em {
-  color: #fff2b0;
+  color: #f5f0d0;
   font-style: normal;
   font-weight: 900;
 }
@@ -370,41 +471,25 @@
 
 @keyframes vault-pop {
   from {
-    filter: brightness(0.7);
+    filter: brightness(0.72);
   }
   to {
     filter: brightness(1);
   }
 }
 
-@keyframes offer-pulse {
-  50% {
-    box-shadow: 0 0 34px rgba(255, 242, 176, 0.28);
-  }
-}
-
-@keyframes feed-in {
-  from {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 @media (max-width: 980px) {
+  .vault-verdict__header,
   .vault-verdict__game-grid {
     grid-template-columns: 1fr;
   }
 
-  .vault-verdict__board {
-    min-height: min(88vw, 620px);
+  .vault-verdict__timer {
+    text-align: left;
   }
 
-  .vault-verdict__ladder {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .vault-verdict__board {
+    min-height: min(88vw, 620px);
   }
 }
 
@@ -413,13 +498,8 @@
     padding-inline: 10px;
   }
 
-  .vault-verdict__header {
-    align-items: start;
-    flex-direction: column;
-  }
-
   .vault-verdict__board {
-    min-height: 530px;
+    min-height: 520px;
   }
 
   .vault-verdict__pod {
@@ -428,9 +508,14 @@
     margin: -29px 0 0 -29px;
   }
 
-  .vault-verdict__eye {
-    width: 140px;
-    height: 88px;
+  .vault-verdict__iris-core {
+    width: 150px;
+    min-height: 92px;
+  }
+
+  .vault-verdict__event-stats,
+  .vault-verdict__amount-grid {
+    grid-template-columns: 1fr;
   }
 
   .vault-verdict__result-list article {

--- a/src/components/VaultVerdict/VaultVerdict.tsx
+++ b/src/components/VaultVerdict/VaultVerdict.tsx
@@ -56,6 +56,7 @@ export default function VaultVerdict(props: GenericMinigameProps) {
   const [feed, setFeed] = useState<BroadcastEvent[]>([]);
   const [feedIndex, setFeedIndex] = useState(0);
   const [committed, setCommitted] = useState(false);
+  const [amountInfoOpen, setAmountInfoOpen] = useState(false);
 
   const initialContestants = useMemo(() => {
     const participants = resolveVaultParticipants(props);
@@ -84,6 +85,29 @@ export default function VaultVerdict(props: GenericMinigameProps) {
   const vaultsLeft = getVaultsLeftThisRound(human);
   const latestOffer = human.offerHistory[human.offerHistory.length - 1] ?? null;
   const finalWallVault = human.vaults.find((vault) => vault.status === 'remainingFinalWallVault');
+  const personalVaultNumber = human.personalVaultId
+    ? human.vaults.find((vault) => vault.vaultId === human.personalVaultId)?.displayNumber ?? null
+    : null;
+  const broadcastMessage = feed[0]?.message ?? (
+    human.personalVaultId
+      ? 'Private booths are live. The Eye Bank is watching every vault.'
+      : 'Vault Verdict is standing by. Choose My Vault to begin.'
+  );
+  const eventEyebrow = !human.personalVaultId
+    ? 'Selection'
+    : human.currentOffer
+      ? human.currentRound >= VAULT_VERDICT_ROUND_SCHEDULE.length ? 'Final Verdict' : 'Eye Bank Offer'
+      : `Round ${human.currentRound} of ${VAULT_VERDICT_ROUND_SCHEDULE.length}`;
+  const eventTitle = !human.personalVaultId
+    ? 'Choose My Vault'
+    : human.currentOffer
+      ? formatVaultAmount(human.currentOffer)
+      : `Open ${vaultsLeft} vault${vaultsLeft === 1 ? '' : 's'}`;
+  const eventDetail = !human.personalVaultId
+    ? 'Select one pod to seal in your private chamber.'
+    : human.currentOffer
+      ? `${latestOffer?.remainingValues.length ?? 0} hidden values remain, including My Vault.`
+      : `My Vault${personalVaultNumber ? ` is Pod ${personalVaultNumber}` : ''}. The next pod you open leaves the board.`;
 
   useEffect(() => {
     if (!human.personalVaultId || human.finalAmount != null) return;
@@ -156,9 +180,20 @@ export default function VaultVerdict(props: GenericMinigameProps) {
     <div className="vault-verdict">
       <div className="vault-verdict__stage">
         <header className="vault-verdict__header">
-          <div>
+          <div className="vault-verdict__brand">
             <span className="vault-verdict__eyebrow">Eye Bank Studio</span>
             <h1>Vault Verdict</h1>
+          </div>
+          <div className="vault-verdict__broadcast-row" aria-live="polite">
+            <span>Vault Verdict</span>
+            <strong>{broadcastMessage}</strong>
+            <div className="vault-verdict__broadcast-chips" aria-label="Contestant booth status">
+              {aiContestants.slice(0, 5).map((contestant) => (
+                <em key={contestant.contestantId}>
+                  {contestant.displayName}: {getContestantBroadcastStatus(contestant, elapsedMs)}
+                </em>
+              ))}
+            </div>
           </div>
           <div className="vault-verdict__timer">
             <span>Finish time</span>
@@ -169,8 +204,9 @@ export default function VaultVerdict(props: GenericMinigameProps) {
         {rankedResults == null ? (
           <main className="vault-verdict__game-grid">
             <section className="vault-verdict__board" aria-label="Vault pod board">
-              <div className="vault-verdict__eye">
-                <span>Eye Bank</span>
+              <div className="vault-verdict__iris-core">
+                <span>Vault Verdict</span>
+                <strong>{human.openedVaultIds.length}/21</strong>
               </div>
               {human.vaults.map((vault, index) => {
                 const angle = ((360 / human.vaults.length) * index - 90) * (Math.PI / 180);
@@ -205,64 +241,45 @@ export default function VaultVerdict(props: GenericMinigameProps) {
               })}
             </section>
 
-            <aside className="vault-verdict__side">
-              <section className="vault-verdict__my-vault">
-                <span>My Vault</span>
-                <strong>
-                  {human.personalVaultId
-                    ? `Pod ${human.vaults.find((vault) => vault.vaultId === human.personalVaultId)?.displayNumber ?? ''}`
-                    : 'Choose a pod'}
-                </strong>
-                <small>{human.personalVaultId ? 'Sealed until the Final Verdict' : 'Your private vault chamber awaits'}</small>
-              </section>
-
-              <section className="vault-verdict__round-panel">
-                <span>Round {human.currentRound || 1} of {VAULT_VERDICT_ROUND_SCHEDULE.length}</span>
-                <strong>{human.personalVaultId ? vaultsLeft : 1}</strong>
-                <small>{human.personalVaultId ? 'vaults left to open this round' : 'pod to claim as My Vault'}</small>
-              </section>
-
-              <section className={`vault-verdict__offer ${human.currentOffer ? 'is-live' : ''}`}>
-                <span>The Eye Bank Offers</span>
-                <strong>{human.currentOffer ? formatVaultAmount(human.currentOffer) : 'Awaiting round result'}</strong>
-                {latestOffer && (
-                  <small>{latestOffer.remainingValues.length} sealed values remain in your private board.</small>
-                )}
-                <div className="vault-verdict__actions">
-                  <button type="button" disabled={!human.currentOffer} onClick={(event) => finishWith(signVerdict, event.timeStamp)}>
-                    Sign the Verdict
-                  </button>
-                  <button type="button" disabled={!human.currentOffer} onClick={(event) => finishWith(riskVault, event.timeStamp)}>
-                    Risk the Vault
-                  </button>
+            <aside className={`vault-verdict__event-panel ${human.currentOffer ? 'is-live' : ''}`}>
+              <div className="vault-verdict__event-topline">
+                <span>{eventEyebrow}</span>
+                <button type="button" className="vault-verdict__info-button" onClick={() => setAmountInfoOpen(true)} aria-label="Show vault values">
+                  i
+                </button>
+              </div>
+              <strong>{eventTitle}</strong>
+              <p>{eventDetail}</p>
+              <dl className="vault-verdict__event-stats">
+                <div>
+                  <dt>My Vault</dt>
+                  <dd>{personalVaultNumber ? `Pod ${personalVaultNumber}` : 'Unclaimed'}</dd>
                 </div>
-              </section>
-            </aside>
-
-            <section className="vault-verdict__ladder" aria-label="Amount ladder">
-              {VAULT_VERDICT_AMOUNTS.slice().reverse().map((amount) => (
-                <span key={amount} className={human.revealedAmounts.includes(amount) ? 'is-opened' : ''}>
-                  {formatVaultAmount(amount)}
-                </span>
-              ))}
-            </section>
-
-            <aside className="vault-verdict__broadcast">
-              <h2>Eye Bank Broadcast</h2>
-              <div className="vault-verdict__feed">
-                {feed.length === 0 ? (
-                  <p>The booths are sealed. The control room is listening.</p>
+                <div>
+                  <dt>Opened</dt>
+                  <dd>{human.openedVaultIds.length}</dd>
+                </div>
+                <div>
+                  <dt>Hidden</dt>
+                  <dd>{22 - human.revealedAmounts.length}</dd>
+                </div>
+              </dl>
+              <div className="vault-verdict__recent-values" aria-label="Recently opened values">
+                {human.revealedAmounts.slice(-4).length === 0 ? (
+                  <span>No reveals yet</span>
                 ) : (
-                  feed.map((event) => <p key={event.id}>{event.message}</p>)
+                  human.revealedAmounts.slice(-4).map((amount) => (
+                    <span key={`${amount}-${human.revealedAmounts.indexOf(amount)}`}>{formatVaultAmount(amount)}</span>
+                  ))
                 )}
               </div>
-              <div className="vault-verdict__booths">
-                {aiContestants.map((contestant) => (
-                  <div key={contestant.contestantId}>
-                    <span>{contestant.displayName}</span>
-                    <strong>{getContestantBroadcastStatus(contestant, elapsedMs)}</strong>
-                  </div>
-                ))}
+              <div className="vault-verdict__actions">
+                <button type="button" disabled={!human.currentOffer} onClick={(event) => finishWith(signVerdict, event.timeStamp)}>
+                  Sign the Verdict
+                </button>
+                <button type="button" disabled={!human.currentOffer} onClick={(event) => finishWith(riskVault, event.timeStamp)}>
+                  Risk the Vault
+                </button>
               </div>
             </aside>
           </main>
@@ -293,6 +310,23 @@ export default function VaultVerdict(props: GenericMinigameProps) {
               Lock Studio Result
             </button>
           </main>
+        )}
+        {amountInfoOpen && (
+          <div className="vault-verdict__amount-modal" role="dialog" aria-modal="true" aria-label="Vault values">
+            <div className="vault-verdict__amount-panel">
+              <div className="vault-verdict__amount-header">
+                <span>Vault Values</span>
+                <button type="button" onClick={() => setAmountInfoOpen(false)} aria-label="Close vault values">x</button>
+              </div>
+              <div className="vault-verdict__amount-grid">
+                {VAULT_VERDICT_AMOUNTS.slice().reverse().map((amount) => (
+                  <span key={amount} className={human.revealedAmounts.includes(amount) ? 'is-opened' : ''}>
+                    {formatVaultAmount(amount)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/VaultVerdict/vaultVerdictLogic.ts
+++ b/src/components/VaultVerdict/vaultVerdictLogic.ts
@@ -138,7 +138,7 @@ function cleanRound(value: number) {
 }
 
 export function formatVaultAmount(value: number) {
-  return `$${value.toLocaleString()}`;
+  return value.toLocaleString();
 }
 
 export function createVaultVerdictRng(seed = 0) {
@@ -387,7 +387,7 @@ function buildBroadcastMessage(options: {
 }) {
   const { contestant, kind, amount, accepted, smallPlayerCount, rng } = options;
   const name = contestant.displayName;
-  if (smallPlayerCount) {
+      if (smallPlayerCount) {
     const vague = [
       'The control room just gasped. No further comment.',
       'Someone in another booth made the host blink twice.',
@@ -400,7 +400,7 @@ function buildBroadcastMessage(options: {
     if (accepted) {
       return pick(rng, [
         `${name} signed a Verdict early. The audience is judging silently.`,
-        `${name} took the money and left the booth glowing.`,
+        `${name} signed and left the booth glowing.`,
         `${name} made peace with The Eye Bank. Bold or blessed?`,
       ]);
     }
@@ -411,9 +411,9 @@ function buildBroadcastMessage(options: {
     ]);
   }
   if (kind === 'amount' && amount != null) {
-    if (amount === 1000000) return 'Someone just opened the $1,000,000 in another booth. The studio went quiet.';
-    if (amount === 404) return 'Somebody found $404. Their prize was not found either.';
-    if (amount === 69) return 'Another booth just opened $69. The audience reacted exactly how you think.';
+    if (amount === 1000000) return 'Someone just opened the 1,000,000 in another booth. The studio went quiet.';
+    if (amount === 404) return 'Somebody found 404. Their prize was not found either.';
+    if (amount === 69) return 'Another booth just opened 69. The audience reacted exactly how you think.';
     return `A contestant just found ${formatVaultAmount(amount)} in another private booth. Painful.`;
   }
   if (kind === 'final') return 'One booth just reached the Final Verdict.';


### PR DESCRIPTION
## Summary
- Modernize the Vault Verdict layout with a cleaner studio-console presentation.
- Collapse My Vault, round status, and Eye Bank offer into one dynamic event panel.
- Replace the always-visible value ladder with an info button and modal, and remove currency symbols from values and broadcast copy.
- Replace the side broadcast section with a compact top Vault Verdict broadcast row that surfaces live booth updates.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- tests/unit/vault-verdict/vaultVerdict.logic.test.ts`