### PR TITLE
Fix Twin Shock confessional and public-meter edge cases

### DIFF
--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -11,6 +11,13 @@ type TwinShockRevealOverlayProps = {
 
 type RevealStage = 'intro' | 'transform' | 'settled' | 'done';
 
+function getTileElement(playerId: string): HTMLElement | null {
+  const escapedId = typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape(playerId)
+    : playerId.replace(/"/g, '\\"');
+  return document.querySelector<HTMLElement>(`[data-player-id="${escapedId}"]`);
+}
+
 export default function TwinShockRevealOverlay({
   reveal,
   getTileRect,
@@ -36,6 +43,21 @@ export default function TwinShockRevealOverlay({
       if (doneFallbackId !== null) window.clearTimeout(doneFallbackId);
     };
   }, [getTileRect, onDone, targetId]);
+
+  useLayoutEffect(() => {
+    const tile = getTileElement(targetId);
+    if (!tile) return undefined;
+
+    const previousOpacity = tile.style.opacity;
+    const previousVisibility = tile.style.visibility;
+    tile.style.opacity = '0';
+    tile.style.visibility = 'hidden';
+
+    return () => {
+      tile.style.opacity = previousOpacity;
+      tile.style.visibility = previousVisibility;
+    };
+  }, [targetId]);
 
   const timings = useMemo(
     () => (

--- a/src/components/TwinShockRevealOverlay/__tests__/TwinShockRevealOverlay.test.tsx
+++ b/src/components/TwinShockRevealOverlay/__tests__/TwinShockRevealOverlay.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TwinShockRevealOverlay from '../TwinShockRevealOverlay';
+
+describe('TwinShockRevealOverlay', () => {
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = vi.fn();
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('temporarily hides the live target tile while the reveal overlay is playing', () => {
+    const tile = document.createElement('div');
+    tile.dataset.playerId = 'ali';
+    document.body.appendChild(tile);
+
+    const { unmount } = render(
+      <TwinShockRevealOverlay
+        reveal={{
+          type: 'ali_enters',
+          replacedPlayerId: 'finn',
+          replacedPlayerName: 'Finn',
+          replacedPlayerAvatar: '/finn.webp',
+          incomingPlayerId: 'ali',
+          incomingName: 'Ali',
+          incomingAvatar: '/ali.webp',
+        }}
+        getTileRect={() => new DOMRect(10, 20, 80, 80)}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(tile.style.opacity).toBe('0');
+    expect(tile.style.visibility).toBe('hidden');
+
+    unmount();
+
+    expect(tile.style.opacity).toBe('');
+    expect(tile.style.visibility).toBe('');
+  });
+});

--- a/src/publicOpinion/publicOpinionMiddleware.ts
+++ b/src/publicOpinion/publicOpinionMiddleware.ts
@@ -136,8 +136,11 @@ function ensureProfiles(
   game: GameState,
 ): Record<string, unknown> {
   let profiles = ((store.getState() as StateWithGame).publicOpinion?.profiles ?? {});
-  if (Object.keys(profiles).length === 0 && game.players?.length > 0) {
-    store.dispatch(initializeProfiles(game.players.map((p) => p.id)));
+  const missingPlayerIds = (game.players ?? [])
+    .map((player) => player.id)
+    .filter((playerId) => !profiles[playerId]);
+  if (missingPlayerIds.length > 0) {
+    store.dispatch(initializeProfiles(missingPlayerIds));
     profiles = ((store.getState() as StateWithGame).publicOpinion?.profiles ?? {});
   }
   return profiles;
@@ -230,13 +233,10 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
 
   const actionType = (action as { type: string }).type;
   const actionPayload = (action as { payload?: unknown }).payload;
+  ensureProfiles(store, game);
 
   // ── Game reset ─────────────────────────────────────────────────────────────
   if (actionType === 'game/resetGame') {
-    const playerIds = game.players?.map((p) => p.id) ?? [];
-    if (playerIds.length > 0) {
-      store.dispatch(initializeProfiles(playerIds));
-    }
     return result;
   }
 

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -928,10 +928,11 @@ function shouldQueueTwinShockBeforeDayEnd(state: GameState): boolean {
     && twinShock.promptStage === null;
 
   if (forcedTwinShock && twinShock.status !== 'resolved_discovered' && twinShock.status !== 'resolved_mission_success') {
-    queueTwinShockConfessional(
-      state,
-      isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID) ? 'day4_initial' : 'secret_lost',
-    );
+    if (!isPlayerActiveInHouse(state, TWIN_SHOCK_LIA_ID)) {
+      state.pendingForcedShock = null;
+      return false;
+    }
+    queueTwinShockConfessional(state, 'day4_initial');
     state.pendingForcedShock = null;
     return true;
   }

--- a/tests/unit/publicOpinion/publicOpinionMiddleware.test.ts
+++ b/tests/unit/publicOpinion/publicOpinionMiddleware.test.ts
@@ -269,5 +269,37 @@ describe('publicOpinionMiddleware', () => {
     const expiredDirection = store.getState().publicOpinion.directions.find((direction) => direction.id === 'dir-1');
     expect(expiredDirection?.status).toBe('expired');
   });
+
+  it('initializes a public profile for a newly added late entrant without resetting existing approvals', () => {
+    const store = configureStore({
+      reducer: {
+        game: gameReducer,
+        publicOpinion: publicOpinionReducer,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware().concat(publicOpinionMiddleware),
+      preloadedState: {
+        game: makeGameState(),
+      },
+    });
+
+    store.dispatch(initializeProfiles(['p1', 'p2']));
+
+    store.dispatch({
+      type: 'game/forcePhase',
+      payload: {
+        players: [
+          makePlayer('p1', 'Aria'),
+          makePlayer('p2', 'Kian'),
+          makePlayer('ali', 'Ali'),
+        ],
+      },
+    });
+
+    const { profiles } = store.getState().publicOpinion;
+    expect(profiles.p1.approval).toBe(50);
+    expect(profiles.p2.approval).toBe(50);
+    expect(profiles.ali.approval).toBe(50);
+  });
 });
 

--- a/tests/unit/twinShock.test.ts
+++ b/tests/unit/twinShock.test.ts
@@ -88,6 +88,21 @@ describe('Twin Shock reducer flow', () => {
     expect(state.twinShockConsumed).toBe(true);
   });
 
+  it('does not surface a secret-lost confessional if Lia was already gone before a forced activation starts', () => {
+    let state = reduce(makeTwinShockState({
+      week: 2,
+      players: makeTwinShockState().players.map((player) =>
+        player.id === 'lia' ? { ...player, status: 'evicted' } : player,
+      ),
+    }), queueForcedShock('twinShock'));
+    state = reduce(state, advance());
+
+    expect(state.pendingForcedShock).toBeNull();
+    expect(state.twinShock?.promptStage).toBeNull();
+    expect(state.twinShock?.status).toBe('inactive');
+    expect(state.twinShockResolution).toBeNull();
+  });
+
   it('turns Lia into Lia & Ali when the player exposes the secret', () => {
     let state = reduce(makeTwinShockState(), advance());
     state = reduce(state, submitTwinShockAnswer('Maybe she has a twin sister?'));


### PR DESCRIPTION
## What changed
- stop the Twin Shock confessional from surfacing a secret-lost message when Lia was already gone before the twist ever activated
- remove the duplicate-looking reveal by hiding the live tile while the overlay is running, so Ali only appears once
- make the public meter auto-create a profile for Ali when she enters as a late entrant
- keep the same regression coverage around the hidden hint, the late reveal path, the overlay, and public-profile initialization

## Why
These were the remaining edge cases after `#1133` merged, and they only exist on the follow-up branch, not on `main`.

## Validation
- `npm run typecheck`
- `npx vitest run tests/unit/twinShock.test.ts tests/unit/publicOpinion/publicOpinionMiddleware.test.ts src/components/TwinShockRevealOverlay/__tests__/TwinShockRevealOverlay.test.tsx`