### PR TITLE
[codex] Fix ceremony badge remeasurement

### DIFF
--- a/src/components/SpotlightAnimation/spotlight-animation.tsx
+++ b/src/components/SpotlightAnimation/spotlight-animation.tsx
@@ -4,7 +4,7 @@
  * Adds on top of CeremonyOverlay:
  *   - Body scroll lock (overflow: hidden) while the overlay is active.
  *   - visualViewport + window resize + capture-scroll listeners when
- *     measureA or measureB callbacks are provided, keeping cutout holes
+ *     measureTiles, measureA, or measureB callbacks are provided, keeping cutout holes
  *     and flying badges aligned during pinch-zoom and page scroll.
  *   - ResizeObserver on tileRefs elements (if provided) to detect tile
  *     reflow due to layout changes.
@@ -26,6 +26,8 @@ import CeremonyOverlay from '../CeremonyOverlay/CeremonyOverlay';
 import type { CeremonyOverlayProps, CeremonyTile } from '../CeremonyOverlay/CeremonyOverlay';
 
 export interface SpotlightAnimationProps extends Omit<CeremonyOverlayProps, 'resolveTiles'> {
+  /** Re-measures the full ceremony tile set in one pass. */
+  measureTiles?: () => CeremonyTile[];
   /** Re-measures tile A (index 0) position on viewport changes. */
   measureA?: () => DOMRect | null;
   /** Re-measures tile B (index 1) position on viewport changes. */
@@ -40,6 +42,7 @@ export interface SpotlightAnimationProps extends Omit<CeremonyOverlayProps, 'res
 
 export default function SpotlightAnimation({
   tiles: initialTiles,
+  measureTiles,
   measureA,
   measureB,
   tileRefs,
@@ -50,7 +53,7 @@ export default function SpotlightAnimation({
   const rafRef = useRef<number>(0);
   const activeRef = useRef(true);
 
-  const hasMeasure = measureA != null || measureB != null;
+  const hasMeasure = measureTiles != null || measureA != null || measureB != null;
   const hasRefs = (tileRefs?.length ?? 0) > 0;
 
   const remeasure = useCallback(() => {
@@ -58,6 +61,10 @@ export default function SpotlightAnimation({
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {
       if (!activeRef.current) return;
+      if (measureTiles) {
+        setTiles(measureTiles());
+        return;
+      }
       setTiles((prev) =>
         prev.map((tile, idx) => {
           const measureFn = idx === 0 ? measureA : idx === 1 ? measureB : undefined;
@@ -71,7 +78,7 @@ export default function SpotlightAnimation({
         }),
       );
     });
-  }, [measureA, measureB, tileRefs]);
+  }, [measureA, measureB, measureTiles, tileRefs]);
 
   useEffect(() => {
     activeRef.current = true;

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -82,7 +82,6 @@ import { computeScores } from '../../minigames/scoring'
 import FloatingActionBar from '../../components/FloatingActionBar/FloatingActionBar'
 import SpotlightEvictionOverlay from '../../components/Eviction/SpotlightEvictionOverlay'
 import DayStartShockPopup from '../../components/DayStartShockPopup/DayStartShockPopup'
-import CeremonyOverlay from '../../components/CeremonyOverlay/CeremonyOverlay'
 import type { CeremonyTile } from '../../components/CeremonyOverlay/CeremonyOverlay'
 import SpotlightAnimation from '../../components/SpotlightAnimation/spotlight-animation'
 import ChatOverlay from '../../components/ChatOverlay/ChatOverlay'
@@ -3272,10 +3271,10 @@ export default function GameScreen() {
       {/* ── Nomination ceremony — spotlight cutout with ❓ badges ─────────── */}
       {/* Shown for BOTH human LOH (deferred commit) and AI LOH (already committed). */}
       {shouldShowNominationCeremony && (
-        <CeremonyOverlay
+        <SpotlightAnimation
           tiles={[]}
           layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={() => {
+          measureTiles={() => {
             const lohId = lohCeremonyTileId
             if (!lohId) return []
             const lohRect = getTileRect(lohId)
@@ -3891,10 +3890,10 @@ export default function GameScreen() {
       {/* When the human was outgoing LOH and skipped the minigame, advance()    */}
       {/* picks the winner directly. This overlay shows the 👑 ceremony.         */}
       {showAdvanceHohCeremony && game.lohId && (
-        <CeremonyOverlay
+        <SpotlightAnimation
           tiles={[]}
           layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={() => {
+          measureTiles={() => {
             const winnerId = game.lohId!
             const winnerPlayer = game.players.find((p) => p.id === winnerId)
             return [{
@@ -3914,10 +3913,9 @@ export default function GameScreen() {
 
       {/* ── CeremonyOverlay — Replacement nominee (human LOH deferred) ──── */}
       {pendingReplacementCeremony && (
-        <CeremonyOverlay
-          tiles={[]}
-          layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={pendingReplacementCeremony.resolveTiles}
+        <SpotlightAnimation
+          tiles={pendingReplacementCeremony.tiles}
+          measureTiles={pendingReplacementCeremony.resolveTiles}
           caption={pendingReplacementCeremony.caption}
           subtitle={pendingReplacementCeremony.subtitle}
           onDone={handleReplacementCeremonyDone}
@@ -3929,10 +3927,10 @@ export default function GameScreen() {
       {/* Only the replacement nominee (last in nomineeIds, pushed by store) gets */}
       {/* a badge. The badge flies from the LOH tile → replacement tile.          */}
       {showAiReplacementAnim && game.nomineeIds.length > 0 && (
-        <CeremonyOverlay
+        <SpotlightAnimation
           tiles={[]}
           layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={() => {
+          measureTiles={() => {
             const replacementId = game.nomineeIds[game.nomineeIds.length - 1]
             const sourceId = game.specialVeto?.activeType === 'diamond' ? game.posWinnerId : game.lohId
             const sourceRect = sourceId ? getTileRect(sourceId) : null
@@ -3963,10 +3961,10 @@ export default function GameScreen() {
       )}
 
       {showPublicSaveCeremony && pendingPublicSaveResult && (
-        <CeremonyOverlay
+        <SpotlightAnimation
           tiles={[]}
           layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={() => [{
+          measureTiles={() => [{
             rect: getTileRect(pendingPublicSaveResult.savedId),
             badge: '❓',
             badgeImageSrc: NOMINATION_BADGE_SRC,
@@ -3984,10 +3982,9 @@ export default function GameScreen() {
 
       {/* ── CeremonyOverlay — POS save ceremony (human POS holder) ────── */}
       {showSaveCeremony && pendingSaveCeremony && (
-        <CeremonyOverlay
-          tiles={[]}
-          layoutSignal={responsiveGameLayout.revision}
-          resolveTiles={pendingSaveCeremony.resolveTiles}
+        <SpotlightAnimation
+          tiles={pendingSaveCeremony.tiles}
+          measureTiles={pendingSaveCeremony.resolveTiles}
           caption={pendingSaveCeremony.caption}
           subtitle={pendingSaveCeremony.subtitle}
           onDone={handleSaveCeremonyDone}

--- a/tests/spotlight.viewport.test.tsx
+++ b/tests/spotlight.viewport.test.tsx
@@ -282,6 +282,99 @@ describe('SpotlightAnimation — viewport tracking with measureA', () => {
   });
 });
 
+describe('SpotlightAnimation — viewport tracking with measureTiles', () => {
+  let visualViewportMock: ReturnType<typeof makeVisualViewport>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visualViewportMock = makeVisualViewport();
+    // @ts-expect-error – attaching mock to window
+    window.visualViewport = visualViewportMock;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    // @ts-expect-error – cleanup
+    delete window.visualViewport;
+  });
+
+  it('requests a fresh multi-tile ceremony measurement on viewport changes', async () => {
+    const initialSourceRect = makeRect(20, 40, 32, 32);
+    const initialTargetRect = makeRect(120, 200, 60, 80);
+    const updatedSourceRect = makeRect(36, 56, 32, 32);
+    const updatedTargetRect = makeRect(148, 228, 60, 80);
+    let useUpdatedRects = false;
+
+    const measureTiles = vi.fn(() => {
+      const sourceRect = useUpdatedRects ? updatedSourceRect : initialSourceRect;
+      const targetRect = useUpdatedRects ? updatedTargetRect : initialTargetRect;
+      return [
+        { rect: sourceRect, glowTone: 'gold' as const },
+        {
+          rect: targetRect,
+          badge: '👑',
+          badgeStart: sourceRect,
+          badgeLabel: 'Winner badge',
+        },
+      ];
+    });
+
+    let rafCallback: FrameRequestCallback | null = null;
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback): number => {
+        rafCallback = cb;
+        return 1;
+      });
+    const cafSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation((_id: number) => {});
+
+    try {
+      const { container } = render(
+        <SpotlightAnimation
+          tiles={measureTiles()}
+          caption="Track the full ceremony"
+          onDone={vi.fn()}
+          measureTiles={measureTiles}
+        />,
+      );
+
+      await act(async () => {});
+      await act(async () => { vi.advanceTimersByTime(200); });
+
+      const badge = container.querySelector<HTMLElement>('.ceremony-overlay__badge');
+      const glows = container.querySelectorAll<HTMLElement>('.ceremony-overlay__glow');
+
+      expect(badge?.style.left).toBe('36px');
+      expect(badge?.style.top).toBe('40px');
+      expect(badge?.dataset.badgeOrigin).toBe('tile');
+      expect(glows[0]?.style.left).toBe('14px');
+      expect(glows[1]?.style.left).toBe('114px');
+
+      useUpdatedRects = true;
+      rafCallback = null;
+      const callsBeforeResize = measureTiles.mock.calls.length;
+
+      await act(async () => {
+        visualViewportMock.dispatchEvent(new Event('resize'));
+      });
+
+      expect(rafCallback).not.toBeNull();
+      await act(async () => {
+        if (rafCallback) rafCallback(0 as unknown as DOMHighResTimeStamp);
+      });
+      await act(async () => {});
+
+      expect(measureTiles.mock.calls.length).toBeGreaterThan(callsBeforeResize);
+    } finally {
+      rafSpy.mockRestore();
+      cafSpy.mockRestore();
+    }
+  });
+});
+
 describe('SpotlightAnimation — immediate fallback for null tiles', () => {
   it('fires onDone immediately when tile rect is null (headless fallback via CeremonyOverlay)', async () => {
     const onDone = vi.fn();

--- a/tests/unit/gameScreen/animationHardening.contract.test.ts
+++ b/tests/unit/gameScreen/animationHardening.contract.test.ts
@@ -12,12 +12,12 @@ describe('GameScreen ceremony animation contracts', () => {
 
     expect(source).toContain('measureA: () => getTileRect(finalWinnerId)')
     expect(source).toContain('measureA={pendingWinnerCeremony.measureA}')
-    expect(source).toContain('layoutSignal={responsiveGameLayout.revision}')
-    expect(source).toContain('resolveTiles={pendingReplacementCeremony.resolveTiles}')
-    expect(source).toContain('resolveTiles={pendingSaveCeremony.resolveTiles}')
+    expect(source).toContain('measureTiles={() => {')
+    expect(source).toContain('measureTiles={pendingReplacementCeremony.resolveTiles}')
+    expect(source).toContain('measureTiles={pendingSaveCeremony.resolveTiles}')
+    expect(source).toContain('measureTiles={() => [{')
     expect(source).toContain("badgeMotion: 'extract' as const")
     expect(source).toContain('const nomCeremonyTileIds = showNomAnim ? nomAnimPlayers.map((p) => p.id) : []')
-    expect(source).toContain('resolveTiles={() => {')
   })
 
   it('keeps eviction/spotlight animation tied to stable avatar tile layout ids', () => {


### PR DESCRIPTION
## What changed
This updates the ceremony spotlight wrapper so badge and cutout animations can re-measure an entire ceremony tile set, not just a single winner tile.

`GameScreen` now routes the affected badge flows through that tracked path:
- nomination ceremony
- advance-picked LOH winner ceremony
- human replacement nominee ceremony
- AI replacement nominee ceremony
- public save extraction ceremony
- human POS save ceremony

It also removes the now-unused direct `CeremonyOverlay` import and updates the animation hardening tests.

## Why this changed
On some mobile layouts, especially when the roster reflowed or the viewport settled after mount, HOH and POS badge animations could use stale tile measurements. That left the spotlight outline or badge travel origin slightly offset from the real tile.

The winner reveal path already had live viewport tracking; the other ceremony flows were still relying on one-shot measurement. This change brings those flows onto the same remeasurement path so cutouts and badge origins stay aligned regardless of tile size or position.

## Impact
Badge-assignment ceremonies should now stay visually locked to the correct houseguest tile more reliably across compact/mobile layouts, scroll adjustments, and viewport changes.

## Validation
- `npx vitest run tests/spotlight.viewport.test.tsx tests/unit/gameScreen/animationHardening.contract.test.ts`
- `npm run typecheck`

## Notes
I also tried the broader ceremony integration slice, but that suite is currently failing earlier on a missing `profiles` store fixture, so I did not list it as passing validation for this PR.