### PR TITLE
Keep debug menu visible and fix advanced settings route

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -613,7 +613,7 @@ export default function DebugPanel() {
                   className="dbg-btn dbg-btn--wide"
                   onClick={() =>
                     navigate({
-                      pathname: '/settingsatiste',
+                      pathname: '/settings-admin',
                       search: searchParams.toString() ? `?${searchParams.toString()}` : '',
                     })
                   }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -113,7 +113,10 @@ export const router = createHashRouter([
       { path: 'public-meter',     element: <PublicMeter />  },
       { path: 'settings',         element: <Settings />     },
       ...(SettingsAdmin != null
-        ? [{ path: 'settingsatiste', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> }]
+        ? [
+            { path: 'settings-admin', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> },
+            { path: 'settingsatiste', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> },
+          ]
         : []),
       ...(import.meta.env.DEV && TwistsTestPage != null
         ? [{ path: 'twists-test', element: <Suspense fallback={null}><TwistsTestPage /></Suspense> }]


### PR DESCRIPTION
Fresh PR for the current fix set: keeps the debug trigger visible in-game for QA/mobile testing and routes the advanced settings button to the real admin screen instead of the 404 path.