### PR TITLE
Keep debug button always visible

### DIFF
--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -64,7 +64,6 @@ import {
 import { startChallenge, selectPendingChallenge, completeChallenge, type PendingChallenge } from '../../store/challengeSlice'
 import { selectLastSocialReport } from '../../social/socialSlice'
 import { setEnergyBankEntry } from '../../social/socialSlice'
-import { useSearchParams } from 'react-router-dom'
 import { selectSocialSummaryOpen } from '../../store/uiSlice'
 import TvZone from '../../components/ui/TvZone'
 import HouseguestGrid from '../../components/HouseguestGrid/HouseguestGrid'
@@ -312,7 +311,6 @@ function buildDoubleEvictionPostVoteAnnouncement(options: {
  * or add action buttons by dispatching events via useAppDispatch().
  */
 export default function GameScreen() {
-  const [searchParams] = useSearchParams()
   const dispatch = useAppDispatch()
   const store = useStore<RootState>()
   const gameScreenRef = useRef<HTMLDivElement | null>(null)
@@ -1166,9 +1164,8 @@ export default function GameScreen() {
   )
 
   // ── Dev: manually trigger nomination animation ────────────────────────────
-  // Only visible in development builds for easy QA verification.
+  // Kept visible in-game for QA/mobile testing.
   const isDebugMode = detectDebugMode()
-  const isQaMode = searchParams.get('qa') === '1'
   const handleDevPlayNomAnim = useCallback(() => {
     const eligible = alivePlayers.filter((p) => !p.isUser)
     const devNominees = eligible.slice(0, 2).map((p) => p.id)
@@ -4371,15 +4368,15 @@ export default function GameScreen() {
         />
       )}
 
-      {/* ── QA: trigger nomination animation (enabled with qa=1) ─────────── */}
-      {isQaMode && !awaitingHumanDecision && (
+      {/* ── Debug: trigger nomination animation ───────────────────────────── */}
+      {!awaitingHumanDecision && (
         <button
           className="dev-nom-anim-btn"
           onClick={handleDevPlayNomAnim}
           type="button"
-          aria-label="QA: Play Nomination Animation"
+          aria-label="Debug: Play Nomination Animation"
         >
-          🎬 QA: Play Nomination Animation
+          🎬 Debug: Play Nomination Animation
         </button>
       )}
 


### PR DESCRIPTION
Makes the nomination/debug button always visible in the game screen for phone QA testing. It no longer depends on `qa=1`, so you can trigger it directly in-app without using a special link.