### PR TITLE
Refine Twin Shock reveals and fallback art

### DIFF
--- a/src/components/SeasonRecapCinematic/seasonRecapData.ts
+++ b/src/components/SeasonRecapCinematic/seasonRecapData.ts
@@ -219,6 +219,19 @@ function uniqueSources(sources: Array<string | null | undefined>): string[] {
   });
 }
 
+function getTabloidMatchTokens(player: Player | undefined): string[] {
+  const tokens = uniqueSources([
+    player?.name,
+    player?.name.split(' ')[0],
+  ]).map(normalizePhotoToken);
+
+  if (player?.id === 'ali' || player?.name === 'Ali') {
+    tokens.push(normalizePhotoToken('Lia'));
+  }
+
+  return [...new Set(tokens)];
+}
+
 function isDicebearCandidate(candidate: string): boolean {
   try {
     const parsed = new URL(candidate, typeof window !== 'undefined' ? window.location.origin : 'https://bbmobilenew.local');
@@ -248,10 +261,7 @@ function pickTabloidPhoto(
   usedPhotoIds: Set<string>,
 ): string | null {
   if (tabloidPhotos.length === 0) return null;
-
-  const firstName = player?.name.split(' ')[0] ?? '';
-  const fullName = player?.name ?? '';
-  const desiredTokens = uniqueSources([firstName, fullName]).map(normalizePhotoToken);
+  const desiredTokens = getTabloidMatchTokens(player);
 
   const matchedPhoto = tabloidPhotos.find(
     (entry) => !usedPhotoIds.has(entry.id) && desiredTokens.includes(entry.matchToken),

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
@@ -86,9 +86,9 @@
 
 .twin-shock-reveal__avatar-wrap {
   position: relative;
-  width: min(82%, 156px);
+  width: min(86%, 164px);
   aspect-ratio: 1;
-  border-radius: 50%;
+  border-radius: 10px;
   display: grid;
   place-items: center;
   overflow: hidden;

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -35,7 +35,7 @@ import {
   pickMissionImmunityDuration,
   type SecretMissionBoxRewardType,
 } from '../../bb/secretMission';
-import { resolveTwinShockTurn } from '../../bb/twinShock';
+import { classifyTwinShockAnswer, resolveTwinShockTurn } from '../../bb/twinShock';
 import { applyInfluenceDelta } from '../../social/socialSlice';
 import {
   createInitialBigEyeState,
@@ -715,7 +715,19 @@ export default function DiaryRoom() {
       return updated;
     });
 
-    if (activeConfessionalDecision?.type === 'twin_shock' && gameState.twinShock?.promptStage) {
+    const latentTwinShockGuess =
+      activeConfessionalDecision?.type !== 'twin_shock' &&
+      gameState.twinShock?.status === 'day4_asked_no_correct_guess' &&
+      gameState.twinShock.promptStage == null &&
+      classifyTwinShockAnswer(text) === 'correct_twin_guess';
+
+    if (
+      gameState.twinShock &&
+      (
+        (activeConfessionalDecision?.type === 'twin_shock' && gameState.twinShock.promptStage) ||
+        latentTwinShockGuess
+      )
+    ) {
       const currentPromptStage = gameState.twinShock.promptStage;
       const twinResult = resolveTwinShockTurn(gameState.twinShock, text, {
         playerName,

--- a/src/screens/GameOver/aftermath.ts
+++ b/src/screens/GameOver/aftermath.ts
@@ -231,14 +231,21 @@ function uniqueSources(sources: Array<string | null | undefined>): string[] {
   });
 }
 
+function getTabloidMatchTokens(player: Player | undefined): string[] {
+  const tokens = uniqueSources([player?.name, firstName(player)]).map(normalizeToken);
+  if (player?.id === 'ali' || player?.name === 'Ali') {
+    tokens.push(normalizeToken('Lia'));
+  }
+  return [...new Set(tokens)];
+}
+
 function pickTabloidPhoto(
   player: Player | undefined,
   photos: TabloidPhotoEntry[],
   usedPhotoIds: Set<string>,
 ): string | null {
   if (photos.length === 0) return null;
-
-  const desiredTokens = uniqueSources([player?.name, firstName(player)]).map(normalizeToken);
+  const desiredTokens = getTabloidMatchTokens(player);
   const matched = photos.find(
     (photo) => !usedPhotoIds.has(photo.id) && desiredTokens.includes(photo.matchToken),
   );

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -37,9 +37,10 @@ import { loadActiveProfile, archiveKeyForActiveProfile, loadProfilesState } from
 import { loadSettings } from './settingsSlice';
 import { getConfiguredCastSize, DEFAULT_ROSTER_SIZE } from './settingsHelpers';
 import { pickPhrase, NOMINEE_PLEA_TEMPLATES } from '../utils/juryUtils';
-import { profilePhotoAvatar } from '../utils/avatar';
+import { profilePhotoAvatar, resolveAvatar } from '../utils/avatar';
 import type { SeasonArchive } from './seasonArchive';
 import { loadSeasonArchives } from './archivePersistence';
+import { resolveSkinAssetPathWithFallback } from '../utils/skinAssets';
 import { resolvePublicSaveNominee } from '../publicOpinion/PublicSaveService';
 import {
   addDirection,
@@ -219,7 +220,14 @@ type SecretMissionTaskBuildResult = {
 const TWIN_SHOCK_RESERVED_IDS = new Set([TWIN_SHOCK_LIA_ID, TWIN_SHOCK_ALI_ID, 'lia_ali']);
 const TWIN_SHOCK_LIA_AVATAR = 'assets/skins/Lia_avatar.webp';
 const TWIN_SHOCK_ALI_AVATAR = 'assets/skins/Ali_avatar.webp';
-const TWIN_SHOCK_COMBINED_AVATAR = 'assets/skins/Lia_Ali_avatar.webp';
+const TWIN_SHOCK_LIA_FLIP_AVATAR = resolveSkinAssetPathWithFallback(
+  'Lia_flip_avatar.webp',
+  'Lia_avatar.webp',
+);
+const TWIN_SHOCK_COMBINED_AVATAR = resolveSkinAssetPathWithFallback(
+  'Ali_lia_avatar.webp',
+  'Lia_Ali_avatar.webp',
+);
 const TWIN_SHOCK_LIA_POOL_ENTRY = {
   id: TWIN_SHOCK_LIA_ID,
   name: 'Lia',
@@ -975,11 +983,17 @@ function ensureCompetitionStateForPlayer(state: GameState, playerId: string) {
   }
 }
 
+function applyTwinShockFlipHint(state: GameState) {
+  const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
+  if (!lia || lia.twinMode === 'combined') return;
+  lia.avatar = TWIN_SHOCK_LIA_FLIP_AVATAR;
+}
+
 function resolveTwinShockDiscovered(state: GameState) {
   const lia = state.players.find((player) => player.id === TWIN_SHOCK_LIA_ID);
   const humanName = getHumanPlayer(state)?.name ?? 'The player';
   const fromName = lia?.name ?? 'Lia';
-  const fromAvatar = lia?.avatar ?? TWIN_SHOCK_LIA_AVATAR;
+  const fromAvatar = lia ? resolveAvatar(lia) : TWIN_SHOCK_LIA_AVATAR;
   if (lia) {
     lia.name = 'Lia & Ali';
     lia.avatar = TWIN_SHOCK_COMBINED_AVATAR;
@@ -1027,7 +1041,15 @@ function resolveTwinShockMissionSuccess(state: GameState) {
     })[0] ?? null;
   const replacedPlayerId = replacement?.id ?? TWIN_SHOCK_ALI_ID;
   const replacedPlayerName = replacement?.name ?? 'an empty house slot';
-  const replacedPlayerAvatar = replacement?.avatar ?? TWIN_SHOCK_ALI_AVATAR;
+  const replacedPlayerAvatar = replacement
+    ? resolveAvatar(replacement)
+    : TWIN_SHOCK_ALI_AVATAR;
+
+  if (lia) {
+    lia.name = 'Lia';
+    lia.avatar = TWIN_SHOCK_LIA_AVATAR;
+    delete lia.twinMode;
+  }
 
   if (replacement) {
     replacement.id = TWIN_SHOCK_ALI_ID;
@@ -1120,6 +1142,10 @@ function applyTwinShockTurnResult(state: GameState, result: TwinShockTurnResult)
     twinShock.queuedDay = previousQueuedDay;
   }
   state.twinShock = twinShock;
+
+  if (result.status === 'day4_asked_no_correct_guess' && result.promptStage === null) {
+    applyTwinShockFlipHint(state);
+  }
 
   if (result.resolution === 'resolved_discovered') resolveTwinShockDiscovered(state);
   if (result.resolution === 'resolved_mission_success') resolveTwinShockMissionSuccess(state);
@@ -3433,14 +3459,19 @@ const gameSlice = createSlice({
       pushEvent(state, `[DEBUG] Blocking flags cleared — Continue button restored. 🔧`, 'game');
     },
     submitTwinShockAnswer(state, action: PayloadAction<string>) {
-      if (!state.twinShock?.promptStage) return;
+      const twinShock = state.twinShock;
+      if (!twinShock) return;
+      const canProcessUnpromptedFollowUpGuess =
+        twinShock.promptStage == null &&
+        twinShock.status === 'day4_asked_no_correct_guess';
+      if (!twinShock.promptStage && !canProcessUnpromptedFollowUpGuess) return;
       const human = getHumanPlayer(state);
       if (!human || human.status === 'evicted' || human.status === 'jury') {
-        state.twinShock.promptStage = null;
-        state.twinShock.queuedDay = null;
+        twinShock.promptStage = null;
+        twinShock.queuedDay = null;
         return;
       }
-      const result = resolveTwinShockTurn(state.twinShock, action.payload, {
+      const result = resolveTwinShockTurn(twinShock, action.payload, {
         playerName: human.name,
         liaActive: isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID),
       });

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -293,12 +293,28 @@ function normalizeNameToken(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
+function isTwinShockAliIdentity(player: Pick<Player, 'id' | 'name'>): boolean {
+  return normalizeNameToken(player.id) === 'ali' || normalizeNameToken(player.name) === 'ali';
+}
+
 function collectAssetLookupTokens(player: Pick<Player, 'id' | 'name'>): string[] {
   const hg = getById(player.id) ?? findByName(player.name);
 
   return [hg?.id, hg?.name, player.id, player.name]
     .filter((value): value is string => Boolean(value))
     .map(normalizeNameToken);
+}
+
+function collectTwinShockFullSizeLookupTokens(player: Pick<Player, 'id' | 'name'>): string[] {
+  const baseTokens = collectAssetLookupTokens(player);
+  if (!isTwinShockAliIdentity(player)) return baseTokens;
+
+  const lia = getById('lia') ?? findByName('Lia');
+  const aliasTokens = [lia?.id, lia?.name, 'lia', 'Lia']
+    .filter((value): value is string => Boolean(value))
+    .map(normalizeNameToken);
+
+  return [...new Set([...baseTokens, ...aliasTokens])];
 }
 
 function listFormalCutoutCandidates(): Array<{ basename: string; source: string }> {
@@ -326,7 +342,7 @@ function listAvatarAssetCandidates(): Array<{ basename: string; source: string }
 }
 
 function resolveFormalCutoutFromFolder(player: Pick<Player, 'id' | 'name'>): string | null {
-  const targetTokens = collectAssetLookupTokens(player);
+  const targetTokens = collectTwinShockFullSizeLookupTokens(player);
   if (targetTokens.length === 0) return null;
 
   const candidates = listFormalCutoutCandidates();
@@ -356,7 +372,10 @@ export function resolveFormalCutout(player: Pick<Player, 'id' | 'name'>): string
     return folderMatch;
   }
 
-  const hg = getById(player.id) ?? findByName(player.name);
+  const aliasPlayer = isTwinShockAliIdentity(player)
+    ? ({ id: 'lia', name: 'Lia' } as const)
+    : player;
+  const hg = getById(aliasPlayer.id) ?? findByName(aliasPlayer.name);
   if (!hg) return null;
   const stem = FORMAL_CUTOUT_MAP[hg.id];
   if (!stem) return null;
@@ -409,7 +428,7 @@ const MALE_AVATAR_EMOJI = '👨';
  *   const cutoutSrc = resolveInformalCutout(player) ?? resolveAvatar(player);
  */
 export function resolveInformalCutout(player: Pick<Player, 'id' | 'name'>): string | null {
-  const targetTokens = collectAssetLookupTokens(player);
+  const targetTokens = collectTwinShockFullSizeLookupTokens(player);
   if (targetTokens.length === 0) return null;
 
   const folderMatch = listInformalCutoutCandidates().find(({ basename }) => {
@@ -418,7 +437,10 @@ export function resolveInformalCutout(player: Pick<Player, 'id' | 'name'>): stri
   });
   if (folderMatch) return folderMatch.source;
 
-  const hg = getById(player.id) ?? findByName(player.name);
+  const aliasPlayer = isTwinShockAliIdentity(player)
+    ? ({ id: 'lia', name: 'Lia' } as const)
+    : player;
+  const hg = getById(aliasPlayer.id) ?? findByName(aliasPlayer.name);
   const stem = hg ? INFORMAL_CUTOUT_MAP[hg.id] : null;
   if (!stem) return null;
   return joinPublicAssetPath(`assets/Informal_attires/${stem}.png`);

--- a/src/utils/skinAssets.ts
+++ b/src/utils/skinAssets.ts
@@ -70,6 +70,23 @@ export function resolveSkinAssetPath(filename: string): string {
   return SKIN_URL_BY_FILENAME.get(filename) ?? buildPublicSkinUrl(filename);
 }
 
+export function hasSkinAsset(filename: string): boolean {
+  return SKIN_URL_BY_FILENAME.has(filename);
+}
+
+export function resolveSkinAssetPathWithFallback(
+  filename: string,
+  fallbackFilename?: string,
+): string {
+  if (hasSkinAsset(filename)) {
+    return resolveSkinAssetPath(filename);
+  }
+  if (fallbackFilename) {
+    return resolveSkinAssetPath(fallbackFilename);
+  }
+  return resolveSkinAssetPath(filename);
+}
+
 function resolveSkinAssetWithoutFallback(key: ThemeKey): SkinAssetResolution | null {
   const entry = getRegistryEntry(key);
   const candidates = unique([entry.canonicalFile, ...(entry.aliases ?? [])]);

--- a/tests/unit/twinShock.test.ts
+++ b/tests/unit/twinShock.test.ts
@@ -9,6 +9,16 @@ import gameReducer, {
 } from '../../src/store/gameSlice';
 import { classifyTwinShockAnswer } from '../../src/bb/twinShock';
 import type { GameState } from '../../src/types';
+import { resolveSkinAssetPathWithFallback } from '../../src/utils/skinAssets';
+
+const TWIN_SHOCK_COMBINED_AVATAR = resolveSkinAssetPathWithFallback(
+  'Ali_lia_avatar.webp',
+  'Lia_Ali_avatar.webp',
+);
+const TWIN_SHOCK_LIA_FLIP_AVATAR = resolveSkinAssetPathWithFallback(
+  'Lia_flip_avatar.webp',
+  'Lia_avatar.webp',
+);
 
 function reduce(state: GameState, action: { type: string; payload?: unknown }): GameState {
   return gameReducer(state, action);
@@ -84,7 +94,7 @@ describe('Twin Shock reducer flow', () => {
 
     const lia = state.players.find((player) => player.id === 'lia');
     expect(lia?.name).toBe('Lia & Ali');
-    expect(lia?.avatar).toBe('assets/skins/Lia_Ali_avatar.webp');
+    expect(lia?.avatar).toBe(TWIN_SHOCK_COMBINED_AVATAR);
     expect(lia?.twinMode).toBe('combined');
     expect(state.players.some((player) => player.id === 'ali')).toBe(false);
     expect(state.twinShockResolution).toBe('discovered');
@@ -92,7 +102,7 @@ describe('Twin Shock reducer flow', () => {
     expect(state.twinShock?.pendingRevealAnimation).toMatchObject({
       type: 'combined',
       playerId: 'lia',
-      toAvatar: 'assets/skins/Lia_Ali_avatar.webp',
+      toAvatar: TWIN_SHOCK_COMBINED_AVATAR,
     });
   });
 
@@ -113,6 +123,33 @@ describe('Twin Shock reducer flow', () => {
 
     expect(state.phase).toBe('eviction_results');
     expect(state.twinShock?.promptStage).toBe('day5_final');
+  });
+
+  it('secretly flips Lia to the hint avatar after the first failed confessional', () => {
+    let state = reduce(makeTwinShockState({ week: 1 }), queueForcedShock('twinShock'));
+    state = reduce(state, advance());
+    state = reduce(state, submitTwinShockAnswer('No idea'));
+
+    const lia = state.players.find((player) => player.id === 'lia');
+    expect(lia?.name).toBe('Lia');
+    expect(lia?.avatar).toBe(TWIN_SHOCK_LIA_FLIP_AVATAR);
+    expect(state.twinShock?.status).toBe('day4_asked_no_correct_guess');
+    expect(state.twinShock?.promptStage).toBeNull();
+  });
+
+  it('lets the player expose the twins later without waiting for the next Big Eye call', () => {
+    let state = reduce(makeTwinShockState({ week: 1 }), queueForcedShock('twinShock'));
+    state = reduce(state, advance());
+    state = reduce(state, submitTwinShockAnswer('No idea'));
+    state = reduce(state, submitTwinShockAnswer('Wait, Lia has a twin sister'));
+
+    const lia = state.players.find((player) => player.id === 'lia');
+    expect(lia?.name).toBe('Lia & Ali');
+    expect(lia?.avatar).toBe(TWIN_SHOCK_COMBINED_AVATAR);
+    expect(lia?.twinMode).toBe('combined');
+    expect(state.twinShockDiscoveredByUser).toBe(true);
+    expect(state.twinShockResolution).toBe('discovered');
+    expect(state.players.some((player) => player.id === 'ali')).toBe(false);
   });
 
   it('replaces the first evicted housemate with Ali when the next-day mission succeeds', () => {


### PR DESCRIPTION
## What changed
- add the hidden post-confessional Lia flip hint so her avatar quietly changes after the first failed Big Eye interview
- allow the player to come back later and expose the twin twist immediately, without waiting for the scheduled next-day callback
- swap the discovered-twins combined art to `Ali_lia_avatar.webp` and fall back to Lia imagery for Ali in recap, tribunal, and tabloid surfaces where no dedicated full-size Ali art exists
- keep the square Twin Shock reveal overlay styling and late-entry replacement art flow aligned with the newer avatar resolver paths
- extend Twin Shock regression coverage for the flip hint, the late reveal path, and the updated combined avatar asset

## Why
The merged overlay polish covered the presentation beats, but the follow-up gameplay wiring still needed the hidden avatar clue, the edge-case late guess path, and the new avatar asset mapping the user asked for.

## Player impact
- after Big Eye first sends the player away to think, Lia quietly returns with the flipped-hair avatar as a subtle clue
- if the player spots the trick later and goes back to the Confessional on their own, the discovered-twins route resolves immediately into the combined Lia & Ali state
- if the mission succeeds instead, Ali still enters with the right avatar while recap-style screens fall back gracefully to Lia's full-size art

## Root cause
The older Twin Shock follow-up work lived on a merged branch, so the requested behavior refinements never made it onto a fresh PR based on current `main`.

## Validation
- `npm run typecheck`
- `npx vitest run tests/unit/twinShock.test.ts src/screens/DiaryRoom/__tests__/DiaryRoom.test.tsx src/screens/DiaryRoom/__tests__/confessionalDecisionPresentation.test.ts`