### PR TITLE
[codex] Polish Big Spender mobile gameplay UI

### DIFF
--- a/src/components/BigSpender/BigSpender.css
+++ b/src/components/BigSpender/BigSpender.css
@@ -65,10 +65,10 @@
 
 .big-spender__status-panel {
   display: grid;
-  grid-template-columns: minmax(7rem, auto) minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.75rem;
-  min-height: 4.2rem;
+  grid-template-columns: 1fr;
+  align-items: start;
+  gap: 0.18rem;
+  min-height: 0;
   padding: 0.65rem 0.75rem;
   border-radius: 0.8rem;
 }
@@ -104,7 +104,7 @@
 .big-spender__table {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(12rem, 17rem);
+  grid-template-columns: minmax(0, 1fr);
   gap: 0.65rem;
 }
 
@@ -112,7 +112,7 @@
   min-height: 0;
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
-  grid-auto-rows: minmax(5.35rem, 1fr);
+  grid-auto-rows: minmax(4.9rem, 1fr);
   gap: 0.45rem;
 }
 
@@ -124,7 +124,7 @@
   align-content: end;
   justify-items: start;
   min-width: 0;
-  min-height: 5.35rem;
+  min-height: 4.9rem;
   padding: 0.48rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 0.55rem;
@@ -191,18 +191,6 @@
   line-height: 1;
   color: #fff5c7;
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.42);
-}
-
-.big-spender__wallet-opener {
-  position: relative;
-  z-index: 1;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.68rem;
-  font-weight: 900;
-  color: rgba(239, 245, 255, 0.72);
 }
 
 .big-spender__players {
@@ -331,6 +319,7 @@
 }
 
 .big-spender__broadcasts p {
+  animation: big-spender-broadcast-pulse 520ms ease-out both;
   color: rgba(239, 245, 255, 0.86);
   font-size: 0.82rem;
   line-height: 1.25;
@@ -390,7 +379,7 @@
   min-height: 0;
   overflow-y: auto;
   display: grid;
-  gap: 0.4rem;
+  gap: 0.32rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -398,18 +387,17 @@
 
 .big-spender__ranking li {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr);
-  gap: 0.1rem 0.55rem;
+  grid-template-columns: 1.75rem minmax(0, 1fr) auto;
+  gap: 0.1rem 0.45rem;
   align-items: center;
-  padding: 0.5rem;
+  padding: 0.42rem 0.5rem;
   border-radius: 0.55rem;
   background: rgba(255, 255, 255, 0.05);
 }
 
 .big-spender__ranking span {
-  grid-row: span 2;
-  width: 1.6rem;
-  height: 1.6rem;
+  width: 1.45rem;
+  height: 1.45rem;
   display: grid;
   place-items: center;
   border-radius: 999px;
@@ -428,30 +416,45 @@
 .big-spender__ranking em {
   font-style: normal;
   color: rgba(218, 231, 255, 0.78);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
+  text-align: right;
 }
 
 @media (max-width: 760px) {
-  .big-spender__status-panel {
-    grid-template-columns: 1fr;
-    align-items: start;
+  .big-spender {
+    gap: 0.5rem;
+    padding: calc(env(safe-area-inset-top, 0px) + 0.55rem) 0.55rem calc(env(safe-area-inset-bottom, 0px) + 0.55rem);
   }
 
-  .big-spender__save-counter {
-    justify-self: start;
+  .big-spender__header {
+    padding: 0.55rem 0.65rem;
   }
 
-  .big-spender__table {
-    grid-template-columns: 1fr;
+  .big-spender__title-block h1 {
+    font-size: 1.3rem;
   }
 
   .big-spender__board {
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    grid-auto-rows: 4.65rem;
+    grid-auto-rows: clamp(4.25rem, 20vw, 4.8rem);
+    gap: 0.35rem;
   }
 
-  .big-spender__players {
-    max-height: 13.5rem;
+  .big-spender__wallet {
+    min-height: 4.25rem;
+    padding: 0.38rem;
+  }
+
+  .big-spender__actions {
+    align-items: stretch;
+    gap: 0.45rem;
+  }
+
+  .big-spender__actions span {
+    align-self: center;
+    min-width: 0;
+    font-size: 0.78rem;
+    line-height: 1.2;
   }
 }
 
@@ -462,6 +465,21 @@
 
   .big-spender__modal-actions {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 340px) {
+  .big-spender__board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .big-spender__ranking li {
+    grid-template-columns: 1.75rem minmax(0, 1fr);
+  }
+
+  .big-spender__ranking em {
+    grid-column: 2;
+    text-align: left;
   }
 }
 
@@ -476,5 +494,17 @@
 
   100% {
     transform: scale(1);
+  }
+}
+
+@keyframes big-spender-broadcast-pulse {
+  0% {
+    opacity: 0;
+    transform: translateY(0.35rem);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GenericMinigameProps } from '../../minigames/reactComponents';
 import { mulberry32 } from '../../store/rng';
 import {
-  BIG_SPENDER_CONFIG,
   BIG_SPENDER_DISPLAY_NAME,
   buildBigSpenderRawResults,
   createInitialBigSpenderState,
@@ -20,16 +19,6 @@ import {
 } from './bigSpenderLogic';
 import './BigSpender.css';
 
-function getInitials(name: string) {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0])
-    .join('')
-    .toUpperCase() || 'P';
-}
-
 function getPlayerLabel(player: BigSpenderPlayerState) {
   if (player.status === 'zeroFinished') return 'Zero';
   if (player.status === 'bombed') return 'Bombed';
@@ -40,16 +29,6 @@ function getPlayerLabel(player: BigSpenderPlayerState) {
 
 function getWalletAriaLabel(wallet: BigSpenderWallet) {
   return `Open wallet ${wallet.boardSlotIndex + 1}, generation ${wallet.generationNumber}`;
-}
-
-function isImageAvatar(avatar?: string) {
-  return Boolean(avatar && (/^(https?:|data:image\/|\/)/.test(avatar) || /\.(avif|jpe?g|png|webp|gif|svg)$/i.test(avatar)));
-}
-
-function getOutcomeCopy(state: BigSpenderState) {
-  const event = state.events.find((entry) => entry.type === 'walletOpened' && entry.outcome);
-  if (!event?.outcome) return 'Pick wallets while the house opens theirs. Lock in whenever you like.';
-  return event.message;
 }
 
 function getWalletResultLabel(wallet: BigSpenderWallet) {
@@ -65,6 +44,14 @@ function chooseAiWallet(state: BigSpenderState, playerId: string, rng: () => num
   return available[Math.floor(rng() * available.length)] ?? available[0] ?? null;
 }
 
+function isBroadcastEvent(event: BigSpenderState['events'][number]) {
+  return event.type === 'walletOpened' || event.type === 'playerLocked' || event.type === 'playerBombed' || event.type === 'playerZeroFinished';
+}
+
+function getBroadcastKey(event: BigSpenderState['events'][number]) {
+  return `${event.type}:${event.playerId ?? 'house'}:${event.walletId ?? ''}:${event.message}`;
+}
+
 export default function BigSpender(props: GenericMinigameProps) {
   const participants = useMemo(
     () => resolveBigSpenderParticipants(props.participants, props.participantIds),
@@ -73,15 +60,18 @@ export default function BigSpender(props: GenericMinigameProps) {
   const seed = props.seed || 73_337;
   const [state, setState] = useState(() => createInitialBigSpenderState(participants, seed));
   const [resultCommitted, setResultCommitted] = useState(false);
+  const [broadcasts, setBroadcasts] = useState<string[]>([]);
   const aiRngRef = useRef(mulberry32((seed ^ 0x5eedcafe) >>> 0));
   const aiTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const broadcastQueueRef = useRef<string[]>([]);
+  const broadcastKeysRef = useRef(new Set<string>());
+  const broadcastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const humanPlayer = useMemo(() => state.players.find((player) => player.isHuman) ?? null, [state.players]);
   const humanBoard = useMemo(
     () => humanPlayer ? getBigSpenderBoardForPlayer(state, humanPlayer.playerId) : state.board,
     [humanPlayer, state],
   );
-  const playersById = useMemo(() => new Map(state.players.map((player) => [player.playerId, player])), [state.players]);
   const ranking = useMemo(() => rankBigSpenderPlayers(state.players), [state.players]);
   const winner = ranking[0] ?? null;
   const canHumanAct = Boolean(
@@ -112,7 +102,7 @@ export default function BigSpender(props: GenericMinigameProps) {
         setState((previous) => {
           const actor = previous.players.find((entry) => entry.playerId === player.playerId);
           if (!actor || actor.isHuman || actor.status !== 'active') return previous;
-          const shouldOpen = decideAiShouldOpen(actor.balance, aiRngRef.current);
+          const shouldOpen = actor.walletsOpened === 0 || decideAiShouldOpen(actor.balance, aiRngRef.current);
           if (!shouldOpen) return lockBigSpenderPlayer(previous, actor.playerId);
           const wallet = chooseAiWallet(previous, actor.playerId, aiRngRef.current);
           if (!wallet) return lockBigSpenderPlayer(previous, actor.playerId);
@@ -130,6 +120,41 @@ export default function BigSpender(props: GenericMinigameProps) {
         clearTimeout(timer);
       }
       timers.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    const newMessages = state.events
+      .filter(isBroadcastEvent)
+      .slice()
+      .reverse()
+      .filter((event) => {
+        const key = getBroadcastKey(event);
+        if (broadcastKeysRef.current.has(key)) return false;
+        broadcastKeysRef.current.add(key);
+        return true;
+      })
+      .map((event) => event.message);
+
+    if (newMessages.length === 0) return;
+    broadcastQueueRef.current.push(...newMessages);
+
+    if (broadcastTimerRef.current) return;
+    const drain = () => {
+      const nextMessage = broadcastQueueRef.current.shift();
+      if (nextMessage) {
+        setBroadcasts((previous) => [nextMessage, ...previous].slice(0, 3));
+      }
+      broadcastTimerRef.current = broadcastQueueRef.current.length > 0 ? setTimeout(drain, 1350) : null;
+    };
+    broadcastTimerRef.current = setTimeout(drain, 450);
+  }, [state.events]);
+
+  useEffect(() => {
+    return () => {
+      if (broadcastTimerRef.current) {
+        clearTimeout(broadcastTimerRef.current);
+      }
     };
   }, []);
 
@@ -167,18 +192,11 @@ export default function BigSpender(props: GenericMinigameProps) {
           <span className="big-spender__eyebrow">Live balance</span>
           <strong>{humanPlayer ? `${humanPlayer.balance} Eyeoleans` : 'Results'}</strong>
         </div>
-        <p>{getOutcomeCopy(state)}</p>
-        {humanPlayer && (
-          <span className="big-spender__save-counter">
-            Ad saves left: {BIG_SPENDER_CONFIG.maxAdBombRescues - humanPlayer.adBombRescuesUsed}
-          </span>
-        )}
       </section>
 
       <main className="big-spender__table">
         <section className="big-spender__board" aria-label="Wallet board">
           {humanBoard.map((wallet) => {
-            const opener = wallet.openedByPlayerId ? playersById.get(wallet.openedByPlayerId) : null;
             const resultLabel = getWalletResultLabel(wallet);
             return (
               <button
@@ -197,10 +215,7 @@ export default function BigSpender(props: GenericMinigameProps) {
                 <span className="big-spender__wallet-flap" aria-hidden="true" />
                 <span className="big-spender__wallet-id">{wallet.boardSlotIndex + 1}</span>
                 {resultLabel ? (
-                  <>
-                    <strong className="big-spender__wallet-result">{resultLabel}</strong>
-                    <span className="big-spender__wallet-opener">{opener?.displayName ?? 'Opened'}</span>
-                  </>
+                  <strong className="big-spender__wallet-result">{resultLabel}</strong>
                 ) : (
                   <span className="big-spender__wallet-generation">Tap</span>
                 )}
@@ -209,35 +224,6 @@ export default function BigSpender(props: GenericMinigameProps) {
           })}
         </section>
 
-        <aside className="big-spender__players" aria-label="Player balances">
-          {state.players.map((player) => (
-            <article
-              key={player.playerId}
-              className={[
-                'big-spender__player',
-                player.isHuman ? 'big-spender__player--human' : '',
-                `big-spender__player--${player.status}`,
-              ].join(' ')}
-            >
-              <span className="big-spender__avatar" aria-hidden="true">
-                {isImageAvatar(player.avatar) ? (
-                  <img src={player.avatar} alt="" />
-                ) : (
-                  player.avatar || getInitials(player.displayName)
-                )}
-              </span>
-              <div className="big-spender__player-copy">
-                <strong>{player.displayName}</strong>
-                <span>{getPlayerLabel(player)} - {player.walletsOpened} wallets</span>
-              </div>
-              {player.isHuman ? (
-                <data value={player.balance}>{player.balance}</data>
-              ) : (
-                <span className="big-spender__score-hidden" aria-label="Score hidden">Hidden</span>
-              )}
-            </article>
-          ))}
-        </aside>
       </main>
 
       {state.status === 'running' && (
@@ -249,14 +235,13 @@ export default function BigSpender(props: GenericMinigameProps) {
         </footer>
       )}
 
-      <section className="big-spender__broadcasts" aria-label="House broadcasts" aria-live="polite">
-        {state.events
-          .filter((entry) => entry.type === 'walletOpened' || entry.type === 'playerLocked' || entry.type === 'playerBombed' || entry.type === 'playerZeroFinished')
-          .slice(0, 4)
-          .map((entry, index) => (
-            <p key={`${entry.type}-${entry.playerId ?? 'house'}-${index}`}>{entry.message}</p>
+      {broadcasts.length > 0 && (
+        <section className="big-spender__broadcasts" aria-label="House broadcasts" aria-live="polite">
+          {broadcasts.map((message) => (
+            <p key={message}>{message}</p>
           ))}
-      </section>
+        </section>
+      )}
 
       {state.pendingAdRescue && humanPlayer?.playerId === state.pendingAdRescue.playerId && (
         <div className="big-spender__overlay">
@@ -282,7 +267,7 @@ export default function BigSpender(props: GenericMinigameProps) {
                 <li key={player.playerId}>
                   <span>{player.rank}</span>
                   <strong>{player.displayName}</strong>
-                  <em>{player.isHuman ? `${player.balance} Eyeoleans` : 'Score hidden'} - {getPlayerLabel(player)}</em>
+                  <em>{player.balance} - {getPlayerLabel(player)} - {player.walletsOpened} wallets</em>
                 </li>
               ))}
             </ol>

--- a/src/components/BigSpender/bigSpenderLogic.ts
+++ b/src/components/BigSpender/bigSpenderLogic.ts
@@ -180,10 +180,12 @@ function appendEvent(state: BigSpenderState, event: BigSpenderEvent) {
 }
 
 function getOutcomeMessage(player: BigSpenderPlayerState, outcome: BigSpenderWalletOutcome) {
+  if (outcome.type === 'bomb' && player.isHuman) return 'You opened a bomb.';
   if (outcome.type === 'bomb') return `Rumors say ${player.displayName} just opened a bomb.`;
   const amount = outcome.amount ?? 0;
-  if (amount < 0) return `${player.displayName} just opened ${amount} Eyeoleans.`;
-  return `${player.displayName} just found +${amount} Eyeoleans.`;
+  if (player.isHuman && amount < 0) return `You opened ${amount} Eyeoleans.`;
+  if (player.isHuman) return `You found +${amount} Eyeoleans.`;
+  return `${player.displayName} opened wallet ${player.walletsOpened}.`;
 }
 
 function nextRandom(state: BigSpenderState) {
@@ -412,7 +414,7 @@ export function sumWeights(items: readonly { weight: number }[]) {
 }
 
 export function getAiActionDelayMs(_startingPlayerCount: number, rng: () => number) {
-  const [min, max] = [1000, 4000];
+  const [min, max] = [1800, 5200];
   return Math.round(min + rng() * (max - min));
 }
 
@@ -648,7 +650,7 @@ export function lockBigSpenderPlayer(previousState: BigSpenderState, playerId: s
   appendEvent(state, {
     type: 'playerLocked',
     playerId,
-    message: `${player.displayName} locked at ${player.balance} Eyeoleans.`,
+    message: `${player.displayName} locked after opening ${player.walletsOpened} wallets.`,
   });
   return completeIfNeeded(state);
 }

--- a/tests/unit/big-spender/bigSpenderLogic.test.ts
+++ b/tests/unit/big-spender/bigSpenderLogic.test.ts
@@ -225,13 +225,13 @@ describe('Big Spender: Broke or Boom logic', () => {
     expect(sameTurn.currentTurnPlayerId).not.toBeNull();
   });
 
-  it('produces randomized AI action delays in the 1-4 second band', () => {
-    expect(getAiActionDelayMs(2, () => 0)).toBe(1000);
-    expect(getAiActionDelayMs(6, () => 1)).toBe(4000);
-    expect(getAiActionDelayMs(7, () => 0)).toBe(1000);
-    expect(getAiActionDelayMs(11, () => 1)).toBe(4000);
-    expect(getAiActionDelayMs(12, () => 0)).toBe(1000);
-    expect(getAiActionDelayMs(16, () => 1)).toBe(4000);
+  it('produces randomized AI action delays in a paced 1.8-5.2 second band', () => {
+    expect(getAiActionDelayMs(2, () => 0)).toBe(1800);
+    expect(getAiActionDelayMs(6, () => 1)).toBe(5200);
+    expect(getAiActionDelayMs(7, () => 0)).toBe(1800);
+    expect(getAiActionDelayMs(11, () => 1)).toBe(5200);
+    expect(getAiActionDelayMs(12, () => 0)).toBe(1800);
+    expect(getAiActionDelayMs(16, () => 1)).toBe(5200);
   });
 
   it('makes AI more likely to open high balances and cautious at low balances', () => {


### PR DESCRIPTION
## Summary
- Reveal all player scores on the final results screen and make the ranking rows more compact.
- Remove the redundant in-game player sidebar that overlapped the wallet grid on mobile.
- Simplify the live status panel to only show the player balance.
- Remove ad-save and latest-opponent-action text from the status panel.
- Change live broadcasts so lock messages do not reveal opponent balances.
- Queue broadcasts gradually with a small pulse animation instead of dumping several messages at once.
- Slow AI action cadence to feel less abrupt and make AIs open at least one wallet before they lock.
- Tighten mobile spacing and wallet grid sizing for phone screens.

## Validation
- `npm run lint`
- `npx vitest run tests/unit/big-spender/bigSpenderLogic.test.ts`
- `npm run typecheck`
- `npm run build`