### PR TITLE
[codex] Restore ceremony cutout mount timing

### DIFF
--- a/src/components/SpotlightAnimation/spotlight-animation.tsx
+++ b/src/components/SpotlightAnimation/spotlight-animation.tsx
@@ -49,7 +49,7 @@ export default function SpotlightAnimation({
   onDone,
   ...rest
 }: SpotlightAnimationProps) {
-  const [tiles, setTiles] = useState<CeremonyTile[]>(initialTiles);
+  const [tiles, setTiles] = useState<CeremonyTile[] | null>(measureTiles ? null : initialTiles);
   const rafRef = useRef<number>(0);
   const activeRef = useRef(true);
 
@@ -66,7 +66,7 @@ export default function SpotlightAnimation({
         return;
       }
       setTiles((prev) =>
-        prev.map((tile, idx) => {
+        (prev ?? []).map((tile, idx) => {
           const measureFn = idx === 0 ? measureA : idx === 1 ? measureB : undefined;
           const refEl = tileRefs?.[idx]?.current ?? null;
           if (!measureFn && !refEl) return tile;
@@ -125,6 +125,11 @@ export default function SpotlightAnimation({
       ro?.disconnect();
     };
   }, [hasMeasure, hasRefs, remeasure, tileRefs]);
+
+  // When a full-tile measurement callback is driving the overlay, wait for the
+  // first post-commit measurement before mounting CeremonyOverlay. Otherwise it
+  // sees an empty tile set and treats the animation as a headless fallback.
+  if (tiles == null) return null;
 
   return <CeremonyOverlay {...rest} tiles={tiles} onDone={onDone} />;
 }

--- a/tests/spotlight.viewport.test.tsx
+++ b/tests/spotlight.viewport.test.tsx
@@ -334,7 +334,7 @@ describe('SpotlightAnimation — viewport tracking with measureTiles', () => {
     try {
       const { container } = render(
         <SpotlightAnimation
-          tiles={measureTiles()}
+          tiles={[]}
           caption="Track the full ceremony"
           onDone={vi.fn()}
           measureTiles={measureTiles}
@@ -342,6 +342,10 @@ describe('SpotlightAnimation — viewport tracking with measureTiles', () => {
       );
 
       await act(async () => {});
+      expect(rafCallback).not.toBeNull();
+      await act(async () => {
+        if (rafCallback) rafCallback(0 as unknown as DOMHighResTimeStamp);
+      });
       await act(async () => { vi.advanceTimersByTime(200); });
 
       const badge = container.querySelector<HTMLElement>('.ceremony-overlay__badge');
@@ -368,6 +372,61 @@ describe('SpotlightAnimation — viewport tracking with measureTiles', () => {
       await act(async () => {});
 
       expect(measureTiles.mock.calls.length).toBeGreaterThan(callsBeforeResize);
+    } finally {
+      rafSpy.mockRestore();
+      cafSpy.mockRestore();
+    }
+  });
+
+  it('does not fall back early when measureTiles ceremonies start with an empty tile list', async () => {
+    const sourceRect = makeRect(20, 40, 32, 32);
+    const targetRect = makeRect(120, 200, 60, 80);
+    const measureTiles = vi.fn(() => [
+      { rect: sourceRect, glowTone: 'gold' as const },
+      {
+        rect: targetRect,
+        badge: '👑',
+        badgeStart: sourceRect,
+        badgeLabel: 'Winner badge',
+      },
+    ]);
+
+    let rafCallback: FrameRequestCallback | null = null;
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback): number => {
+        rafCallback = cb;
+        return 1;
+      });
+    const cafSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation((_id: number) => {});
+
+    try {
+      const onDone = vi.fn();
+      const { container } = render(
+        <SpotlightAnimation
+          tiles={[]}
+          caption="Track the full ceremony"
+          onDone={onDone}
+          measureTiles={measureTiles}
+        />,
+      );
+
+      await act(async () => {});
+      expect(onDone).not.toHaveBeenCalled();
+      expect(container.querySelector('.ceremony-overlay')).toBeNull();
+      expect(rafCallback).not.toBeNull();
+
+      await act(async () => {
+        if (rafCallback) rafCallback(0 as unknown as DOMHighResTimeStamp);
+      });
+      await act(async () => { vi.advanceTimersByTime(200); });
+
+      expect(measureTiles).toHaveBeenCalled();
+      expect(onDone).not.toHaveBeenCalled();
+      expect(container.querySelector('.ceremony-overlay')).not.toBeNull();
+      expect(container.querySelector('.ceremony-overlay__glow')).not.toBeNull();
     } finally {
       rafSpy.mockRestore();
       cafSpy.mockRestore();


### PR DESCRIPTION
## What changed
This follow-up restores the ceremony cutout/highlight overlay for badge animations that use the new `measureTiles` viewport-tracking path.

It updates:
- `src/components/SpotlightAnimation/spotlight-animation.tsx`
- `tests/spotlight.viewport.test.tsx`

## Root cause
The hardening work moved several ceremony flows onto `SpotlightAnimation` with `measureTiles`, but those flows mounted the wrapper with an empty `tiles` array and only measured after commit.

That meant `CeremonyOverlay` could mount before the first measurement, see no valid tiles, and take its headless fallback path immediately. The result was the cutout/highlight layer disappearing while the badge animation still appeared.

## Fix
When `measureTiles` is driving the overlay, `SpotlightAnimation` now waits for the first post-commit measurement before mounting `CeremonyOverlay`.

That preserves both things we want:
- the stronger remeasurement behavior for mobile/reflow cases
- the original spotlight cutout/highlight animation

## Smoke test
After checking out this branch or once it is merged:

1. Open a game state that can trigger a ceremony with a badge landing on a tile.
2. Trigger an LOH badge ceremony.
3. Verify the dark dim layer appears with a visible cutout/highlight around the target tile.
4. Verify the badge flies in and lands on the same tile as the cutout.
5. Repeat on a compact/mobile-sized layout.
6. Repeat for a POS save or replacement-nominee ceremony if available.

Expected result: the cutout/highlight is visible again, and the badge still lands in the correct place.

## Validation
- focused viewport-tracking test coverage was updated for the empty-initial-tiles case
- typecheck had already been clean for the restoration path in the local fix flow

## Notes
This PR is intentionally scoped only to the missing restoration so you have a clean branch from `main` to test.