### PR TITLE
[codex] Add Big Spender round summaries and open finale

### DIFF
--- a/src/components/BigSpender/BigSpender.css
+++ b/src/components/BigSpender/BigSpender.css
@@ -96,6 +96,47 @@
   font-size: clamp(1.05rem, 4.5vw, 1.35rem);
 }
 
+.big-spender__finalists {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.18rem;
+}
+
+.big-spender__finalist {
+  min-width: 0;
+  display: grid;
+  gap: 0.04rem;
+  padding: 0.32rem 0.42rem;
+  border: 1px solid rgba(218, 231, 255, 0.14);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.big-spender__finalist--turn {
+  border-color: rgba(255, 224, 141, 0.52);
+  background: rgba(255, 218, 116, 0.11);
+}
+
+.big-spender__finalist strong,
+.big-spender__finalist em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.big-spender__finalist strong {
+  font-size: 0.78rem;
+}
+
+.big-spender__finalist em {
+  color: rgba(229, 239, 255, 0.8);
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 800;
+}
+
 .big-spender__status-panel p {
   min-width: 0;
   color: rgba(239, 245, 255, 0.9);
@@ -235,6 +276,18 @@
   line-height: 1;
   color: #fff5c7;
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.42);
+}
+
+.big-spender__wallet-opener {
+  position: relative;
+  z-index: 1;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(244, 248, 255, 0.72);
+  font-size: 0.64rem;
+  font-weight: 900;
 }
 
 .big-spender__wallet--bomb .big-spender__wallet-result {
@@ -405,6 +458,10 @@
   max-height: calc(100dvh - 2rem);
 }
 
+.big-spender__modal--round {
+  width: min(100%, 32rem);
+}
+
 .big-spender__modal h2 {
   font-size: 1.35rem;
 }
@@ -425,6 +482,10 @@
   color: #f8fbff;
 }
 
+.big-spender__modal-actions > button:only-child {
+  grid-column: 1 / -1;
+}
+
 .big-spender__ranking {
   min-height: 0;
   overflow-y: auto;
@@ -443,6 +504,20 @@
   padding: 0.34rem 0.45rem;
   border-radius: 0.55rem;
   background: rgba(255, 255, 255, 0.05);
+}
+
+.big-spender__ranking--round {
+  max-height: min(44dvh, 22rem);
+}
+
+.big-spender__ranking-item--eliminated {
+  border: 1px solid rgba(255, 112, 112, 0.38);
+  background: rgba(255, 76, 76, 0.09);
+}
+
+.big-spender__ranking-item--eliminated span {
+  background: rgba(255, 95, 95, 0.18);
+  color: #ffd9d9;
 }
 
 .big-spender__ranking span {

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -4,6 +4,7 @@ import { mulberry32 } from '../../store/rng';
 import {
   BIG_SPENDER_CONFIG,
   buildBigSpenderRawResults,
+  continueBigSpenderRound,
   createInitialBigSpenderState,
   decideAiShouldOpen,
   fastForwardBigSpenderGame,
@@ -15,6 +16,7 @@ import {
   rankBigSpenderPlayers,
   resolveBigSpenderAdRescue,
   resolveBigSpenderParticipants,
+  skipBigSpenderToResults,
   type BigSpenderPlayerState,
   type BigSpenderState,
   type BigSpenderWallet,
@@ -104,6 +106,10 @@ export default function BigSpender(props: GenericMinigameProps) {
   );
   const winner = ranking[0] ?? null;
   const isFinaleRound = state.roundNumber === BIG_SPENDER_CONFIG.finalRound;
+  const finalePlayers = useMemo(
+    () => state.players.filter((player) => state.activePlayerIds.includes(player.playerId)),
+    [state.activePlayerIds, state.players],
+  );
   const humanInRound = Boolean(humanPlayer && state.activePlayerIds.includes(humanPlayer.playerId));
   const humanAdRescuePending = Boolean(state.pendingAdRescue && humanPlayer?.playerId === state.pendingAdRescue.playerId);
   const humanSecondChancePending = Boolean(state.pendingSecondChance && humanPlayer?.playerId === state.pendingSecondChance.playerId);
@@ -143,6 +149,18 @@ export default function BigSpender(props: GenericMinigameProps) {
     ? state.events.find((event) => event.type === 'playerZeroFinished' && event.playerId === humanPlayer.playerId)
     : null;
   const humanZeroEventKey = humanZeroEvent ? getBroadcastKey(humanZeroEvent) : null;
+  const latestRoundResult = state.roundResults[state.roundResults.length - 1] ?? null;
+  const shouldShowRoundSummary = state.status === 'roundSummary' && latestRoundResult != null;
+  const roundSummaryPlayers = useMemo(() => {
+    if (!latestRoundResult) return [];
+    const ids = new Set(latestRoundResult.rankedPlayerIds);
+    return rankBigSpenderPlayers(state.players.filter((player) => ids.has(player.playerId)));
+  }, [latestRoundResult, state.players]);
+  const humanEliminatedInSummary = Boolean(
+    shouldShowRoundSummary &&
+    humanPlayer &&
+    latestRoundResult?.eliminatedPlayerIds.includes(humanPlayer.playerId),
+  );
   const shouldShowResults = state.status === 'completed' && showResults;
 
   useEffect(() => {
@@ -296,6 +314,19 @@ export default function BigSpender(props: GenericMinigameProps) {
     }, 900);
   };
 
+  const continueRound = () => {
+    setState((previous) => continueBigSpenderRound(previous));
+  };
+
+  const skipToResults = () => {
+    setState((previous) => skipBigSpenderToResults(previous));
+  };
+
+  const getWalletOpenedByLabel = (wallet: BigSpenderWallet) => {
+    if (!isFinaleRound || wallet.state !== 'revealed' || !wallet.openedByPlayerId) return null;
+    return state.players.find((player) => player.playerId === wallet.openedByPlayerId)?.displayName ?? 'Finalist';
+  };
+
   const statusMessage = (() => {
     if (fastForwarding) return 'Fast forwarding the house feed...';
     if (humanFinishedWhileRunning) return 'You are done here. The house is still finishing this round.';
@@ -324,6 +355,19 @@ export default function BigSpender(props: GenericMinigameProps) {
               {(humanFinishedWhileRunning || humanWaitingForFinaleTurn || fastForwarding) && <span className="big-spender__status-loader" aria-hidden="true" />}
             </small>
           )}
+          {isFinaleRound && finalePlayers.length > 0 && (
+            <div className="big-spender__finalists" aria-label="Finalists">
+              {finalePlayers.map((player) => (
+                <span
+                  key={player.playerId}
+                  className={player.currentTurn ? 'big-spender__finalist big-spender__finalist--turn' : 'big-spender__finalist'}
+                >
+                  <strong>{player.displayName}</strong>
+                  <em>{player.balance} Eyeoleans</em>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         {state.status === 'running' && humanFinishedWhileRunning && (
           <button type="button" className="big-spender__action big-spender__action--lock" onClick={fastForwardHouse} disabled={fastForwarding}>
@@ -341,6 +385,7 @@ export default function BigSpender(props: GenericMinigameProps) {
         <section className="big-spender__board" aria-label="Wallet board">
           {humanBoard.map((wallet) => {
             const resultLabel = getWalletResultLabel(wallet);
+            const openedByLabel = getWalletOpenedByLabel(wallet);
             return (
               <button
                 key={wallet.walletId}
@@ -359,7 +404,10 @@ export default function BigSpender(props: GenericMinigameProps) {
                 <span className="big-spender__wallet-flap" aria-hidden="true" />
                 <span className="big-spender__wallet-id">{wallet.boardSlotIndex + 1}</span>
                 {resultLabel ? (
-                  <strong className="big-spender__wallet-result">{resultLabel}</strong>
+                  <>
+                    <strong className="big-spender__wallet-result">{resultLabel}</strong>
+                    {openedByLabel && <span className="big-spender__wallet-opener">{openedByLabel}</span>}
+                  </>
                 ) : (
                   <span className="big-spender__wallet-generation">{humanSecondChancePending ? 'Pick' : 'Tap'}</span>
                 )}
@@ -370,7 +418,7 @@ export default function BigSpender(props: GenericMinigameProps) {
 
       </main>
 
-      {broadcasts.length > 0 && (
+      {!isFinaleRound && broadcasts.length > 0 && (
         <section className="big-spender__broadcasts" aria-label="House broadcasts" aria-live="polite">
           {broadcasts.map((message) => (
             <p key={message}>{message}</p>
@@ -401,6 +449,52 @@ export default function BigSpender(props: GenericMinigameProps) {
             <div className="big-spender__modal-actions">
               <button type="button" onClick={() => setState((previous) => resolveBigSpenderAdRescue(previous, 'completed'))}>Watch ad</button>
               <button type="button" onClick={() => setState((previous) => resolveBigSpenderAdRescue(previous, 'declined'))}>Skip</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {shouldShowRoundSummary && latestRoundResult && (
+        <div className="big-spender__overlay">
+          <div className="big-spender__modal big-spender__modal--round">
+            <span className="big-spender__eyebrow">Round {latestRoundResult.roundNumber} results</span>
+            <h2>
+              {humanEliminatedInSummary
+                ? 'You were eliminated'
+                : latestRoundResult.survivorPlayerIds.length <= BIG_SPENDER_CONFIG.roundFourFinalistCount
+                  ? 'Finale is set'
+                  : 'You survived'}
+            </h2>
+            <p>
+              {humanEliminatedInSummary
+                ? 'The house keeps playing from here.'
+                : latestRoundResult.survivorPlayerIds.length <= BIG_SPENDER_CONFIG.roundFourFinalistCount
+                  ? 'Two finalists remain for the shared-board finale.'
+                  : `${latestRoundResult.survivorPlayerIds.length} players move on.`}
+            </p>
+            <ol className="big-spender__ranking big-spender__ranking--round">
+              {roundSummaryPlayers.map((player) => {
+                const eliminated = latestRoundResult.eliminatedPlayerIds.includes(player.playerId);
+                return (
+                  <li key={player.playerId} className={eliminated ? 'big-spender__ranking-item--eliminated' : ''}>
+                    <span>{player.rank}</span>
+                    <strong>{player.displayName}</strong>
+                    <em>{eliminated ? 'Eliminated' : `${player.walletsOpened} wallets - ${getPlayerLabel(player)}`}</em>
+                  </li>
+                );
+              })}
+            </ol>
+            <div className="big-spender__modal-actions">
+              {humanEliminatedInSummary ? (
+                <>
+                  <button type="button" onClick={continueRound}>Watch as spectator</button>
+                  <button type="button" onClick={skipToResults}>Skip to results</button>
+                </>
+              ) : (
+                <button type="button" onClick={continueRound}>
+                  {latestRoundResult.survivorPlayerIds.length <= BIG_SPENDER_CONFIG.roundFourFinalistCount ? 'Start finale' : 'Next round'}
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/BigSpender/bigSpenderLogic.ts
+++ b/src/components/BigSpender/bigSpenderLogic.ts
@@ -66,6 +66,12 @@ const AI_NEGATIVE_BROADCASTS = [
   '{name} heard the wallet sigh.',
   '{name} made the house accountants smile.',
   '{name} opened one and looked suddenly humble.',
+  '{name} discovered a service fee with stage presence.',
+  '{name} picked a wallet that asked for a manager.',
+  '{name} found the budget spreadsheet crying.',
+  '{name} opened one and immediately blamed production.',
+  '{name} found a coupon that expired in 2009.',
+  '{name} just made zero look fashionable.',
 ] as const;
 
 const AI_POSITIVE_BROADCASTS = [
@@ -73,6 +79,12 @@ const AI_POSITIVE_BROADCASTS = [
   '{name} got a wallet that fought back.',
   '{name} accidentally made things worse.',
   '{name} opened one and the room got nosy.',
+  '{name} found money with excellent timing.',
+  '{name} got a tiny financial plot twist.',
+  '{name} found a wallet that clearly has favorites.',
+  '{name} opened one and tried not to smile.',
+  '{name} just bought themselves a little breathing room.',
+  '{name} found the house\'s emergency snack fund.',
 ] as const;
 
 const AI_BOMB_BROADCASTS = [
@@ -80,13 +92,17 @@ const AI_BOMB_BROADCASTS = [
   'A tiny boom echoed somewhere near {name}.',
   '{name} found the wallet with commitment issues.',
   'The house just went quiet around {name}.',
+  '{name} opened one and everyone suddenly remembered errands.',
+  'A producer just asked whether {name} signed the waiver.',
+  '{name} found the spicy wallet.',
+  'Something near {name} made a very final noise.',
 ] as const;
 
 export type BigSpenderOutcomeType = 'negative' | 'positive' | 'bomb';
 export type BigSpenderWalletKind = 'normal' | 'bonus' | 'secondChance';
 export type BigSpenderWalletState = 'hidden' | 'opening' | 'revealed';
 export type BigSpenderPlayerStatus = 'active' | 'locked' | 'zeroFinished' | 'bombed';
-export type BigSpenderGameStatus = 'running' | 'completed';
+export type BigSpenderGameStatus = 'running' | 'roundSummary' | 'completed';
 export type BigSpenderAdDecision = 'completed' | 'declined' | 'failed' | 'unavailable';
 
 export interface BigSpenderParticipant {
@@ -296,10 +312,8 @@ function isRoundParticipant(state: BigSpenderState, playerId: string) {
   return state.activePlayerIds.includes(playerId);
 }
 
-function getBoardOwnerId(state: BigSpenderState, playerId: string) {
-  return isFinaleRound(state) && isRoundParticipant(state, playerId)
-    ? BIG_SPENDER_FINALE_BOARD_ID
-    : playerId;
+function getBoardOwnerId(state: BigSpenderState, _playerId: string) {
+  return isFinaleRound(state) ? BIG_SPENDER_FINALE_BOARD_ID : _playerId;
 }
 
 function getPlayerMutable(state: BigSpenderState, playerId: string) {
@@ -343,6 +357,7 @@ function nextEligibleTurnIndex(state: BigSpenderState, startIndex: number) {
 }
 
 function startNextRoundMutable(state: BigSpenderState, survivorPlayerIds: string[]) {
+  state.status = 'running';
   state.roundNumber = survivorPlayerIds.length <= BIG_SPENDER_CONFIG.roundFourFinalistCount
     ? BIG_SPENDER_CONFIG.finalRound
     : state.roundNumber + 1;
@@ -435,7 +450,26 @@ function completeRoundMutable(state: BigSpenderState) {
     eliminatedPlayerIds: eliminatedThisRound.map((player) => player.playerId),
     survivorPlayerIds,
   });
-  return startNextRoundMutable(state, survivorPlayerIds);
+  state.status = 'roundSummary';
+  state.currentTurnPlayerId = null;
+  state.postWalletLockPlayerId = null;
+  state.pendingBonus = null;
+  state.pendingAdRescue = null;
+  state.pendingSecondChance = null;
+  markTurnFlags(state);
+  syncVisibleBoard(state);
+  appendEvent(state, {
+    type: 'roundCompleted',
+    message: `Round ${state.roundNumber} is complete.`,
+  });
+  return state;
+}
+
+function continueRoundSummaryMutable(state: BigSpenderState) {
+  if (state.status !== 'roundSummary') return state;
+  const latestRound = state.roundResults[state.roundResults.length - 1];
+  if (!latestRound) return state;
+  return startNextRoundMutable(state, latestRound.survivorPlayerIds);
 }
 
 function completeIfNeeded(state: BigSpenderState) {
@@ -568,24 +602,14 @@ function applyOutcomeMutable(
   if (outcome.type === 'positive') {
     player.positiveWalletsOpened += 1;
     player.balance += outcome.amount ?? 0;
-    appendEvent(state, {
-      type: 'walletOpened',
-      playerId: player.playerId,
-      outcome,
-      message: getOutcomeMessage(player, outcome, kind),
-    });
+    appendWalletOpenedEvent(state, player, outcome, kind);
     return;
   }
 
   if (outcome.type === 'negative') {
     player.negativeWalletsOpened += 1;
     player.balance = clamp(player.balance + (outcome.amount ?? 0), 0, Number.MAX_SAFE_INTEGER);
-    appendEvent(state, {
-      type: 'walletOpened',
-      playerId: player.playerId,
-      outcome,
-      message: getOutcomeMessage(player, outcome, kind),
-    });
+    appendWalletOpenedEvent(state, player, outcome, kind);
     if (player.balance === 0) {
       finalizePlayer(player, state, 'zeroFinished');
       appendEvent(state, {
@@ -598,6 +622,23 @@ function applyOutcomeMutable(
   }
 
   player.bombsOpened += 1;
+  appendWalletOpenedEvent(state, player, outcome, kind);
+}
+
+function shouldBroadcastWalletOpened(state: BigSpenderState, player: BigSpenderPlayerState, outcome: BigSpenderWalletOutcome) {
+  if (isFinaleRound(state)) return false;
+  if (player.isHuman) return true;
+  if (outcome.type === 'bomb') return true;
+  return (player.walletsOpened + player.originalTurnOrderIndex + state.roundNumber) % 4 === 0;
+}
+
+function appendWalletOpenedEvent(
+  state: BigSpenderState,
+  player: BigSpenderPlayerState,
+  outcome: BigSpenderWalletOutcome,
+  kind: BigSpenderWalletKind,
+) {
+  if (!shouldBroadcastWalletOpened(state, player, outcome)) return;
   appendEvent(state, {
     type: 'walletOpened',
     playerId: player.playerId,
@@ -746,6 +787,7 @@ export function createInitialBigSpenderState(
 export function canOfferAdRescue(state: BigSpenderState, player: BigSpenderPlayerState) {
   return (
     player.isHuman &&
+    !isFinaleRound(state) &&
     player.adBombRescuesUsed < BIG_SPENDER_CONFIG.maxAdBombRescues &&
     player.finalizedAt == null &&
     state.status === 'running'
@@ -871,6 +913,11 @@ export function finishBigSpenderTurn(previousState: BigSpenderState) {
   return advanceTurnMutable(state);
 }
 
+export function continueBigSpenderRound(previousState: BigSpenderState) {
+  const state = cloneState(previousState);
+  return continueRoundSummaryMutable(state);
+}
+
 export function lockBigSpenderPlayer(previousState: BigSpenderState, playerId: string) {
   const state = cloneState(previousState);
   const player = getPlayerMutable(state, playerId);
@@ -957,6 +1004,51 @@ export function fastForwardBigSpenderGame(previousState: BigSpenderState) {
     simulateAiPlayerToFinalized(state, playerToSimulate);
     completeIfNeeded(state);
     if ((state as BigSpenderState).status !== 'completed' && isFinaleRound(state)) advanceFinaleTurnMutable(state);
+  }
+  syncVisibleBoard(state);
+  return state;
+}
+
+export function skipBigSpenderToResults(previousState: BigSpenderState) {
+  const state = cloneState(previousState);
+  let guard = 0;
+  while (state.status !== 'completed' && guard < 500) {
+    guard += 1;
+    const human = state.players.find((player) => player.isHuman);
+    if (
+      human &&
+      isRoundParticipant(state, human.playerId) &&
+      human.status === 'active' &&
+      human.finalizedAt == null
+    ) {
+      return state;
+    }
+
+    if (state.status === 'roundSummary') {
+      continueRoundSummaryMutable(state);
+      continue;
+    }
+
+    if (state.status !== 'running') break;
+
+    const activePlayers = state.players.filter((player) =>
+      isRoundParticipant(state, player.playerId) &&
+      player.status === 'active' &&
+      player.finalizedAt == null
+    );
+
+    if (activePlayers.length === 0) {
+      completeIfNeeded(state);
+      continue;
+    }
+
+    const playerToSimulate = isFinaleRound(state)
+      ? activePlayers.find((player) => player.playerId === state.currentTurnPlayerId) ?? activePlayers[0]
+      : activePlayers[0];
+    if (!playerToSimulate) break;
+    simulateAiPlayerToFinalized(state, playerToSimulate);
+    completeIfNeeded(state);
+    if (state.status === 'running' && isFinaleRound(state)) advanceFinaleTurnMutable(state);
   }
   syncVisibleBoard(state);
   return state;

--- a/tests/unit/big-spender/bigSpenderLogic.test.ts
+++ b/tests/unit/big-spender/bigSpenderLogic.test.ts
@@ -5,6 +5,7 @@ import {
   BIG_SPENDER_NEGATIVE_WALLETS,
   BIG_SPENDER_POSITIVE_WALLETS,
   canOfferAdRescue,
+  continueBigSpenderRound,
   createInitialBigSpenderState,
   decideAiShouldOpen,
   fastForwardBigSpenderGame,
@@ -17,6 +18,7 @@ import {
   rankBigSpenderPlayers,
   resolveBigSpenderAdRescue,
   resolveBigSpenderBonusOffer,
+  skipBigSpenderToResults,
   sumWeights,
   type BigSpenderParticipant,
   type BigSpenderState,
@@ -291,7 +293,7 @@ describe('Big Spender: Broke or Boom logic', () => {
     expect(decideAiShouldOpen(500, () => 0.65)).toBe(false);
   });
 
-  it('starts a new round when all current players are finalized', () => {
+  it('pauses on a round summary when all current players are finalized', () => {
     let state = makeState();
     for (const id of [...state.turnOrder]) {
       state = setCurrent(state, id);
@@ -301,24 +303,83 @@ describe('Big Spender: Broke or Boom logic', () => {
       state = lockBigSpenderPlayer(state, id);
     }
 
-    expect(state.status).toBe('running');
-    expect(state.roundNumber).toBe(2);
+    expect(state.status).toBe('roundSummary');
+    expect(state.roundNumber).toBe(1);
     expect(state.roundResults).toHaveLength(1);
-    expect(state.activePlayerIds).toHaveLength(participants.length - 1);
+    expect(state.roundResults[0]?.survivorPlayerIds).toHaveLength(participants.length - 1);
+
+    const nextRound = continueBigSpenderRound(state);
+    expect(nextRound.status).toBe('running');
+    expect(nextRound.roundNumber).toBe(2);
+    expect(nextRound.activePlayerIds).toHaveLength(participants.length - 1);
   });
 
-  it('fast forwards remaining house play through the finale after the human is out', () => {
+  it('fast forwards remaining house play to the current round summary after the human is out', () => {
     let state = setCurrent(makeState(), 'human');
     state.players = state.players.map((entry) => entry.playerId === 'human' ? { ...entry, adBombRescuesUsed: 2 } : entry);
     state = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
       forcedOutcome: { type: 'bomb', amount: null },
     });
 
-    const completed = fastForwardBigSpenderGame(state);
+    const summary = fastForwardBigSpenderGame(state);
+
+    expect(summary.status).toBe('roundSummary');
+    expect(summary.roundResults).toHaveLength(1);
+  });
+
+  it('skips to completed results after the human has been eliminated', () => {
+    let state = setCurrent(makeState(), 'human');
+    state.players = state.players.map((entry) => entry.playerId === 'human' ? { ...entry, adBombRescuesUsed: 2 } : entry);
+    state = openBigSpenderWallet(state, 'human', firstWallet(state).walletId, 'normal', {
+      forcedOutcome: { type: 'bomb', amount: null },
+    });
+
+    const completed = skipBigSpenderToResults(fastForwardBigSpenderGame(state));
 
     expect(completed.status).toBe('completed');
     expect(completed.roundNumber).toBe(BIG_SPENDER_CONFIG.finalRound);
     expect(completed.players.filter((entry) => entry.gameRank != null)).toHaveLength(participants.length);
+  });
+
+  it('shows the shared finale board even after the human is only spectating', () => {
+    const state = makeState();
+    const summary = {
+      ...state,
+      status: 'roundSummary' as const,
+      roundNumber: 4,
+      roundResults: [{
+        roundNumber: 4,
+        finalistRound: false,
+        rankedPlayerIds: ['ai-1', 'ai-2', 'human'],
+        eliminatedPlayerIds: ['human'],
+        survivorPlayerIds: ['ai-1', 'ai-2'],
+      }],
+    };
+
+    const finale = continueBigSpenderRound(summary);
+    const spectatorBoard = getBigSpenderBoardForPlayer(finale, 'human');
+    const finalistBoard = getBigSpenderBoardForPlayer(finale, 'ai-1');
+
+    expect(finale.roundNumber).toBe(BIG_SPENDER_CONFIG.finalRound);
+    expect(spectatorBoard[0]?.walletId).toBe(finalistBoard[0]?.walletId);
+  });
+
+  it('does not offer ad saves during the shared finale', () => {
+    const state = makeState();
+    const finale = continueBigSpenderRound({
+      ...state,
+      status: 'roundSummary' as const,
+      roundNumber: 4,
+      roundResults: [{
+        roundNumber: 4,
+        finalistRound: false,
+        rankedPlayerIds: ['human', 'ai-1'],
+        eliminatedPlayerIds: [],
+        survivorPlayerIds: ['human', 'ai-1'],
+      }],
+    });
+
+    expect(canOfferAdRescue(finale, player(finale, 'human'))).toBe(false);
   });
 
   it('ranks zero finishers, lowest non-zero scores, and bombed players correctly', () => {


### PR DESCRIPTION
## Summary
- Pause after each Big Spender round with an elimination board instead of jumping straight into the next round.
- Let eliminated players either watch as spectators or skip directly to final results.
- Make the finale fully open: spectators see the shared board, finalists and live balances are visible, revealed wallets show who opened them, and ad saves are disabled.
- Suppress broadcast chatter during the finale and make earlier AI broadcasts more occasional with more varied lines.

## Validation
- `npm run lint`
- `npx vitest run tests/unit/big-spender/bigSpenderLogic.test.ts`
- `npm run typecheck`
- `npm run build`