### PR TITLE
Fix Twin Shock reveal flow

### DIFF
--- a/src/bb/twinShock.ts
+++ b/src/bb/twinShock.ts
@@ -273,7 +273,7 @@ export function resolveTwinShockTurn(
           'Here is the secret.',
           'All along, Lia has been secretly switching places with her twin sister, Ali.',
           'Their secret mission was successful.',
-          'Ali will now enter the House as a full contestant.',
+          'Ali will now take over the first empty place in the House as a full contestant.',
           'You are free to return and inform the others.',
         ],
         status: 'resolved_mission_success',

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
@@ -1,0 +1,174 @@
+.twin-shock-reveal {
+  position: fixed;
+  inset: 0;
+  z-index: 8800;
+  pointer-events: none;
+  color: #fff;
+}
+
+.twin-shock-reveal__shade {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 10, 18, 0.84);
+  animation: twin-shock-fade-in 260ms ease-out both;
+}
+
+.twin-shock-reveal__beam {
+  position: absolute;
+  left: calc(var(--twin-shock-left) - 10px);
+  top: calc(var(--twin-shock-top) - 10px);
+  width: calc(var(--twin-shock-width) + 20px);
+  height: calc(var(--twin-shock-height) + 20px);
+  border: 2px solid rgba(255, 214, 102, 0.96);
+  box-shadow:
+    0 0 0 9999px rgba(0, 0, 0, 0.18),
+    0 0 26px rgba(255, 214, 102, 0.82),
+    inset 0 0 20px rgba(255, 255, 255, 0.22);
+  border-radius: 12px;
+  animation: twin-shock-pulse 920ms ease-in-out infinite alternate;
+}
+
+.twin-shock-reveal--combined.twin-shock-reveal--after .twin-shock-reveal__beam {
+  border-color: rgba(112, 231, 255, 0.96);
+  box-shadow:
+    0 0 0 9999px rgba(0, 0, 0, 0.18),
+    0 0 30px rgba(112, 231, 255, 0.9),
+    inset 0 0 20px rgba(255, 255, 255, 0.24);
+}
+
+.twin-shock-reveal--ali_enters.twin-shock-reveal--after .twin-shock-reveal__beam {
+  border-color: rgba(102, 255, 178, 0.96);
+  box-shadow:
+    0 0 0 9999px rgba(0, 0, 0, 0.18),
+    0 0 30px rgba(102, 255, 178, 0.86),
+    inset 0 0 20px rgba(255, 255, 255, 0.24);
+}
+
+.twin-shock-reveal__tile {
+  position: absolute;
+  left: var(--twin-shock-left);
+  top: var(--twin-shock-top);
+  width: var(--twin-shock-width);
+  height: var(--twin-shock-height);
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  align-items: center;
+  justify-items: center;
+  overflow: hidden;
+  border-radius: 10px;
+  background: rgba(13, 18, 26, 0.74);
+  transform-origin: center;
+  animation: twin-shock-tile-rise 620ms ease-out both;
+}
+
+.twin-shock-reveal--after .twin-shock-reveal__tile {
+  animation: twin-shock-swap 680ms ease-out both;
+}
+
+.twin-shock-reveal__avatar-wrap {
+  width: min(74%, 136px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.twin-shock-reveal__avatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.twin-shock-reveal__avatar-fallback {
+  font-size: clamp(1rem, 3vw, 2rem);
+  font-weight: 800;
+}
+
+.twin-shock-reveal__name {
+  width: 100%;
+  min-height: 1.9rem;
+  padding: 0.24rem 0.45rem 0.42rem;
+  background: rgba(0, 0, 0, 0.46);
+  text-align: center;
+  font-size: clamp(0.78rem, 1.5vw, 1.04rem);
+  font-weight: 800;
+  line-height: 1.08;
+}
+
+.twin-shock-reveal__caption {
+  position: absolute;
+  left: max(14px, calc(var(--twin-shock-left) - 24px));
+  top: min(
+    calc(100vh - 66px),
+    calc(var(--twin-shock-top) + var(--twin-shock-height) + 20px)
+  );
+  max-width: min(420px, calc(100vw - 28px));
+  padding: 0.48rem 0.7rem;
+  border-radius: 7px;
+  background: rgba(5, 10, 18, 0.88);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+  font-size: clamp(0.82rem, 1.7vw, 1rem);
+  font-weight: 750;
+  line-height: 1.18;
+  animation: twin-shock-caption 360ms ease-out both;
+}
+
+@keyframes twin-shock-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes twin-shock-pulse {
+  from { transform: scale(0.99); opacity: 0.72; }
+  to { transform: scale(1.025); opacity: 1; }
+}
+
+@keyframes twin-shock-tile-rise {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes twin-shock-swap {
+  0% {
+    opacity: 0.1;
+    transform: scale(0.88) rotate(-1deg);
+  }
+  58% {
+    opacity: 1;
+    transform: scale(1.08) rotate(0deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes twin-shock-caption {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .twin-shock-reveal__shade,
+  .twin-shock-reveal__beam,
+  .twin-shock-reveal__tile,
+  .twin-shock-reveal__caption,
+  .twin-shock-reveal--after .twin-shock-reveal__tile {
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
+  }
+}

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import type { CSSProperties } from 'react';
+import type { TwinShockRevealAnimation } from '../../types';
+import './TwinShockRevealOverlay.css';
+
+type TwinShockRevealOverlayProps = {
+  reveal: TwinShockRevealAnimation;
+  getTileRect: (playerId: string) => DOMRect | null;
+  onDone: () => void;
+};
+
+type RevealStage = 'before' | 'after' | 'done';
+
+export default function TwinShockRevealOverlay({
+  reveal,
+  getTileRect,
+  onDone,
+}: TwinShockRevealOverlayProps) {
+  const targetId = reveal.type === 'combined' ? reveal.playerId : reveal.incomingPlayerId;
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [stage, setStage] = useState<RevealStage>('before');
+
+  useLayoutEffect(() => {
+    const measured = getTileRect(targetId);
+    setRect(measured);
+    if (!measured) {
+      const id = window.setTimeout(onDone, 100);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [getTileRect, onDone, targetId]);
+
+  useEffect(() => {
+    if (!rect) return undefined;
+    const swapId = window.setTimeout(() => setStage('after'), 950);
+    const doneId = window.setTimeout(() => {
+      setStage('done');
+      onDone();
+    }, 2700);
+    return () => {
+      window.clearTimeout(swapId);
+      window.clearTimeout(doneId);
+    };
+  }, [onDone, rect]);
+
+  const display = useMemo(() => {
+    const after = stage !== 'before';
+    if (reveal.type === 'combined') {
+      return {
+        name: after ? reveal.toName : reveal.fromName,
+        avatar: after ? reveal.toAvatar : reveal.fromAvatar,
+        caption: after ? 'Lia & Ali are revealed' : 'Lia steps into the spotlight',
+      };
+    }
+    return {
+      name: after ? reveal.incomingName : reveal.replacedPlayerName,
+      avatar: after ? reveal.incomingAvatar : reveal.replacedPlayerAvatar,
+      caption: after
+        ? `${reveal.incomingName} takes the empty place`
+        : `${reveal.replacedPlayerName}'s place goes dark`,
+    };
+  }, [reveal, stage]);
+
+  if (!rect || stage === 'done') return null;
+
+  const style = {
+    '--twin-shock-left': `${rect.left}px`,
+    '--twin-shock-top': `${rect.top}px`,
+    '--twin-shock-width': `${rect.width}px`,
+    '--twin-shock-height': `${rect.height}px`,
+  } as CSSProperties;
+
+  return (
+    <div
+      className={`twin-shock-reveal twin-shock-reveal--${reveal.type} twin-shock-reveal--${stage}`}
+      style={style}
+      role="status"
+      aria-live="assertive"
+      aria-label={display.caption}
+    >
+      <div className="twin-shock-reveal__shade" />
+      <div className="twin-shock-reveal__beam" />
+      <div className="twin-shock-reveal__tile">
+        <div className="twin-shock-reveal__avatar-wrap">
+          {display.avatar ? (
+            <img
+              className="twin-shock-reveal__avatar"
+              src={display.avatar}
+              alt=""
+              draggable={false}
+            />
+          ) : (
+            <span className="twin-shock-reveal__avatar-fallback">
+              {display.name.slice(0, 2).toUpperCase()}
+            </span>
+          )}
+        </div>
+        <div className="twin-shock-reveal__name">{display.name}</div>
+      </div>
+      <div className="twin-shock-reveal__caption">{display.caption}</div>
+    </div>
+  );
+}

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -21,13 +21,20 @@ export default function TwinShockRevealOverlay({
   const [stage, setStage] = useState<RevealStage>('before');
 
   useLayoutEffect(() => {
-    const measured = getTileRect(targetId);
-    setRect(measured);
-    if (!measured) {
-      const id = window.setTimeout(onDone, 100);
-      return () => window.clearTimeout(id);
-    }
-    return undefined;
+    let doneFallbackId: number | null = null;
+    const frameId = window.requestAnimationFrame(() => {
+      const measured = getTileRect(targetId);
+      if (!measured) {
+        doneFallbackId = window.setTimeout(onDone, 100);
+        return;
+      }
+      setRect(measured);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      if (doneFallbackId !== null) window.clearTimeout(doneFallbackId);
+    };
   }, [getTileRect, onDone, targetId]);
 
   useEffect(() => {

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -426,6 +426,26 @@ export default function DiaryRoom() {
     });
   }, [playerId]);
 
+  const appendBigEyeMessagesSequentially = useCallback(async (lines: string[]) => {
+    for (const line of lines) {
+      setBbTyping(true);
+      await new Promise<void>((resolve) => setTimeout(resolve, 550));
+      setBbTyping(false);
+      const nextMessage: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: 'bb',
+        text: line,
+        timestamp: Date.now(),
+      };
+      setMessages((prev) => {
+        const updated = [...prev, nextMessage];
+        saveChat(playerId, updated);
+        return updated;
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 220));
+    }
+  }, [playerId]);
+
   // Track which mission already had its reward-pending message injected.
   const rewardMsgInjectedForMissionRef = useRef<string | null>(null);
   const rewardMissionKey = secretMission
@@ -469,10 +489,16 @@ export default function DiaryRoom() {
     }
 
     const nextConversationState = createInitialBigEyeState();
-    const visitCount = recordConfessionalVisit(playerId);
-    const greeting = buildEntryGreeting(playerNameRef.current, seedRef.current ?? 0, visitCount);
     setConversationState(nextConversationState);
     saveConversationState(playerId, nextConversationState);
+    if (confessionalDecisionPending) {
+      setMessages([]);
+      saveChat(playerId, []);
+      return;
+    }
+
+    const visitCount = recordConfessionalVisit(playerId);
+    const greeting = buildEntryGreeting(playerNameRef.current, seedRef.current ?? 0, visitCount);
     setMessages([greeting]);
     saveChat(playerId, [greeting]);
   }, [confessionalLocked, playerId]);
@@ -683,28 +709,25 @@ export default function DiaryRoom() {
     });
 
     if (activeConfessionalDecision?.type === 'twin_shock' && gameState.twinShock?.promptStage) {
+      const currentPromptStage = gameState.twinShock.promptStage;
       const twinResult = resolveTwinShockTurn(gameState.twinShock, text, {
         playerName,
         liaActive: alivePlayers.some((player) => player.id === 'lia'),
       });
       dispatch(submitTwinShockAnswer(text));
-      setBbTyping(true);
-      await new Promise<void>((resolve) => setTimeout(resolve, 550));
-      setBbTyping(false);
-      const bbMessages: ChatMessage[] = twinResult.messages.map((messageText) => ({
-        id: crypto.randomUUID(),
-        role: 'bb',
-        text: messageText,
-        timestamp: Date.now(),
-      }));
       setMessages((prev) => {
         const withSeen = prev.map((m) =>
           m.role === 'user' && m.status !== 'seen' ? { ...m, status: 'seen' as MessageStatus } : m,
         );
-        const withReply = [...withSeen, ...bbMessages];
-        saveChat(playerId, withReply);
-        return withReply;
+        saveChat(playerId, withSeen);
+        return withSeen;
       });
+      const nextPromptWillRender =
+        twinResult.promptStage !== null &&
+        twinResult.promptStage !== currentPromptStage;
+      if (!nextPromptWillRender) {
+        await appendBigEyeMessagesSequentially(twinResult.messages);
+      }
       setLoading(false);
       return;
     }

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -501,7 +501,7 @@ export default function DiaryRoom() {
     const greeting = buildEntryGreeting(playerNameRef.current, seedRef.current ?? 0, visitCount);
     setMessages([greeting]);
     saveChat(playerId, [greeting]);
-  }, [confessionalLocked, playerId]);
+  }, [confessionalDecisionPending, confessionalLocked, playerId]);
 
   useEffect(() => {
     if (confessionalLocked || !activeDecisionPresentation) return;

--- a/src/screens/DiaryRoom/confessionalDecisionPresentation.ts
+++ b/src/screens/DiaryRoom/confessionalDecisionPresentation.ts
@@ -129,12 +129,11 @@ export function getConfessionalDecisionPresentation(
     case 'twin_shock': {
       const stage = game.twinShock?.promptStage;
       if (stage === 'day4_initial') {
-        const humanName = game.players.find((player) => player.isUser)?.name ?? 'Houseguest';
-        prompt = `Hi, ${humanName}. How have you been lately? Thank you for sharing. We may come back to this later. But right now, I need to ask you something. Have you noticed anything off about Lia?`;
+        prompt = 'I need to ask you something. Have you noticed anything off about Lia?';
       } else if (stage === 'day4_detail') {
         prompt = 'What exactly have you noticed?';
       } else if (stage === 'day5_final') {
-        prompt = 'Yesterday, I asked you whether you had noticed anything off about Lia. I will ask one last time. What do you think is going on?';
+        prompt = 'Last time, I asked you whether you had noticed anything off about Lia. I will ask one last time. What do you think is going on?';
       } else if (stage === 'day5_give_up') {
         prompt = 'Say that you give up, and I will tell you the secret.';
       } else if (stage === 'secret_lost') {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -59,6 +59,7 @@ import {
   resolveDemocraciaPublicBreaker,
   submitCoLohNomination,
   submitPosTieBreak,
+  completeTwinShockRevealAnimation,
 } from '../../store/gameSlice'
 import { startChallenge, selectPendingChallenge, completeChallenge, type PendingChallenge } from '../../store/challengeSlice'
 import { selectLastSocialReport } from '../../social/socialSlice'
@@ -118,6 +119,7 @@ import { mulberry32 } from '../../store/rng'
 import { isSurvivorRunTerminal } from '../../modes/survivorRun'
 import PublicFavoriteOverlay from '../../components/PublicFavoriteOverlay/PublicFavoriteOverlay'
 import JuryPhaseRevealOverlay from '../../components/JuryPhaseRevealOverlay/JuryPhaseRevealOverlay'
+import TwinShockRevealOverlay from '../../components/TwinShockRevealOverlay/TwinShockRevealOverlay'
 import { rankPublicEvictionTieNominees } from '../../publicOpinion/PublicEvictionTieService'
 import { resolvePublicSaveNominee } from '../../publicOpinion/PublicSaveService'
 import { updateApproval } from '../../publicOpinion/publicOpinionSlice'
@@ -425,6 +427,10 @@ export default function GameScreen() {
   const getTileRect = useCallback((playerId: string): DOMRect | null => {
     return getCeremonyTileRect(playerId)
   }, [])
+  const twinShockReveal = game.twinShock?.pendingRevealAnimation ?? null
+  const handleTwinShockRevealDone = useCallback(() => {
+    dispatch(completeTwinShockRevealAnimation())
+  }, [dispatch])
 
   // ── CeremonyOverlay — deferred LOH / POS winner commit ─────────────────
   // When MinigameHost reports a winner, we show the CeremonyOverlay with a
@@ -4049,6 +4055,16 @@ export default function GameScreen() {
             player={dayStartShockPlayer}
             reason={dayStartShock.reason}
             onConfirm={handleDayStartShockConfirm}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {twinShockReveal && (
+          <TwinShockRevealOverlay
+            key={`${twinShockReveal.type}-${twinShockReveal.type === 'combined' ? twinShockReveal.playerId : twinShockReveal.incomingPlayerId}`}
+            reveal={twinShockReveal}
+            getTileRect={getTileRect}
+            onDone={handleTwinShockRevealDone}
           />
         )}
       </AnimatePresence>

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -217,10 +217,13 @@ type SecretMissionTaskBuildResult = {
 };
 
 const TWIN_SHOCK_RESERVED_IDS = new Set([TWIN_SHOCK_LIA_ID, TWIN_SHOCK_ALI_ID, 'lia_ali']);
+const TWIN_SHOCK_LIA_AVATAR = 'assets/skins/Lia_avatar.webp';
+const TWIN_SHOCK_ALI_AVATAR = 'assets/skins/Ali_avatar.webp';
+const TWIN_SHOCK_COMBINED_AVATAR = 'assets/skins/Lia_Ali_avatar.webp';
 const TWIN_SHOCK_LIA_POOL_ENTRY = {
   id: TWIN_SHOCK_LIA_ID,
   name: 'Lia',
-  avatar: 'Lia',
+  avatar: TWIN_SHOCK_LIA_AVATAR,
 };
 
 function buildSecretMissionTargetCandidates(state: GameState): string[] {
@@ -278,8 +281,11 @@ function buildUserPlayer(): Player {
 function pickHouseguests(rosterSize = GAME_ROSTER_SIZE, twinShockConsumed = false): Player[] {
   const seed = (Math.floor(Math.random() * 0x100000000)) >>> 0;
   const rng = mulberry32(seed);
-  const lia = HOUSEGUEST_POOL.find((houseguest) => houseguest.id === TWIN_SHOCK_LIA_ID)
-    ?? TWIN_SHOCK_LIA_POOL_ENTRY;
+  const lia = {
+    ...(HOUSEGUEST_POOL.find((houseguest) => houseguest.id === TWIN_SHOCK_LIA_ID)
+      ?? TWIN_SHOCK_LIA_POOL_ENTRY),
+    avatar: TWIN_SHOCK_LIA_AVATAR,
+  };
   const eligiblePool = HOUSEGUEST_POOL.filter((houseguest) => (
     twinShockConsumed
       ? !TWIN_SHOCK_RESERVED_IDS.has(houseguest.id)
@@ -528,13 +534,15 @@ function getReplacementEligiblePlayers(
   state: GameState,
   alivePlayers: Player[],
   neededCount = 1,
-  options: { allowLoh?: boolean } = {},
+  options: { allowLoh?: boolean; actorId?: string | null } = {},
 ): Player[] {
+  const actorId = options.actorId === undefined ? state.lohId : options.actorId;
   const baseEligible = alivePlayers.filter(
     (pl) =>
       (options.allowLoh === true || pl.id !== state.lohId) &&
       pl.id !== state.posWinnerId &&
-      !state.nomineeIds.includes(pl.id),
+      !state.nomineeIds.includes(pl.id) &&
+      canPlayerTargetPlayer(state, actorId, pl.id),
   );
   const protectedIds = new Set(getPovProtectedIds(state));
   const nonProtected = baseEligible.filter((player) => !protectedIds.has(player.id));
@@ -545,7 +553,7 @@ function isEligibleReplacementNominee(
   state: GameState,
   playerId: string,
   neededCount = 1,
-  options: { allowLoh?: boolean } = {},
+  options: { allowLoh?: boolean; actorId?: string | null } = {},
 ): boolean {
   const alivePlayers = state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
   return getReplacementEligiblePlayers(state, alivePlayers, neededCount, options)
@@ -816,6 +824,48 @@ function isPlayerActiveInHouse(state: GameState, playerId: string): boolean {
   return Boolean(player && player.status !== 'evicted' && player.status !== 'jury');
 }
 
+function isTwinShockActivePair(state: GameState): boolean {
+  return state.twinShockResolution === 'mission_success'
+    && isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID)
+    && isPlayerActiveInHouse(state, TWIN_SHOCK_ALI_ID);
+}
+
+function isTwinAlliancePair(state: GameState, firstId: string | null | undefined, secondId: string | null | undefined): boolean {
+  if (!firstId || !secondId || firstId === secondId || !isTwinShockActivePair(state)) return false;
+  return (
+    (firstId === TWIN_SHOCK_LIA_ID && secondId === TWIN_SHOCK_ALI_ID) ||
+    (firstId === TWIN_SHOCK_ALI_ID && secondId === TWIN_SHOCK_LIA_ID)
+  );
+}
+
+function canPlayerTargetPlayer(state: GameState, actorId: string | null | undefined, targetId: string): boolean {
+  return !isTwinAlliancePair(state, actorId, targetId);
+}
+
+function getTwinNomineeToSave(
+  state: GameState,
+  holderId: string | null | undefined,
+  nominees?: Player[],
+): Player | null {
+  if (!holderId || !isTwinShockActivePair(state)) return null;
+  const nomineePool = nominees ?? state.players.filter((player) => state.nomineeIds.includes(player.id));
+  return nomineePool.find((nominee) => isTwinAlliancePair(state, holderId, nominee.id)) ?? null;
+}
+
+function pickSafetySaveTarget(
+  state: GameState,
+  holderId: string | null | undefined,
+  nominees: Player[],
+  rng: () => number,
+): Player | null {
+  return getTwinNomineeToSave(state, holderId, nominees)
+    ?? pickStrategicAiPlayer(state, nominees, rng, 'lowest');
+}
+
+function shouldUseSafetyForTwin(state: GameState, holderId: string | null | undefined, nominees: Player[]): boolean {
+  return getTwinNomineeToSave(state, holderId, nominees) !== null;
+}
+
 function getHumanPlayer(state: GameState): Player | undefined {
   return state.players.find((player) => player.isUser);
 }
@@ -837,6 +887,7 @@ function queueTwinShockConfessional(state: GameState, stage: NonNullable<GameSta
     state.liaForcedUntilTwinShockResolved = true;
   }
   state.twinShock = twinShock;
+  state.twistActivatedThisWeek = true;
   pushEvent(state, 'The Big Eye wants you in the Confessional.', 'diary', {
     major: 'twin_shock_confessional',
   });
@@ -869,7 +920,7 @@ function shouldQueueTwinShockBeforeDayEnd(state: GameState): boolean {
   }
 
   if (
-    state.week === 5 &&
+    state.week === (twinShock.queuedDay ?? 4) + 1 &&
     twinShock.status === 'day4_asked_no_correct_guess' &&
     twinShock.promptStage === null
   ) {
@@ -908,9 +959,11 @@ function ensureCompetitionStateForPlayer(state: GameState, playerId: string) {
 function resolveTwinShockDiscovered(state: GameState) {
   const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
   const humanName = getHumanPlayer(state)?.name ?? 'The player';
+  const fromName = lia?.name ?? 'Lia';
+  const fromAvatar = lia?.avatar ?? TWIN_SHOCK_LIA_AVATAR;
   if (lia) {
     lia.name = 'Lia & Ali';
-    lia.avatar = 'Lia_Ali';
+    lia.avatar = TWIN_SHOCK_COMBINED_AVATAR;
     lia.twinMode = 'combined';
     if (lia.status === 'evicted' || lia.status === 'jury') lia.status = 'active';
   }
@@ -924,7 +977,14 @@ function resolveTwinShockDiscovered(state: GameState) {
     state.twinShock.promptStage = null;
     state.twinShock.queuedDay = null;
     state.twinShock.retryCount = 0;
-    state.twinShock.pendingRevealAnimation = 'combined';
+    state.twinShock.pendingRevealAnimation = {
+      type: 'combined',
+      playerId: TWIN_SHOCK_LIA_ID,
+      fromName,
+      fromAvatar,
+      toName: 'Lia & Ali',
+      toAvatar: TWIN_SHOCK_COMBINED_AVATAR,
+    };
   }
   pushTwinShockAnnouncement(
     state,
@@ -935,11 +995,36 @@ function resolveTwinShockDiscovered(state: GameState) {
 
 function resolveTwinShockMissionSuccess(state: GameState) {
   const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
-  if (!state.players.some((player) => player.id === TWIN_SHOCK_ALI_ID)) {
+  const replacement = state.players
+    .filter((player) =>
+      !player.isUser &&
+      player.id !== TWIN_SHOCK_LIA_ID &&
+      player.id !== TWIN_SHOCK_ALI_ID &&
+      (player.status === 'evicted' || player.status === 'jury'))
+    .sort((a, b) => {
+      const placementDiff = (b.seasonPlacement ?? -1) - (a.seasonPlacement ?? -1);
+      if (placementDiff !== 0) return placementDiff;
+      return (a.evictedAtWeek ?? Number.MAX_SAFE_INTEGER) - (b.evictedAtWeek ?? Number.MAX_SAFE_INTEGER);
+    })[0] ?? null;
+  const replacedPlayerId = replacement?.id ?? TWIN_SHOCK_ALI_ID;
+  const replacedPlayerName = replacement?.name ?? 'an empty house slot';
+  const replacedPlayerAvatar = replacement?.avatar ?? TWIN_SHOCK_ALI_AVATAR;
+
+  if (replacement) {
+    replacement.id = TWIN_SHOCK_ALI_ID;
+    replacement.name = 'Ali';
+    replacement.avatar = TWIN_SHOCK_ALI_AVATAR;
+    replacement.status = 'active';
+    replacement.lateEntrant = true;
+    replacement.evictedAtWeek = undefined;
+    replacement.seasonPlacement = undefined;
+    replacement.finalRank = undefined;
+    replacement.stats = { lohWins: 0, posWins: 0, timesNominated: 0 };
+  } else if (!state.players.some((player) => player.id === TWIN_SHOCK_ALI_ID)) {
     state.players.push({
       id: TWIN_SHOCK_ALI_ID,
       name: 'Ali',
-      avatar: 'Ali',
+      avatar: TWIN_SHOCK_ALI_AVATAR,
       status: 'active',
       lateEntrant: true,
       stats: { lohWins: 0, posWins: 0, timesNominated: 0 },
@@ -956,11 +1041,21 @@ function resolveTwinShockMissionSuccess(state: GameState) {
     state.twinShock.promptStage = null;
     state.twinShock.queuedDay = null;
     state.twinShock.retryCount = 0;
-    state.twinShock.pendingRevealAnimation = 'ali_enters';
+    state.twinShock.pendingRevealAnimation = {
+      type: 'ali_enters',
+      replacedPlayerId,
+      replacedPlayerName,
+      replacedPlayerAvatar,
+      incomingPlayerId: TWIN_SHOCK_ALI_ID,
+      incomingName: 'Ali',
+      incomingAvatar: TWIN_SHOCK_ALI_AVATAR,
+    };
   }
   pushTwinShockAnnouncement(
     state,
-    'TWIN SHOCK REVEALED! Lia has been secretly switching places with her twin sister, Ali, all along. Because the secret mission was successful, Ali has earned her place as a full contestant. Welcome Ali to the House!',
+    replacement
+      ? `TWIN SHOCK REVEALED! Lia has been secretly switching places with her twin sister, Ali, all along. Because the secret mission was successful, Ali takes over ${replacedPlayerName}'s empty spot as a full contestant. Welcome Ali to the House!`
+      : 'TWIN SHOCK REVEALED! Lia has been secretly switching places with her twin sister, Ali, all along. Because the secret mission was successful, Ali has earned her place as a full contestant. Welcome Ali to the House!',
     'twin_shock_mission_success',
   );
   if (lia) {
@@ -995,11 +1090,16 @@ function resolveTwinShockSecretLost(state: GameState) {
 }
 
 function applyTwinShockTurnResult(state: GameState, result: TwinShockTurnResult) {
+  const previousQueuedDay = state.twinShock?.queuedDay ?? null;
   const twinShock = state.twinShock ?? createInitialTwinShockState();
   twinShock.status = result.status;
   twinShock.promptStage = result.promptStage;
   twinShock.retryCount = result.retryCount;
-  if (result.promptStage === null) twinShock.queuedDay = null;
+  if (result.promptStage === null && result.status !== 'day4_asked_no_correct_guess') {
+    twinShock.queuedDay = null;
+  } else if (result.status === 'day4_asked_no_correct_guess' && previousQueuedDay !== null) {
+    twinShock.queuedDay = previousQueuedDay;
+  }
   state.twinShock = twinShock;
 
   if (result.resolution === 'resolved_discovered') resolveTwinShockDiscovered(state);
@@ -1745,7 +1845,7 @@ const gameSlice = createSlice({
       if (!state.awaitingNominations || state.phase !== 'nomination_results') return;
       const id = action.payload;
       const alive = state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
-      const eligible = alive.filter((p) => p.id !== state.lohId);
+      const eligible = alive.filter((p) => p.id !== state.lohId && canPlayerTargetPlayer(state, state.lohId, p.id));
       if (!eligible.some((p) => p.id === id)) return;
       state.pendingNominee1Id = id;
     },
@@ -1763,7 +1863,7 @@ const gameSlice = createSlice({
       const id1 = state.pendingNominee1Id;
       if (!id1 || id2 === id1) return;
       const alive = state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
-      const eligible = alive.filter((p) => p.id !== state.lohId);
+      const eligible = alive.filter((p) => p.id !== state.lohId && canPlayerTargetPlayer(state, state.lohId, p.id));
       if (!eligible.some((p) => p.id === id2)) return;
       if (!eligible.some((p) => p.id === id1)) return;
 
@@ -1810,7 +1910,7 @@ const gameSlice = createSlice({
       const expectedCount = isDoubleEviction ? 3 : 2;
       if (ids.length !== expectedCount) return;
       if (new Set(ids).size !== ids.length) return; // duplicates check
-      const eligible = alive.filter((p) => p.id !== state.lohId);
+      const eligible = alive.filter((p) => p.id !== state.lohId && canPlayerTargetPlayer(state, state.lohId, p.id));
       if (!ids.every((id) => eligible.some((p) => p.id === id))) return;
 
       const nominees = ids.map((id) => state.players.find((p) => p.id === id)!).filter(Boolean);
@@ -1925,7 +2025,9 @@ const gameSlice = createSlice({
       if (!state.awaitingPovDecision) return;
       state.awaitingPovDecision = false;
       const posWinner = state.players.find((p) => p.id === state.posWinnerId);
-      if (action.payload) {
+      const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
+      const willUsePower = action.payload || shouldUseSafetyForTwin(state, posWinner?.id, nominees);
+      if (willUsePower) {
         const svType = state.specialVeto?.activeType;
         if (svType === 'coup') {
           // Detox: remove both nominees, await holder replacement picks
@@ -1976,6 +2078,8 @@ const gameSlice = createSlice({
       const posWinner = state.players.find((p) => p.id === state.posWinnerId);
       const lohPlayer = state.players.find((p) => p.id === state.lohId);
       if (!savedPlayer || !posWinner) return;
+      const twinSaveTarget = getTwinNomineeToSave(state, posWinner.id);
+      if (twinSaveTarget && twinSaveTarget.id !== saveId) return;
 
       // Save the selected nominee
       state.nomineeIds = state.nomineeIds.filter((id) => id !== saveId);
@@ -2002,7 +2106,7 @@ const gameSlice = createSlice({
         } else {
           // AI holder names replacement
           const alive = state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
-          const eligible = getReplacementEligiblePlayers(state, alive);
+          const eligible = getReplacementEligiblePlayers(state, alive, 1, { actorId: posWinner.id });
           if (eligible.length > 0) {
             const rng = mulberry32(state.seed);
             const replacement = seededPick(rng, eligible);
@@ -2068,6 +2172,7 @@ const gameSlice = createSlice({
       if (!state.nomineeIds.includes(nomineeId)) return;
       const humanPlayer = state.players.find((p) => p.isUser);
       if (!humanPlayer) return;
+      if (!canPlayerTargetPlayer(state, humanPlayer.id, nomineeId)) return;
       if (!state.votes) state.votes = {};
       state.votes[humanPlayer.id] = nomineeId;
       state.awaitingHumanVote = false;
@@ -2087,6 +2192,7 @@ const gameSlice = createSlice({
       const evictee = state.players.find((p) => p.id === nomineeId);
       const lohPlayer = state.players.find((p) => p.id === state.lohId);
       if (!evictee) return;
+      if (!canPlayerTargetPlayer(state, lohPlayer?.id, nomineeId)) return;
 
       state.awaitingTieBreak = false;
       state.tiedNomineeIds = null;
@@ -2247,6 +2353,7 @@ const gameSlice = createSlice({
       const humanPlayer = state.players.find((p) => p.isUser);
       if (!humanPlayer) return;
       if (targetId === humanPlayer.id) return; // no self-vote
+      if (!canPlayerTargetPlayer(state, humanPlayer.id, targetId)) return;
       if (!dem.candidateIds.includes(targetId)) return; // must be a candidate
       if (!dem.eligibleVoterIds.includes(humanPlayer.id)) return; // must be eligible voter
       dem.votesByVoterId[humanPlayer.id] = targetId;
@@ -2821,7 +2928,7 @@ const gameSlice = createSlice({
 
       if (state.specialVeto.awaitingCoupReplacement1) {
         if (id === state.posWinnerId || state.nomineeIds.includes(id)) return;
-        if (!isEligibleReplacementNominee(state, id, 2, { allowLoh: true })) return;
+        if (!isEligibleReplacementNominee(state, id, 2, { allowLoh: true, actorId: povHolder?.id })) return;
         state.specialVeto.coupReplacement1Id = id;
         state.specialVeto.awaitingCoupReplacement1 = false;
         state.specialVeto.awaitingCoupReplacement2 = true;
@@ -2834,7 +2941,7 @@ const gameSlice = createSlice({
         const rep1Id = state.specialVeto.coupReplacement1Id;
         if (id === state.posWinnerId || id === rep1Id || state.nomineeIds.includes(id)) return;
         if (!alive.some((p) => p.id === id)) return;
-        const availableSecondChoices = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true })
+        const availableSecondChoices = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true, actorId: povHolder?.id })
           .filter((player) => player.id !== rep1Id);
         if (!availableSecondChoices.some((player) => player.id === id)) return;
 
@@ -2860,7 +2967,9 @@ const gameSlice = createSlice({
       if (!state.specialVeto?.awaitingVipSecondUseDecision) return;
       state.specialVeto.awaitingVipSecondUseDecision = false;
       const povHolder = state.players.find((p) => p.id === state.posWinnerId);
-      if (action.payload) {
+      const nominees = state.players.filter((player) => state.nomineeIds.includes(player.id));
+      const willUseSecond = action.payload || shouldUseSafetyForTwin(state, povHolder?.id, nominees);
+      if (willUseSecond) {
         state.specialVeto.awaitingVipSecondSaveTarget = true;
         pushEvent(
           state,
@@ -2890,6 +2999,8 @@ const gameSlice = createSlice({
       const povHolder = state.players.find((p) => p.id === state.posWinnerId);
       const lohPlayer = state.players.find((p) => p.id === state.lohId);
       if (!savedPlayer || !povHolder) return;
+      const twinSaveTarget = getTwinNomineeToSave(state, povHolder.id);
+      if (twinSaveTarget && twinSaveTarget.id !== saveId) return;
 
       state.nomineeIds = state.nomineeIds.filter((id) => id !== saveId);
       savedPlayer.status = 'active';
@@ -3317,6 +3428,11 @@ const gameSlice = createSlice({
       applyTwinShockTurnResult(state, result);
     },
 
+    completeTwinShockRevealAnimation(state) {
+      if (!state.twinShock) return;
+      state.twinShock.pendingRevealAnimation = null;
+    },
+
     /**
      * Archive the completed season.  Prepends the archive entry and caps the
      * list at 50 entries to bound memory usage.
@@ -3463,7 +3579,8 @@ const gameSlice = createSlice({
         state.democracia?.awaitingPublicBreaker ||
         state.awaitingCoLohNomination ||
         state.awaitingPosTieBreak ||
-        state.twinShock?.promptStage != null
+        state.twinShock?.promptStage != null ||
+        state.twinShock?.pendingRevealAnimation != null
       ) {
         return;
       }
@@ -3874,9 +3991,10 @@ const gameSlice = createSlice({
             state,
             state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury'),
           );
-          const useSecond = shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+          const useSecond = shouldUseSafetyForTwin(state, povHolder?.id, nominees)
+            || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
           if (useSecond && nominees.length > 0) {
-            const nominee2 = pickStrategicAiPlayer(state, nominees, rng2, 'lowest');
+            const nominee2 = pickSafetySaveTarget(state, povHolder?.id, nominees, rng2);
             if (!nominee2) {
               state.specialVeto.vipUseStage = -1;
               return;
@@ -4197,7 +4315,7 @@ const gameSlice = createSlice({
             // Cast AI votes (no self-vote)
             for (const voter of demAlive) {
               if (!voter.isUser) {
-                const candidates = demAlive.filter((c) => c.id !== voter.id);
+                const candidates = demAlive.filter((c) => c.id !== voter.id && canPlayerTargetPlayer(state, voter.id, c.id));
                 if (candidates.length > 0) {
                   const vSeed = (state.seed ^ (voter.id.charCodeAt(0) * 31 + voter.id.charCodeAt(voter.id.length - 1))) >>> 0;
                   const vRng = mulberry32(vSeed);
@@ -4264,7 +4382,11 @@ const gameSlice = createSlice({
               const coLoh = state.players.find((p) => p.id === coLohId);
               if (coLoh?.isUser) continue; // human handled below
               const coPool = coAlive.filter(
-                (p) => p.id !== coLohId && !coLohIds.includes(p.id) && !state.nomineeIds.includes(p.id),
+                (p) =>
+                  p.id !== coLohId &&
+                  !coLohIds.includes(p.id) &&
+                  !state.nomineeIds.includes(p.id) &&
+                  canPlayerTargetPlayer(state, coLohId, p.id),
               );
               if (coPool.length > 0) {
                 const nominee = pickStrategicAiPlayer(state, coPool, rng, 'highest') ?? seededPick(rng, coPool);
@@ -4305,7 +4427,7 @@ const gameSlice = createSlice({
           const canUsePublicNomineeRule = publicModeEnabled && !isDoubleEviction;
           const nomineeCount = isDoubleEviction ? 3 : 2;
           // Guard: need LOH + nomineeCount eligible players.
-          const pool = alive.filter((p) => p.id !== state.lohId);
+          const pool = alive.filter((p) => p.id !== state.lohId && canPlayerTargetPlayer(state, state.lohId, p.id));
           if (pool.length < nomineeCount) break;
 
           const lohPlayer = state.players.find((p) => p.id === state.lohId);
@@ -4488,7 +4610,7 @@ const gameSlice = createSlice({
               // AI: pick one nominee to save
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
               if (nominees.length > 0) {
-                const nomineeToSave = pickStrategicAiPlayer(state, nominees, rng, 'lowest');
+                const nomineeToSave = pickSafetySaveTarget(state, posWinner?.id, nominees, rng);
                 if (!nomineeToSave) break;
                 const savedName = nomineeToSave.name;
                 state.nomineeIds = state.nomineeIds.filter((id) => id !== nomineeToSave.id);
@@ -4523,7 +4645,7 @@ const gameSlice = createSlice({
                 state.specialVeto!.awaitingHolderReplacement = true;
                 pushEvent(state, `${posWinner.name}, as the Halo Exchange holder, you must name the backup nominee. 😇`, 'game');
               } else {
-                const eligible = getReplacementEligiblePlayers(state, alive);
+                const eligible = getReplacementEligiblePlayers(state, alive, 1, { actorId: posWinner.id });
                 if (eligible.length > 0) {
                   const replacement = pickStrategicAiPlayer(state, eligible, rng, 'highest');
                   if (replacement) {
@@ -4537,11 +4659,12 @@ const gameSlice = createSlice({
               pushEvent(state, `${posWinner.name}, will you use Halo Exchange? 😇`, 'game');
             } else {
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
-              const eligible = getReplacementEligiblePlayers(state, alive);
-              const useIt = shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+              const eligible = getReplacementEligiblePlayers(state, alive, 1, { actorId: posWinner?.id });
+              const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
+                || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
               if (useIt) {
                 if (nominees.length > 0) {
-                  const nomineeToSave = pickStrategicAiPlayer(state, nominees, rng, 'lowest');
+                  const nomineeToSave = pickSafetySaveTarget(state, posWinner?.id, nominees, rng);
                   if (!nomineeToSave) break;
                   state.nomineeIds = state.nomineeIds.filter((id) => id !== nomineeToSave.id);
                   const savedP = state.players.find((p) => p.id === nomineeToSave.id);
@@ -4581,7 +4704,7 @@ const gameSlice = createSlice({
               const removedNames = oldNominees.map((n) => n.name).join(' and ');
               pushDetoxEvent(state, `${posWinner.name} has decided to use Detox. ⚡`);
               pushDetoxEvent(state, `${posWinner.name} used Detox and cleared ${removedNames} from the block! ⚡`);
-              const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true });
+              const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true, actorId: posWinner.id });
               const replacements = pickStrategicAiPlayers(
                 state,
                 eligible,
@@ -4605,8 +4728,9 @@ const gameSlice = createSlice({
               );
             } else {
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
-              const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true });
-              const useIt = shouldAiUseTargetedSafetyPower(state, nominees, eligible, {
+              const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true, actorId: posWinner?.id });
+              const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
+                || shouldAiUseTargetedSafetyPower(state, nominees, eligible, {
                 replacementCount: Math.min(2, nominees.length),
                 preferLoh: true,
               });
@@ -4666,10 +4790,11 @@ const gameSlice = createSlice({
             } else {
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
               const eligible = getReplacementEligiblePlayers(state, alive);
-              const useIt = shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+              const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
+                || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
               if (useIt) {
                 if (nominees.length > 0) {
-                  const nomineeToSave = pickStrategicAiPlayer(state, nominees, rng, 'lowest');
+                  const nomineeToSave = pickSafetySaveTarget(state, posWinner?.id, nominees, rng);
                   if (!nomineeToSave) {
                     state.specialVeto!.vipUseStage = -1;
                     break;
@@ -4759,7 +4884,14 @@ const gameSlice = createSlice({
           );
           for (const voter of eligibleVoters) {
             if (!voter.isUser) {
-              state.votes[voter.id] = chooseAiEvictionVote(voter.id, state.nomineeIds, state.seed);
+              const eligibleNomineeIds = state.nomineeIds.filter((nomineeId) =>
+                canPlayerTargetPlayer(state, voter.id, nomineeId),
+              );
+              state.votes[voter.id] = chooseAiEvictionVote(
+                voter.id,
+                eligibleNomineeIds.length > 0 ? eligibleNomineeIds : state.nomineeIds,
+                state.seed,
+              );
             }
           }
 
@@ -5492,6 +5624,7 @@ export const {
   hydrateGame,
   setHasSeenConfessionalSpotlight,
   submitTwinShockAnswer,
+  completeTwinShockRevealAnimation,
   triggerSecretMission,
   markSecondSecretMissionChanceResolved,
   offerSecretMission,
@@ -5847,7 +5980,8 @@ function resolveDebugBlockers(
       game.specialVeto?.activeType === 'coup' ? 2 : 1,
       { allowLoh: true },
     );
-    const usePower = shouldAiUseTargetedSafetyPower(game, nominees, eligible, {
+    const usePower = shouldUseSafetyForTwin(game, game.posWinnerId, nominees)
+      || shouldAiUseTargetedSafetyPower(game, nominees, eligible, {
       replacementCount: game.specialVeto?.activeType === 'coup' ? 2 : 1,
       preferLoh: true,
     });
@@ -5860,7 +5994,7 @@ function resolveDebugBlockers(
     const nominees = game.nomineeIds
       .map((id) => game.players.find((player) => player.id === id))
       .filter((player): player is Player => Boolean(player));
-    const nomineeToSave = pickStrategicAiPlayer(game, nominees, rng, 'lowest');
+    const nomineeToSave = pickSafetySaveTarget(game, game.posWinnerId, nominees, rng);
     if (nomineeToSave) {
       dispatch(submitPovSaveTarget(nomineeToSave.id));
     } else {
@@ -5870,7 +6004,7 @@ function resolveDebugBlockers(
   }
 
   if (game.specialVeto?.awaitingHolderReplacement) {
-    const eligible = getReplacementEligiblePlayers(game, alive);
+    const eligible = getReplacementEligiblePlayers(game, alive, 1, { actorId: game.posWinnerId });
     const replacement = pickStrategicAiPlayer(game, eligible, rng, 'highest');
     if (replacement) {
       dispatch(submitDiamondReplacement(replacement.id));
@@ -5881,7 +6015,7 @@ function resolveDebugBlockers(
   }
 
   if (game.specialVeto?.awaitingCoupReplacement1 || game.specialVeto?.awaitingCoupReplacement2) {
-    const eligible = getReplacementEligiblePlayers(game, alive, 2, { allowLoh: true });
+    const eligible = getReplacementEligiblePlayers(game, alive, 2, { allowLoh: true, actorId: game.posWinnerId });
     const replacement = pickStrategicAiPlayer(game, eligible, rng, 'highest', { preferLoh: true });
     if (replacement) {
       dispatch(submitCoupReplacement(replacement.id));
@@ -5894,7 +6028,8 @@ function resolveDebugBlockers(
   if (game.specialVeto?.awaitingVipSecondUseDecision) {
     const nominees = game.players.filter((player) => game.nomineeIds.includes(player.id));
     const eligible = getReplacementEligiblePlayers(game, alive);
-    const useSecond = shouldAiUseTargetedSafetyPower(game, nominees, eligible, { preferLoh: true });
+    const useSecond = shouldUseSafetyForTwin(game, game.posWinnerId, nominees)
+      || shouldAiUseTargetedSafetyPower(game, nominees, eligible, { preferLoh: true });
     dispatch(submitVipSecondUseDecision(useSecond));
     return true;
   }
@@ -5903,7 +6038,7 @@ function resolveDebugBlockers(
     const nominees = game.nomineeIds
       .map((id) => game.players.find((player) => player.id === id))
       .filter((player): player is Player => Boolean(player));
-    const nomineeToSave = pickStrategicAiPlayer(game, nominees, rng, 'lowest');
+    const nomineeToSave = pickSafetySaveTarget(game, game.posWinnerId, nominees, rng);
     if (nomineeToSave) {
       dispatch(submitVipSecondSaveTarget(nomineeToSave.id));
     } else {
@@ -6206,6 +6341,12 @@ export const tryActivateSecretMission =
     if (game.week < 3) return false;
     if (aliveCount <= 5) return false;
     if (seasonMissionCount >= 2) return false;
+    if (game.twistActivatedThisWeek) return false;
+    if (game.twinShock?.promptStage || game.twinShock?.pendingRevealAnimation) return false;
+    if (
+      game.twinShock?.status === 'day4_pending' ||
+      game.twinShock?.status === 'day4_asked_no_correct_guess'
+    ) return false;
     if (!canReplaceSecretMissionSlot(game.secretMission)) return false;
 
     const maxDaySpan = aliveCount - 5;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -443,13 +443,32 @@ export type TwinShockResolution =
   | 'mission_success'
   | 'secret_lost';
 
+export type TwinShockRevealAnimation =
+  | {
+      type: 'combined';
+      playerId: string;
+      fromName: string;
+      fromAvatar: string;
+      toName: string;
+      toAvatar: string;
+    }
+  | {
+      type: 'ali_enters';
+      replacedPlayerId: string;
+      replacedPlayerName: string;
+      replacedPlayerAvatar: string;
+      incomingPlayerId: string;
+      incomingName: string;
+      incomingAvatar: string;
+    };
+
 export interface TwinShockState {
   status: TwinShockStatus;
   promptStage: TwinShockPromptStage | null;
   queuedDay: number | null;
   retryCount: number;
   cluesShownDays: number[];
-  pendingRevealAnimation?: 'combined' | 'ali_enters' | null;
+  pendingRevealAnimation?: TwinShockRevealAnimation | null;
 }
 
 // ─── Public's Favorite voting twist ──────────────────────────────────────────

--- a/tests/unit/twinShock.test.ts
+++ b/tests/unit/twinShock.test.ts
@@ -3,6 +3,8 @@ import gameReducer, {
   advance,
   createInitialGameState,
   queueForcedShock,
+  submitPovDecision,
+  submitPovSaveTarget,
   submitTwinShockAnswer,
 } from '../../src/store/gameSlice';
 import { classifyTwinShockAnswer } from '../../src/bb/twinShock';
@@ -43,12 +45,14 @@ describe('Twin Shock classifier', () => {
 describe('Twin Shock reducer flow', () => {
   it('queues the mandatory Day 4 Confessional after eviction results when Lia survived', () => {
     const next = reduce(makeTwinShockState(), advance());
+    const lia = next.players.find((player) => player.id === 'lia');
 
     expect(next.phase).toBe('eviction_results');
     expect(next.twinShock?.status).toBe('day4_pending');
     expect(next.twinShock?.promptStage).toBe('day4_initial');
     expect(next.twinShockConsumed).toBe(true);
     expect(next.twinShockActivatedSeason).toBe(next.season);
+    expect(lia?.avatar).toBe('assets/skins/Lia_avatar.webp');
   });
 
   it('does not consume the twist if Lia left before the Day 4 post-eviction check', () => {
@@ -80,22 +84,62 @@ describe('Twin Shock reducer flow', () => {
 
     const lia = state.players.find((player) => player.id === 'lia');
     expect(lia?.name).toBe('Lia & Ali');
-    expect(lia?.avatar).toBe('Lia_Ali');
+    expect(lia?.avatar).toBe('assets/skins/Lia_Ali_avatar.webp');
     expect(lia?.twinMode).toBe('combined');
     expect(state.players.some((player) => player.id === 'ali')).toBe(false);
     expect(state.twinShockResolution).toBe('discovered');
     expect(state.twinShockDiscoveredByUser).toBe(true);
+    expect(state.twinShock?.pendingRevealAnimation).toMatchObject({
+      type: 'combined',
+      playerId: 'lia',
+      toAvatar: 'assets/skins/Lia_Ali_avatar.webp',
+    });
   });
 
-  it('adds Ali as a late entrant when the Day 5 mission succeeds', () => {
+  it('continues the debug-forced prompt on the next day after the first answer', () => {
+    let state = reduce(makeTwinShockState({ week: 1 }), queueForcedShock('twinShock'));
+    state = reduce(state, advance());
+    state = reduce(state, submitTwinShockAnswer('No idea'));
+
+    expect(state.twinShock?.status).toBe('day4_asked_no_correct_guess');
+    expect(state.twinShock?.queuedDay).toBe(1);
+
+    state = {
+      ...state,
+      week: 2,
+      phase: 'eviction_results',
+    };
+    state = reduce(state, advance());
+
+    expect(state.phase).toBe('eviction_results');
+    expect(state.twinShock?.promptStage).toBe('day5_final');
+  });
+
+  it('replaces the first evicted housemate with Ali when the next-day mission succeeds', () => {
+    const base = makeTwinShockState();
+    const evicted = base.players.find((player) => !player.isUser && player.id !== 'lia');
+    if (!evicted) throw new Error('expected a non-user housemate to evict');
+    const originalLength = base.players.length;
+    const replacedId = evicted.id;
+
     const state = makeTwinShockState({
-      week: 5,
+      week: 2,
+      players: base.players.map((player) =>
+        player.id === replacedId
+          ? {
+            ...player,
+            status: 'evicted',
+            evictedAtWeek: 1,
+            seasonPlacement: originalLength,
+          }
+          : player,
+      ),
       twinShockConsumed: true,
       twinShockActivatedSeason: 1,
       twinShock: {
         status: 'day4_asked_no_correct_guess',
         promptStage: null,
-        queuedDay: null,
+        queuedDay: 1,
         retryCount: 0,
         cluesShownDays: [],
         pendingRevealAnimation: null,
@@ -112,10 +156,83 @@ describe('Twin Shock reducer flow', () => {
     const ali = next.players.find((player) => player.id === 'ali');
     const lia = next.players.find((player) => player.id === 'lia');
 
+    expect(next.players).toHaveLength(originalLength);
+    expect(next.players.some((player) => player.id === replacedId)).toBe(false);
     expect(ali?.name).toBe('Ali');
+    expect(ali?.avatar).toBe('assets/skins/Ali_avatar.webp');
     expect(ali?.status).toBe('active');
     expect(ali?.lateEntrant).toBe(true);
     expect(lia?.name).toBe('Lia');
     expect(next.twinShockResolution).toBe('mission_success');
+    expect(next.twinShock?.pendingRevealAnimation).toMatchObject({
+      type: 'ali_enters',
+      replacedPlayerId: replacedId,
+      incomingPlayerId: 'ali',
+      incomingAvatar: 'assets/skins/Ali_avatar.webp',
+    });
+  });
+
+  it('keeps Lia and Ali from nominating each other after the mission succeeds', () => {
+    const base = makeTwinShockState({
+      phase: 'nomination_results',
+      lohId: 'lia',
+      twinShockResolution: 'mission_success',
+      players: [
+        ...makeTwinShockState().players.map((player) => ({
+          ...player,
+          status: player.id === 'lia' || player.isUser ? 'active' as const : player.status,
+        })),
+        {
+          id: 'ali',
+          name: 'Ali',
+          avatar: 'assets/skins/Ali_avatar.webp',
+          status: 'active' as const,
+          lateEntrant: true,
+        },
+      ],
+    });
+
+    const next = reduce(base, advance());
+
+    expect(next.nomineeIds).not.toContain('ali');
+  });
+
+  it('forces a twin safety holder to save her nominated sister', () => {
+    const base = makeTwinShockState({
+      awaitingPovDecision: true,
+      phase: 'pos_ceremony_results',
+      posWinnerId: 'lia',
+      lohId: 'user',
+      nomineeIds: ['ali', 'zed'],
+      twinShockResolution: 'mission_success',
+      players: [
+        ...makeTwinShockState().players.map((player) =>
+          player.id === 'zed'
+            ? { ...player, status: 'nominated' as const }
+            : {
+              ...player,
+              status: player.id === 'lia' || player.isUser ? 'active' as const : player.status,
+            },
+        ),
+        {
+          id: 'ali',
+          name: 'Ali',
+          avatar: 'assets/skins/Ali_avatar.webp',
+          status: 'nominated' as const,
+          lateEntrant: true,
+        },
+      ],
+    });
+
+    let next = reduce(base, submitPovDecision(false));
+    expect(next.awaitingPovSaveTarget).toBe(true);
+
+    next = reduce(next, submitPovSaveTarget('zed'));
+    expect(next.nomineeIds).toContain('ali');
+    expect(next.nomineeIds).toContain('zed');
+
+    next = reduce(next, submitPovSaveTarget('ali'));
+    expect(next.nomineeIds).not.toContain('ali');
+    expect(next.povSavedId).toBe('ali');
   });
 });


### PR DESCRIPTION
## Summary
- Fix Lia/Ali avatar states and add the post-Confessional Twin Shock reveal overlay
- Make mission success replace the first evicted slot with Ali instead of adding a 17th housemate
- Enforce Lia/Ali alliance targeting rules across nominations, votes, and safety powers
- Make forced/debug Twin Shock continuation happen the next day and prevent secret mission overlap
- Pace Twin Shock Confessional messages one by one without duplicate prompts

## Tests
- npm run typecheck
- npx vitest run tests/unit/twinShock.test.ts