### PR TITLE
[codex] Add Twin Shock twist

### DIFF
--- a/src/bb/twinShock.ts
+++ b/src/bb/twinShock.ts
@@ -1,0 +1,301 @@
+import type { TwinShockPromptStage, TwinShockState, TwinShockStatus } from '../types';
+
+export const TWIN_SHOCK_LIA_ID = 'lia';
+export const TWIN_SHOCK_ALI_ID = 'ali';
+export const TWIN_SHOCK_COMBINED_ID = 'lia_ali';
+
+export type TwinShockAnswerIntent =
+  | 'correct_twin_guess'
+  | 'positive_lia_suspicion'
+  | 'negative_lia_suspicion'
+  | 'unknown_lia_suspicion'
+  | 'give_up_confirmation'
+  | 'unclear';
+
+export interface TwinShockTurnContext {
+  playerName: string;
+  liaActive: boolean;
+}
+
+export interface TwinShockTurnResult {
+  intent: TwinShockAnswerIntent;
+  messages: string[];
+  status: TwinShockStatus;
+  promptStage: TwinShockPromptStage | null;
+  retryCount: number;
+  resolution?: 'resolved_discovered' | 'resolved_mission_success' | 'resolved_secret_lost';
+}
+
+const CORRECT_PATTERNS = [
+  /\btwins?\b/,
+  /\btwin sister\b/,
+  /\bsisters?\b/,
+  /\bsiblings?\b/,
+  /\bidentical\b/,
+  /\bdouble\b/,
+  /\blookalike\b/,
+  /\bdoppelganger\b/,
+  /\bclone\b/,
+  /\banother lia\b/,
+  /\btwo lias\b/,
+  /\btwo of her\b/,
+  /\bsomeone else\b/,
+  /\bswitch(?:ing)? places\b/,
+  /\bswapp?ing\b/,
+  /\bswap places\b/,
+  /\bimpostou?r\b/,
+  /\bnot the same lia\b/,
+  /\bali\b/,
+];
+
+const GIVE_UP_PATTERNS = [
+  /\bi give up\b/,
+  /\bgive up\b/,
+  /\bi surrender\b/,
+  /\btell me\b/,
+  /\breveal it\b/,
+  /\bshow me\b/,
+  /\bok(?:ay)?\b/,
+  /\bfine\b/,
+  /\bsure\b/,
+  /\bi dont know\b/,
+  /\bjust tell me\b/,
+];
+
+const POSITIVE_PATTERNS = [
+  /\byes\b/,
+  /\byeah\b/,
+  /\byep\b/,
+  /\bdefinitely\b/,
+  /\bsomething is off\b/,
+  /\bweird\b/,
+  /\bacting strange\b/,
+  /\bshe changed\b/,
+  /\bshe is different\b/,
+  /\bsuspicious\b/,
+  /\bnot herself\b/,
+  /\bi noticed\b/,
+  /\bodd\b/,
+];
+
+const NEGATIVE_PATTERNS = [
+  /\bno\b/,
+  /\bnope\b/,
+  /\bnothing\b/,
+  /\bnot really\b/,
+  /\bseems normal\b/,
+  /\bhavent noticed\b/,
+  /\bhave not noticed\b/,
+  /\ball good\b/,
+  /\bshe is fine\b/,
+];
+
+const UNKNOWN_PATTERNS = [
+  /\bi dont know\b/,
+  /\bidk\b/,
+  /\bnot sure\b/,
+  /\bmaybe\b/,
+  /\bcant tell\b/,
+  /\bunclear\b/,
+  /\bhard to say\b/,
+  /\bno idea\b/,
+];
+
+function normalizeTwinShockAnswer(input: string): string {
+  return input
+    .slice(0, 360)
+    .replace(/[’']/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function hasPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function hasNonNegatedCorrectGuess(text: string): boolean {
+  if (!hasPattern(text, CORRECT_PATTERNS)) return false;
+
+  if (/\bnot the same lia\b/.test(text)) return true;
+  if (/\b(?:maybe|unless|could be|might be|is she|wait)\b.{0,40}\b(twins?|sisters?|ali|switch(?:ing)? places)\b/.test(text)) {
+    return true;
+  }
+  if (/\b(?:i dont know|not sure|no idea)\b.{0,50}\b(?:maybe|unless|but|wait)\b.{0,50}\b(twins?|sisters?|ali|switch(?:ing)? places)\b/.test(text)) {
+    return true;
+  }
+  if (/\b(?:dont|do not|doesnt|does not|isnt|is not|no)\b.{0,25}\b(twins?|sisters?|ali|switch(?:ing)? places)\b/.test(text)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function classifyTwinShockAnswer(input: string): TwinShockAnswerIntent {
+  const text = normalizeTwinShockAnswer(input);
+  if (!text) return 'unclear';
+  if (hasNonNegatedCorrectGuess(text)) return 'correct_twin_guess';
+  if (hasPattern(text, GIVE_UP_PATTERNS)) return 'give_up_confirmation';
+  if (hasPattern(text, POSITIVE_PATTERNS)) return 'positive_lia_suspicion';
+  if (hasPattern(text, NEGATIVE_PATTERNS)) return 'negative_lia_suspicion';
+  if (hasPattern(text, UNKNOWN_PATTERNS)) return 'unknown_lia_suspicion';
+  return 'unclear';
+}
+
+function unclearMessage(stage: TwinShockPromptStage | null, retryCount: number): string {
+  if (stage === 'day5_final' || stage === 'day5_give_up') {
+    return retryCount <= 0
+      ? 'This is your final chance. Either make a guess, or say that you give up.'
+      : 'The Big Eye needs a choice now. Make your guess, or say that you give up.';
+  }
+  return retryCount <= 0
+    ? 'I need a clearer answer. Do you think something is off about Lia?'
+    : 'Answer clearly, Houseguest. What exactly do you think is happening with Lia?';
+}
+
+export function createInitialTwinShockState(): TwinShockState {
+  return {
+    status: 'inactive',
+    promptStage: null,
+    queuedDay: null,
+    retryCount: 0,
+    cluesShownDays: [],
+    pendingRevealAnimation: null,
+  };
+}
+
+export function resolveTwinShockTurn(
+  current: TwinShockState | undefined,
+  input: string,
+  context: TwinShockTurnContext,
+): TwinShockTurnResult {
+  const state = current ?? createInitialTwinShockState();
+  const intent = classifyTwinShockAnswer(input);
+  const playerName = context.playerName || 'Houseguest';
+  const stage = state.promptStage;
+
+  if (stage === 'secret_lost') {
+    return {
+      intent,
+      messages: [
+        'As Lia is no longer in the House, her secret will remain unrevealed.',
+        'You are free to leave.',
+      ],
+      status: 'resolved_secret_lost',
+      promptStage: null,
+      retryCount: 0,
+      resolution: 'resolved_secret_lost',
+    };
+  }
+
+  if (intent === 'correct_twin_guess') {
+    const late = stage === 'day5_final' || stage === 'day5_give_up';
+    return {
+      intent,
+      messages: late
+        ? [
+          'Late, but sharp. You got it.',
+          'Lia has been secretly switching places with her twin sister, Ali.',
+          'Because you exposed the secret before it was completed, Lia and Ali will now continue as one contestant.',
+          'You may return to the House and inform the others.',
+        ]
+        : [
+          `Very good, ${playerName}. You saw what the House missed.`,
+          'Lia has not been alone in this game. She has been secretly switching places with her twin sister, Ali.',
+          'Because you exposed the secret, Lia and Ali will now continue as one contestant.',
+          'Good job. You may return to the House and inform the others.',
+        ],
+      status: 'resolved_discovered',
+      promptStage: null,
+      retryCount: 0,
+      resolution: 'resolved_discovered',
+    };
+  }
+
+  if (stage === 'day4_initial' && intent === 'positive_lia_suspicion') {
+    return {
+      intent,
+      messages: ['What exactly have you noticed?'],
+      status: 'day4_pending',
+      promptStage: 'day4_detail',
+      retryCount: 0,
+    };
+  }
+
+  if (stage === 'day4_initial' || stage === 'day4_detail') {
+    if (intent === 'unclear' && state.retryCount < 1) {
+      return {
+        intent,
+        messages: [unclearMessage(stage, state.retryCount)],
+        status: 'day4_pending',
+        promptStage: stage ?? 'day4_initial',
+        retryCount: state.retryCount + 1,
+      };
+    }
+    return {
+      intent,
+      messages: [
+        'Interesting. Keep watching. Some secrets survive because people stop looking too soon.',
+        'You may be called back tomorrow.',
+      ],
+      status: 'day4_asked_no_correct_guess',
+      promptStage: null,
+      retryCount: 0,
+    };
+  }
+
+  if (stage === 'day5_final') {
+    if (intent === 'unclear' && state.retryCount < 1) {
+      return {
+        intent,
+        messages: [unclearMessage(stage, state.retryCount)],
+        status: 'day4_asked_no_correct_guess',
+        promptStage: 'day5_final',
+        retryCount: state.retryCount + 1,
+      };
+    }
+    return {
+      intent,
+      messages: ['Say that you give up, and I will tell you the secret.'],
+      status: 'day4_asked_no_correct_guess',
+      promptStage: 'day5_give_up',
+      retryCount: 0,
+    };
+  }
+
+  if (stage === 'day5_give_up') {
+    if (intent === 'give_up_confirmation' || intent === 'unknown_lia_suspicion' || state.retryCount >= 1) {
+      return {
+        intent,
+        messages: [
+          'All right. I am not going to torture you anymore.',
+          'Here is the secret.',
+          'All along, Lia has been secretly switching places with her twin sister, Ali.',
+          'Their secret mission was successful.',
+          'Ali will now enter the House as a full contestant.',
+          'You are free to return and inform the others.',
+        ],
+        status: 'resolved_mission_success',
+        promptStage: null,
+        retryCount: 0,
+        resolution: 'resolved_mission_success',
+      };
+    }
+    return {
+      intent,
+      messages: [unclearMessage(stage, state.retryCount)],
+      status: 'day4_asked_no_correct_guess',
+      promptStage: 'day5_give_up',
+      retryCount: state.retryCount + 1,
+    };
+  }
+
+  return {
+    intent,
+    messages: [unclearMessage(stage, state.retryCount)],
+    status: state.status,
+    promptStage: stage,
+    retryCount: state.retryCount + 1,
+  };
+}

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -100,6 +100,7 @@ const FORCED_SHOCK_OPTIONS: Array<{ value: ForcedShockType; label: string }> = [
   { value: 'coup', label: 'Detox Safety' },
   { value: 'spotlight', label: 'Force Majeure Safety' },
   { value: 'democracia', label: 'Democracia' },
+  { value: 'twinShock', label: 'Twin Shock' },
 ];
 
 let incomingSeedCounter = 0;

--- a/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
@@ -69,4 +69,26 @@ describe('DebugPanel forced shock controls', () => {
 
     expect(store.getState().game.pendingForcedShock?.type).toBe('dayStartShock')
   })
+
+  it('includes Twin Shock in the force shock dropdown and queues it', async () => {
+    const user = userEvent.setup()
+    const store = makeStore()
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/game?debug=1&qa=1']}>
+          <DebugPanel />
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    const forceShockSelect = screen.getByRole('combobox', { name: 'Force Shock' })
+
+    expect(screen.getByRole('option', { name: 'Twin Shock' })).toBeDefined()
+
+    await user.selectOptions(forceShockSelect, 'twinShock')
+    await user.click(screen.getByRole('button', { name: 'Queue' }))
+
+    expect(store.getState().game.pendingForcedShock?.type).toBe('twinShock')
+  })
 })

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -22,6 +22,7 @@ import {
   declineSecretMission,
   claimMissionReward,
   recordSecretMissionEasterEgg,
+  submitTwinShockAnswer,
   selectAlivePlayers,
 } from '../../store/gameSlice';
 import { selectActiveConfessionalDecision } from '../../store/confessionalDecisionSelectors';
@@ -34,6 +35,7 @@ import {
   pickMissionImmunityDuration,
   type SecretMissionBoxRewardType,
 } from '../../bb/secretMission';
+import { resolveTwinShockTurn } from '../../bb/twinShock';
 import { applyInfluenceDelta } from '../../social/socialSlice';
 import {
   createInitialBigEyeState,
@@ -679,6 +681,33 @@ export default function DiaryRoom() {
       saveChat(playerId, updated);
       return updated;
     });
+
+    if (activeConfessionalDecision?.type === 'twin_shock' && gameState.twinShock?.promptStage) {
+      const twinResult = resolveTwinShockTurn(gameState.twinShock, text, {
+        playerName,
+        liaActive: alivePlayers.some((player) => player.id === 'lia'),
+      });
+      dispatch(submitTwinShockAnswer(text));
+      setBbTyping(true);
+      await new Promise<void>((resolve) => setTimeout(resolve, 550));
+      setBbTyping(false);
+      const bbMessages: ChatMessage[] = twinResult.messages.map((messageText) => ({
+        id: crypto.randomUUID(),
+        role: 'bb',
+        text: messageText,
+        timestamp: Date.now(),
+      }));
+      setMessages((prev) => {
+        const withSeen = prev.map((m) =>
+          m.role === 'user' && m.status !== 'seen' ? { ...m, status: 'seen' as MessageStatus } : m,
+        );
+        const withReply = [...withSeen, ...bbMessages];
+        saveChat(playerId, withReply);
+        return withReply;
+      });
+      setLoading(false);
+      return;
+    }
 
     try {
       const resp = await generateBigBrotherReply({

--- a/src/screens/DiaryRoom/confessionalDecisionPresentation.ts
+++ b/src/screens/DiaryRoom/confessionalDecisionPresentation.ts
@@ -126,6 +126,25 @@ export function getConfessionalDecisionPresentation(
       );
       break;
     }
+    case 'twin_shock': {
+      const stage = game.twinShock?.promptStage;
+      if (stage === 'day4_initial') {
+        const humanName = game.players.find((player) => player.isUser)?.name ?? 'Houseguest';
+        prompt = `Hi, ${humanName}. How have you been lately? Thank you for sharing. We may come back to this later. But right now, I need to ask you something. Have you noticed anything off about Lia?`;
+      } else if (stage === 'day4_detail') {
+        prompt = 'What exactly have you noticed?';
+      } else if (stage === 'day5_final') {
+        prompt = 'Yesterday, I asked you whether you had noticed anything off about Lia. I will ask one last time. What do you think is going on?';
+      } else if (stage === 'day5_give_up') {
+        prompt = 'Say that you give up, and I will tell you the secret.';
+      } else if (stage === 'secret_lost') {
+        prompt = 'As Lia is no longer in the House, her secret will remain unrevealed. You are free to leave.';
+      } else {
+        prompt = 'The Big Eye wants to ask you about Lia.';
+      }
+      keyParts.push(`stage=${stage ?? 'none'}`, `queued=${game.twinShock?.queuedDay ?? 'none'}`);
+      break;
+    }
     default:
       break;
   }

--- a/src/store/confessionalDecisionSelectors.ts
+++ b/src/store/confessionalDecisionSelectors.ts
@@ -28,7 +28,8 @@ export type ConfessionalDecisionType =
   | 'vip_second_use'       // VIP second-use yes/no decision
   | 'pos_save_target'      // Human POS holder picks who to save
   | 'replacement_nominee'  // Human LOH (or POS holder) names replacement
-  | 'tie_break';           // Human LOH breaks a tied eviction vote
+  | 'tie_break'            // Human LOH breaks a tied eviction vote
+  | 'twin_shock';          // Mandatory Lia/Ali story Confessional
 
 export interface ActiveConfessionalDecision {
   /** What kind of decision must be resolved. */
@@ -76,6 +77,7 @@ function getActiveConfessionalDecisionFromGame(
   const humanPlayer = game.players?.find((p) => p.isUser);
   if (!humanPlayer) return null;
   if (humanPlayer.status === 'evicted' || humanPlayer.status === 'jury') return null;
+  if (game.twinShock?.promptStage) return { type: 'twin_shock', week, phase };
 
   // ── Nominations ─────────────────────────────────────────────────────────
   if (game.awaitingNominations) {

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -74,6 +74,13 @@ import {
   calculateRequiredDoubleEvictionSlots,
 } from '../features/twists/doubleEvictionTieUtils';
 import { buildDayStartShockSelection } from '../features/twists/dayStartShock';
+import {
+  createInitialTwinShockState,
+  resolveTwinShockTurn,
+  TWIN_SHOCK_ALI_ID,
+  TWIN_SHOCK_LIA_ID,
+  type TwinShockTurnResult,
+} from '../bb/twinShock';
 import { LIVE_VOTE_PITCHES_EVENT_KEY, LIVE_VOTE_PITCHES_TEXT } from '../constants/tvEvents';
 
 // ─── Canonical phase order ────────────────────────────────────────────────────
@@ -145,9 +152,15 @@ function formatForcedShockLabel(type: ForcedShockType): string {
       return 'Democracia';
     case 'dayStartShock':
       return 'Morning Shock';
+    case 'twinShock':
+      return 'Twin Shock';
     default:
       return type;
   }
+}
+
+function isSpecialVetoType(type: ForcedShockType): type is SpecialVetoType {
+  return type === 'vip' || type === 'diamond' || type === 'coup' || type === 'spotlight';
 }
 
 function formatDemocraciaResultNames(state: GameState, candidateIds: string[]): string {
@@ -178,6 +191,8 @@ function getForcedShockSafePhase(type: ForcedShockType): Phase {
       return 'nominations';
     case 'battleBack':
       return 'eviction_results';
+    case 'twinShock':
+      return 'eviction_results';
     case 'democracia':
       return 'loh_comp_announcement';
     case 'dayStartShock':
@@ -199,6 +214,13 @@ const HOUSEGUEST_POOL = HOUSEGUESTS.map((hg) => ({
 type SecretMissionTaskBuildResult = {
   templateId: string;
   tasks: MissionTask[];
+};
+
+const TWIN_SHOCK_RESERVED_IDS = new Set([TWIN_SHOCK_LIA_ID, TWIN_SHOCK_ALI_ID, 'lia_ali']);
+const TWIN_SHOCK_LIA_POOL_ENTRY = {
+  id: TWIN_SHOCK_LIA_ID,
+  name: 'Lia',
+  avatar: 'Lia',
 };
 
 function buildSecretMissionTargetCandidates(state: GameState): string[] {
@@ -253,18 +275,28 @@ function buildUserPlayer(): Player {
  * rosterSize is read from persisted settings (gameUX.castSize) with a
  * fallback to the GAME_ROSTER_SIZE constant.
  */
-function pickHouseguests(rosterSize = GAME_ROSTER_SIZE): Player[] {
+function pickHouseguests(rosterSize = GAME_ROSTER_SIZE, twinShockConsumed = false): Player[] {
   const seed = (Math.floor(Math.random() * 0x100000000)) >>> 0;
   const rng = mulberry32(seed);
-  return seededPickN(rng, HOUSEGUEST_POOL, rosterSize - 1).map((hg) => ({
+  const lia = HOUSEGUEST_POOL.find((houseguest) => houseguest.id === TWIN_SHOCK_LIA_ID)
+    ?? TWIN_SHOCK_LIA_POOL_ENTRY;
+  const eligiblePool = HOUSEGUEST_POOL.filter((houseguest) => (
+    twinShockConsumed
+      ? !TWIN_SHOCK_RESERVED_IDS.has(houseguest.id)
+      : houseguest.id !== TWIN_SHOCK_LIA_ID && houseguest.id !== TWIN_SHOCK_ALI_ID
+  ));
+  const pickCount = twinShockConsumed ? rosterSize - 1 : Math.max(0, rosterSize - 2);
+  const picked = seededPickN(rng, eligiblePool, pickCount);
+  const roster = !twinShockConsumed && lia ? [lia, ...picked] : picked;
+  return roster.map((hg) => ({
     ...hg,
     status: 'active' as const,
   }));
 }
 
-function buildInitialPlayers(): Player[] {
+function buildInitialPlayers(twinShockConsumed = false): Player[] {
   const rosterSize = getConfiguredCastSize();
-  return [buildUserPlayer(), ...pickHouseguests(rosterSize)];
+  return [buildUserPlayer(), ...pickHouseguests(rosterSize, twinShockConsumed)];
 }
 
 function buildInitialCompetitionSeasonState(players: Player[]): Record<string, ReturnType<typeof getDefaultCompetitionSeasonState>> {
@@ -293,8 +325,9 @@ function nextSeasonNumber(archives: SeasonArchive[]): number {
  * each new season always uses the latest persisted configuration rather than
  * stale module-scope values.
  */
-export function createInitialGameState(): GameState {
-  const freshPlayers = buildInitialPlayers();
+export function createInitialGameState(options?: { twinShockConsumed?: boolean }): GameState {
+  const twinShockConsumed = options?.twinShockConsumed === true;
+  const freshPlayers = buildInitialPlayers(twinShockConsumed);
   const freshSettings = loadSettings();
   // Guest mode never persists archives — treat as an empty history so guest
   // sessions always start at Season 1 regardless of any logged-in user data.
@@ -381,6 +414,13 @@ export function createInitialGameState(): GameState {
     },
     pendingForcedShock: null,
     dayStartShock: null,
+    twinShock: createInitialTwinShockState(),
+    twinShockConsumed,
+    twinShockActivatedSeason: null,
+    twinShockResolution: null,
+    twinShockResolvedDay: null,
+    twinShockDiscoveredByUser: false,
+    liaForcedUntilTwinShockResolved: !twinShockConsumed,
     democracia: {
       usedThisSeason: false,
       active: false,
@@ -769,6 +809,220 @@ function applyCompetitionSeasonUpdateToState(
 
 function getAlivePlayers(state: GameState): Player[] {
   return state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
+}
+
+function isPlayerActiveInHouse(state: GameState, playerId: string): boolean {
+  const player = state.players.find((candidate) => candidate.id === playerId);
+  return Boolean(player && player.status !== 'evicted' && player.status !== 'jury');
+}
+
+function getHumanPlayer(state: GameState): Player | undefined {
+  return state.players.find((player) => player.isUser);
+}
+
+function canHumanReceiveTwinShockConfessional(state: GameState): boolean {
+  const human = getHumanPlayer(state);
+  return Boolean(human && human.status !== 'evicted' && human.status !== 'jury');
+}
+
+function queueTwinShockConfessional(state: GameState, stage: NonNullable<GameState['twinShock']>['promptStage']) {
+  const twinShock = state.twinShock ?? createInitialTwinShockState();
+  twinShock.promptStage = stage;
+  twinShock.queuedDay = state.week;
+  twinShock.retryCount = 0;
+  if (stage === 'day4_initial') {
+    twinShock.status = 'day4_pending';
+    state.twinShockConsumed = true;
+    state.twinShockActivatedSeason = state.season;
+    state.liaForcedUntilTwinShockResolved = true;
+  }
+  state.twinShock = twinShock;
+  pushEvent(state, 'The Big Eye wants you in the Confessional.', 'diary', {
+    major: 'twin_shock_confessional',
+  });
+}
+
+function shouldQueueTwinShockBeforeDayEnd(state: GameState): boolean {
+  if (!canHumanReceiveTwinShockConfessional(state)) return false;
+  const twinShock = state.twinShock ?? createInitialTwinShockState();
+  const forcedTwinShock = state.pendingForcedShock?.type === 'twinShock'
+    && state.week >= state.pendingForcedShock.earliestWeek
+    && twinShock.promptStage === null;
+
+  if (forcedTwinShock && twinShock.status !== 'resolved_discovered' && twinShock.status !== 'resolved_mission_success') {
+    queueTwinShockConfessional(
+      state,
+      isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID) ? 'day4_initial' : 'secret_lost',
+    );
+    state.pendingForcedShock = null;
+    return true;
+  }
+
+  if (
+    !state.twinShockConsumed &&
+    twinShock.status === 'inactive' &&
+    state.week === 4 &&
+    isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID)
+  ) {
+    queueTwinShockConfessional(state, 'day4_initial');
+    return true;
+  }
+
+  if (
+    state.week === 5 &&
+    twinShock.status === 'day4_asked_no_correct_guess' &&
+    twinShock.promptStage === null
+  ) {
+    queueTwinShockConfessional(
+      state,
+      isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID) ? 'day5_final' : 'secret_lost',
+    );
+    return true;
+  }
+
+  return false;
+}
+
+function pushTwinShockAnnouncement(state: GameState, text: string, major: string) {
+  const ts = Date.now();
+  state.tvFeed = [
+    {
+      id: `${state.phase}-w${state.week}-${ts}-${major}`,
+      text,
+      type: 'twist' as const,
+      timestamp: ts,
+      major,
+      meta: buildTvMeta(state, { major }),
+    },
+    ...state.tvFeed,
+  ].slice(0, 50);
+}
+
+function ensureCompetitionStateForPlayer(state: GameState, playerId: string) {
+  if (!state.competitionSeasonStateByPlayerId) state.competitionSeasonStateByPlayerId = {};
+  if (!state.competitionSeasonStateByPlayerId[playerId]) {
+    state.competitionSeasonStateByPlayerId[playerId] = getDefaultCompetitionSeasonState();
+  }
+}
+
+function resolveTwinShockDiscovered(state: GameState) {
+  const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
+  const humanName = getHumanPlayer(state)?.name ?? 'The player';
+  if (lia) {
+    lia.name = 'Lia & Ali';
+    lia.avatar = 'Lia_Ali';
+    lia.twinMode = 'combined';
+    if (lia.status === 'evicted' || lia.status === 'jury') lia.status = 'active';
+  }
+  state.twinShockConsumed = true;
+  state.twinShockResolution = 'discovered';
+  state.twinShockResolvedDay = state.week;
+  state.twinShockDiscoveredByUser = true;
+  state.liaForcedUntilTwinShockResolved = false;
+  if (state.twinShock) {
+    state.twinShock.status = 'resolved_discovered';
+    state.twinShock.promptStage = null;
+    state.twinShock.queuedDay = null;
+    state.twinShock.retryCount = 0;
+    state.twinShock.pendingRevealAnimation = 'combined';
+  }
+  pushTwinShockAnnouncement(
+    state,
+    `TWIN SHOCK! ${humanName} exposed that Lia had a twin. Lia has been secretly switching places with her twin sister, Ali. What a shock! Welcome Ali to the House. From now on, Lia & Ali will play as one contestant.`,
+    'twin_shock_discovered',
+  );
+}
+
+function resolveTwinShockMissionSuccess(state: GameState) {
+  const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
+  if (!state.players.some((player) => player.id === TWIN_SHOCK_ALI_ID)) {
+    state.players.push({
+      id: TWIN_SHOCK_ALI_ID,
+      name: 'Ali',
+      avatar: 'Ali',
+      status: 'active',
+      lateEntrant: true,
+      stats: { lohWins: 0, posWins: 0, timesNominated: 0 },
+    });
+  }
+  ensureCompetitionStateForPlayer(state, TWIN_SHOCK_ALI_ID);
+  state.twinShockConsumed = true;
+  state.twinShockResolution = 'mission_success';
+  state.twinShockResolvedDay = state.week;
+  state.twinShockDiscoveredByUser = false;
+  state.liaForcedUntilTwinShockResolved = false;
+  if (state.twinShock) {
+    state.twinShock.status = 'resolved_mission_success';
+    state.twinShock.promptStage = null;
+    state.twinShock.queuedDay = null;
+    state.twinShock.retryCount = 0;
+    state.twinShock.pendingRevealAnimation = 'ali_enters';
+  }
+  pushTwinShockAnnouncement(
+    state,
+    'TWIN SHOCK REVEALED! Lia has been secretly switching places with her twin sister, Ali, all along. Because the secret mission was successful, Ali has earned her place as a full contestant. Welcome Ali to the House!',
+    'twin_shock_mission_success',
+  );
+  if (lia) {
+    pushEvent(state, `${lia.name} and Ali share a powerful bond after the reveal.`, 'social', {
+      major: 'twin_shock_bond',
+    });
+  }
+}
+
+function resolveTwinShockSecretLost(state: GameState) {
+  state.twinShockConsumed = true;
+  state.twinShockResolution = 'secret_lost';
+  state.twinShockResolvedDay = state.week;
+  state.twinShockDiscoveredByUser = false;
+  state.liaForcedUntilTwinShockResolved = false;
+  if (state.twinShock) {
+    state.twinShock.status = 'resolved_secret_lost';
+    state.twinShock.promptStage = null;
+    state.twinShock.queuedDay = null;
+    state.twinShock.retryCount = 0;
+    state.twinShock.pendingRevealAnimation = null;
+  }
+  state.history = [
+    ...(state.history ?? []),
+    {
+      type: 'twinShock',
+      week: state.week,
+      data: { resolution: 'secret_lost' },
+      timestamp: Date.now(),
+    },
+  ];
+}
+
+function applyTwinShockTurnResult(state: GameState, result: TwinShockTurnResult) {
+  const twinShock = state.twinShock ?? createInitialTwinShockState();
+  twinShock.status = result.status;
+  twinShock.promptStage = result.promptStage;
+  twinShock.retryCount = result.retryCount;
+  if (result.promptStage === null) twinShock.queuedDay = null;
+  state.twinShock = twinShock;
+
+  if (result.resolution === 'resolved_discovered') resolveTwinShockDiscovered(state);
+  if (result.resolution === 'resolved_mission_success') resolveTwinShockMissionSuccess(state);
+  if (result.resolution === 'resolved_secret_lost') resolveTwinShockSecretLost(state);
+}
+
+function maybePushTwinShockClue(state: GameState) {
+  if (state.twinShockConsumed || !isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID)) return;
+  if (state.week < 2 || state.week > 4) return;
+  const twinShock = state.twinShock ?? createInitialTwinShockState();
+  if (twinShock.cluesShownDays.includes(state.week) || twinShock.cluesShownDays.length >= 2) return;
+
+  const clues = [
+    'Lia seemed unusually quiet this morning, then suddenly full of energy by lunch.',
+    'Lia laughed at a joke she claimed not to understand yesterday.',
+    'Someone mentioned that Lia looked different in the garden, but nobody pushed it further.',
+    'Lia forgot a conversation she had only a day ago.',
+  ];
+  const clue = clues[(state.week + twinShock.cluesShownDays.length) % clues.length];
+  twinShock.cluesShownDays = [...twinShock.cluesShownDays, state.week];
+  state.twinShock = twinShock;
+  pushEvent(state, clue, 'social', { major: 'twin_shock_clue' });
 }
 
 function resolveCompetitionParticipants(state: GameState): string[] {
@@ -3048,6 +3302,21 @@ const gameSlice = createSlice({
       state.dayStartShock = null;
       pushEvent(state, `[DEBUG] Blocking flags cleared — Continue button restored. 🔧`, 'game');
     },
+    submitTwinShockAnswer(state, action: PayloadAction<string>) {
+      if (!state.twinShock?.promptStage) return;
+      const human = getHumanPlayer(state);
+      if (!human || human.status === 'evicted' || human.status === 'jury') {
+        state.twinShock.promptStage = null;
+        state.twinShock.queuedDay = null;
+        return;
+      }
+      const result = resolveTwinShockTurn(state.twinShock, action.payload, {
+        playerName: human.name,
+        liaActive: isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID),
+      });
+      applyTwinShockTurnResult(state, result);
+    },
+
     /**
      * Archive the completed season.  Prepends the archive entry and caps the
      * list at 50 entries to bound memory usage.
@@ -3088,15 +3357,22 @@ const gameSlice = createSlice({
       // Derive the next season number from the maximum archived seasonIndex so the
       // result is stable even after the 50-entry archive cap or non-contiguous entries.
       const season = nextSeasonNumber(seasonArchives);
+      const twinShockConsumed = state.twinShockConsumed === true;
       // Use the factory to build a fully fresh initial state from the latest
       // persisted settings/profile, then override seed, seasonArchives, and season.
       const fresh = {
-        ...createInitialGameState(),
+        ...createInitialGameState({ twinShockConsumed }),
         seed,
         seasonArchives,
         season,
         status: 'active' as const,
       };
+      fresh.twinShockConsumed = twinShockConsumed;
+      fresh.twinShockActivatedSeason = state.twinShockActivatedSeason ?? null;
+      fresh.twinShockResolution = state.twinShockResolution ?? null;
+      fresh.twinShockResolvedDay = state.twinShockResolvedDay ?? null;
+      fresh.twinShockDiscoveredByUser = state.twinShockDiscoveredByUser ?? false;
+      fresh.liaForcedUntilTwinShockResolved = !twinShockConsumed;
       // Update the welcome message to reflect the actual season number.
       // publicModeEnabled is already derived from settings inside createInitialGameState().
       fresh.tvFeed = [
@@ -3128,6 +3404,13 @@ const gameSlice = createSlice({
         gameId: action.payload.gameId ?? crypto.randomUUID(),
         hasSeenConfessionalSpotlight: action.payload.hasSeenConfessionalSpotlight ?? false,
         status: action.payload.status ?? 'active',
+        twinShock: action.payload.twinShock ?? createInitialTwinShockState(),
+        twinShockConsumed: action.payload.twinShockConsumed ?? false,
+        twinShockActivatedSeason: action.payload.twinShockActivatedSeason ?? null,
+        twinShockResolution: action.payload.twinShockResolution ?? null,
+        twinShockResolvedDay: action.payload.twinShockResolvedDay ?? null,
+        twinShockDiscoveredByUser: action.payload.twinShockDiscoveredByUser ?? false,
+        liaForcedUntilTwinShockResolved: action.payload.liaForcedUntilTwinShockResolved ?? !(action.payload.twinShockConsumed ?? false),
       };
     },
 
@@ -3179,7 +3462,8 @@ const gameSlice = createSlice({
         state.democracia?.awaitingHumanVote ||
         state.democracia?.awaitingPublicBreaker ||
         state.awaitingCoLohNomination ||
-        state.awaitingPosTieBreak
+        state.awaitingPosTieBreak ||
+        state.twinShock?.promptStage != null
       ) {
         return;
       }
@@ -3817,6 +4101,10 @@ const gameSlice = createSlice({
       const nextIdx = (currentIdx + 1) % PHASE_ORDER.length;
       let nextPhase: Phase = PHASE_ORDER[nextIdx];
 
+      if (state.phase === 'eviction_results' && nextPhase === 'week_end') {
+        if (shouldQueueTwinShockBeforeDayEnd(state)) return;
+      }
+
       // Advance seed: consume one RNG value so each advance uses a different seed
       const seedRng = mulberry32(state.seed);
       state.seed = (seedRng() * 0x100000000) >>> 0;
@@ -3953,6 +4241,7 @@ const gameSlice = createSlice({
           break;
         }
         case 'social_1': {
+          maybePushTwinShockClue(state);
           const hohName = state.players.find((p) => p.id === state.lohId)?.name ?? 'The new LOH';
           pushEvent(state, `Housemates congratulate ${hohName}. Alliances are already forming… 💬`, 'social');
           break;
@@ -5202,6 +5491,7 @@ export const {
   rerollSeed,
   hydrateGame,
   setHasSeenConfessionalSpotlight,
+  submitTwinShockAnswer,
   triggerSecretMission,
   markSecondSecretMissionChanceResolved,
   offerSecretMission,
@@ -6273,13 +6563,7 @@ export const tryActivatePendingForcedSpecialVeto =
     const { game } = getState();
     const pending = game.pendingForcedShock;
 
-    if (
-      !pending ||
-      pending.type === 'doubleEviction' ||
-      pending.type === 'battleBack' ||
-      pending.type === 'democracia' ||
-      pending.type === 'dayStartShock'
-    ) return false;
+    if (!pending || !isSpecialVetoType(pending.type)) return false;
     if (game.phase !== 'pos_results') return false;
     if (game.week < pending.earliestWeek) return false;
     if (game.doubleEviction?.weekActive) return false;

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -46,7 +46,8 @@ export const selectIsWaitingForInput = (state: RootState): boolean => {
     Boolean(game.democracia?.awaitingPublicBreaker) ||
     Boolean(game.democracia?.resultDisplay) ||
     Boolean(game.awaitingCoLohNomination) ||
-    Boolean(game.awaitingPosTieBreak)
+    Boolean(game.awaitingPosTieBreak) ||
+    Boolean(game.twinShock?.promptStage)
   );
 };
 
@@ -148,6 +149,9 @@ export const selectConfessionalAlertCount = (state: RootState): number => {
     count += 1;
   }
   if (state.game?.awaitingVoteDeductionPrompt) count += 1;
+  if (state.game?.twinShock?.promptStage && activeConfessionalDecision?.type !== 'twin_shock') {
+    count += 1;
+  }
 
   // Ceremony decisions routed to the confessional add a mandatory alert.
   if (activeConfessionalDecision !== null) count += 1;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,10 @@ export interface Player {
   finalRank?: number;
   /** True once the player is confirmed season winner. */
   isWinner?: boolean;
+  /** Twin Shock: Lia keeps her id but plays as the combined Lia & Ali contestant. */
+  twinMode?: 'combined';
+  /** True for housemates inserted after the starting roster. */
+  lateEntrant?: boolean;
 }
 
 // ─── Minigame types ───────────────────────────────────────────────────────────
@@ -383,7 +387,13 @@ export interface SpecialVetoState {
   awaitingVipSecondSaveTarget: boolean;
 }
 
-export type ForcedShockType = 'doubleEviction' | 'battleBack' | SpecialVetoType | 'democracia' | 'dayStartShock';
+export type ForcedShockType =
+  | 'doubleEviction'
+  | 'battleBack'
+  | SpecialVetoType
+  | 'democracia'
+  | 'dayStartShock'
+  | 'twinShock';
 
 export interface ForcedShockState {
   /** Shock that should be triggered from the debug menu at the next safe chance. */
@@ -410,6 +420,36 @@ export interface DayStartShockState {
   triggeredWeek: number;
   /** Whether the shock was triggered by the random roll or the debug queue. */
   source: 'random' | 'debug';
+}
+
+export type TwinShockStatus =
+  | 'inactive'
+  | 'day4_pending'
+  | 'day4_asked_no_correct_guess'
+  | 'resolved_discovered'
+  | 'resolved_mission_success'
+  | 'resolved_secret_lost'
+  | 'cancelled_pre_day4_eviction';
+
+export type TwinShockPromptStage =
+  | 'day4_initial'
+  | 'day4_detail'
+  | 'day5_final'
+  | 'day5_give_up'
+  | 'secret_lost';
+
+export type TwinShockResolution =
+  | 'discovered'
+  | 'mission_success'
+  | 'secret_lost';
+
+export interface TwinShockState {
+  status: TwinShockStatus;
+  promptStage: TwinShockPromptStage | null;
+  queuedDay: number | null;
+  retryCount: number;
+  cluesShownDays: number[];
+  pendingRevealAnimation?: 'combined' | 'ali_enters' | null;
 }
 
 // ─── Public's Favorite voting twist ──────────────────────────────────────────
@@ -732,6 +772,15 @@ export interface GameState {
    * Feature-gated via settings.sim.enableFavoritePlayer.
    */
   favoritePlayer?: FavoritePlayerState;
+  /** One-time hidden identity twist centered on Lia and Ali. */
+  twinShock?: TwinShockState;
+  /** Global per-save flag: once activated, Twin Shock never repeats. */
+  twinShockConsumed?: boolean;
+  twinShockActivatedSeason?: number | null;
+  twinShockResolution?: TwinShockResolution | null;
+  twinShockResolvedDay?: number | null;
+  twinShockDiscoveredByUser?: boolean;
+  liaForcedUntilTwinShockResolved?: boolean;
   /** Explicit post-jury finale state machine controlling the end-of-season flow. */
   seasonFinale?: SeasonFinaleState | null;
   /**

--- a/tests/unit/twinShock.test.ts
+++ b/tests/unit/twinShock.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import gameReducer, {
+  advance,
+  createInitialGameState,
+  queueForcedShock,
+  submitTwinShockAnswer,
+} from '../../src/store/gameSlice';
+import { classifyTwinShockAnswer } from '../../src/bb/twinShock';
+import type { GameState } from '../../src/types';
+
+function reduce(state: GameState, action: { type: string; payload?: unknown }): GameState {
+  return gameReducer(state, action);
+}
+
+function makeTwinShockState(overrides: Partial<GameState> = {}): GameState {
+  const state = createInitialGameState();
+  return {
+    ...state,
+    week: 4,
+    phase: 'eviction_results',
+    pendingEviction: null,
+    voteResults: null,
+    players: state.players.map((player) => ({
+      ...player,
+      status: player.id === 'lia' || player.isUser ? 'active' : player.status,
+    })),
+    ...overrides,
+  };
+}
+
+describe('Twin Shock classifier', () => {
+  it('counts direct and late twin guesses as correct', () => {
+    expect(classifyTwinShockAnswer('Wait, is she a twin?')).toBe('correct_twin_guess');
+    expect(classifyTwinShockAnswer('I give up, unless she has a twin?')).toBe('correct_twin_guess');
+    expect(classifyTwinShockAnswer('Ali')).toBe('correct_twin_guess');
+  });
+
+  it('does not count a negated twin guess as correct', () => {
+    expect(classifyTwinShockAnswer("I don't think she has a twin")).toBe('unclear');
+  });
+});
+
+describe('Twin Shock reducer flow', () => {
+  it('queues the mandatory Day 4 Confessional after eviction results when Lia survived', () => {
+    const next = reduce(makeTwinShockState(), advance());
+
+    expect(next.phase).toBe('eviction_results');
+    expect(next.twinShock?.status).toBe('day4_pending');
+    expect(next.twinShock?.promptStage).toBe('day4_initial');
+    expect(next.twinShockConsumed).toBe(true);
+    expect(next.twinShockActivatedSeason).toBe(next.season);
+  });
+
+  it('does not consume the twist if Lia left before the Day 4 post-eviction check', () => {
+    const state = makeTwinShockState({
+      players: makeTwinShockState().players.map((player) =>
+        player.id === 'lia' ? { ...player, status: 'evicted' } : player,
+      ),
+    });
+    const next = reduce(state, advance());
+
+    expect(next.phase).toBe('week_end');
+    expect(next.twinShockConsumed).toBe(false);
+    expect(next.twinShock?.status).toBe('inactive');
+  });
+
+  it('can be queued from the debug forced shock menu', () => {
+    let state = reduce(makeTwinShockState({ week: 2 }), queueForcedShock('twinShock'));
+    state = reduce(state, advance());
+
+    expect(state.phase).toBe('eviction_results');
+    expect(state.pendingForcedShock).toBeNull();
+    expect(state.twinShock?.promptStage).toBe('day4_initial');
+    expect(state.twinShockConsumed).toBe(true);
+  });
+
+  it('turns Lia into Lia & Ali when the player exposes the secret', () => {
+    let state = reduce(makeTwinShockState(), advance());
+    state = reduce(state, submitTwinShockAnswer('Maybe she has a twin sister?'));
+
+    const lia = state.players.find((player) => player.id === 'lia');
+    expect(lia?.name).toBe('Lia & Ali');
+    expect(lia?.avatar).toBe('Lia_Ali');
+    expect(lia?.twinMode).toBe('combined');
+    expect(state.players.some((player) => player.id === 'ali')).toBe(false);
+    expect(state.twinShockResolution).toBe('discovered');
+    expect(state.twinShockDiscoveredByUser).toBe(true);
+  });
+
+  it('adds Ali as a late entrant when the Day 5 mission succeeds', () => {
+    const state = makeTwinShockState({
+      week: 5,
+      twinShockConsumed: true,
+      twinShockActivatedSeason: 1,
+      twinShock: {
+        status: 'day4_asked_no_correct_guess',
+        promptStage: null,
+        queuedDay: null,
+        retryCount: 0,
+        cluesShownDays: [],
+        pendingRevealAnimation: null,
+      },
+    });
+
+    let next = reduce(state, advance());
+    expect(next.twinShock?.promptStage).toBe('day5_final');
+
+    next = reduce(next, submitTwinShockAnswer('No idea'));
+    expect(next.twinShock?.promptStage).toBe('day5_give_up');
+
+    next = reduce(next, submitTwinShockAnswer('I give up'));
+    const ali = next.players.find((player) => player.id === 'ali');
+    const lia = next.players.find((player) => player.id === 'lia');
+
+    expect(ali?.name).toBe('Ali');
+    expect(ali?.status).toBe('active');
+    expect(ali?.lateEntrant).toBe(true);
+    expect(lia?.name).toBe('Lia');
+    expect(next.twinShockResolution).toBe('mission_success');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the one-time Twin Shock Lia/Ali story flow with Day 4 and Day 5 Confessional prompts.
- Forces Lia into fresh casts until the twist is consumed, then excludes the reserved twin identities from future seasons.
- Supports both outcomes: the player exposes the twin secret and Lia becomes Lia & Ali, or Ali enters as a late contestant if the mission succeeds.
- Adds Twin Shock to the debug Force Shock menu.

## Validation
- npm run typecheck
- npx vitest run tests\unit\twinShock.test.ts src\components\DebugPanel\__tests__\DebugPanel.test.tsx