### PR TITLE
Keep debug session available on mobile

### DIFF
--- a/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
+++ b/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { getAll } from '../../data/houseguests';
 import { resolveAvatar } from '../../utils/avatar';
 import { preloadImage, preloadImages } from '../../utils/preload';
@@ -22,6 +22,7 @@ function getAvatarUrls(): string[] {
 
 export default function AssetPreloaderOverlay() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState('Opening the competition arena.');
   const doneFiredRef = useRef(false);
@@ -48,14 +49,14 @@ export default function AssetPreloaderOverlay() {
       if (cancelled || doneFiredRef.current) return;
       doneFiredRef.current = true;
       setStatus('Entering the house.');
-      navigate('/game');
+      navigate({ pathname: '/game', search: location.search });
     }
 
     void run();
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [location.search, navigate]);
 
   return (
     <KolequantSplash

--- a/src/components/DebugPanel/DebugPanel.css
+++ b/src/components/DebugPanel/DebugPanel.css
@@ -3,7 +3,7 @@
 /* Floating action button (bottom-right corner) */
 .dbg-fab {
   position: fixed;
-  bottom: 5rem; /* above nav bar */
+  bottom: calc(5rem + env(safe-area-inset-bottom, 0px)); /* above nav bar */
   right: 1rem;
   z-index: 9000;
   width: 2.75rem;
@@ -241,6 +241,11 @@
 
 /* Hide on very small screens (phones in portrait) by tucking behind toggle */
 @media (max-width: 360px) {
+  .dbg-fab {
+    right: 0.75rem;
+    bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+  }
+
   .dbg-panel {
     width: 100vw;
   }

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
@@ -172,6 +172,12 @@ export default function DebugPanel() {
   const [selectedPov, setSelectedPov] = useState('');
   const [selectedF4Evictee, setSelectedF4Evictee] = useState('');
   const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction');
+
+  useEffect(() => {
+    const openPanel = () => setIsOpen(true);
+    window.addEventListener('bbm:open-debug-panel', openPanel);
+    return () => window.removeEventListener('bbm:open-debug-panel', openPanel);
+  }, []);
 
   if (!isDebug) return null;
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -31,10 +31,7 @@ import NotFound             from './screens/NotFound/NotFound';
 import { canAccessSpecialSettings } from './utils/debugMode';
 import { lazy, Suspense }   from 'react';
 
-// Admin/debug screens stay hidden unless the current session has QA debug access.
-const SettingsAdmin = import.meta.env.DEV || canAccessSpecialSettings()
-  ? lazy(() => import('./screens/SettingsAdmin/SettingsAdmin'))
-  : null;
+const SettingsAdminPage = lazy(() => import('./screens/SettingsAdmin/SettingsAdmin'));
 const GameDebug = import.meta.env.DEV
   ? lazy(() => import('./screens/GameDebug/GameDebug'))
   : null;
@@ -90,6 +87,14 @@ const MinigameLab = import.meta.env.DEV
   ? lazy(() => import('./screens/MinigameLab/MinigameLab'))
   : null;
 
+function SettingsAdminRoute() {
+  if (!canAccessSpecialSettings()) {
+    return <NotFound />;
+  }
+
+  return <Suspense fallback={null}><SettingsAdminPage /></Suspense>;
+}
+
 export const router = createHashRouter([
   {
     path: '/',
@@ -112,12 +117,8 @@ export const router = createHashRouter([
       { path: 'rules',            element: <Rules />        },
       { path: 'public-meter',     element: <PublicMeter />  },
       { path: 'settings',         element: <Settings />     },
-      ...(SettingsAdmin != null
-        ? [
-            { path: 'settings-admin', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> },
-            { path: 'settingsatiste', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> },
-          ]
-        : []),
+      { path: 'settings-admin', element: <SettingsAdminRoute /> },
+      { path: 'settingsatiste', element: <SettingsAdminRoute /> },
       ...(import.meta.env.DEV && TwistsTestPage != null
         ? [{ path: 'twists-test', element: <Suspense fallback={null}><TwistsTestPage /></Suspense> }]
         : []),

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -225,12 +225,20 @@ body:has(.game-screen-shell) {
   border-radius: 6px;
   border: 1px dashed rgba(255, 200, 0, 0.7);
   background: rgba(0, 0, 0, 0.6);
-  color: #ffd700;
+  color: transparent;
   font-size: 0.72rem;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
   letter-spacing: 0.03em;
   transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dev-nom-anim-btn::after {
+  content: 'Debug Menu';
+  color: #ffd700;
 }
 
 .game-screen:has(.game-control-dock) .dev-nom-anim-btn {
@@ -245,6 +253,10 @@ body:has(.game-screen-shell) {
     transform: translateX(-50%);
     width: min(calc(100vw - 20px), 320px);
     padding: 12px 14px;
+    font-size: 0.82rem;
+  }
+
+  .dev-nom-anim-btn::after {
     font-size: 0.82rem;
   }
 }

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -1166,17 +1166,9 @@ export default function GameScreen() {
   // ── Dev: manually trigger nomination animation ────────────────────────────
   // Kept visible in-game for QA/mobile testing.
   const isDebugMode = detectDebugMode()
-  const handleDevPlayNomAnim = useCallback(() => {
-    const eligible = alivePlayers.filter((p) => !p.isUser)
-    const devNominees = eligible.slice(0, 2).map((p) => p.id)
-    if (devNominees.length === 2) {
-      console.log('DEV: Play Nomination Animation', devNominees)
-      const autoId = canUsePublicNomineeRule ? (game.lastHohCompFinisherId ?? null) : null
-      const fullIds = autoId && !devNominees.includes(autoId) ? [...devNominees, autoId] : devNominees
-      setAiNomAnimConsumedKey(`w${game.week}-${[...fullIds].sort().join(',')}`)
-      setPendingNominees(devNominees)
-    }
-  }, [alivePlayers, canUsePublicNomineeRule, game.lastHohCompFinisherId, game.week, setAiNomAnimConsumedKey, setPendingNominees])
+  const handleOpenDebugPanel = useCallback(() => {
+    window.dispatchEvent(new Event('bbm:open-debug-panel'))
+  }, [])
 
   // ── Human POS holder decision (use veto or not) ──────────────────────────
   const humanIsPosHolder = humanPlayer && game.posWinnerId === humanPlayer.id
@@ -4372,9 +4364,10 @@ export default function GameScreen() {
       {!awaitingHumanDecision && (
         <button
           className="dev-nom-anim-btn"
-          onClick={handleDevPlayNomAnim}
+          onClick={handleOpenDebugPanel}
           type="button"
-          aria-label="Debug: Play Nomination Animation"
+          aria-label="Open Debug Panel"
+          title="Open Debug Panel"
         >
           🎬 Debug: Play Nomination Animation
         </button>

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -267,7 +267,7 @@ export default function HomeHub() {
     dispatch(hydrateGame(snapshot.game));
     dispatch(hydrateFinale(snapshot.finale));
     dispatch(hydrateSocial(snapshot.social));
-    navigate('/game');
+    navigate({ pathname: '/game', search: location.search });
   }
 
   function startClassicRun() {


### PR DESCRIPTION
## Summary
- Preserve debug query params when moving from HomeHub and the game preloader into `/game`
- Keep the advanced settings route available at runtime instead of dropping into 404 when QA flags are present
- Replace the confusing in-game nomination animation trigger with a clear Debug Menu button that opens the panel
- Improve the debug button safe-area positioning on phones