### PR TITLE
Fix finale shock and public vote bugs

### DIFF
--- a/src/components/FinalFaceoff/FinalFaceoff.tsx
+++ b/src/components/FinalFaceoff/FinalFaceoff.tsx
@@ -30,6 +30,14 @@ import {
 import { selectSettings } from '../../store/settingsSlice';
 import { setMusicScene } from '../../store/uiSlice';
 import { tallyVotes, aiJurorVote } from '../../utils/juryUtils';
+import {
+  resolveAvatarCandidates,
+  resolveFormalCutout,
+  resolveInformalCutoutCandidates,
+  resolveSilhouetteFallback,
+} from '../../utils/avatar';
+import { preloadImages } from '../../utils/preload';
+import { resolveSkinAssetPath } from '../../utils/skinAssets';
 import { selectPublicOpinion } from '../../publicOpinion';
 import { showInterstitial } from '../../services/ads/adsService';
 import { SoundManager } from '../../services/sound/SoundManager';
@@ -62,6 +70,23 @@ export default function FinalFaceoff() {
   const { play } = useSound();
 
   const jurorListRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sources = game.players.flatMap((player) => [
+      resolveAvatarCandidates(player)[0],
+      ...resolveInformalCutoutCandidates(player),
+      resolveFormalCutout(player),
+      resolveSilhouetteFallback(player),
+    ]);
+    sources.push(
+      resolveSkinAssetPath('thegirls.webp'),
+      resolveSkinAssetPath('the boys.webp'),
+    );
+
+    // Start warming every tribunal and recap portrait as soon as the finale
+    // mounts; the clue act provides a buffer before the recap uses them.
+    void preloadImages([...new Set(sources.filter((source): source is string => Boolean(source)))]);
+  }, [game.players]);
 
   // ── Phase management ───────────────────────────────────────────────────
   // 'clues'       → auto-reveal juror messages (no vote chips)

--- a/src/components/JuryPhaseRevealOverlay/JuryPhaseRevealOverlay.tsx
+++ b/src/components/JuryPhaseRevealOverlay/JuryPhaseRevealOverlay.tsx
@@ -16,7 +16,13 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import type { Player } from '../../types'
-import { resolveAvatarCandidates, isEmoji } from '../../utils/avatar'
+import {
+  resolveAvatarCandidates,
+  resolveFormalCutout,
+  resolveSilhouetteFallback,
+  isEmoji,
+} from '../../utils/avatar'
+import { preloadImages } from '../../utils/preload'
 import './JuryPhaseRevealOverlay.css'
 
 // ── Timing constants (ms) ─────────────────────────────────────────────────────
@@ -68,6 +74,17 @@ export default function JuryPhaseRevealOverlay({ open, jurors, onEnterVote, onSp
    */
   const [instant, setInstant] = useState(false)
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+
+  useEffect(() => {
+    if (!open) return
+    const sources = jurors.flatMap((juror) => [
+      resolveAvatarCandidates(juror)[0],
+      resolveFormalCutout(juror),
+      resolveSilhouetteFallback(juror),
+    ]).filter((source): source is string => Boolean(source))
+
+    void preloadImages([...new Set(sources)])
+  }, [jurors, open])
 
   const prefersReducedMotion =
     typeof window !== 'undefined' && typeof window.matchMedia === 'function'

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -80,6 +80,25 @@
   background: linear-gradient(180deg, rgba(17, 20, 34, 0.96), rgba(12, 14, 24, 0.94));
 }
 
+.pf-overlay__announcement-slot {
+  flex-shrink: 0;
+  display: grid;
+  min-height: 7.5rem;
+}
+
+.pf-overlay__announcement-slot > *,
+.pf-overlay__announcement-panel {
+  grid-area: 1 / 1;
+  min-height: 0;
+}
+
+.pf-overlay__announcement-panel,
+.pf-overlay__announcement-panel > .pf-overlay__header,
+.pf-overlay__announcement-slot > .pf-overlay__elimination {
+  height: 100%;
+  box-sizing: border-box;
+}
+
 .pf-overlay__header-topline,
 .pf-overlay__leader-meta,
 .pf-overlay__rank-name-row,

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -329,7 +329,13 @@ function HousemateSpotlightCard({
   const { player } = item;
 
   return (
-    <motion.section className="pf-overlay__spotlight" aria-label="Housemate Spotlight" layout>
+    <motion.section
+      className="pf-overlay__spotlight"
+      role="region"
+      aria-label="Housemate Spotlight"
+      data-testid="housemate-spotlight"
+      layout
+    >
       <div className="pf-overlay__leader-copy">
         <p className="pf-overlay__leader-kicker">
           {finalTwoNames ? `Final two: ${finalTwoNames}` : 'Housemate Spotlight'}
@@ -523,8 +529,8 @@ export default function PublicFavoriteOverlay({
   const surgeRequestLockRef = useRef(false);
   const previousRanksRef = useRef<Record<string, number>>({});
   const previousEliminatedCountRef = useRef(0);
+  const eliminatedIdsRef = useRef<Set<string>>(new Set());
   const mountedRef = useRef(true);
-  const [spotlightRotation, setSpotlightRotation] = useState(0);
 
   const candidateIds = useMemo(() => candidates.map((candidate) => candidate.id), [candidates]);
   const candidatesById = useMemo(
@@ -539,6 +545,10 @@ export default function PublicFavoriteOverlay({
     tickIntervalMs: VOTE_TICK_INTERVAL_MS,
     driftAmount: VOTE_DRIFT_AMOUNT,
     surgeTargetId: surgeActive?.playerId ?? null,
+  });
+  const [spotlightRotation, setSpotlightRotation] = useState(() => {
+    const firstEligibleIndex = candidates.findIndex((candidate) => !eliminated.includes(candidate.id));
+    return Math.max(firstEligibleIndex, 0);
   });
   const displayStep: Step = isComplete && step === 'voting' ? 'winner' : step;
 
@@ -587,15 +597,14 @@ export default function PublicFavoriteOverlay({
     () => getActiveSpotlightPlayers(candidates, eliminated),
     [candidates, eliminated],
   );
-  const activePlayerKey = useMemo(
-    () => activePlayers.map((candidate) => candidate.id).join('|'),
-    [activePlayers],
-  );
+  eliminatedIdsRef.current = new Set(eliminated);
   const rankedPlayers = useMemo(
     () => [...activePlayers].sort((left, right) => (votes[right.id] ?? 0) - (votes[left.id] ?? 0)),
     [activePlayers, votes],
   );
-  const spotlightItems = useMemo(() => buildHouseguestSpotlightItems(activePlayers), [activePlayers]);
+  // Keep the rotation source stable when an elimination arrives. The current
+  // housemate holds their full beat, then the next timer skips eliminated IDs.
+  const spotlightItems = useMemo(() => buildHouseguestSpotlightItems(candidates), [candidates]);
   const spotlight = useMemo(
     () => selectSpotlightItem(spotlightItems, spotlightRotation),
     [spotlightItems, spotlightRotation],
@@ -608,20 +617,22 @@ export default function PublicFavoriteOverlay({
       : null;
 
   useEffect(() => {
-    setSpotlightRotation((rotation) => {
-      if (spotlightItems.length === 0) return 0;
-      return rotation % spotlightItems.length;
-    });
-  }, [activePlayerKey, spotlightItems.length]);
-
-  useEffect(() => {
     if (displayStep !== 'voting' || !spotlightFact || !spotlightPlayerId) return;
     const timeoutMs = getSpotlightRotationDelayMs(spotlightFact);
     const id = window.setTimeout(() => {
-      setSpotlightRotation((rotation) => rotation + 1);
+      setSpotlightRotation((rotation) => {
+        for (let offset = 1; offset <= spotlightItems.length; offset += 1) {
+          const nextRotation = rotation + offset;
+          const nextPlayerId = selectSpotlightItem(spotlightItems, nextRotation)?.item.player.id;
+          if (nextPlayerId && !eliminatedIdsRef.current.has(nextPlayerId)) {
+            return nextRotation;
+          }
+        }
+        return rotation;
+      });
     }, timeoutMs);
     return () => window.clearTimeout(id);
-  }, [displayStep, spotlightFact, spotlightPlayerId]);
+  }, [displayStep, spotlightFact, spotlightItems, spotlightPlayerId]);
 
   useEffect(() => {
     const firstActiveId = activePlayers[0]?.id ?? null;
@@ -774,21 +785,23 @@ export default function PublicFavoriteOverlay({
           </button>
         )}
 
-        <AnimatePresence>
-          {phase !== 'final_reveal' && (
-            <PublicVoteHeader
-              title="PUBLIC FAVORITE VOTE"
-              subtitle="Viewer board"
-              statusLine={statusLine}
-            />
-          )}
-        </AnimatePresence>
-
-        <AnimatePresence>
-          {eliminationActive && phase !== 'final_reveal' && (
-            <EliminationMoment player={eliminationActive.player} />
-          )}
-        </AnimatePresence>
+        {phase !== 'final_reveal' && (
+          <div className="pf-overlay__announcement-slot">
+            <AnimatePresence mode="wait" initial={false}>
+              {eliminationActive ? (
+                <EliminationMoment key={`elimination-${eliminationActive.player.id}`} player={eliminationActive.player} />
+              ) : (
+                <motion.div key="public-vote-header" className="pf-overlay__announcement-panel">
+                  <PublicVoteHeader
+                    title="PUBLIC FAVORITE VOTE"
+                    subtitle="Viewer board"
+                    statusLine={statusLine}
+                  />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        )}
 
         {displayStep === 'voting' && (
           <div className="pf-overlay__broadcast">

--- a/src/components/PublicFavoriteOverlay/publicFavoriteSpotlight.ts
+++ b/src/components/PublicFavoriteOverlay/publicFavoriteSpotlight.ts
@@ -7,8 +7,8 @@ export interface HouseguestSpotlightItem {
   facts: string[];
 }
 
-const SPOTLIGHT_ROTATION_MIN_MS = 3000;
-const SPOTLIGHT_ROTATION_MAX_MS = 5000;
+const SPOTLIGHT_ROTATION_MIN_MS = 4500;
+const SPOTLIGHT_ROTATION_MAX_MS = 6000;
 
 function cleanText(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
@@ -84,7 +84,7 @@ export function buildHouseguestSpotlightItems(candidates: Player[]): HouseguestS
 
 export function getSpotlightRotationDelayMs(fact: string): number {
   const wordCount = Math.max(1, fact.split(/\s+/).filter(Boolean).length);
-  const scaledDelay = 3000 + Math.min(2000, Math.max(0, (wordCount - 8) * 110));
+  const scaledDelay = 4500 + Math.min(1500, Math.max(0, (wordCount - 8) * 110));
   return Math.max(SPOTLIGHT_ROTATION_MIN_MS, Math.min(SPOTLIGHT_ROTATION_MAX_MS, scaledDelay));
 }
 

--- a/src/components/SeasonRecapCinematic/EvictionLadder.css
+++ b/src/components/SeasonRecapCinematic/EvictionLadder.css
@@ -305,7 +305,9 @@
   font-weight: 800;
   letter-spacing: 0.14em;
   color: var(--ladder-text-muted);
-  white-space: nowrap;
+  line-height: 1.25;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .eviction-ladder__status-icon {
@@ -433,5 +435,10 @@
   .eviction-ladder__ranking {
     padding: 0.56rem 0.6rem 0.56rem 0.66rem;
     gap: 0.56rem;
+  }
+
+  .eviction-ladder__status {
+    font-size: 0.56rem;
+    letter-spacing: 0.1em;
   }
 }

--- a/src/components/SeasonRecapCinematic/SeasonRecapCinematic.tsx
+++ b/src/components/SeasonRecapCinematic/SeasonRecapCinematic.tsx
@@ -328,7 +328,7 @@ function LadderWaveScene({
         caption={caption}
         compact={entries.length >= 6}
         animationDelayMs={220}
-        stepDelayMs={130}
+        stepDelayMs={375}
       />
     </SceneFrame>
   );

--- a/src/components/SeasonRecapCinematic/seasonRecapTimeline.ts
+++ b/src/components/SeasonRecapCinematic/seasonRecapTimeline.ts
@@ -31,7 +31,7 @@ export const RECAP_EXIT_FADE_MS = 420;
 const HEADLINE_GIRLS_DURATION_MS = seconds(4);
 const PHONE_POST_BOYS_DURATION_MS = seconds(4);
 const LADDER_INTRO_DURATION_MS = seconds(3.5);
-const LADDER_WAVE_DURATION_MS = seconds(4.25);
+const LADDER_WAVE_DURATION_MS = seconds(8.5);
 const MOMENT_OF_TRUTH_DURATION_MS = seconds(6);
 
 export function buildSeasonRecapTimeline(categoryIds: string[], evictionWaveCount: number): RecapTimelineScene[] {

--- a/src/components/TribunalMemberStage/TribunalMemberStage.tsx
+++ b/src/components/TribunalMemberStage/TribunalMemberStage.tsx
@@ -19,7 +19,11 @@ import { useEffect, useState } from 'react';
 import type { Player } from '../../types';
 import type { JurorReveal } from '../../store/finaleSlice';
 import { PUBLIC_JUROR_ID } from '../../store/finaleSlice';
-import { resolveFormalCutout, resolveSilhouetteFallback } from '../../utils/avatar';
+import {
+  resolveFormalCutout,
+  resolveFullSizeCutoutFallback,
+  resolveSilhouetteFallback,
+} from '../../utils/avatar';
 import PlayerAvatar from '../PlayerAvatar/PlayerAvatar';
 import {
   PHRASE_TYPING_CHAR_INTERVAL_MS,
@@ -114,7 +118,7 @@ export default function TribunalMemberStage({
 
   const isPublic = current?.juror.id === PUBLIC_JUROR_ID;
   const formalSrc = current && !isPublic ? resolveFormalCutout(current.juror) : null;
-  const fallbackSrc = current && !isPublic ? resolveSilhouetteFallback(current.juror) : null;
+  const fallbackSrc = current && !isPublic ? resolveFullSizeCutoutFallback(current.juror) : null;
   const cutoutSrc = current && !isPublic && fallbackSrc
     ? failedCutoutId === current.juror.id || !formalSrc
       ? fallbackSrc

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.css
@@ -86,16 +86,13 @@
 
 .twin-shock-reveal__avatar-wrap {
   position: relative;
-  width: min(86%, 164px);
-  aspect-ratio: 1;
-  border-radius: 10px;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
   display: grid;
   place-items: center;
   overflow: hidden;
   background: rgba(255, 255, 255, 0.1);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
-    0 0 0 6px rgba(255, 255, 255, 0.04);
 }
 
 .twin-shock-reveal__avatar {
@@ -119,9 +116,10 @@
 
 .twin-shock-reveal__avatar--after,
 .twin-shock-reveal__avatar-fallback--after {
-  opacity: 0;
-  transform: scale(0.88);
+  opacity: 1;
+  transform: scale(1);
   filter: saturate(1.14);
+  animation: twin-shock-avatar-arrive 900ms ease-out both;
 }
 
 .twin-shock-reveal__avatar-fallback {
@@ -148,6 +146,19 @@
 .twin-shock-reveal--settled .twin-shock-reveal__avatar-fallback--after {
   opacity: 1;
   transform: scale(1);
+}
+
+@keyframes twin-shock-avatar-arrive {
+  from {
+    opacity: 0;
+    transform: scale(1.08);
+    filter: blur(4px) saturate(1.2);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0) saturate(1.14);
+  }
 }
 
 @keyframes twin-shock-fade-in {

--- a/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
+++ b/src/components/TwinShockRevealOverlay/TwinShockRevealOverlay.tsx
@@ -102,6 +102,10 @@ export default function TwinShockRevealOverlay({
     };
   }, [reveal]);
 
+  const showingIncomingAvatar = stage !== 'intro';
+  const visibleAvatar = showingIncomingAvatar ? display.afterAvatar : display.beforeAvatar;
+  const visibleName = showingIncomingAvatar ? display.afterName : display.beforeName;
+
   if (!rect || stage === 'done') return null;
 
   const style = {
@@ -124,28 +128,17 @@ export default function TwinShockRevealOverlay({
       <div className="twin-shock-reveal__beam" />
       <div className="twin-shock-reveal__tile">
         <div className="twin-shock-reveal__avatar-wrap">
-          {display.beforeAvatar ? (
+          {visibleAvatar ? (
             <img
-              className="twin-shock-reveal__avatar twin-shock-reveal__avatar--before"
-              src={display.beforeAvatar}
+              key={`${showingIncomingAvatar ? 'after' : 'before'}-${visibleAvatar}`}
+              className={`twin-shock-reveal__avatar twin-shock-reveal__avatar--${showingIncomingAvatar ? 'after' : 'before'}`}
+              src={visibleAvatar}
               alt=""
               draggable={false}
             />
           ) : (
-            <span className="twin-shock-reveal__avatar-fallback twin-shock-reveal__avatar-fallback--before">
-              {display.beforeName.slice(0, 2).toUpperCase()}
-            </span>
-          )}
-          {display.afterAvatar ? (
-            <img
-              className="twin-shock-reveal__avatar twin-shock-reveal__avatar--after"
-              src={display.afterAvatar}
-              alt=""
-              draggable={false}
-            />
-          ) : (
-            <span className="twin-shock-reveal__avatar-fallback twin-shock-reveal__avatar-fallback--after">
-              {display.afterName.slice(0, 2).toUpperCase()}
+            <span className={`twin-shock-reveal__avatar-fallback twin-shock-reveal__avatar-fallback--${showingIncomingAvatar ? 'after' : 'before'}`}>
+              {visibleName.slice(0, 2).toUpperCase()}
             </span>
           )}
         </div>

--- a/src/components/TwinShockRevealOverlay/__tests__/TwinShockRevealOverlay.test.tsx
+++ b/src/components/TwinShockRevealOverlay/__tests__/TwinShockRevealOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import TwinShockRevealOverlay from '../TwinShockRevealOverlay';
 
@@ -50,5 +50,33 @@ describe('TwinShockRevealOverlay', () => {
 
     expect(tile.style.opacity).toBe('');
     expect(tile.style.visibility).toBe('');
+  });
+
+  it('renders exactly one full-frame portrait throughout the swap', () => {
+    const { container, unmount } = render(
+      <TwinShockRevealOverlay
+        reveal={{
+          type: 'ali_enters',
+          replacedPlayerId: 'finn',
+          replacedPlayerName: 'Finn',
+          replacedPlayerAvatar: '/finn.webp',
+          incomingPlayerId: 'ali',
+          incomingName: 'Ali',
+          incomingAvatar: '/ali.webp',
+        }}
+        getTileRect={() => new DOMRect(10, 20, 80, 100)}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelectorAll('.twin-shock-reveal__avatar')).toHaveLength(1);
+    expect(container.querySelector('img')).toHaveAttribute('src', '/finn.webp');
+
+    act(() => vi.advanceTimersByTime(2100));
+
+    expect(container.querySelectorAll('.twin-shock-reveal__avatar')).toHaveLength(1);
+    expect(container.querySelector('img')).toHaveAttribute('src', '/ali.webp');
+
+    unmount();
   });
 });

--- a/src/features/twists/__tests__/dayStartShock.test.ts
+++ b/src/features/twists/__tests__/dayStartShock.test.ts
@@ -22,4 +22,15 @@ describe('day start shock selection', () => {
     expect(selection?.templateId).toBeTruthy();
     expect(rng).toHaveBeenCalledTimes(2);
   });
+
+  it('never selects the user player', () => {
+    const players: Player[] = [
+      { id: 'user', name: 'You', avatar: '🧑', status: 'active', isUser: true },
+      { id: 'ai', name: 'Housemate', avatar: '👩', status: 'active' },
+    ];
+
+    const selection = buildDayStartShockSelection(players, () => 0);
+
+    expect(selection?.targetId).toBe('ai');
+  });
 });

--- a/src/features/twists/dayStartShock.ts
+++ b/src/features/twists/dayStartShock.ts
@@ -141,8 +141,19 @@ function formatShockReason(template: ShockTemplate, name: string): string {
   return template.text.replace(/\{\{name\}\}/g, name);
 }
 
-export function buildDayStartShockSelection(players: Player[], rng: () => number): DayStartShockSelection | null {
-  const activePlayers = players.filter((player) => player.status !== 'evicted' && player.status !== 'jury');
+export function buildDayStartShockSelection(
+  players: Player[],
+  rng: () => number,
+  excludedPlayerIds: Iterable<string> = [],
+): DayStartShockSelection | null {
+  const excludedIds = new Set(excludedPlayerIds);
+  const activePlayers = players.filter(
+    (player) =>
+      player.status !== 'evicted'
+      && player.status !== 'jury'
+      && !player.isUser
+      && !excludedIds.has(player.id),
+  );
   if (activePlayers.length === 0) return null;
 
   const target = seededPick(rng, activePlayers);

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -428,6 +428,7 @@ export function createInitialGameState(options?: { twinShockConsumed?: boolean }
     },
     pendingForcedShock: null,
     dayStartShock: null,
+    dayStartShockUsedThisSeason: false,
     twinShock: createInitialTwinShockState(),
     twinShockConsumed,
     twinShockActivatedSeason: null,
@@ -2913,6 +2914,7 @@ const gameSlice = createSlice({
      */
     activateDayStartShock(state, action: PayloadAction<DayStartShockState>) {
       state.dayStartShock = action.payload;
+      state.dayStartShockUsedThisSeason = true;
       state.twistActivatedThisWeek = true;
     },
 
@@ -6466,6 +6468,7 @@ export const tryActivateDayStartShock =
     if (!settings.sim.enableTwists) return false;
     if (game.phase !== 'week_start') return false;
     if (game.dayStartShock) return false;
+    if (game.dayStartShockUsedThisSeason) return false;
     if (game.pendingForcedShock) return false;
     if (game.twistActivatedThisWeek) return false;
     if (game.week < DAY_START_SHOCK_MIN_WEEK) return false;
@@ -6481,7 +6484,11 @@ export const tryActivateDayStartShock =
     const rng = mulberry32((game.seed ^ DAY_START_SHOCK_RNG_SALT) >>> 0);
     if (rng() * 100 >= chance) return false;
 
-    const selection = buildDayStartShockSelection(game.players, rng);
+    const selection = buildDayStartShockSelection(
+      game.players,
+      rng,
+      game.players.filter((player) => player.isUser).map((player) => player.id),
+    );
     if (!selection) return false;
 
     dispatch(
@@ -6510,6 +6517,10 @@ export const tryActivatePendingForcedDayStartShock =
     if (game.phase !== 'week_start') return false;
     if (game.week < pending.earliestWeek) return false;
     if (game.dayStartShock) return false;
+    if (game.dayStartShockUsedThisSeason) {
+      dispatch(clearForcedShock());
+      return false;
+    }
     if (game.twistActivatedThisWeek) return false;
 
     const activePlayers = game.players.filter(
@@ -6521,7 +6532,11 @@ export const tryActivatePendingForcedDayStartShock =
     }
 
     const rng = mulberry32((game.seed ^ (DAY_START_SHOCK_RNG_SALT ^ 0x1f1f1f1f)) >>> 0);
-    const selection = buildDayStartShockSelection(game.players, rng);
+    const selection = buildDayStartShockSelection(
+      game.players,
+      rng,
+      game.players.filter((player) => player.isUser).map((player) => player.id),
+    );
     if (!selection) {
       dispatch(clearForcedShock());
       return false;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -813,6 +813,8 @@ export interface GameState {
    * confirms the eviction.
    */
   dayStartShock?: DayStartShockState | null;
+  /** True after Morning Shock activates, preventing another activation this season. */
+  dayStartShockUsedThisSeason?: boolean;
   /**
    * When set, the VoteResultsPopup is shown with the vote tally before
    * advancing. Maps nominee ID → number of votes received.

--- a/tests/unit/publicFavoriteOverlay.test.tsx
+++ b/tests/unit/publicFavoriteOverlay.test.tsx
@@ -260,23 +260,23 @@ describe('PublicFavoriteOverlay', () => {
       />,
     );
 
-    let spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    let spotlight = screen.getByTestId('housemate-spotlight');
     expect(within(spotlight).getByRole('heading', { name: 'Jordan' })).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(3999);
+      vi.advanceTimersByTime(4499);
     });
-    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    spotlight = screen.getByTestId('housemate-spotlight');
     expect(within(spotlight).getByRole('heading', { name: 'Jordan' })).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(1);
+      vi.advanceTimersByTime(1501);
     });
-    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    spotlight = screen.getByTestId('housemate-spotlight');
     expect(within(spotlight).getByRole('heading', { name: 'Taylor' })).toBeInTheDocument();
   });
 
-  it('does not restart the spotlight timer when vote eliminations change the active pool', () => {
+  it('holds the current spotlight through an elimination, then skips eliminated candidates', () => {
     let votingState = {
       votes: { p1: 10, p2: 70, p3: 20 },
       eliminated: [] as string[],
@@ -293,7 +293,7 @@ describe('PublicFavoriteOverlay', () => {
       />,
     );
 
-    let spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
+    let spotlight = screen.getByTestId('housemate-spotlight');
     expect(within(spotlight).getByRole('heading', { name: 'Jordan' })).toBeInTheDocument();
 
     act(() => {
@@ -315,15 +315,15 @@ describe('PublicFavoriteOverlay', () => {
       />,
     );
 
-    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
-    expect(within(spotlight).getByRole('heading', { name: 'Taylor' })).toBeInTheDocument();
+    spotlight = screen.getByTestId('housemate-spotlight');
+    expect(within(spotlight).getByRole('heading', { name: 'Jordan' })).toBeInTheDocument();
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(2500);
     });
 
-    spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });
-    expect(within(spotlight).getByRole('heading', { name: 'Morgan' })).toBeInTheDocument();
+    spotlight = screen.getByTestId('housemate-spotlight');
+    expect(within(spotlight).getByRole('heading', { name: 'Taylor' })).toBeInTheDocument();
   });
 
   it('removes vote-eliminated players from the spotlight pool and marks the final two', () => {
@@ -373,7 +373,7 @@ describe('PublicFavoriteOverlay', () => {
     const firstFinnFact = within(spotlight).getByText(/marine architect/i).textContent;
 
     act(() => {
-      vi.advanceTimersByTime(12000);
+      vi.advanceTimersByTime(18000);
     });
 
     spotlight = screen.getByRole('region', { name: /houseguest spotlight/i });


### PR DESCRIPTION
## What changed
- Limits Morning Shock to one activation per season and excludes the user from its targets.
- Preloads tribunal, recap, cutout, silhouette, and finale imagery ahead of cinematic use.
- Makes the Twin Shock reveal use one full-frame portrait instead of two overlapping images.
- Slows the final-recap eviction ladder and prevents label clipping on smaller screens.
- Keeps Public Favorite eliminations in the fixed announcement area and holds each housemate spotlight for 4.5–6 seconds.

## Why
These changes address issues #1142–#1146: repeated Morning Shocks, late-loading finale images, rushed/clipped ladder beats, doubled Twin Shock avatars, and Public Favorite layout/spotlight instability.

## Validation
- `npm run typecheck`
- Focused Vitest coverage for Twin Shock, Morning Shock, tribunal voting, Public Favorite spotlight pacing, and eviction ladder scenes.