### PR TITLE
[codex] survivor soft elimination flow

### DIFF
--- a/src/routes/GameRoute.tsx
+++ b/src/routes/GameRoute.tsx
@@ -1,8 +1,16 @@
 import { Navigate } from 'react-router-dom';
 import GameScreen from '../screens/GameScreen/GameScreen';
 import { useAppSelector } from '../store/hooks';
+import { isSurvivorRunTerminal } from '../modes/survivorRun';
 
 export default function GameRoute() {
-  const isGameActive = useAppSelector((state) => state.game.status === 'active');
-  return isGameActive ? <GameScreen /> : <Navigate to="/" replace />;
+  const game = useAppSelector((state) => state.game);
+  const shouldStayInSurvivorFlow = game.mode === 'survival' && isSurvivorRunTerminal(game);
+  const isGameActive = game.status === 'active';
+
+  if (isGameActive || shouldStayInSurvivorFlow) {
+    return <GameScreen />;
+  }
+
+  return <Navigate to="/" replace />;
 }

--- a/tests/gameRoute.test.tsx
+++ b/tests/gameRoute.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import gameReducer from '../src/store/gameSlice';
+import profilesReducer from '../src/store/profilesSlice';
+import settingsReducer from '../src/store/settingsSlice';
+import publicOpinionReducer from '../src/publicOpinion/publicOpinionSlice';
+import GameRoute from '../src/routes/GameRoute';
+import { createSurvivorRun, terminalizeSurvivorRun } from '../src/modes/survivorRun';
+
+vi.mock('../src/screens/GameScreen/GameScreen', () => ({
+  default: () => <div>Game Screen</div>,
+}));
+
+function makeStore(gameOverrides: Record<string, unknown>) {
+  const baseGame = gameReducer(undefined, { type: '@@INIT' });
+  const baseSettings = settingsReducer(undefined, { type: '@@INIT' });
+  const baseProfiles = profilesReducer(undefined, { type: '@@INIT' });
+  const basePublicOpinion = publicOpinionReducer(undefined, { type: '@@INIT' });
+
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+      settings: settingsReducer,
+      profiles: profilesReducer,
+      publicOpinion: publicOpinionReducer,
+    },
+    preloadedState: {
+      game: {
+        ...baseGame,
+        ...gameOverrides,
+      },
+      settings: baseSettings,
+      profiles: baseProfiles,
+      publicOpinion: basePublicOpinion,
+    },
+  });
+}
+
+describe('GameRoute', () => {
+  it('keeps terminal survivor runs on the game screen for the soft elimination flow', async () => {
+    const terminalSurvivor = terminalizeSurvivorRun(createSurvivorRun());
+    const store = makeStore(terminalSurvivor as Record<string, unknown>);
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/game']}>
+          <Routes>
+            <Route path="/" element={<div>Home</div>} />
+            <Route path="/game" element={<GameRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    expect(screen.getByText('Game Screen')).toBeInTheDocument();
+    expect(screen.queryByText('Home')).toBeNull();
+  });
+
+  it('still returns to home for non-survivor inactive runs', async () => {
+    const store = makeStore({
+      status: 'failed',
+      mode: 'classic',
+    });
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/game']}>
+          <Routes>
+            <Route path="/" element={<div>Home</div>} />
+            <Route path="/game" element={<GameRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Home')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Game Screen')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed
- Kept terminal Survivor runs on the game route instead of redirecting them back to Home.
- Added a regression test for the survivor terminal route behavior.

## Why
- Survivor eliminations already have a soft end-of-run flow in the game UI.
- Redirecting terminal survivor runs to `/` made the app feel like it restarted and skipped that modal.

## Impact
- Eliminated Survivor players now see the intended end-of-run modal with the choice to start a new run or return home.
- Classic inactive runs still return to Home as before.

## Checks
- `npm test -- tests/gameRoute.test.tsx`
- `npm run typecheck`