### PR TITLE
Polish Twin Shock animation overlay

### DIFF
--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
@@ -63,9 +63,7 @@
   width: var(--twin-shock-width);
   height: var(--twin-shock-height);
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  align-items: center;
-  justify-items: center;
+  place-items: center;
   overflow: hidden;
   border-radius: 10px;
   background:
@@ -88,7 +86,7 @@
 
 .twin-shock-reveal__avatar-wrap {
   position: relative;
-  width: min(74%, 136px);
+  width: min(82%, 156px);
   aspect-ratio: 1;
   border-radius: 50%;
   display: grid;
@@ -152,46 +150,6 @@
   transform: scale(1);
 }
 
-.twin-shock-reveal__headline {
-  margin-top: 0.44rem;
-  padding: 0.18rem 0.55rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
-  font-size: clamp(0.62rem, 1.2vw, 0.78rem);
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.twin-shock-reveal__name {
-  width: 100%;
-  min-height: 1.9rem;
-  padding: 0.24rem 0.45rem 0.42rem;
-  background: rgba(0, 0, 0, 0.38);
-  text-align: center;
-  font-size: clamp(0.78rem, 1.5vw, 1.04rem);
-  font-weight: 800;
-  line-height: 1.08;
-}
-
-.twin-shock-reveal__caption {
-  position: absolute;
-  left: max(14px, calc(var(--twin-shock-left) - 24px));
-  top: min(
-    calc(100vh - 66px),
-    calc(var(--twin-shock-top) + var(--twin-shock-height) + 20px)
-  );
-  max-width: min(420px, calc(100vw - 28px));
-  padding: 0.48rem 0.7rem;
-  border-radius: 7px;
-  background: rgba(5, 10, 18, 0.9);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
-  font-size: clamp(0.82rem, 1.7vw, 1rem);
-  font-weight: 750;
-  line-height: 1.18;
-  animation: twin-shock-caption 620ms ease-out both;
-}
-
 @keyframes twin-shock-fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -236,23 +194,11 @@
   }
 }
 
-@keyframes twin-shock-caption {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .twin-shock-reveal__shade,
   .twin-shock-reveal__flare,
   .twin-shock-reveal__beam,
   .twin-shock-reveal__tile,
-  .twin-shock-reveal__caption,
   .twin-shock-reveal--transform .twin-shock-reveal__tile,
   .twin-shock-reveal__avatar {
     animation-duration: 1ms;

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -40,8 +40,8 @@ export default function TwinShockRevealOverlay({
   const timings = useMemo(
     () => (
       reveal.type === 'ali_enters'
-        ? { transformAt: 1800, settledAt: 3200, doneAt: 5600 }
-        : { transformAt: 1550, settledAt: 2850, doneAt: 4900 }
+        ? { transformAt: 2100, settledAt: 3900, doneAt: 6600 }
+        : { transformAt: 1850, settledAt: 3450, doneAt: 5800 }
     ),
     [reveal.type],
   );
@@ -62,20 +62,13 @@ export default function TwinShockRevealOverlay({
   }, [onDone, rect, timings]);
 
   const display = useMemo(() => {
-    const transformed = stage !== 'intro';
-    const settled = stage === 'settled';
     if (reveal.type === 'combined') {
       return {
         beforeName: reveal.fromName,
         beforeAvatar: reveal.fromAvatar,
         afterName: reveal.toName,
         afterAvatar: reveal.toAvatar,
-        headline: settled ? 'Twin Shock Exposed' : 'The spotlight tightens',
-        caption: settled
-          ? 'Lia & Ali will continue the game together as one contestant.'
-          : transformed
-            ? 'The house sees both twins at once.'
-            : 'Lia steps into the spotlight alone.',
+        ariaLabel: 'Twin Shock revealed',
       };
     }
     return {
@@ -83,14 +76,9 @@ export default function TwinShockRevealOverlay({
       beforeAvatar: reveal.replacedPlayerAvatar,
       afterName: reveal.incomingName,
       afterAvatar: reveal.incomingAvatar,
-      headline: settled ? 'New Housemate' : 'A place in the House opens',
-      caption: settled
-        ? `${reveal.incomingName} is now officially in the game.`
-        : transformed
-          ? `${reveal.incomingName} steps into the House.`
-          : `${reveal.replacedPlayerName}'s tile fades from the board.`,
+      ariaLabel: 'New housemate revealed',
     };
-  }, [reveal, stage]);
+  }, [reveal]);
 
   if (!rect || stage === 'done') return null;
 
@@ -107,7 +95,7 @@ export default function TwinShockRevealOverlay({
       style={style}
       role="status"
       aria-live="assertive"
-      aria-label={display.caption}
+      aria-label={display.ariaLabel}
     >
       <div className="twin-shock-reveal__shade" />
       <div className="twin-shock-reveal__flare" />
@@ -139,12 +127,7 @@ export default function TwinShockRevealOverlay({
             </span>
           )}
         </div>
-        <div className="twin-shock-reveal__headline">{display.headline}</div>
-        <div className="twin-shock-reveal__name">
-          {stage === 'intro' ? display.beforeName : display.afterName}
-        </div>
       </div>
-      <div className="twin-shock-reveal__caption">{display.caption}</div>
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- removed all visible text from the Twin Shock reveal overlay so the cutout animation is avatar-only
- slowed both reveal paths so the spotlight, swap, and settle beats are easier to follow
- increased the avatar focal area so the transition reads more clearly on screen

## Why
The follow-up feedback was that the reveal still felt too busy and too fast. The game-style cutout should focus on the avatar transformation itself, without extra labels or captions competing for attention.

## Player impact
- the discovered-twins reveal now holds longer on Lia before smoothly switching to the Lia & Ali avatar
- the Ali-enters reveal now gives the replacement moment more room to land and feels more like a proper housemate entrance
- no overlay text appears during either reveal; the game returns to the normal flow after the animation finishes

## Validation
- `npm run typecheck`