### PR TITLE
Fix juror battle-back flow and pre-jury game over

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -7,6 +7,7 @@ import {
   forceHoH,
   forceNominees,
   forcePovWinner,
+  forcePlayerStatus,
   forcePhase,
   finalizeFinal4Eviction,
   clearBlockingFlags,
@@ -170,6 +171,7 @@ export default function DebugPanel() {
   const [nominee1, setNominee1] = useState('');
   const [nominee2, setNominee2] = useState('');
   const [selectedPov, setSelectedPov] = useState('');
+  const [selectedStatusPlayer, setSelectedStatusPlayer] = useState('');
   const [selectedF4Evictee, setSelectedF4Evictee] = useState('');
   const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction');
 
@@ -441,6 +443,19 @@ export default function DebugPanel() {
                 >
                   Set
                 </button>
+              </div>
+
+              <div className="dbg-row dbg-row--col">
+                <label className="dbg-label">Player House Status</label>
+                <select aria-label="Player House Status" className="dbg-select" value={selectedStatusPlayer} onChange={(e) => setSelectedStatusPlayer(e.target.value)}>
+                  <option value="">— pick player —</option>
+                  {game.players.map((p) => <option key={p.id} value={p.id}>{p.name} ({p.status})</option>)}
+                </select>
+                <div className="dbg-row">
+                  <button className="dbg-btn" disabled={!selectedStatusPlayer} onClick={() => dispatch(forcePlayerStatus({ playerId: selectedStatusPlayer, status: 'jury' }))}>Set Tribunal</button>
+                  <button className="dbg-btn" disabled={!selectedStatusPlayer} onClick={() => dispatch(forcePlayerStatus({ playerId: selectedStatusPlayer, status: 'evicted' }))}>Set Pre-jury Evicted</button>
+                  <button className="dbg-btn" disabled={!selectedStatusPlayer} onClick={() => dispatch(forcePlayerStatus({ playerId: selectedStatusPlayer, status: 'active' }))}>Restore Active</button>
+                </div>
               </div>
 
               <div className="dbg-row">

--- a/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
@@ -26,6 +26,20 @@ function makeStore() {
 }
 
 describe('DebugPanel forced shock controls', () => {
+  it('can place a player in the Tribunal for battle-back testing', async () => {
+    const user = userEvent.setup()
+    const store = makeStore()
+    const player = store.getState().game.players[0]
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/game?debug=1&qa=1']}><DebugPanel /></MemoryRouter>
+      </Provider>,
+    )
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Player House Status' }), player.id)
+    await user.click(screen.getByRole('button', { name: 'Set Tribunal' }))
+    expect(store.getState().game.players.find((candidate) => candidate.id === player.id)?.status).toBe('jury')
+  })
+
   it('includes Back 2 the Game in the force shock dropdown and queues it', async () => {
     const user = userEvent.setup()
     const store = makeStore()

--- a/src/screens/GameScreen/GameScreen.css
+++ b/src/screens/GameScreen/GameScreen.css
@@ -332,5 +332,15 @@ body:has(.game-screen-shell) {
   pointer-events: none;
 }
 
+.game-screen__battle-back-minigame {
+  position: fixed;
+  inset: 0;
+  z-index: 9200;
+  isolation: isolate;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  background: #07170f;
+}
+
 
 /* ── end of GameScreen.css ─────────────────────────────────────────────────── */

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -60,11 +60,12 @@ import {
   submitCoLohNomination,
   submitPosTieBreak,
   completeTwinShockRevealAnimation,
+  resetGame,
 } from '../../store/gameSlice'
 import { startChallenge, selectPendingChallenge, completeChallenge, type PendingChallenge } from '../../store/challengeSlice'
 import { selectLastSocialReport } from '../../social/socialSlice'
 import { setEnergyBankEntry } from '../../social/socialSlice'
-import { useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { selectSocialSummaryOpen } from '../../store/uiSlice'
 import TvZone from '../../components/ui/TvZone'
 import HouseguestGrid from '../../components/HouseguestGrid/HouseguestGrid'
@@ -98,6 +99,7 @@ import SocialSummaryPopup from '../../components/SocialSummary/SocialSummaryPopu
 import SpectatorView from '../../components/ui/SpectatorView'
 import type { SpectatorVariant } from '../../components/ui/SpectatorView'
 import Capitalization from '../../components/Capitalization/Capitalization'
+import ConfirmExitModal from '../../components/ConfirmExitModal/ConfirmExitModal'
 import Final3Ceremony from '../../components/Final3Ceremony/Final3Ceremony'
 import { getProfilePhotoAvatarId, resolveAvatar } from '../../utils/avatar'
 import { pickPhrase, NOMINEE_PLEA_TEMPLATES } from '../../utils/juryUtils'
@@ -313,6 +315,7 @@ function buildDoubleEvictionPostVoteAnnouncement(options: {
  */
 export default function GameScreen() {
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const store = useStore<RootState>()
   const gameScreenRef = useRef<HTMLDivElement | null>(null)
@@ -404,6 +407,16 @@ export default function GameScreen() {
 
   const humanPlayer = game.players.find((p) => p.isUser)
   const humanPlayerEliminated = humanPlayer?.status === 'evicted' || humanPlayer?.status === 'jury'
+  const preJuryGameOver = game.mode !== 'survival' && humanPlayer?.status === 'evicted'
+  const handleStartNewSeason = useCallback(() => {
+    dispatch(resetGame())
+    dispatch({ type: 'challenge/setPendingChallenge', payload: null })
+    navigate('/', { replace: true })
+  }, [dispatch, navigate])
+  const handlePreJuryReturnHome = useCallback(() => {
+    dispatch({ type: 'challenge/setPendingChallenge', payload: null })
+    navigate('/', { replace: true })
+  }, [dispatch, navigate])
   const confessionalTvAnnouncement = confessionalPromptTriggered && showConfessionalTvPrompt
     ? {
       key: 'confessional_required',
@@ -4089,16 +4102,18 @@ export default function GameScreen() {
 
       {/* ── Back 2 the Game / Jury Return twist overlay ──────────────────── */}
       {showBattleBackOverlay && useBattleBackMinigame && (
-        <Capitalization
-          key={`${battleBackCandidateIds.join('-')}-bb-cap-${battleBackAttemptIndex}`}
-          context="battleBack"
-          participantIds={battleBackCandidateIds}
-          participants={battleBackCapitalizationParticipants}
-          seed={battleBackAttemptSeed}
-          onFinish={(_value, _tiebreakerMs, completion) => {
-            handleBattleBackComplete(completion?.authoritativeWinnerId ?? null)
-          }}
-        />
+        <div className="game-screen__battle-back-minigame" aria-label="Back 2 the Game competition">
+          <Capitalization
+            key={`${battleBackCandidateIds.join('-')}-bb-cap-${battleBackAttemptIndex}`}
+            context="battleBack"
+            participantIds={battleBackCandidateIds}
+            participants={battleBackCapitalizationParticipants}
+            seed={battleBackAttemptSeed}
+            onFinish={(_value, _tiebreakerMs, completion) => {
+              handleBattleBackComplete(completion?.authoritativeWinnerId ?? null)
+            }}
+          />
+        </div>
       )}
       {showBattleBackOverlay && !useBattleBackMinigame && (
         <SpectatorView
@@ -4111,6 +4126,15 @@ export default function GameScreen() {
           onDone={() => handleBattleBackComplete()}
         />
       )}
+      <ConfirmExitModal
+        open={preJuryGameOver}
+        title="Your season is over"
+        description="You were eliminated before the Tribunal began, so you cannot return to the game or cast a finale vote."
+        confirmLabel="Start New Season"
+        cancelLabel="Return Home"
+        onConfirm={handleStartNewSeason}
+        onCancel={handlePreJuryReturnHome}
+      />
 
       {/* ── Public's Favorite Player voting overlay ───────────────────────── */}
       {isPublicModeEnabled(game.mode) && showFavoriteVoting && favoritePlayer && (

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -3336,6 +3336,29 @@ const gameSlice = createSlice({
         pushEvent(state, `[DEBUG] ${player.name} forced as POS winner. 🎭`, 'game');
       }
     },
+    /** Force a player's house status without leaving stale competition roles (debug only). */
+    forcePlayerStatus(
+      state,
+      action: PayloadAction<{ playerId: string; status: 'active' | 'jury' | 'evicted' }>,
+    ) {
+      const { playerId, status } = action.payload;
+      const player = state.players.find((candidate) => candidate.id === playerId);
+      if (!player) return;
+      if (status !== 'active') {
+        state.nomineeIds = state.nomineeIds.filter((id) => id !== playerId);
+        state.povProtectedIds = (state.povProtectedIds ?? []).filter((id) => id !== playerId);
+        if (state.lohId === playerId) state.lohId = null;
+        if (state.posWinnerId === playerId) state.posWinnerId = null;
+        player.evictedAtWeek = player.evictedAtWeek ?? state.week;
+      } else {
+        player.evictedAtWeek = undefined;
+        player.finalRank = undefined;
+        player.seasonPlacement = undefined;
+        player.isWinner = false;
+      }
+      player.status = status;
+      pushEvent(state, `[DEBUG] ${player.name} forced to ${status} status.`, 'game');
+    },
     /** Force entry into Final 4 eviction phase (debug only). */
     forcePhase(state, action: PayloadAction<Phase>) {
       state.phase = action.payload;
@@ -5667,6 +5690,7 @@ export const {
   forceHoH,
   forceNominees,
   forcePovWinner,
+  forcePlayerStatus,
   forcePhase,
   clearBlockingFlags,
   archiveSeason,


### PR DESCRIPTION
## What changed

- Keep the Back 2 the Game Capitalization minigame above the houseguest roster so its input, submit, and skip controls remain playable.
- Add debug controls to place any player in the Tribunal, mark them pre-jury evicted, or restore them to active status.
- Restore a blocking game-over modal when the user is eliminated before the Tribunal begins.
- Add regression coverage for the Tribunal debug control.

## Root cause

The human battle-back minigame was mounted directly inside GameScreen without the fullscreen stacking layer used by other minigame hosts. Higher-z-index roster tiles therefore painted over the competition. The pre-jury terminal state also had no standard-mode blocking UI after the older behavior disappeared.

## Impact

Jurors can now complete Back 2 the Game without the roster obscuring controls. Pre-jury evictees receive a clear terminal outcome, while Tribunal members remain eligible for return competitions and finale voting.

## Validation

- npm run typecheck
- targeted DebugPanel Vitest suite (4 passing)
- ESLint on changed TypeScript files
- git diff --check