### PR TITLE
Extend Blackjack tournament scoring

### DIFF
--- a/src/components/BlackjackTournamentComp/BlackjackTournamentComp.css
+++ b/src/components/BlackjackTournamentComp/BlackjackTournamentComp.css
@@ -480,6 +480,14 @@
   text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
 }
 
+.bjt-final-score {
+  margin: -0.35rem 0 0.25rem;
+  color: rgba(255, 215, 0, 0.86);
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
 .bjt-actions {
   display: flex;
   gap: 0.75rem;
@@ -753,6 +761,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #f0e6d3;
+}
+
+.bjt-roster-score {
+  font-size: 0.54rem;
+  font-weight: 800;
+  color: #ffd700;
+  line-height: 1;
 }
 
 .bjt-roster-ctrl {

--- a/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
+++ b/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
@@ -24,6 +24,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import type { RootState } from '../../store/store';
 import {
+  FINAL_TARGET_SCORE,
   initBlackjackTournament,
   resolveSpinner,
   selectPair,
@@ -136,11 +137,21 @@ interface RosterBarProps {
   controllingId: string | null;
   humanId: string | null;
   getName: (id: string) => string;
+  playerScores?: Record<string, number>;
+  finalistIds?: [string, string] | null;
 }
 
 // ─── RosterBar ────────────────────────────────────────────────────────────────
 
-function RosterBar({ allIds, eliminatedIds, controllingId, humanId, getName }: RosterBarProps) {
+function RosterBar({
+  allIds,
+  eliminatedIds,
+  controllingId,
+  humanId,
+  getName,
+  playerScores = {},
+  finalistIds = null,
+}: RosterBarProps) {
   return (
     <div className="bjt-roster-wrap" aria-label="Remaining players">
       <div className="bjt-roster">
@@ -148,6 +159,13 @@ function RosterBar({ allIds, eliminatedIds, controllingId, humanId, getName }: R
           const isElim = eliminatedIds.includes(id);
           const isController = id === controllingId;
           const isYou = id === humanId;
+          const score = playerScores[id];
+          const scoreLabel =
+            score == null || isElim
+              ? null
+              : finalistIds?.includes(id)
+                ? `${score}/${FINAL_TARGET_SCORE}`
+                : `${score} pts`;
           const classes = [
             'bjt-roster-item',
             isElim ? 'bjt-roster-item--eliminated' : '',
@@ -167,6 +185,7 @@ function RosterBar({ allIds, eliminatedIds, controllingId, humanId, getName }: R
                 }}
               />
               <span className="bjt-roster-name">{getName(id)}</span>
+              {scoreLabel && <span className="bjt-roster-score">{scoreLabel}</span>}
               {isController && !isElim && (
                 <span className="bjt-roster-ctrl" aria-label="In control">⭐</span>
               )}
@@ -474,6 +493,7 @@ export default function BlackjackTournamentComp({
 
   // Maintain a stable full-order list of all participant IDs.
   const allParticipantIds = participantIds;
+  const isFinalDuelActive = bt.finalistIds !== null;
 
   // ─── Render ──────────────────────────────────────────────────────────────
 
@@ -544,6 +564,8 @@ export default function BlackjackTournamentComp({
           controllingId={null}
           humanId={bt.humanPlayerId}
           getName={getName}
+          playerScores={bt.playerScores}
+          finalistIds={bt.finalistIds}
         />
       </div>
     );
@@ -578,7 +600,11 @@ export default function BlackjackTournamentComp({
     return (
       <div className="bjt-container bjt-pick" role="region" aria-label="Fighter selection">
         <div className="bjt-players-remaining" role="status" aria-live="polite">
-          <span className="bjt-badge">{bt.remainingPlayerIds.length} remaining</span>
+          <span className="bjt-badge">
+            {isFinalDuelActive
+              ? `Final duel: first to ${FINAL_TARGET_SCORE}`
+              : `${bt.remainingPlayerIds.length} remaining`}
+          </span>
           {bt.eliminatedPlayerIds.length > 0 && (
             <span className="bjt-eliminated-list">
               Eliminated: {bt.eliminatedPlayerIds.map((id) => getName(id)).join(', ')}
@@ -686,6 +712,8 @@ export default function BlackjackTournamentComp({
           controllingId={controllerId}
           humanId={bt.humanPlayerId}
           getName={getName}
+          playerScores={bt.playerScores}
+          finalistIds={bt.finalistIds}
         />
       </div>
     );
@@ -711,7 +739,15 @@ export default function BlackjackTournamentComp({
 
     return (
       <div className="bjt-container bjt-duel" role="region" aria-label="Blackjack duel">
-        <h2 className="bjt-title">⚔️ Duel: {aName} vs {bName}</h2>
+        <h2 className="bjt-title">
+          ⚔️ {isFinalDuelActive ? 'Final Duel' : 'Duel'}: {aName} vs {bName}
+        </h2>
+        {isFinalDuelActive && (
+          <p className="bjt-final-score">
+            First to {FINAL_TARGET_SCORE}: {aName} {bt.playerScores[duel.fighterAId] ?? 0} -
+            {bt.playerScores[duel.fighterBId] ?? 0} {bName}
+          </p>
+        )}
 
         {/* Fast-forward button */}
         <button
@@ -818,6 +854,8 @@ export default function BlackjackTournamentComp({
           controllingId={bt.controllingPlayerId}
           humanId={bt.humanPlayerId}
           getName={getName}
+          playerScores={bt.playerScores}
+          finalistIds={bt.finalistIds}
         />
       </div>
     );
@@ -856,6 +894,8 @@ export default function BlackjackTournamentComp({
             controllingId={bt.controllingPlayerId}
             humanId={bt.humanPlayerId}
             getName={getName}
+            playerScores={bt.playerScores}
+            finalistIds={bt.finalistIds}
           />
         </div>
       );
@@ -863,6 +903,14 @@ export default function BlackjackTournamentComp({
 
     const winnerName = bt.duelWinnerId ? getName(bt.duelWinnerId) : '';
     const loserName = bt.duelLoserId ? getName(bt.duelLoserId) : '';
+    const loserEliminated = bt.duelEliminatedId === bt.duelLoserId;
+    const winnerPreviewScore = bt.duelWinnerId
+      ? (bt.playerScores[bt.duelWinnerId] ?? 0) + 1
+      : 0;
+    const loserPreviewScore = bt.duelLoserId
+      ? Math.max(0, (bt.playerScores[bt.duelLoserId] ?? 0) - 1)
+      : 0;
+    const finalWinPending = isFinalDuelActive && winnerPreviewScore >= FINAL_TARGET_SCORE;
 
     return (
       <div className="bjt-container bjt-result" role="status" aria-live="assertive">
@@ -909,18 +957,33 @@ export default function BlackjackTournamentComp({
         </div>
 
         <p className="bjt-eliminated-msg">
-          💀 {loserName} has been eliminated!
+          {isFinalDuelActive
+            ? finalWinPending
+              ? `🏁 ${winnerName} reaches ${FINAL_TARGET_SCORE} and wins the final duel!`
+              : `${winnerName} scores! ${winnerPreviewScore}/${FINAL_TARGET_SCORE}`
+            : loserEliminated
+              ? `💀 ${loserName} has been eliminated!`
+              : `${winnerName} gains 1 point; ${loserName} drops to ${loserPreviewScore}.`}
         </p>
         <p className="bjt-remaining-msg">
-          {bt.remainingPlayerIds.filter((id) => id !== bt.duelLoserId).length} players remain
+          {isFinalDuelActive
+            ? `Final score preview: ${winnerName} ${winnerPreviewScore}/${FINAL_TARGET_SCORE}`
+            : loserEliminated
+              ? `${bt.remainingPlayerIds.filter((id) => id !== bt.duelLoserId).length} players remain`
+              : `${bt.remainingPlayerIds.length} players remain`}
         </p>
 
         <RosterBar
           allIds={allParticipantIds}
-          eliminatedIds={[...bt.eliminatedPlayerIds, ...(bt.duelLoserId ? [bt.duelLoserId] : [])]}
+          eliminatedIds={[
+            ...bt.eliminatedPlayerIds,
+            ...(bt.duelEliminatedId ? [bt.duelEliminatedId] : []),
+          ]}
           controllingId={null}
           humanId={bt.humanPlayerId}
           getName={getName}
+          playerScores={bt.playerScores}
+          finalistIds={bt.finalistIds}
         />
       </div>
     );
@@ -956,6 +1019,8 @@ export default function BlackjackTournamentComp({
                 controllingId={bt.winnerId ?? null}
                 humanId={bt.humanPlayerId}
                 getName={getName}
+                playerScores={bt.playerScores}
+                finalistIds={bt.finalistIds}
               />
             </>
           ) : undefined}

--- a/src/features/blackjackTournament/blackjackTournamentSlice.ts
+++ b/src/features/blackjackTournament/blackjackTournamentSlice.ts
@@ -77,6 +77,10 @@ export interface BlackjackTournamentState {
   allPlayerIds: string[];
   remainingPlayerIds: string[];
   eliminatedPlayerIds: string[];
+  /** Main tournament starts each player at 3 points/lives. Finalists reset to 0. */
+  playerScores: Record<string, number>;
+  /** Set when the final duel begins; finalists race from 0 to FINAL_TARGET_SCORE. */
+  finalistIds: [string, string] | null;
 
   humanPlayerId: string | null;
   /** True once the human has been eliminated (spectator mode). */
@@ -94,6 +98,8 @@ export interface BlackjackTournamentState {
   duelWinnerId: string | null;
   /** Loser of the most recently completed duel. */
   duelLoserId: string | null;
+  /** Set when the duel loser has reached 0 and is actually eliminated. */
+  duelEliminatedId: string | null;
   /** True when the last duel ended in a tie — rematch required. */
   isDuelTie: boolean;
   /** Running count of rematches for the current duel pair (resets on new pair). */
@@ -121,6 +127,8 @@ const AI_DECISION_RNG_MASK = 0xdeadbeef;
 const REMATCH_CAP_RNG_OFFSET = 128;
 /** Maximum number of rematches before forcing a deterministic fallback winner. */
 export const REMATCH_CAP = 100;
+export const STARTING_PLAYER_SCORE = 3;
+export const FINAL_TARGET_SCORE = 3;
 
 /** AI stands on this total or higher (standard soft-17 rule). */
 export const AI_STAND_THRESHOLD = 17;
@@ -342,6 +350,8 @@ const initialState: BlackjackTournamentState = {
   allPlayerIds: [],
   remainingPlayerIds: [],
   eliminatedPlayerIds: [],
+  playerScores: {},
+  finalistIds: null,
 
   humanPlayerId: null,
   isSpectating: false,
@@ -353,6 +363,7 @@ const initialState: BlackjackTournamentState = {
   currentDuel: null,
   duelWinnerId: null,
   duelLoserId: null,
+  duelEliminatedId: null,
   isDuelTie: false,
   rematchCount: 0,
   duelIndex: 0,
@@ -381,6 +392,14 @@ function autoSetFighters(
     state.fighterAId = null;
     state.fighterBId = null;
   }
+}
+
+function enterFinalDuel(state: BlackjackTournamentState): void {
+  if (state.remainingPlayerIds.length !== 2) return;
+  const finalists = [state.remainingPlayerIds[0], state.remainingPlayerIds[1]] as [string, string];
+  state.finalistIds = finalists;
+  state.playerScores[finalists[0]] = 0;
+  state.playerScores[finalists[1]] = 0;
 }
 
 /**
@@ -449,6 +468,10 @@ const blackjackTournamentSlice = createSlice({
       state.allPlayerIds = [...participantIds];
       state.remainingPlayerIds = [...participantIds];
       state.eliminatedPlayerIds = [];
+      state.playerScores = Object.fromEntries(
+        participantIds.map((id) => [id, STARTING_PLAYER_SCORE]),
+      );
+      state.finalistIds = null;
       state.humanPlayerId = humanPlayerId;
       state.isSpectating = false;
       state.controllingPlayerId = null;
@@ -457,6 +480,7 @@ const blackjackTournamentSlice = createSlice({
       state.currentDuel = null;
       state.duelWinnerId = null;
       state.duelLoserId = null;
+      state.duelEliminatedId = null;
       state.isDuelTie = false;
       state.rematchCount = 0;
       state.duelIndex = 0;
@@ -468,6 +492,9 @@ const blackjackTournamentSlice = createSlice({
         state.winnerId = participantIds[0] ?? null;
         state.phase = 'complete';
       } else {
+        if (participantIds.length === 2) {
+          enterFinalDuel(state);
+        }
         state.phase = 'spin';
       }
     },
@@ -578,15 +605,26 @@ const blackjackTournamentSlice = createSlice({
           );
           state.duelWinnerId = fallback === 'fighterA' ? duel.fighterAId : duel.fighterBId;
           state.duelLoserId = fallback === 'fighterA' ? duel.fighterBId : duel.fighterAId;
+          state.duelEliminatedId =
+            state.finalistIds === null &&
+            ((state.playerScores[state.duelLoserId] ?? STARTING_PLAYER_SCORE) <= 1)
+              ? state.duelLoserId
+              : null;
           state.isDuelTie = false;
         } else {
           state.duelWinnerId = null;
           state.duelLoserId = null;
+          state.duelEliminatedId = null;
           state.isDuelTie = true;
         }
       } else {
         state.duelWinnerId = outcome === 'fighterA' ? duel.fighterAId : duel.fighterBId;
         state.duelLoserId = outcome === 'fighterA' ? duel.fighterBId : duel.fighterAId;
+        state.duelEliminatedId =
+          state.finalistIds === null &&
+          ((state.playerScores[state.duelLoserId] ?? STARTING_PLAYER_SCORE) <= 1)
+            ? state.duelLoserId
+            : null;
         state.isDuelTie = false;
       }
       state.phase = 'duel_result';
@@ -619,21 +657,59 @@ const blackjackTournamentSlice = createSlice({
         state.isDuelTie = false;
         state.duelWinnerId = null;
         state.duelLoserId = null;
+        state.duelEliminatedId = null;
         state.phase = 'duel';
         return;
       }
 
-      if (!state.duelLoserId) return;
+      if (!state.duelWinnerId || !state.duelLoserId) return;
 
+      const winner = state.duelWinnerId;
       const loser = state.duelLoserId;
-      state.remainingPlayerIds = state.remainingPlayerIds.filter((id) => id !== loser);
-      state.eliminatedPlayerIds.push(loser);
+      const isFinalDuel = state.finalistIds !== null;
 
-      if (state.humanPlayerId === loser) {
-        state.isSpectating = true;
+      if (isFinalDuel) {
+        const nextWinnerScore = (state.playerScores[winner] ?? 0) + 1;
+        state.playerScores[winner] = nextWinnerScore;
+
+        state.controllingPlayerId = winner;
+        state.fighterAId = null;
+        state.fighterBId = null;
+        state.currentDuel = null;
+        state.duelEliminatedId = null;
+        state.rematchCount = 0;
+        state.duelIndex++;
+
+        if (nextWinnerScore >= FINAL_TARGET_SCORE) {
+          state.winnerId = winner;
+          state.phase = 'complete';
+          return;
+        }
+
+        autoSetFighters(state);
+        state.phase = 'pick_opponent';
+        return;
       }
 
-      state.controllingPlayerId = state.duelWinnerId;
+      state.playerScores[winner] = (state.playerScores[winner] ?? STARTING_PLAYER_SCORE) + 1;
+      const nextLoserScore = Math.max(0, (state.playerScores[loser] ?? STARTING_PLAYER_SCORE) - 1);
+      state.playerScores[loser] = nextLoserScore;
+
+      if (nextLoserScore <= 0) {
+        state.remainingPlayerIds = state.remainingPlayerIds.filter((id) => id !== loser);
+        if (!state.eliminatedPlayerIds.includes(loser)) {
+          state.eliminatedPlayerIds.push(loser);
+        }
+        state.duelEliminatedId = loser;
+
+        if (state.humanPlayerId === loser) {
+          state.isSpectating = true;
+        }
+      } else {
+        state.duelEliminatedId = null;
+      }
+
+      state.controllingPlayerId = winner;
       state.fighterAId = null;
       state.fighterBId = null;
       state.currentDuel = null;
@@ -644,6 +720,9 @@ const blackjackTournamentSlice = createSlice({
         state.winnerId = state.remainingPlayerIds[0] ?? null;
         state.phase = 'complete';
       } else {
+        if (state.remainingPlayerIds.length === 2 && state.finalistIds === null) {
+          enterFinalDuel(state);
+        }
         autoSetFighters(state);
         state.phase = 'pick_opponent';
       }

--- a/tests/integration/minigame.blackjackTournament.integration.test.ts
+++ b/tests/integration/minigame.blackjackTournament.integration.test.ts
@@ -95,6 +95,15 @@ function runOneDuelHeadless(store: ReturnType<typeof makeIntegrationStore>): voi
   }
 }
 
+function runUntilCompleteHeadless(
+  store: ReturnType<typeof makeIntegrationStore>,
+  safety = 1200,
+): void {
+  while (store.getState().blackjackTournament.phase !== 'complete' && safety-- > 0) {
+    runOneDuelHeadless(store);
+  }
+}
+
 // ─── Registry wiring ──────────────────────────────────────────────────────────
 
 describe('Registry — blackjackTournament entry', () => {
@@ -174,7 +183,7 @@ describe('Integration — full 2-player tournament', () => {
   it('resolves to complete with a valid winner', () => {
     const store = makeIntegrationStore();
     init2PlayerStore(store);
-    runOneDuelHeadless(store);
+    runUntilCompleteHeadless(store);
     const bt = store.getState().blackjackTournament;
     expect(bt.phase).toBe('complete');
     expect(['alice', 'bob']).toContain(bt.winnerId);
@@ -183,7 +192,7 @@ describe('Integration — full 2-player tournament', () => {
   it('eliminated + remaining = all players', () => {
     const store = makeIntegrationStore();
     init2PlayerStore(store);
-    runOneDuelHeadless(store);
+    runUntilCompleteHeadless(store);
     const bt = store.getState().blackjackTournament;
     const combined = [...bt.remainingPlayerIds, ...bt.eliminatedPlayerIds].sort();
     expect(combined).toEqual(bt.allPlayerIds.slice().sort());
@@ -204,7 +213,7 @@ describe('resolveBlackjackTournamentOutcome — idempotency', () => {
         humanPlayerId: null,
       }),
     );
-    runOneDuelHeadless(store);
+    runUntilCompleteHeadless(store);
     expect(store.getState().blackjackTournament.phase).toBe('complete');
     return store;
   }
@@ -238,7 +247,7 @@ describe('resolveBlackjackTournamentOutcome — idempotency', () => {
         humanPlayerId: null,
       }),
     );
-    runOneDuelHeadless(store);
+    runUntilCompleteHeadless(store);
     expect(store.getState().blackjackTournament.phase).toBe('complete');
     store.dispatch(resolveBlackjackTournamentOutcome());
     // Should be a no-op (phase mismatch)

--- a/tests/minigames.blackjackTournament.rules.test.ts
+++ b/tests/minigames.blackjackTournament.rules.test.ts
@@ -30,7 +30,7 @@ describe('Blackjack Tournament rules', () => {
   it('resolves duels without ambiguity', () => {
     expect(resolveDuelOutcome([10, 7], [9, 7])).toBe('fighterA');
     expect(resolveDuelOutcome([10, 7], [10, 8])).toBe('fighterB');
-    expect(resolveDuelOutcome([10, 10, 5], [9, 9, 4])).toBe('fighterB');
+    expect(resolveDuelOutcome([10, 10, 5], [9, 9, 4])).toBe('tie');
     expect(resolveDuelOutcome([10, 10, 2], [10, 10, 2])).toBe('tie');
     expect(resolveDuelOutcome([10, 10, 5], [10, 10, 6])).toBe('tie');
   });

--- a/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
+++ b/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
@@ -100,6 +100,12 @@ function runOneDuel(store: Store): void {
   }
 }
 
+function runUntilComplete(store: Store, safety = 1200): void {
+  while (getState(store).phase !== 'complete' && safety-- > 0) {
+    runOneDuel(store);
+  }
+}
+
 // ─── computeTotal ─────────────────────────────────────────────────────────────
 
 describe('computeTotal', () => {
@@ -678,7 +684,7 @@ describe('Tie → Rematch', () => {
     }
     expect(getState(store).phase).toBe('complete');
     expect(['alice', 'bob']).toContain(getState(store).winnerId);
-    expect(getState(store).eliminatedPlayerIds).toHaveLength(1);
+    expect(getState(store).finalistIds).toEqual(['alice', 'bob']);
   });
 });
 
@@ -704,15 +710,17 @@ describe('advanceFromDuelResult', () => {
     }
   }
 
-  it('eliminates the loser from remainingPlayerIds', () => {
+  it('deducts one point from the loser without immediate elimination', () => {
     const store = makeStore();
     initStore(store, ['a', 'b', 'c'], 42);
     reachResult(store);
     const before = getState(store);
     const loser = before.duelLoserId!;
+    const scoreBefore = before.playerScores[loser];
     store.dispatch(advanceFromDuelResult());
-    expect(getState(store).remainingPlayerIds).not.toContain(loser);
-    expect(getState(store).eliminatedPlayerIds).toContain(loser);
+    expect(getState(store).remainingPlayerIds).toContain(loser);
+    expect(getState(store).eliminatedPlayerIds).not.toContain(loser);
+    expect(getState(store).playerScores[loser]).toBe(scoreBefore - 1);
   });
 
   it('transitions to pick_opponent when ≥2 remain', () => {
@@ -723,13 +731,14 @@ describe('advanceFromDuelResult', () => {
     expect(getState(store).phase).toBe('pick_opponent');
   });
 
-  it('transitions to complete when 1 remains', () => {
+  it('two-player games enter the final race instead of completing after one duel', () => {
     const store = makeStore();
     initStore(store, ['a', 'b'], 42);
     reachResult(store);
     store.dispatch(advanceFromDuelResult());
-    expect(getState(store).phase).toBe('complete');
-    expect(getState(store).winnerId).not.toBeNull();
+    expect(getState(store).phase).toBe('pick_opponent');
+    expect(getState(store).winnerId).toBeNull();
+    expect(getState(store).finalistIds).toEqual(['a', 'b']);
   });
 
   it('increments duelIndex on decisive result', () => {
@@ -757,7 +766,7 @@ describe('Full 2-player tournament', () => {
   it('completes with a winner', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob'], 42);
-    runOneDuel(store);
+    runUntilComplete(store);
     const s = getState(store);
     expect(s.phase).toBe('complete');
     expect(s.winnerId).toBeDefined();
@@ -767,7 +776,7 @@ describe('Full 2-player tournament', () => {
   it('winner is in allPlayerIds', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob'], 42);
-    runOneDuel(store);
+    runUntilComplete(store);
     const s = getState(store);
     expect(s.allPlayerIds).toContain(s.winnerId);
   });
@@ -775,7 +784,7 @@ describe('Full 2-player tournament', () => {
   it('eliminated + remaining = all', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob'], 42);
-    runOneDuel(store);
+    runUntilComplete(store);
     const s = getState(store);
     expect([...s.remainingPlayerIds, ...s.eliminatedPlayerIds].sort()).toEqual(
       s.allPlayerIds.slice().sort(),
@@ -786,23 +795,20 @@ describe('Full 2-player tournament', () => {
 // ─── Full 3-player tournament ─────────────────────────────────────────────────
 
 describe('Full 3-player tournament', () => {
-  it('completes after 2 decisive duels', () => {
+  it('eventually completes under the point-based format', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob', 'carol'], 42);
-    runOneDuel(store);
-    expect(getState(store).phase).toBe('pick_opponent');
-    runOneDuel(store);
+    runUntilComplete(store);
     expect(getState(store).phase).toBe('complete');
-    // duelIndex counts completed decisive duels (ties don't increment it).
-    expect(getState(store).duelIndex).toBe(2);
+    expect(['alice', 'bob', 'carol']).toContain(getState(store).winnerId);
   });
 
-  it('elimination order has 2 entries for 3 players', () => {
+  it('eliminates one player before the final duel in a 3-player game', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob', 'carol'], 42);
-    runOneDuel(store);
-    runOneDuel(store);
-    expect(getState(store).eliminatedPlayerIds).toHaveLength(2);
+    runUntilComplete(store);
+    expect(getState(store).eliminatedPlayerIds).toHaveLength(1);
+    expect(getState(store).finalistIds).toHaveLength(2);
   });
 });
 
@@ -868,9 +874,8 @@ describe('Deterministic tournament simulation', () => {
       else if (ph === 'duel_result') store.dispatch(advanceFromDuelResult());
     }
     expect(getState(store).phase).toBe('complete');
-    expect(getState(store).eliminatedPlayerIds).toHaveLength(4);
-    // 4 decisive duels required for 5 players.
-    expect(getState(store).duelIndex).toBe(4);
+    expect(getState(store).eliminatedPlayerIds).toHaveLength(3);
+    expect(getState(store).duelIndex).toBeGreaterThan(4);
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace instant Blackjack eliminations with point-based main tournament scoring: players start at 3, duel winners gain 1, duel losers lose 1, and only players at 0 are eliminated.
- Add a final-duel mode when two players remain: finalists reset to 0 and race to 3 points for the tournament win.
- Surface scores in the Blackjack roster/result UI and update result copy so losing a duel is not shown as elimination unless the player actually hits 0.
- Update Blackjack unit/rules/integration tests for the longer point-based format.

## Validation
- `npx eslint src/features/blackjackTournament/blackjackTournamentSlice.ts src/features/blackjackTournament/thunks.ts src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts tests/minigames.blackjackTournament.rules.test.ts tests/integration/minigame.blackjackTournament.integration.test.ts`
- `npx vitest run tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts tests/minigames.blackjackTournament.rules.test.ts tests/integration/minigame.blackjackTournament.integration.test.ts`
- `git diff --check`