### PR TITLE
[codex] Stabilize iPhone bottom controls

### DIFF
--- a/src/components/GameBottomNav/GameBottomNav.css
+++ b/src/components/GameBottomNav/GameBottomNav.css
@@ -132,10 +132,6 @@
   border-radius: 6px;
 }
 
-:root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav {
-  margin-bottom: calc(-0.35 * var(--safe-bottom));
-}
-
 :root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav__items {
   padding-top: 2px;
   padding-bottom: 2px;

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -200,9 +200,11 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const compactNavContentHeight = Math.min(normalNavContentHeight, COMPACT_NAV_HEIGHT)
   const normalNavHeight = normalNavContentHeight + input.safeBottom
   const compactNavHeight = compactNavContentHeight + input.safeBottom
-  const measuredDockHeight = input.dockHeight || estimateDockHeight(stageWidth)
-  const normalDockHeight = input.hasDock ? measuredDockHeight : 0
-  const compactDockHeight = input.hasDock ? Math.max(56, measuredDockHeight * COMPACT_DOCK_SCALE) : 0
+  const estimatedDockHeight = estimateDockHeight(stageWidth)
+  const measuredDockHeight = input.dockHeight || estimatedDockHeight
+  const baselineDockHeight = Math.max(measuredDockHeight, estimatedDockHeight)
+  const normalDockHeight = input.hasDock ? baselineDockHeight : 0
+  const compactDockHeight = input.hasDock ? Math.max(56, baselineDockHeight * COMPACT_DOCK_SCALE) : 0
   const normalDockClearance = input.hasDock ? normalDockHeight + NORMAL_DOCK_GAP : 0
   const compactDockClearance = input.hasDock ? compactDockHeight + COMPACT_DOCK_GAP : 0
   const measuredStageAndNavHeight = stageHeight + measuredNavHeight
@@ -433,10 +435,9 @@ function readViewportInput<TStage extends HTMLElement>(
 ): ResponsiveGameLayoutInput {
   const visualViewport = window.visualViewport
   const viewportWidth = visualViewport?.width ?? window.innerWidth
-  const viewportHeight = visualViewport?.height ?? window.innerHeight
+  const viewportHeight = Math.max(visualViewport?.height ?? 0, window.innerHeight)
   const stageRect = stageRef.current?.getBoundingClientRect()
   const navRect = document.querySelector<HTMLElement>('.nav-bar')?.getBoundingClientRect()
-  const dockRect = document.querySelector<HTMLElement>('.game-control-dock')?.getBoundingClientRect()
   const rootStyle = getComputedStyle(document.documentElement)
   const safeTop = Math.max(
     readPx(rootStyle.getPropertyValue('--safe-top')),
@@ -456,7 +457,7 @@ function readViewportInput<TStage extends HTMLElement>(
     safeTop,
     safeBottom,
     navHeight: navRect?.height ?? DEFAULT_NAV_HEIGHT + safeBottom,
-    dockHeight: dockRect?.height ?? 0,
+    dockHeight: options.hasDock ? estimateDockHeight(stageRect?.width ?? Math.min(viewportWidth, DEFAULT_PHONE_WIDTH)) : 0,
     hasDock: options.hasDock,
     playerCount: options.playerCount,
     userCompactRoster: options.userCompactRoster,
@@ -510,12 +511,9 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
     measure()
     window.addEventListener('resize', measure)
     window.visualViewport?.addEventListener('resize', measure)
-    window.visualViewport?.addEventListener('scroll', measure)
-
     const observed = [
       stageRef.current,
       document.querySelector<HTMLElement>('.nav-bar'),
-      document.querySelector<HTMLElement>('.game-control-dock'),
     ].filter((el): el is HTMLElement => el instanceof HTMLElement)
     let resizeObserver: ResizeObserver | null = null
     if (typeof ResizeObserver !== 'undefined') {
@@ -526,7 +524,6 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
     return () => {
       window.removeEventListener('resize', measure)
       window.visualViewport?.removeEventListener('resize', measure)
-      window.visualViewport?.removeEventListener('scroll', measure)
       resizeObserver?.disconnect()
     }
   }, [measure, stageRef])

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -65,6 +65,27 @@ describe('responsive game layout budget', () => {
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
   })
 
+  it('keeps iPhone Pro bottom controls stable after compact controls resize themselves', () => {
+    const normalMeasuredBudget = computeResponsiveGameLayout(makeInput({
+      viewportHeight: 852,
+      stageHeight: 699,
+      navHeight: 94,
+      dockHeight: 70,
+      playerCount: 16,
+    }))
+    const compactMeasuredBudget = computeResponsiveGameLayout(makeInput({
+      viewportHeight: 852,
+      stageHeight: 713,
+      navHeight: 80,
+      dockHeight: 63,
+      playerCount: 16,
+    }))
+
+    expect(normalMeasuredBudget.bottomControlsMode).toBe('compact')
+    expect(compactMeasuredBudget.bottomControlsMode).toBe('compact')
+    expect(compactMeasuredBudget.signature).toBe(normalMeasuredBudget.signature)
+  })
+
   it('does not change avatar tile size when transient vertical budget changes', () => {
     const dayEndBudget = computeResponsiveGameLayout(makeInput({
       viewportWidth: 393,


### PR DESCRIPTION
## Summary

Stabilizes the main game bottom controls on iPhone Pro-sized screens where the navbar and action dock could flicker or move vertically.

## Root Cause

The responsive game layout was feeding measured compact control dimensions back into the next layout calculation. On affected iPhones, `visualViewport` updates and compact/normal control resizing could cause the layout signature to bounce, which made the bottom navbar/action dock visibly jump. The compact nav also applied a negative safe-area margin, amplifying the vertical movement.

## Changes

- Use a stable estimated dock baseline instead of measuring the already-resized compact dock as the next baseline.
- Stop remeasuring the full game layout on `visualViewport.scroll` events.
- Keep viewport height at least `window.innerHeight` to avoid transient iOS visual viewport dips shrinking the game budget.
- Remove the compact nav negative safe-area margin.
- Add a regression test for the iPhone Pro compact-control self-resize case.

## Validation

- `npx vitest run tests/unit/layout/responsiveGameLayout.test.ts`
- `npm run typecheck`