### PR TITLE
[codex] Add Battery Low finale effects

### DIFF
--- a/src/components/VaultVerdict/VaultVerdict.css
+++ b/src/components/VaultVerdict/VaultVerdict.css
@@ -132,6 +132,7 @@
 .vault-verdict__status.is-offer {
   border: 1px solid rgba(125, 247, 202, 0.22);
   background: rgba(125, 247, 202, 0.08);
+  animation: offer-arrival 680ms ease both;
 }
 
 .vault-verdict__decision-buttons {
@@ -184,6 +185,7 @@
     linear-gradient(90deg, rgba(125, 247, 202, 0.05) 1px, transparent 1px),
     linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01));
   background-size: 34px 34px, 34px 34px, auto;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
 }
 
 .vault-verdict__board::before {
@@ -193,6 +195,52 @@
   border: 1px solid rgba(125, 247, 202, 0.12);
   border-radius: 6px;
   pointer-events: none;
+}
+
+.vault-verdict__board.has-offer {
+  border-color: rgba(255, 207, 112, 0.34);
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.25), 0 0 34px rgba(255, 207, 112, 0.1);
+}
+
+.vault-verdict__board.has-dramatic-reveal {
+  border-color: rgba(255, 95, 109, 0.38);
+  animation: rack-warning 520ms ease both;
+}
+
+.vault-verdict__reveal-flash {
+  position: absolute;
+  top: 17px;
+  left: 50%;
+  z-index: 3;
+  display: grid;
+  min-width: min(300px, calc(100% - 86px));
+  padding: 8px 12px;
+  border: 1px solid rgba(125, 247, 202, 0.28);
+  border-radius: 7px;
+  background: rgba(5, 10, 13, 0.88);
+  color: #f5f7df;
+  text-align: center;
+  pointer-events: none;
+  transform: translateX(-50%);
+  animation: reveal-flash 1500ms ease both;
+}
+
+.vault-verdict__reveal-flash span {
+  color: rgba(125, 247, 202, 0.78);
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.vault-verdict__reveal-flash strong {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.vault-verdict__reveal-flash.is-special {
+  border-color: rgba(255, 207, 112, 0.42);
+  box-shadow: 0 0 26px rgba(255, 207, 112, 0.16);
 }
 
 .vault-verdict__info-button,
@@ -394,6 +442,10 @@
   animation: voltage-drop 460ms ease;
 }
 
+.vault-verdict__core-shell.is-holding {
+  animation: max-holding 560ms ease;
+}
+
 .vault-verdict__core-battery small {
   color: rgba(238, 248, 245, 0.78);
   font-size: 0.9rem;
@@ -418,6 +470,151 @@
   place-items: center;
   padding: 18px;
   background: rgba(0, 0, 0, 0.62);
+}
+
+.vault-verdict__finale {
+  display: grid;
+  min-height: min(72vh, 720px);
+}
+
+.vault-verdict__finale-panel {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 16px;
+  min-height: 100%;
+  padding: clamp(20px, 4vw, 40px);
+  border: 1px solid rgba(255, 207, 112, 0.34);
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 50% 28%, rgba(255, 207, 112, 0.16), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
+    rgba(5, 10, 13, 0.92);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.34), 0 0 44px rgba(255, 207, 112, 0.12);
+  text-align: center;
+  overflow: hidden;
+}
+
+.vault-verdict__finale-panel > span {
+  color: #ffcf70;
+  font-size: 0.72rem;
+  font-weight: 1000;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.vault-verdict__finale-panel h2,
+.vault-verdict__finale-panel p {
+  margin: 0;
+}
+
+.vault-verdict__finale-panel h2 {
+  color: #f5f7df;
+  font-size: clamp(2rem, 6vw, 4.8rem);
+  line-height: 0.95;
+  text-transform: uppercase;
+}
+
+.vault-verdict__finale-panel p {
+  max-width: 680px;
+  color: rgba(238, 248, 245, 0.82);
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.vault-verdict__finale-batteries {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  width: min(820px, 100%);
+  gap: 10px;
+}
+
+.vault-verdict__finale-battery {
+  position: relative;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  min-height: 190px;
+  padding: 16px;
+  border: 1px solid rgba(134, 216, 205, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  overflow: hidden;
+}
+
+.vault-verdict__finale-battery::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  height: var(--charge, 0%);
+  max-height: calc(100% - 20px);
+  border-radius: 6px;
+  background: linear-gradient(0deg, rgba(99, 240, 168, 0.72), rgba(245, 247, 223, 0.42));
+  opacity: 0.86;
+  transition: height 900ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.vault-verdict__finale-battery small,
+.vault-verdict__finale-battery strong,
+.vault-verdict__finale-battery em {
+  position: relative;
+  z-index: 1;
+}
+
+.vault-verdict__finale-battery small {
+  color: rgba(125, 247, 202, 0.78);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.vault-verdict__finale-battery strong {
+  color: #f5f7df;
+  font-size: clamp(1.5rem, 4vw, 3rem);
+  line-height: 1;
+}
+
+.vault-verdict__finale-battery em {
+  color: #ffcf70;
+  font-size: 0.78rem;
+  font-style: normal;
+  font-weight: 1000;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.vault-verdict__finale-battery.is-reserve {
+  border-color: rgba(255, 207, 112, 0.46);
+  animation: finale-reserve-pulse 1.6s ease infinite;
+}
+
+.vault-verdict__finale-battery.is-offer,
+.vault-verdict__finale-battery.is-wall {
+  opacity: 0.78;
+}
+
+.vault-verdict__finale-battery.is-offer::before,
+.vault-verdict__finale-battery.is-wall::before {
+  display: none;
+}
+
+.vault-verdict__finale-panel button {
+  min-height: 44px;
+  border: 0;
+  border-radius: 6px;
+  padding: 12px 16px;
+  color: #06100d;
+  background: #ffcf70;
+  cursor: pointer;
+  font-weight: 1000;
+}
+
+.vault-verdict__finale-panel button:disabled {
+  opacity: 0.46;
+  cursor: default;
 }
 
 .vault-verdict__amount-panel {
@@ -544,6 +741,43 @@
   }
 }
 
+@keyframes offer-arrival {
+  from {
+    box-shadow: inset 0 0 0 1px rgba(255, 207, 112, 0), 0 0 0 rgba(255, 207, 112, 0);
+    filter: brightness(0.9);
+  }
+  to {
+    box-shadow: inset 0 0 0 1px rgba(255, 207, 112, 0.18), 0 0 22px rgba(255, 207, 112, 0.08);
+    filter: brightness(1);
+  }
+}
+
+@keyframes reveal-flash {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -8px) scale(0.98);
+  }
+  16%,
+  78% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -4px) scale(0.99);
+  }
+}
+
+@keyframes rack-warning {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  45% {
+    filter: brightness(1.16);
+  }
+}
+
 @keyframes battery-scan {
   0% {
     transform: translateY(-100%);
@@ -569,6 +803,26 @@
   }
 }
 
+@keyframes max-holding {
+  0%,
+  100% {
+    box-shadow: inset 0 0 32px rgba(0, 0, 0, 0.34), 0 0 34px rgba(125, 247, 202, 0.11);
+  }
+  50% {
+    box-shadow: inset 0 0 32px rgba(0, 0, 0, 0.34), 0 0 44px rgba(125, 247, 202, 0.26);
+  }
+}
+
+@keyframes finale-reserve-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 20px rgba(255, 207, 112, 0.08);
+  }
+  50% {
+    box-shadow: 0 0 34px rgba(255, 207, 112, 0.2);
+  }
+}
+
 @media (max-width: 860px) {
   .vault-verdict__control-row {
     grid-template-columns: minmax(82px, 0.22fr) minmax(0, 1fr) auto;
@@ -591,6 +845,14 @@
   .vault-verdict__core-shell {
     width: min(180px, 62%);
     aspect-ratio: 0.72;
+  }
+
+  .vault-verdict__finale-batteries {
+    grid-template-columns: 1fr;
+  }
+
+  .vault-verdict__finale-battery {
+    min-height: 130px;
   }
 }
 

--- a/src/components/VaultVerdict/VaultVerdict.tsx
+++ b/src/components/VaultVerdict/VaultVerdict.tsx
@@ -26,6 +26,15 @@ import './VaultVerdict.css';
 
 const FINAL_FEED_LIMIT = 18;
 
+interface FinaleReveal {
+  reserveNumber: number;
+  reserveAmount: number;
+  wallNumber: number | null;
+  wallAmount: number | null;
+  offerAmount: number;
+  step: 'charging' | 'revealed';
+}
+
 function formatTime(ms: number | null) {
   if (ms == null) return '--';
   const seconds = Math.floor(ms / 1000);
@@ -91,6 +100,8 @@ export default function BatteryLow(props: GenericMinigameProps) {
   const [feedIndex, setFeedIndex] = useState(0);
   const [committed, setCommitted] = useState(false);
   const [amountInfoOpen, setAmountInfoOpen] = useState(false);
+  const [finaleReveal, setFinaleReveal] = useState<FinaleReveal | null>(null);
+  const [finaleComplete, setFinaleComplete] = useState(false);
 
   const initialContestants = useMemo(() => {
     const participants = resolveVaultParticipants(props);
@@ -105,7 +116,9 @@ export default function BatteryLow(props: GenericMinigameProps) {
   const [contestants, setContestants] = useState<VaultContestantState[]>(initialContestants);
   const human = contestants.find((contestant) => contestant.isUserControlled) ?? contestants[0]!;
   const aiContestants = contestants.filter((contestant) => !contestant.isUserControlled);
-  const rankedResults: RankedVaultResult[] | null = human.finalAmount == null
+  const gameActive = human.finalAmount == null;
+  const showFinale = finaleReveal != null && !finaleComplete;
+  const rankedResults: RankedVaultResult[] | null = human.finalAmount == null || showFinale
     ? null
     : rankVaultContestants(contestants);
   const visibleFeedPool = useMemo(
@@ -124,15 +137,32 @@ export default function BatteryLow(props: GenericMinigameProps) {
   const highestRemaining = getHighestRemainingValue(human);
   const latestReveal = human.revealedAmounts[human.revealedAmounts.length - 1] ?? null;
   const latestRevealLabel = latestReveal == null ? null : getSpecialRevealLabel(latestReveal);
+  const coreMood = latestReveal == null
+    ? 'is-idle'
+    : latestReveal > highestRemaining
+      ? 'is-voltage-drop'
+      : 'is-holding';
+  const eventTone = human.currentOffer != null
+    ? 'has-offer'
+    : latestRevealLabel
+      ? 'has-dramatic-reveal'
+      : '';
   const leftRail = human.vaults.slice(0, 11);
   const rightRail = human.vaults.slice(11);
   const tickerMessages = [
     ...(feed.length > 0 ? feed.map((event) => event.message) : []),
+    human.currentOffer != null && human.currentRound >= VAULT_VERDICT_ROUND_SCHEDULE.length
+      ? 'Final Bank Offer is on the table. The reserve circuit is armed.'
+      : null,
+    human.currentOffer != null && human.currentRound < VAULT_VERDICT_ROUND_SCHEDULE.length
+      ? 'The Bank Offer just landed. Control room holding breath.'
+      : null,
+    latestRevealLabel ? `${latestRevealLabel}. The rack just reacted.` : null,
     human.personalVaultId ? 'Private charging booths are live.' : 'Choose a Reserve Battery to begin.',
     'The Bank is watching the rack.',
     'A private booth just hit final battery territory.',
     'The control room just gasped. No further comment.',
-  ];
+  ].filter((message): message is string => message != null);
   const middleStatus = human.currentOffer != null
     ? formatVaultAmount(human.currentOffer)
     : human.personalVaultId
@@ -168,6 +198,14 @@ export default function BatteryLow(props: GenericMinigameProps) {
     return () => window.clearTimeout(timer);
   }, [feed, feedIndex, human.currentRound, human.finalAmount, human.personalVaultId, rng, visibleFeedPool]);
 
+  useEffect(() => {
+    if (!finaleReveal || finaleReveal.step === 'revealed') return;
+    const timer = window.setTimeout(() => {
+      setFinaleReveal((current) => current ? { ...current, step: 'revealed' } : current);
+    }, 1600);
+    return () => window.clearTimeout(timer);
+  }, [finaleReveal]);
+
   function updateHuman(updater: (current: VaultContestantState) => VaultContestantState) {
     setContestants((previous) =>
       previous.map((contestant) => (contestant.contestantId === human.contestantId ? updater(contestant) : contestant)),
@@ -192,6 +230,30 @@ export default function BatteryLow(props: GenericMinigameProps) {
     const finishTimeMs = startTimeRef.current == null ? elapsedMs : eventTimeMs - startTimeRef.current;
     setElapsedMs(finishTimeMs);
     updateHuman((current) => updater(current, finishTimeMs));
+  }
+
+  function handleRejectOffer(eventTimeMs: number) {
+    const finishTimeMs = startTimeRef.current == null ? elapsedMs : eventTimeMs - startTimeRef.current;
+    if (human.currentOffer != null && human.currentRound >= VAULT_VERDICT_ROUND_SCHEDULE.length) {
+      const resolvedHuman = riskVault(human, finishTimeMs);
+      const reserveBattery = resolvedHuman.vaults.find((battery) => battery.vaultId === resolvedHuman.personalVaultId);
+      const wallBattery = resolvedHuman.vaults.find((battery) => battery.status === 'remainingFinalWallVault');
+      setElapsedMs(finishTimeMs);
+      setFinaleComplete(false);
+      setFinaleReveal({
+        reserveNumber: reserveBattery?.displayNumber ?? 0,
+        reserveAmount: reserveBattery?.amount ?? resolvedHuman.finalAmount ?? 0,
+        wallNumber: wallBattery?.displayNumber ?? null,
+        wallAmount: wallBattery?.amount ?? null,
+        offerAmount: human.currentOffer,
+        step: 'charging',
+      });
+      setContestants((previous) =>
+        previous.map((contestant) => (contestant.contestantId === human.contestantId ? resolvedHuman : contestant)),
+      );
+      return;
+    }
+    finishWith(riskVault, eventTimeMs);
   }
 
   function handleCommitResults() {
@@ -238,13 +300,13 @@ export default function BatteryLow(props: GenericMinigameProps) {
               </div>
             </div>
           </div>
-          {rankedResults == null && (
+          {gameActive && (
             <div className="vault-verdict__control-row">
               <div className="vault-verdict__timer">
                 <span>Time</span>
                 <strong>{formatTime(human.finishTimeMs ?? elapsedMs)}</strong>
               </div>
-              <div className={`vault-verdict__status ${human.currentOffer != null ? 'is-offer' : ''}`}>
+              <div key={human.offerHistory.length} className={`vault-verdict__status ${human.currentOffer != null ? 'is-offer' : ''}`}>
                 <span>{human.currentOffer != null ? 'Bank Offer' : 'Status'}</span>
                 <strong>{middleStatus}</strong>
               </div>
@@ -261,7 +323,7 @@ export default function BatteryLow(props: GenericMinigameProps) {
                   <button
                     type="button"
                     className="vault-verdict__reject"
-                    onClick={(event) => finishWith(riskVault, event.timeStamp)}
+                    onClick={(event) => handleRejectOffer(event.timeStamp)}
                     aria-label="Reject Bank Offer"
                   >
                     ×
@@ -272,9 +334,9 @@ export default function BatteryLow(props: GenericMinigameProps) {
           )}
         </header>
 
-        {rankedResults == null ? (
+        {gameActive ? (
           <main className="vault-verdict__game-grid">
-            <section className="vault-verdict__board" aria-label="Battery rack board">
+            <section className={`vault-verdict__board ${eventTone}`} aria-label="Battery rack board">
               <button
                 type="button"
                 className="vault-verdict__info-button"
@@ -283,6 +345,12 @@ export default function BatteryLow(props: GenericMinigameProps) {
               >
                 i
               </button>
+              {latestReveal != null && (
+                <div key={`${latestReveal}-${human.openedVaultIds.length}`} className={`vault-verdict__reveal-flash ${latestRevealLabel ? 'is-special' : ''}`} aria-hidden="true">
+                  <span>{latestRevealLabel ?? 'Battery Exposed'}</span>
+                  <strong>{formatVaultAmount(latestReveal)}</strong>
+                </div>
+              )}
               <div className="vault-verdict__rail vault-verdict__rail--left">
                 {leftRail.map((battery) => (
                   <BatteryTile
@@ -297,7 +365,8 @@ export default function BatteryLow(props: GenericMinigameProps) {
                 <span>Max Charge Left</span>
                 <strong>{formatVaultAmount(highestRemaining)}</strong>
                 <div
-                  className={`vault-verdict__core-shell ${latestReveal != null && latestReveal >= highestRemaining ? 'is-voltage-drop' : 'is-scan'}`}
+                  key={`${human.openedVaultIds.length}-${highestRemaining}`}
+                  className={`vault-verdict__core-shell ${coreMood}`}
                   style={{ '--charge': `${highestRemaining}%` } as CSSProperties}
                 >
                   <div className="vault-verdict__core-fill" />
@@ -320,11 +389,52 @@ export default function BatteryLow(props: GenericMinigameProps) {
               </div>
             </section>
           </main>
+        ) : showFinale && finaleReveal ? (
+          <main className="vault-verdict__finale" aria-live="polite">
+            <section className={`vault-verdict__finale-panel is-${finaleReveal.step}`}>
+              <span>Grand Finale</span>
+              <h2>Reserve Battery {finaleReveal.reserveNumber || ''}</h2>
+              <div className="vault-verdict__finale-batteries">
+                <div className="vault-verdict__finale-battery is-offer">
+                  <small>Rejected Bank Offer</small>
+                  <strong>{formatVaultAmount(finaleReveal.offerAmount)}</strong>
+                </div>
+                <div
+                  className="vault-verdict__finale-battery is-reserve"
+                  style={{ '--charge': `${finaleReveal.step === 'revealed' ? finaleReveal.reserveAmount : 0}%` } as CSSProperties}
+                >
+                  <small>Reserve Battery</small>
+                  <strong>{finaleReveal.step === 'revealed' ? formatVaultAmount(finaleReveal.reserveAmount) : 'Scanning'}</strong>
+                  {finaleReveal.step === 'revealed' && getSpecialRevealLabel(finaleReveal.reserveAmount) && (
+                    <em>{getSpecialRevealLabel(finaleReveal.reserveAmount)}</em>
+                  )}
+                </div>
+                <div className="vault-verdict__finale-battery is-wall">
+                  <small>Final Rack Battery</small>
+                  <strong>
+                    {finaleReveal.step === 'revealed' && finaleReveal.wallAmount != null
+                      ? formatVaultAmount(finaleReveal.wallAmount)
+                      : finaleReveal.wallNumber != null ? `Battery ${finaleReveal.wallNumber}` : '--'}
+                  </strong>
+                </div>
+              </div>
+              <p>
+                {finaleReveal.step === 'revealed'
+                  ? finaleReveal.reserveAmount >= finaleReveal.offerAmount
+                    ? 'The risk paid off. Your reserve held more charge than the Bank wanted to give you.'
+                    : 'The Bank had the better read, but the Reserve Battery is now locked as your final charge.'
+                  : 'The rack is discharging the final circuit. Reserve value incoming.'}
+              </p>
+              <button type="button" disabled={finaleReveal.step !== 'revealed'} onClick={() => setFinaleComplete(true)}>
+                Reveal Results
+              </button>
+            </section>
+          </main>
         ) : (
           <main className="vault-verdict__results">
             <section className="vault-verdict__result-hero">
               <span>Final Results</span>
-              <h2>{rankedResults[0]?.displayName} wins Battery Low</h2>
+              <h2>{rankedResults?.[0]?.displayName} wins Battery Low</h2>
               <p>
                 You finished with {formatVaultAmount(human.finalAmount ?? 0)} by{' '}
                 {human.outcomeType === 'signedVerdict' ? 'locking the Bank Offer' : 'opening the Reserve Battery'}.
@@ -336,7 +446,7 @@ export default function BatteryLow(props: GenericMinigameProps) {
               )}
             </section>
             <section className="vault-verdict__result-list">
-              {rankedResults.map((result) => (
+              {(rankedResults ?? []).map((result) => (
                 <article key={result.contestantId} className={result.isUserControlled ? 'is-human' : ''}>
                   <span>#{result.placement}</span>
                   <strong>{result.displayName}</strong>


### PR DESCRIPTION
## Summary
- Adds a ceremonial Grand Finale flow when the player rejects the final Bank Offer, revealing the Reserve Battery before results.
- Adds lightweight drama hooks: offer pulse, dramatic reveal flash, rack warning, and central max-charge hold/drop animations.
- Keeps the existing Battery Low logic intact while making the final two-battery moment feel more complete.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- tests\unit\battery-low\batteryLow.logic.test.ts`