### PR TITLE
[codex] Anchor action bar badges to icons

### DIFF
--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -102,6 +102,8 @@
   top: 31%;
   width: 11%;
   height: 34%;
+  --dock-badge-x: 64%;
+  --dock-badge-y: 9%;
 }
 
 .hit-requests {
@@ -109,6 +111,8 @@
   top: 31%;
   width: 11%;
   height: 34%;
+  --dock-badge-x: 64%;
+  --dock-badge-y: 9%;
 }
 
 .hit-play {
@@ -123,6 +127,8 @@
   top: 31%;
   width: 11%;
   height: 34%;
+  --dock-badge-x: 64%;
+  --dock-badge-y: 9%;
 }
 
 .hit-confessional {
@@ -130,6 +136,8 @@
   top: 31%;
   width: 11%;
   height: 34%;
+  --dock-badge-x: 64%;
+  --dock-badge-y: 9%;
 }
 
 .dock-hit-area:hover {
@@ -147,8 +155,9 @@
 
 .dock-hit-area__badge {
   position: absolute;
-  top: -4px;
-  right: -4px;
+  top: var(--dock-badge-y, 9%);
+  left: var(--dock-badge-x, 64%);
+  transform: translate(-50%, -50%);
   min-width: 16px;
   height: 16px;
   padding: 0 3px;
@@ -164,8 +173,6 @@
 
 /* Turkish blue variant — secret mission badge on the Confessional FAB button */
 .dock-hit-area__badge--mission {
-  top: -6px;
-  right: -7px;
   min-width: 18px;
   height: 18px;
   padding: 0 5px;
@@ -271,22 +278,22 @@
 @keyframes confessional-badge-announce {
   0%,
   100% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
     box-shadow:
       0 0 0 1px rgba(255, 255, 255, 0.18),
       0 8px 18px rgba(23, 65, 74, 0.34);
   }
   28% {
-    transform: scale(1.16) translateY(-1px);
+    transform: translate(-50%, -50%) translateY(-1px) scale(1.16);
     box-shadow:
       0 0 0 1px rgba(255, 255, 255, 0.22),
       0 10px 20px rgba(47, 126, 145, 0.42);
   }
   52% {
-    transform: scale(0.96);
+    transform: translate(-50%, -50%) scale(0.96);
   }
   76% {
-    transform: scale(1.08);
+    transform: translate(-50%, -50%) scale(1.08);
   }
 }
 


### PR DESCRIPTION
## What changed

Anchors the action bar number badges to each icon/button area instead of the far edge of the wider invisible tap target.

## Why

The numeric badges could look too far away from their icon and could visually overlap nearby dock elements because they were positioned from the hit area's top-right corner. The hit area is intentionally wider than the icon for mobile tap comfort, so the badge needed its own icon-relative anchor.

## Scope safety

This PR intentionally changes only:

- `src/components/GameControlDock/GameControlDock.css`

It does not touch ceremony, spotlight, nomination, LOH, POS, or `GameScreen` code.

## Validation

- `npm run test -- src/components/GameControlDock/__tests__/GameControlDock.test.tsx src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx`
- `npm run typecheck`
- `npm run build`
- Local preview smoke-tested at `http://127.0.0.1:4179/bbmobilenew/`