### PR TITLE
Fix gameplay polish issues

### DIFF
--- a/src/components/HoldTheWallComp/HoldTheWallComp.css
+++ b/src/components/HoldTheWallComp/HoldTheWallComp.css
@@ -246,6 +246,17 @@
   transform: none;
 }
 
+.htw-wall--spectator {
+  cursor: default;
+  opacity: 0.72;
+  pointer-events: none;
+  filter: saturate(0.88) brightness(0.86);
+}
+
+.htw-wall--expanded.htw-wall--spectator:active {
+  transform: none;
+}
+
 .htw-wall-icon {
   font-size: 3rem;
   pointer-events: none;
@@ -298,6 +309,30 @@
   font-size: 0.9rem;
   opacity: 0.75;
   border: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.htw-fast-forward {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  margin-top: 0.6rem;
+  padding: 0 1rem;
+  border: 1px solid rgba(131, 191, 255, 0.4);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(131, 191, 255, 0.22), rgba(255, 107, 157, 0.18));
+  color: rgba(255, 255, 255, 0.92);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.htw-fast-forward:disabled {
+  cursor: default;
+  opacity: 0.68;
 }
 
 /* ── Complete screen ─────────────────────────────────────────────────────────── */

--- a/src/components/HoldTheWallComp/HoldTheWallComp.tsx
+++ b/src/components/HoldTheWallComp/HoldTheWallComp.tsx
@@ -99,6 +99,7 @@ const NARRATION = {
 
 /** How long the winner screen stays visible before MinigameHost dismisses it. */
 const WINNER_SCREEN_DURATION_MS = 5000;
+const SPECTATOR_FAST_FORWARD_SPEED = 2;
 
 /** Minimum ms between periodic "still holding" narration messages. */
 const MIN_NARRATION_INTERVAL_MS = 8000;
@@ -179,6 +180,7 @@ export default function HoldTheWallComp({
   // Local UI state
   const [isHolding, setIsHolding] = useState(false);
   const [elapsedMs, setElapsedMs] = useState(0);
+  const [fastForward, setFastForward] = useState(false);
   // Track round start for the complete screen "last player standing after Xs" message
   const [roundStartKey, setRoundStartKey] = useState(0);
   const [narrativeMsg, setNarrativeMsg] = useState('Get ready to hold on for dear life…');
@@ -225,20 +227,14 @@ export default function HoldTheWallComp({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── Schedule AI drops + start 2-second hold rule when game becomes active ──
+  // ── Start round state + 2-second hold rule when game becomes active ──
   useEffect(() => {
     if (htw.status !== 'active') return;
 
     startTimeRef.current = Date.now();
+    setFastForward(false);
     // Increment roundStartKey to restart the Hourglass animation on each new round
     setRoundStartKey((k) => k + 1);
-
-    // Schedule each AI's deterministic drop
-    const timeouts = Object.entries(htw.aiDropSchedule).map(([id, delayMs]) =>
-      window.setTimeout(() => {
-        dispatch(dropPlayer(id));
-      }, delayMs),
-    );
 
     // Start the 2-second initial-hold enforcement rule (server-authoritative)
     let unsubElim: (() => void) | undefined;
@@ -266,13 +262,39 @@ export default function HoldTheWallComp({
     }
 
     return () => {
-      timeouts.forEach((t) => window.clearTimeout(t));
       unsubElim?.();
       effectsScheduler?.destroy();
       controllerRef.current?.endRound();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [htw.status]);
+
+  // ── Schedule AI drops; spectator fast-forward compresses the remaining timers ──
+  useEffect(() => {
+    if (htw.status !== 'active') return;
+
+    const startTime = startTimeRef.current ?? Date.now();
+    if (startTimeRef.current === null) {
+      startTimeRef.current = startTime;
+    }
+
+    const elapsed = Date.now() - startTime;
+    const humanDroppedForSpeed = humanId ? htw.droppedIds.includes(humanId) : false;
+    const timerSpeed =
+      fastForward && humanDroppedForSpeed ? SPECTATOR_FAST_FORWARD_SPEED : 1;
+
+    const timeouts = Object.entries(htw.aiDropSchedule)
+      .filter(([id]) => !htw.droppedIds.includes(id))
+      .map(([id, dropAtMs]) =>
+        window.setTimeout(() => {
+          dispatch(dropPlayer(id));
+        }, Math.max(0, (dropAtMs - elapsed) / timerSpeed)),
+      );
+
+    return () => {
+      timeouts.forEach((t) => window.clearTimeout(t));
+    };
+  }, [dispatch, fastForward, htw.aiDropSchedule, htw.droppedIds, htw.status, humanId]);
 
   // ── Elapsed timer (requestAnimationFrame loop) ────────────────────────────
   useEffect(() => {
@@ -401,6 +423,8 @@ export default function HoldTheWallComp({
   const winnerPlayer = htw.winnerId ? playerMap[htw.winnerId] : null;
   const humanDropped = humanId ? htw.droppedIds.includes(humanId) : false;
   const humanIsWinner = htw.winnerId === humanId;
+  const canHoldWall = htw.status === 'active' && !humanDropped;
+  const fastForwardActive = htw.status === 'active' && humanDropped && fastForward;
 
   // Wind modifier class — applied to root so CSS can target participant avatars
   const windActive = 'wind' in activeEffects;
@@ -477,28 +501,29 @@ export default function HoldTheWallComp({
         <span className="htw-narrative-text">{narrativeMsg}</span>
       </div>
 
-      {/* Wall panel — expands to fill remaining space; shown while human is active */}
-      {htw.status === 'active' && !humanDropped && (
+      {/* Wall panel — expands to fill remaining space and stays visible while spectating */}
+      {htw.status === 'active' && (
         <div
           className={[
             'htw-wall',
             'htw-wall--expanded',
             isHolding ? 'htw-wall--holding' : '',
+            !canHoldWall ? 'htw-wall--spectator' : '',
           ]
             .filter(Boolean)
             .join(' ')}
           data-testid="htw-wall"
-          role="button"
-          aria-label="Hold the wall"
-          aria-pressed={isHolding}
-          onPointerDown={handleHoldStart}
-          onPointerUp={handleHoldEnd}
-          onPointerLeave={handleHoldEnd}
+          role={canHoldWall ? 'button' : 'img'}
+          aria-label={canHoldWall ? 'Hold the wall' : 'Wall still in play'}
+          aria-pressed={canHoldWall ? isHolding : undefined}
+          onPointerDown={canHoldWall ? handleHoldStart : undefined}
+          onPointerUp={canHoldWall ? handleHoldEnd : undefined}
+          onPointerLeave={canHoldWall ? handleHoldEnd : undefined}
           onContextMenu={handleContextMenu}
         >
           <span className="htw-wall-icon">🧱</span>
           <span className="htw-wall-instruction">
-            {isHolding ? 'HOLDING!' : 'PRESS & HOLD'}
+            {canHoldWall ? (isHolding ? 'HOLDING!' : 'PRESS & HOLD') : 'WALL CONTINUES'}
           </span>
         </div>
       )}
@@ -507,6 +532,15 @@ export default function HoldTheWallComp({
       {htw.status === 'active' && humanDropped && (
         <div className="htw-spectating" data-testid="htw-spectating">
           <p>You dropped! Watching {remaining} player{remaining !== 1 ? 's' : ''} remaining…</p>
+          <button
+            type="button"
+            className="htw-fast-forward"
+            onClick={() => setFastForward(true)}
+            disabled={fastForwardActive}
+            aria-pressed={fastForwardActive}
+          >
+            {fastForwardActive ? '2x speed active' : 'Fast-forward 2x'}
+          </button>
           {/* Auto-drop feedback: shown when eliminated by the 2-second rule */}
           {isAutoDropped && (
             <p className="htw-auto-drop-notice" data-testid="htw-auto-drop-notice">

--- a/src/components/KolequantSplash/KolequantSplash.css
+++ b/src/components/KolequantSplash/KolequantSplash.css
@@ -1,4 +1,6 @@
 .kq-splash {
+  --kq-splash-logo-width: min(52vmin, 240px);
+
   position: fixed;
   inset: 0;
   z-index: 99999;
@@ -52,7 +54,7 @@
 .kq-splash__logo {
   position: relative;
   z-index: 1;
-  width: min(52vmin, 240px);
+  width: var(--kq-splash-logo-width);
   max-width: 300px;
   opacity: 0;
   transform: scale(0.96) translateY(8px);
@@ -63,7 +65,8 @@
 .kq-splash__preload {
   position: relative;
   z-index: 1;
-  width: min(340px, 78vw);
+  width: var(--kq-splash-logo-width);
+  max-width: 300px;
   margin-top: 28px;
   opacity: 0;
   transform: translateY(8px);
@@ -159,16 +162,10 @@
 
 @media (max-width: 420px) {
   .kq-splash {
+    --kq-splash-logo-width: 60vmin;
+
     padding-right: 22px;
     padding-left: 22px;
-  }
-
-  .kq-splash__logo {
-    width: 60vmin;
-  }
-
-  .kq-splash__preload {
-    width: min(320px, 86vw);
   }
 
   .kq-splash__preload-row {

--- a/src/components/KolequantSplash/KolequantSplash.tsx
+++ b/src/components/KolequantSplash/KolequantSplash.tsx
@@ -16,13 +16,13 @@ const LOGO_SRC = `${import.meta.env.BASE_URL}assets/kolequant.png`;
 const EXIT_MS = 360;
 
 const DEFAULT_MESSAGES = [
-  'Opening the house doors.',
-  'Polishing the nomination wall.',
-  'Calibrating the Big Eye signal.',
-  'Lighting the diary room.',
+  'Starting the Kolequant engine.',
+  'Mapping today\'s strategy board.',
+  'Calibrating the signal.',
+  'Warming up the challenge floor.',
   'Stacking the social energy chips.',
   'Calling the camera drone into position.',
-  'Preparing the live-show floor.',
+  'Preparing the live floor.',
 ] as const;
 
 function clampProgress(value: number): number {

--- a/src/components/TiltLabyrinthComp/TiltLabyrinthComp.tsx
+++ b/src/components/TiltLabyrinthComp/TiltLabyrinthComp.tsx
@@ -82,6 +82,7 @@ const DOOR_RADIUS = 12;
 const GOAL_RADIUS = 10;
 
 const TIME_LIMIT_MS = 60_000;
+const FAILED_RUN_SCORE_MS = TIME_LIMIT_MS + 1;
 
 const MEDALS = ['🥇', '🥈', '🥉'];
 
@@ -164,6 +165,10 @@ function cellCenter(col: number, row: number): FeaturePoint {
 
 function randomInt(rng: () => number, min: number, max: number): number {
   return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function formatTiltLabyrinthScore(timeMs: number): string {
+  return timeMs > TIME_LIMIT_MS ? 'DNF' : `${(timeMs / 1000).toFixed(2)}s`;
 }
 
 function pickFeaturePoint(
@@ -635,6 +640,14 @@ export default function TiltLabyrinthComp({
       if (!gs.finished) {
         gs.elapsed = performance.now() - gs.startTime;
 
+        if (gs.elapsed >= TIME_LIMIT_MS) {
+          gs.finished = true;
+          gs.finishTime = FAILED_RUN_SCORE_MS;
+          handleFinish(FAILED_RUN_SCORE_MS);
+          drawMaze(ctx, maze, gs, gs.elapsed);
+          return;
+        }
+
         // Compute acceleration
         let ax = 0;
         let ay = 0;
@@ -892,9 +905,12 @@ export default function TiltLabyrinthComp({
     const continueValue = labState.humanScore ?? 0;
     let resultsSummary = 'Final standings recorded.';
     if (humanEntry) {
-      resultsSummary = `Your time: ${(humanEntry.timeMs / 1000).toFixed(2)}s`;
+      resultsSummary =
+        humanEntry.timeMs > TIME_LIMIT_MS
+          ? 'You did not finish before time ran out.'
+          : `Your time: ${formatTiltLabyrinthScore(humanEntry.timeMs)}`;
     } else if (winnerEntry) {
-      resultsSummary = `${winnerEntry.name} finished in ${(winnerEntry.timeMs / 1000).toFixed(2)}s`;
+      resultsSummary = `${winnerEntry.name} finished in ${formatTiltLabyrinthScore(winnerEntry.timeMs)}`;
     }
 
     return (
@@ -926,7 +942,7 @@ export default function TiltLabyrinthComp({
                   )}
                 </span>
                 <span className="tilt-labyrinth-time">
-                  {(entry.timeMs / 1000).toFixed(2)}s
+                  {formatTiltLabyrinthScore(entry.timeMs)}
                 </span>
               </li>
             ))}

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -460,6 +460,7 @@ export default function TvZone(props: TvZoneProps) {
   const isShockAnnouncement =
     activeAnnouncement != null && SHOCK_ANNOUNCEMENT_KEYS.has(activeAnnouncement.key);
   const showInlineAnnouncement = activeAnnouncement != null && !(shockIntroActive && isShockAnnouncement);
+  const showOccupancyChip = occupancyChip != null && !showInlineAnnouncement;
   const suppressStaleLiveVotePitchMessage =
     displayedEvent?.meta?.key === LIVE_VOTE_PITCHES_EVENT_KEY &&
     gameState.phase !== 'social_2';
@@ -900,7 +901,7 @@ export default function TvZone(props: TvZoneProps) {
       {/* ── Bezel + Viewport ────────────────────────────────────────────────── */}
       <div className="tv-zone__bezel">
         <div className="tv-zone__bezel-frame">
-          {occupancyChip && (
+          {showOccupancyChip && (
             <span className="tv-zone__occupancy-chip" aria-label={occupancyChip.ariaLabel}>
               {occupancyChip.label}
             </span>

--- a/src/features/majorityRules/majorityRulesSlice.ts
+++ b/src/features/majorityRules/majorityRulesSlice.ts
@@ -119,6 +119,18 @@ function clearRoundHintState(state: MajorityRulesState) {
   state.roundHintPeekedAnswers = null;
 }
 
+function distributionsMatch(
+  left: Record<string, number> | null,
+  right: Record<string, number>,
+): boolean {
+  if (!left) return false;
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if ((left[key] ?? 0) !== (right[key] ?? 0)) return false;
+  }
+  return true;
+}
+
 function prepareQuestion(state: MajorityRulesState) {
   const question = pickMajorityRulesQuestion(state.seed, state.roundNumber, state.usedQuestionIds);
   state.currentQuestion = question;
@@ -433,10 +445,24 @@ const majorityRulesSlice = createSlice({
     advanceReveal(state) {
       if (state.phase !== 'reveal' || !state.revealState) return;
       const { result } = state.revealState;
+      const repeatedThreeWayRevote =
+        state.activeIds.length === 3 &&
+        result.kind === 'revote' &&
+        state.revoteNumber > 0 &&
+        distributionsMatch(state.previousDistribution, result.distribution);
 
       state.previousDistribution = result.distribution;
 
       if (result.kind === 'revote') {
+        if (repeatedThreeWayRevote) {
+          state.roundNumber += 1;
+          state.revoteNumber = 0;
+          state.previousDistribution = null;
+          state.blockedAnswers = {};
+          prepareQuestion(state);
+          state.phase = 'question';
+          return;
+        }
         if (state.activeIds.length === 3 && state.revoteNumber >= 2) {
           advanceToThreeWayDuel(state);
           return;


### PR DESCRIPTION
## Summary
- Hide the TV occupancy pill while an inline announcement/info button is visible so it cannot overlap the info button.
- Match the Kolequant splash progress bar width to the logo and replace Big Brother/Diary Room wording with neutral Kolequant/game vocabulary.
- Make Tilt Labyrinth timeouts authoritative DNF results so a failed human run cannot win.
- Break repeated three-player Majority Rules revote deadlocks by moving to a fresh question.
- Keep the Hold the Wall wall visible after the user drops and add a 2x spectator fast-forward for remaining AI drops.

## Validation
- `npx eslint src/components/HoldTheWallComp/HoldTheWallComp.tsx src/components/HoldTheWallComp/HoldTheWallComp.css src/components/KolequantSplash/KolequantSplash.tsx src/components/KolequantSplash/KolequantSplash.css src/components/TiltLabyrinthComp/TiltLabyrinthComp.tsx src/components/ui/TvZone.tsx src/features/majorityRules/majorityRulesSlice.ts` (0 errors; CSS ignored by config)
- `npx vitest run src/components/KolequantSplash/__tests__/KolequantSplash.test.tsx`
- `git diff --check`

Note: full `npm run typecheck` was attempted twice but exceeded the tool timeout before returning a result.