### PR TITLE
[codex] force survivor end modal visibility

### DIFF
--- a/src/screens/GameScreen/__tests__/gameScreenUiGuards.test.ts
+++ b/src/screens/GameScreen/__tests__/gameScreenUiGuards.test.ts
@@ -15,6 +15,6 @@ describe('shouldShowGameControlDock', () => {
   });
 
   it('keeps the dock visible for terminal survivor runs so the end modal can mount', () => {
-    expect(shouldShowGameControlDock(false, [false, false], true)).toBe(true);
+    expect(shouldShowGameControlDock(false, [false, true], true)).toBe(true);
   });
 });

--- a/src/screens/GameScreen/gameScreenUiGuards.ts
+++ b/src/screens/GameScreen/gameScreenUiGuards.ts
@@ -1,7 +1,8 @@
 export function shouldShowGameControlDock(
   hasStartedGame: boolean,
   blockers: readonly boolean[],
-  allowWhenInactive = false,
+  forceVisible = false,
 ): boolean {
-  return (hasStartedGame || allowWhenInactive) && !blockers.some(Boolean);
+  if (forceVisible) return true;
+  return hasStartedGame && !blockers.some(Boolean);
 }


### PR DESCRIPTION
## What changed
- Force the game control dock to stay mounted during terminal Survivor runs, even if another blocker flag is still true.
- Updated the guard test to cover an inactive Survivor terminal state with an active blocker.

## Why
The previous fix kept the dock mounted after `game.status` stopped being active, but it still respected the normal fullscreen blocker list. If an eviction/vote blocker flag lingered after the Survivor terminal state, the dock could still unmount, taking the `Start New Survival / Return Home` modal with it.

## Impact
- Survivor elimination now always keeps the end-of-run modal mount path available.
- Normal game states still hide the dock when blockers are active.

## Checks
- `npm test -- src/screens/GameScreen/__tests__/gameScreenUiGuards.test.ts`
- `npm run typecheck`