### PR TITLE
Show debug button in production

### DIFF
--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -1111,7 +1111,6 @@ export default function GameScreen() {
 
   // ── Dev: manually trigger nomination animation ────────────────────────────
   // Only visible in development builds for easy QA verification.
-  const isDev = import.meta.env.DEV
   const isDebugMode = detectDebugMode()
   const handleDevPlayNomAnim = useCallback(() => {
     const eligible = alivePlayers.filter((p) => !p.isUser)
@@ -4019,7 +4018,7 @@ export default function GameScreen() {
       )}
 
       {/* ── Dev: trigger nomination animation (dev builds only) ──────────── */}
-      {isDev && !awaitingHumanDecision && (
+      {!awaitingHumanDecision && (
         <button
           className="dev-nom-anim-btn"
           onClick={handleDevPlayNomAnim}


### PR DESCRIPTION
Keeps the nomination debug button visible in production for mobile QA testing, while leaving the rest of the debug gating unchanged.