### PR TITLE
Polish Twin Shock confessional and reveal

### DIFF
--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
@@ -4,13 +4,29 @@
   z-index: 8800;
   pointer-events: none;
   color: #fff;
+  --twin-shock-beam-color: rgba(255, 214, 102, 0.96);
+  --twin-shock-glow-color: rgba(255, 214, 102, 0.82);
 }
 
 .twin-shock-reveal__shade {
   position: absolute;
   inset: 0;
-  background: rgba(5, 10, 18, 0.84);
-  animation: twin-shock-fade-in 260ms ease-out both;
+  background:
+    radial-gradient(circle at center, rgba(15, 22, 34, 0.08) 0, rgba(5, 10, 18, 0.88) 72%),
+    rgba(5, 10, 18, 0.82);
+  animation: twin-shock-fade-in 520ms ease-out both;
+}
+
+.twin-shock-reveal__flare {
+  position: absolute;
+  left: calc(var(--twin-shock-left) - 40px);
+  top: calc(var(--twin-shock-top) - 60px);
+  width: calc(var(--twin-shock-width) + 80px);
+  height: calc(var(--twin-shock-height) + 120px);
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.22) 0, rgba(255, 255, 255, 0) 70%);
+  opacity: 0.35;
+  filter: blur(12px);
+  animation: twin-shock-flare 1600ms ease-in-out infinite alternate;
 }
 
 .twin-shock-reveal__beam {
@@ -19,29 +35,25 @@
   top: calc(var(--twin-shock-top) - 10px);
   width: calc(var(--twin-shock-width) + 20px);
   height: calc(var(--twin-shock-height) + 20px);
-  border: 2px solid rgba(255, 214, 102, 0.96);
+  border: 2px solid var(--twin-shock-beam-color);
   box-shadow:
     0 0 0 9999px rgba(0, 0, 0, 0.18),
-    0 0 26px rgba(255, 214, 102, 0.82),
+    0 0 26px var(--twin-shock-glow-color),
     inset 0 0 20px rgba(255, 255, 255, 0.22);
   border-radius: 12px;
-  animation: twin-shock-pulse 920ms ease-in-out infinite alternate;
+  animation: twin-shock-pulse 1500ms ease-in-out infinite alternate;
 }
 
-.twin-shock-reveal--combined.twin-shock-reveal--after .twin-shock-reveal__beam {
-  border-color: rgba(112, 231, 255, 0.96);
-  box-shadow:
-    0 0 0 9999px rgba(0, 0, 0, 0.18),
-    0 0 30px rgba(112, 231, 255, 0.9),
-    inset 0 0 20px rgba(255, 255, 255, 0.24);
+.twin-shock-reveal--combined.twin-shock-reveal--transform,
+.twin-shock-reveal--combined.twin-shock-reveal--settled {
+  --twin-shock-beam-color: rgba(112, 231, 255, 0.96);
+  --twin-shock-glow-color: rgba(112, 231, 255, 0.9);
 }
 
-.twin-shock-reveal--ali_enters.twin-shock-reveal--after .twin-shock-reveal__beam {
-  border-color: rgba(102, 255, 178, 0.96);
-  box-shadow:
-    0 0 0 9999px rgba(0, 0, 0, 0.18),
-    0 0 30px rgba(102, 255, 178, 0.86),
-    inset 0 0 20px rgba(255, 255, 255, 0.24);
+.twin-shock-reveal--ali_enters.twin-shock-reveal--transform,
+.twin-shock-reveal--ali_enters.twin-shock-reveal--settled {
+  --twin-shock-beam-color: rgba(102, 255, 178, 0.96);
+  --twin-shock-glow-color: rgba(102, 255, 178, 0.86);
 }
 
 .twin-shock-reveal__tile {
@@ -56,41 +68,106 @@
   justify-items: center;
   overflow: hidden;
   border-radius: 10px;
-  background: rgba(13, 18, 26, 0.74);
+  background:
+    linear-gradient(180deg, rgba(18, 25, 39, 0.9), rgba(8, 13, 22, 0.86));
+  border: 1px solid rgba(255, 255, 255, 0.1);
   transform-origin: center;
-  animation: twin-shock-tile-rise 620ms ease-out both;
+  box-shadow:
+    0 18px 42px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  animation: twin-shock-tile-rise 850ms ease-out both;
 }
 
-.twin-shock-reveal--after .twin-shock-reveal__tile {
-  animation: twin-shock-swap 680ms ease-out both;
+.twin-shock-reveal--transform .twin-shock-reveal__tile {
+  animation: twin-shock-swap 1100ms ease-out both;
+}
+
+.twin-shock-reveal--settled .twin-shock-reveal__tile {
+  transform: scale(1.03);
 }
 
 .twin-shock-reveal__avatar-wrap {
+  position: relative;
   width: min(74%, 136px);
   aspect-ratio: 1;
   border-radius: 50%;
   display: grid;
   place-items: center;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    0 0 0 6px rgba(255, 255, 255, 0.04);
 }
 
 .twin-shock-reveal__avatar {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition:
+    opacity 900ms ease,
+    transform 900ms ease,
+    filter 900ms ease;
+}
+
+.twin-shock-reveal__avatar--before,
+.twin-shock-reveal__avatar-fallback--before {
+  opacity: 1;
+  transform: scale(1);
+  filter: saturate(0.94);
+}
+
+.twin-shock-reveal__avatar--after,
+.twin-shock-reveal__avatar-fallback--after {
+  opacity: 0;
+  transform: scale(0.88);
+  filter: saturate(1.14);
 }
 
 .twin-shock-reveal__avatar-fallback {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
   font-size: clamp(1rem, 3vw, 2rem);
   font-weight: 800;
+}
+
+.twin-shock-reveal--transform .twin-shock-reveal__avatar--before,
+.twin-shock-reveal--transform .twin-shock-reveal__avatar-fallback--before,
+.twin-shock-reveal--settled .twin-shock-reveal__avatar--before,
+.twin-shock-reveal--settled .twin-shock-reveal__avatar-fallback--before {
+  opacity: 0;
+  transform: scale(1.16);
+  filter: blur(5px);
+}
+
+.twin-shock-reveal--transform .twin-shock-reveal__avatar--after,
+.twin-shock-reveal--transform .twin-shock-reveal__avatar-fallback--after,
+.twin-shock-reveal--settled .twin-shock-reveal__avatar--after,
+.twin-shock-reveal--settled .twin-shock-reveal__avatar-fallback--after {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.twin-shock-reveal__headline {
+  margin-top: 0.44rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: clamp(0.62rem, 1.2vw, 0.78rem);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .twin-shock-reveal__name {
   width: 100%;
   min-height: 1.9rem;
   padding: 0.24rem 0.45rem 0.42rem;
-  background: rgba(0, 0, 0, 0.46);
+  background: rgba(0, 0, 0, 0.38);
   text-align: center;
   font-size: clamp(0.78rem, 1.5vw, 1.04rem);
   font-weight: 800;
@@ -107,12 +184,12 @@
   max-width: min(420px, calc(100vw - 28px));
   padding: 0.48rem 0.7rem;
   border-radius: 7px;
-  background: rgba(5, 10, 18, 0.88);
+  background: rgba(5, 10, 18, 0.9);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
   font-size: clamp(0.82rem, 1.7vw, 1rem);
   font-weight: 750;
   line-height: 1.18;
-  animation: twin-shock-caption 360ms ease-out both;
+  animation: twin-shock-caption 620ms ease-out both;
 }
 
 @keyframes twin-shock-fade-in {
@@ -125,10 +202,21 @@
   to { transform: scale(1.025); opacity: 1; }
 }
 
+@keyframes twin-shock-flare {
+  from {
+    opacity: 0.18;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 0.44;
+    transform: scale(1.06);
+  }
+}
+
 @keyframes twin-shock-tile-rise {
   from {
     opacity: 0;
-    transform: scale(0.92);
+    transform: scale(0.88) translateY(12px);
   }
   to {
     opacity: 1;
@@ -138,16 +226,13 @@
 
 @keyframes twin-shock-swap {
   0% {
-    opacity: 0.1;
-    transform: scale(0.88) rotate(-1deg);
+    transform: scale(0.96);
   }
-  58% {
-    opacity: 1;
-    transform: scale(1.08) rotate(0deg);
+  42% {
+    transform: scale(1.12);
   }
   100% {
-    opacity: 1;
-    transform: scale(1);
+    transform: scale(1.03);
   }
 }
 
@@ -164,11 +249,14 @@
 
 @media (prefers-reduced-motion: reduce) {
   .twin-shock-reveal__shade,
+  .twin-shock-reveal__flare,
   .twin-shock-reveal__beam,
   .twin-shock-reveal__tile,
   .twin-shock-reveal__caption,
-  .twin-shock-reveal--after .twin-shock-reveal__tile {
+  .twin-shock-reveal--transform .twin-shock-reveal__tile,
+  .twin-shock-reveal__avatar {
     animation-duration: 1ms;
     animation-iteration-count: 1;
+    transition-duration: 1ms;
   }
 }

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -9,7 +9,7 @@ type TwinShockRevealOverlayProps = {
   onDone: () => void;
 };
 
-type RevealStage = 'before' | 'after' | 'done';
+type RevealStage = 'intro' | 'transform' | 'settled' | 'done';
 
 export default function TwinShockRevealOverlay({
   reveal,
@@ -18,7 +18,7 @@ export default function TwinShockRevealOverlay({
 }: TwinShockRevealOverlayProps) {
   const targetId = reveal.type === 'combined' ? reveal.playerId : reveal.incomingPlayerId;
   const [rect, setRect] = useState<DOMRect | null>(null);
-  const [stage, setStage] = useState<RevealStage>('before');
+  const [stage, setStage] = useState<RevealStage>('intro');
 
   useLayoutEffect(() => {
     let doneFallbackId: number | null = null;
@@ -37,34 +37,58 @@ export default function TwinShockRevealOverlay({
     };
   }, [getTileRect, onDone, targetId]);
 
+  const timings = useMemo(
+    () => (
+      reveal.type === 'ali_enters'
+        ? { transformAt: 1800, settledAt: 3200, doneAt: 5600 }
+        : { transformAt: 1550, settledAt: 2850, doneAt: 4900 }
+    ),
+    [reveal.type],
+  );
+
   useEffect(() => {
     if (!rect) return undefined;
-    const swapId = window.setTimeout(() => setStage('after'), 950);
+    const transformId = window.setTimeout(() => setStage('transform'), timings.transformAt);
+    const settledId = window.setTimeout(() => setStage('settled'), timings.settledAt);
     const doneId = window.setTimeout(() => {
       setStage('done');
       onDone();
-    }, 2700);
+    }, timings.doneAt);
     return () => {
-      window.clearTimeout(swapId);
+      window.clearTimeout(transformId);
+      window.clearTimeout(settledId);
       window.clearTimeout(doneId);
     };
-  }, [onDone, rect]);
+  }, [onDone, rect, timings]);
 
   const display = useMemo(() => {
-    const after = stage !== 'before';
+    const transformed = stage !== 'intro';
+    const settled = stage === 'settled';
     if (reveal.type === 'combined') {
       return {
-        name: after ? reveal.toName : reveal.fromName,
-        avatar: after ? reveal.toAvatar : reveal.fromAvatar,
-        caption: after ? 'Lia & Ali are revealed' : 'Lia steps into the spotlight',
+        beforeName: reveal.fromName,
+        beforeAvatar: reveal.fromAvatar,
+        afterName: reveal.toName,
+        afterAvatar: reveal.toAvatar,
+        headline: settled ? 'Twin Shock Exposed' : 'The spotlight tightens',
+        caption: settled
+          ? 'Lia & Ali will continue the game together as one contestant.'
+          : transformed
+            ? 'The house sees both twins at once.'
+            : 'Lia steps into the spotlight alone.',
       };
     }
     return {
-      name: after ? reveal.incomingName : reveal.replacedPlayerName,
-      avatar: after ? reveal.incomingAvatar : reveal.replacedPlayerAvatar,
-      caption: after
-        ? `${reveal.incomingName} takes the empty place`
-        : `${reveal.replacedPlayerName}'s place goes dark`,
+      beforeName: reveal.replacedPlayerName,
+      beforeAvatar: reveal.replacedPlayerAvatar,
+      afterName: reveal.incomingName,
+      afterAvatar: reveal.incomingAvatar,
+      headline: settled ? 'New Housemate' : 'A place in the House opens',
+      caption: settled
+        ? `${reveal.incomingName} is now officially in the game.`
+        : transformed
+          ? `${reveal.incomingName} steps into the House.`
+          : `${reveal.replacedPlayerName}'s tile fades from the board.`,
     };
   }, [reveal, stage]);
 
@@ -86,23 +110,39 @@ export default function TwinShockRevealOverlay({
       aria-label={display.caption}
     >
       <div className="twin-shock-reveal__shade" />
+      <div className="twin-shock-reveal__flare" />
       <div className="twin-shock-reveal__beam" />
       <div className="twin-shock-reveal__tile">
         <div className="twin-shock-reveal__avatar-wrap">
-          {display.avatar ? (
+          {display.beforeAvatar ? (
             <img
-              className="twin-shock-reveal__avatar"
-              src={display.avatar}
+              className="twin-shock-reveal__avatar twin-shock-reveal__avatar--before"
+              src={display.beforeAvatar}
               alt=""
               draggable={false}
             />
           ) : (
-            <span className="twin-shock-reveal__avatar-fallback">
-              {display.name.slice(0, 2).toUpperCase()}
+            <span className="twin-shock-reveal__avatar-fallback twin-shock-reveal__avatar-fallback--before">
+              {display.beforeName.slice(0, 2).toUpperCase()}
+            </span>
+          )}
+          {display.afterAvatar ? (
+            <img
+              className="twin-shock-reveal__avatar twin-shock-reveal__avatar--after"
+              src={display.afterAvatar}
+              alt=""
+              draggable={false}
+            />
+          ) : (
+            <span className="twin-shock-reveal__avatar-fallback twin-shock-reveal__avatar-fallback--after">
+              {display.afterName.slice(0, 2).toUpperCase()}
             </span>
           )}
         </div>
-        <div className="twin-shock-reveal__name">{display.name}</div>
+        <div className="twin-shock-reveal__headline">{display.headline}</div>
+        <div className="twin-shock-reveal__name">
+          {stage === 'intro' ? display.beforeName : display.afterName}
+        </div>
       </div>
       <div className="twin-shock-reveal__caption">{display.caption}</div>
     </div>

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -261,6 +261,11 @@ function buildEntryGreeting(playerName: string, seed: number, visitCount: number
   };
 }
 
+function getBigEyeTypingDelay(text: string): number {
+  const normalizedLength = text.trim().length;
+  return Math.max(420, Math.min(1180, 260 + normalizedLength * 12));
+}
+
 function hasSummaryEmitted(playerId: string): boolean {
   try {
     return sessionStorage.getItem(summaryKey(playerId)) === '1';
@@ -429,7 +434,7 @@ export default function DiaryRoom() {
   const appendBigEyeMessagesSequentially = useCallback(async (lines: string[]) => {
     for (const line of lines) {
       setBbTyping(true);
-      await new Promise<void>((resolve) => setTimeout(resolve, 550));
+      await new Promise<void>((resolve) => setTimeout(resolve, getBigEyeTypingDelay(line)));
       setBbTyping(false);
       const nextMessage: ChatMessage = {
         id: crypto.randomUUID(),
@@ -442,7 +447,7 @@ export default function DiaryRoom() {
         saveChat(playerId, updated);
         return updated;
       });
-      await new Promise<void>((resolve) => setTimeout(resolve, 220));
+      await new Promise<void>((resolve) => setTimeout(resolve, /[.!?]$/.test(line) ? 340 : 240));
     }
   }, [playerId]);
 
@@ -454,6 +459,8 @@ export default function DiaryRoom() {
 
   const dispatchRef = useRef(dispatch);
   useEffect(() => { dispatchRef.current = dispatch; }, [dispatch]);
+  const confessionalDecisionPendingRef = useRef(confessionalDecisionPending);
+  useEffect(() => { confessionalDecisionPendingRef.current = confessionalDecisionPending; }, [confessionalDecisionPending]);
 
   useEffect(() => {
     if (!confessionalDecisionPending && navigationBlockerState === 'blocked' && resetNavigationBlocker) {
@@ -491,7 +498,7 @@ export default function DiaryRoom() {
     const nextConversationState = createInitialBigEyeState();
     setConversationState(nextConversationState);
     saveConversationState(playerId, nextConversationState);
-    if (confessionalDecisionPending) {
+    if (confessionalDecisionPendingRef.current) {
       setMessages([]);
       saveChat(playerId, []);
       return;
@@ -501,7 +508,7 @@ export default function DiaryRoom() {
     const greeting = buildEntryGreeting(playerNameRef.current, seedRef.current ?? 0, visitCount);
     setMessages([greeting]);
     saveChat(playerId, [greeting]);
-  }, [confessionalDecisionPending, confessionalLocked, playerId]);
+  }, [confessionalLocked, playerId]);
 
   useEffect(() => {
     if (confessionalLocked || !activeDecisionPresentation) return;

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -842,6 +842,25 @@ function canPlayerTargetPlayer(state: GameState, actorId: string | null | undefi
   return !isTwinAlliancePair(state, actorId, targetId);
 }
 
+function usesPluralPlayerGrammar(player: Pick<Player, 'name'> & Partial<Pick<Player, 'twinMode'>> | null | undefined): boolean {
+  if (!player) return false;
+  return player.twinMode === 'combined' || player.name.includes('&');
+}
+
+function getPlayerBeVerb(
+  player: Pick<Player, 'name'> & Partial<Pick<Player, 'twinMode'>> | null | undefined,
+  singular: string,
+  plural: string,
+): string {
+  return usesPluralPlayerGrammar(player) ? plural : singular;
+}
+
+function getPlayerReflexive(
+  player: Pick<Player, 'name'> & Partial<Pick<Player, 'twinMode'>> | null | undefined,
+): string {
+  return usesPluralPlayerGrammar(player) ? 'themselves' : 'themself';
+}
+
 function getTwinNomineeToSave(
   state: GameState,
   holderId: string | null | undefined,
@@ -1059,7 +1078,7 @@ function resolveTwinShockMissionSuccess(state: GameState) {
     'twin_shock_mission_success',
   );
   if (lia) {
-    pushEvent(state, `${lia.name} and Ali share a powerful bond after the reveal.`, 'social', {
+    pushEvent(state, 'Lia and Ali share a powerful bond after the reveal.', 'social', {
       major: 'twin_shock_bond',
     });
   }
@@ -2039,7 +2058,7 @@ const gameSlice = createSlice({
           state.povProtectedIds = oldNominees.map((nominee) => nominee.id);
           pushDetoxEvent(
             state,
-            `${posWinner?.name ?? 'The Detox holder'} has decided to use Detox. ⚡`,
+            `${posWinner?.name ?? 'The Detox holder'} ${getPlayerBeVerb(posWinner, 'has', 'have')} decided to use Detox. ⚡`,
           );
           pushDetoxEvent(
             state,
@@ -2058,7 +2077,7 @@ const gameSlice = createSlice({
         }
         pushEvent(
           state,
-          `${posWinner?.name ?? 'The holder'} has decided NOT to use the power. The nominations remain the same. ⚡`,
+          `${posWinner?.name ?? 'The holder'} ${getPlayerBeVerb(posWinner, 'has', 'have')} decided NOT to use the power. The nominations remain the same. ⚡`,
           'game',
         );
       }
@@ -4702,7 +4721,8 @@ const gameSlice = createSlice({
               state.povSavedId = null;
               state.povProtectedIds = oldNominees.map((nominee) => nominee.id);
               const removedNames = oldNominees.map((n) => n.name).join(' and ');
-              pushDetoxEvent(state, `${posWinner.name} has decided to use Detox. ⚡`);
+              pushDetoxEvent(state, `${posWinner.name} ${getPlayerBeVerb(posWinner, 'has', 'have')} decided to use Detox. ⚡`);
+
               pushDetoxEvent(state, `${posWinner.name} used Detox and cleared ${removedNames} from the block! ⚡`);
               const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true, actorId: posWinner.id });
               const replacements = pickStrategicAiPlayers(
@@ -4741,7 +4761,7 @@ const gameSlice = createSlice({
                 state.povSavedId = null;
                 state.povProtectedIds = oldNominees.map((nominee) => nominee.id);
                 const removedNames = oldNominees.map((n) => n.name).join(' and ');
-                pushDetoxEvent(state, `${posWinner?.name ?? 'The Detox holder'} has decided to use Detox. ⚡`);
+                pushDetoxEvent(state, `${posWinner?.name ?? 'The Detox holder'} ${getPlayerBeVerb(posWinner, 'has', 'have')} decided to use Detox. ⚡`);
                 pushDetoxEvent(state, `${posWinner?.name ?? 'The Detox holder'} used Detox! ${removedNames} are cleared from the block! ⚡`);
                 if (eligible.length >= 2) {
                   const replacements = pickStrategicAiPlayers(state, eligible, 2, rng, { preferLoh: true });
@@ -4838,7 +4858,7 @@ const gameSlice = createSlice({
             const lohName = state.players.find((pl) => pl.id === state.lohId)?.name ?? 'The LOH';
             pushEvent(
               state,
-              `${savedName} has decided to use the Power of Safety on themself. ${lohName} must now name a backup nominee.`,
+              `${savedName} ${getPlayerBeVerb(posWinner, 'has', 'have')} decided to use the Power of Safety on ${getPlayerReflexive(posWinner)}. ${lohName} must now name a backup nominee.`,
               'game',
             );
 

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -106,6 +106,21 @@ function joinPublicAssetPath(path: string): string {
   return path;
 }
 
+function normalizeExplicitAvatarPath(avatar: string | null | undefined): string | null {
+  if (!avatar) return null;
+  if (avatar.startsWith('http') || avatar.startsWith('/')) return avatar;
+
+  const normalized = avatar.replace(/^\.\//, '');
+  if (
+    normalized.startsWith('assets/')
+    || /\.(png|webp|svg|jpg|jpeg|wp2)$/i.test(normalized)
+  ) {
+    return joinPublicAssetPath(normalized);
+  }
+
+  return null;
+}
+
 /** Capitalises the first letter of a string and lowercases the rest. */
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
@@ -148,15 +163,15 @@ export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'av
     candidates.push(remoteAvatarUrl);
   }
 
-  // If player.avatar is already a full URL or absolute path, use it first
-  if (player.avatar && (player.avatar.startsWith('http') || player.avatar.startsWith('/'))) {
-    candidates.push(player.avatar);
+  const explicitAvatarPath = normalizeExplicitAvatarPath(player.avatar);
+  if (explicitAvatarPath) {
+    candidates.push(explicitAvatarPath);
   }
 
   if (!isUserPlayer) {
     const folderAvatar = listAvatarAssetCandidates().find(({ basename }) => {
       const token = normalizeNameToken(basename.replace(/_avatar$/i, ''));
-      return lookupTokens.includes(token) || lookupTokens.some((target) => token.includes(target) || target.includes(token));
+      return lookupTokens.includes(token);
     });
     if (folderAvatar) {
       candidates.push(folderAvatar.source);

--- a/tests/unit/avatarCandidates.test.ts
+++ b/tests/unit/avatarCandidates.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAvatarCandidates } from '../../src/utils/avatar';
+
+describe('resolveAvatarCandidates', () => {
+  it('prefers an explicit Lia avatar path before any scanned avatar asset', () => {
+    const candidates = resolveAvatarCandidates({
+      id: 'lia',
+      name: 'Lia',
+      avatar: 'assets/skins/Lia_avatar.webp',
+    });
+
+    expect(candidates[0]).toContain('assets/skins/Lia_avatar.webp');
+  });
+
+  it('does not fuzzy-match Lia to the combined Lia_Ali avatar', () => {
+    const candidates = resolveAvatarCandidates({
+      id: 'lia',
+      name: 'Lia',
+      avatar: 'assets/skins/Lia_avatar.webp',
+    });
+
+    expect(candidates[0]).not.toContain('Lia_Ali_avatar');
+  });
+});


### PR DESCRIPTION
## Summary
- preserve Twin Shock confessional chat history within the same visit and slow the Big Eye pacing to match the normal diary-room feel
- tighten avatar resolution so Lia starts with the single avatar and only switches to the combined or Ali-specific art on the correct reveal path
- upgrade the Twin Shock reveal overlay with clearer staged beats and add avatar regression coverage

## Verification
- npm run lint:ci
- npm run typecheck