### PR TITLE
Redesign the Kolequant synthesis splash

### DIFF
--- a/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
+++ b/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
@@ -3,17 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { getAll } from '../../data/houseguests';
 import { resolveAvatar } from '../../utils/avatar';
 import { preloadImage, preloadImages } from '../../utils/preload';
-import KolequantSplash from '../KolequantSplash/KolequantSplash';
+import GameLoadingSplash from '../GameLoadingSplash/GameLoadingSplash';
 
 const GAMEPLAY_BG = '/assets/bb-gameplay-bg.svg';
-const GAMEPLAY_MESSAGES = [
-  'Opening the competition arena.',
-  'Lighting the game board.',
-  'Positioning the houseguests.',
-  'Priming the challenge controls.',
-  'Rolling cameras for the next scene.',
-] as const;
-
 function getAvatarUrls(): string[] {
   return getAll().map((hg) =>
     resolveAvatar({ id: hg.id, name: hg.name, avatar: '' }),
@@ -58,12 +50,9 @@ export default function AssetPreloaderOverlay() {
   }, [navigate]);
 
   return (
-    <KolequantSplash
-      duration={600000}
-      ready={false}
+    <GameLoadingSplash
       progress={progress}
       status={status}
-      messages={GAMEPLAY_MESSAGES}
     />
   );
 }

--- a/src/components/GameLoadingSplash/GameLoadingSplash.css
+++ b/src/components/GameLoadingSplash/GameLoadingSplash.css
@@ -1,0 +1,157 @@
+.game-loading {
+  --game-loading-width: min(72vw, 232px);
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  min-height: 100dvh;
+  overflow: hidden;
+  color: #f7faff;
+  background:
+    radial-gradient(ellipse 64% 42% at 50% -8%, rgba(103, 75, 172, 0.18), transparent 70%),
+    radial-gradient(ellipse 48% 42% at -8% 72%, rgba(21, 72, 117, 0.17), transparent 72%),
+    radial-gradient(ellipse 48% 42% at 108% 66%, rgba(34, 105, 117, 0.14), transparent 72%),
+    radial-gradient(ellipse 42% 26% at 50% 41%, rgba(70, 92, 185, 0.11), transparent 74%),
+    linear-gradient(155deg, #111126 0%, #060b1a 48%, #060915 100%);
+  pointer-events: none;
+  isolation: isolate;
+}
+
+.game-loading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: radial-gradient(circle at center, transparent 66%, rgba(0, 0, 0, 0.27) 100%);
+}
+
+.game-loading__center {
+  position: absolute;
+  z-index: 2;
+  top: 37%;
+  left: 50%;
+  width: var(--game-loading-width);
+  transform: translate(-50%, -50%);
+  text-align: center;
+}
+
+.game-loading__eye {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 210 / 124;
+  opacity: 0;
+  transform: translateY(3px) scale(0.985);
+  animation: game-loading-eye-in 440ms cubic-bezier(0.22, 1, 0.36, 1) 40ms forwards;
+}
+
+.game-loading__eye::before {
+  content: '';
+  position: absolute;
+  inset: 22% 7% 14%;
+  border-radius: 50%;
+  background: rgba(72, 91, 194, 0.09);
+  filter: blur(20px);
+}
+
+.game-loading__eye-svg { position: relative; display: block; width: 100%; height: 100%; overflow: visible; }
+.game-loading__eye-surface { fill: rgba(8, 13, 25, 0.86); }
+.game-loading__eye-track,
+.game-loading__eye-progress,
+.game-loading__eye-sweep { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.game-loading__eye-track { stroke: #3a4355; stroke-width: 2; }
+.game-loading__eye-progress {
+  stroke: url(#game-loading-gradient);
+  stroke-width: 2.5;
+  filter: url(#game-loading-glow);
+  transition: stroke-dasharray 260ms ease-out;
+}
+.game-loading__eye-sweep {
+  stroke: rgba(221, 247, 255, 0.82);
+  stroke-width: 1.4;
+  stroke-dasharray: 3 97;
+  opacity: 0.48;
+  filter: url(#game-loading-glow);
+  animation: game-loading-sweep 1.55s linear infinite;
+}
+.game-loading__iris-bed { fill: url(#game-loading-iris); stroke: #303a50; stroke-width: 1.4; }
+.game-loading__iris-ring { fill: none; stroke: url(#game-loading-gradient); stroke-width: 1.5; opacity: 0.68; }
+.game-loading__iris-rotor {
+  transform-box: view-box;
+  transform-origin: 105px 62px;
+  animation: game-loading-iris 7.5s linear infinite;
+}
+.game-loading__aperture-blade {
+  fill: rgba(67, 82, 139, 0.22);
+  stroke: rgba(111, 130, 190, 0.66);
+  stroke-width: 0.85;
+  stroke-linejoin: round;
+}
+.game-loading__pupil-ring { fill: #080c17; stroke: #4c5873; stroke-width: 1.2; }
+.game-loading__pupil { fill: #010309; }
+.game-loading__glint { fill: rgba(225, 245, 255, 0.72); }
+
+.game-loading__status {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 15px;
+  color: rgba(216, 225, 241, 0.72);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(12px, 3vw, 13.5px);
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: 0.018em;
+  opacity: 0;
+  transform: translateY(3px);
+  animation: game-loading-copy-in 360ms ease 220ms forwards;
+}
+.game-loading__status span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left; }
+.game-loading__status span:last-child { color: rgba(222, 235, 255, 0.5); font-variant-numeric: tabular-nums; }
+
+.game-loading__brand {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  bottom: max(34px, calc(env(safe-area-inset-bottom, 0px) + 22px));
+  left: 0;
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  padding: 0 24px;
+  opacity: 0;
+  transform: translateY(6px);
+  animation: game-loading-brand-in 460ms ease 300ms forwards;
+}
+.game-loading__logo { width: clamp(154px, 38vw, 188px); height: auto; object-fit: contain; }
+.game-loading__tagline {
+  color: rgba(197, 206, 224, 0.52);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(10.5px, 2.55vw, 11.75px);
+  line-height: 1.3;
+  letter-spacing: 0.012em;
+  white-space: nowrap;
+  transform: translateX(11px);
+}
+
+@keyframes game-loading-eye-in { to { opacity: 1; transform: translateY(0) scale(1); } }
+@keyframes game-loading-copy-in { to { opacity: 1; transform: translateY(0); } }
+@keyframes game-loading-brand-in { to { opacity: 1; transform: translateY(0); } }
+@keyframes game-loading-sweep { to { stroke-dashoffset: -100; } }
+@keyframes game-loading-iris { to { transform: rotate(360deg); } }
+
+@media (max-height: 660px) {
+  .game-loading__center { top: 34%; }
+  .game-loading__brand { bottom: max(25px, calc(env(safe-area-inset-bottom, 0px) + 16px)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .game-loading__eye,
+  .game-loading__eye-sweep,
+  .game-loading__iris-rotor,
+  .game-loading__status,
+  .game-loading__brand {
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
+  }
+}

--- a/src/components/GameLoadingSplash/GameLoadingSplash.tsx
+++ b/src/components/GameLoadingSplash/GameLoadingSplash.tsx
@@ -1,0 +1,87 @@
+import type { CSSProperties } from 'react';
+import './GameLoadingSplash.css';
+
+interface Props {
+  progress: number;
+  status: string;
+}
+
+const LOGO_SRC = `${import.meta.env.BASE_URL}assets/kolequant.png`;
+
+function clampProgress(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+export default function GameLoadingSplash({ progress, status }: Props) {
+  const value = clampProgress(progress);
+  const eyePath = 'M10 62C52 16 158 16 200 62C158 108 52 108 10 62Z';
+  const style = { '--game-loading-progress': `${value}%` } as CSSProperties;
+
+  return (
+    <div
+      className="game-loading"
+      style={style}
+      role="status"
+      aria-live="polite"
+      aria-label={`${status} ${value}%`}
+    >
+      <div className="game-loading__center" aria-hidden="true">
+        <div className="game-loading__eye">
+          <svg className="game-loading__eye-svg" viewBox="0 0 210 124" fill="none">
+            <defs>
+              <linearGradient id="game-loading-gradient" x1="10" y1="38" x2="200" y2="86" gradientUnits="userSpaceOnUse">
+                <stop stopColor="#9957ff" />
+                <stop offset="0.52" stopColor="#6378ff" />
+                <stop offset="1" stopColor="#22d7df" />
+              </linearGradient>
+              <radialGradient id="game-loading-iris" cx="43%" cy="38%" r="70%">
+                <stop stopColor="#18213b" />
+                <stop offset="1" stopColor="#070b15" />
+              </radialGradient>
+              <filter id="game-loading-glow" x="-25%" y="-35%" width="150%" height="170%">
+                <feGaussianBlur stdDeviation="1.6" result="blur" />
+                <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+              </filter>
+            </defs>
+
+            <path className="game-loading__eye-surface" d={eyePath} />
+            <circle className="game-loading__iris-bed" cx="105" cy="62" r="37" />
+            <circle className="game-loading__iris-ring" cx="105" cy="62" r="33" />
+            <g className="game-loading__iris-rotor">
+              {Array.from({ length: 8 }, (_, index) => (
+                <path
+                  key={index}
+                  className="game-loading__aperture-blade"
+                  d="M105 30A32 32 0 0 1 125 37L113 55L105 62Z"
+                  transform={`rotate(${index * 45} 105 62)`}
+                />
+              ))}
+            </g>
+            <circle className="game-loading__pupil-ring" cx="105" cy="62" r="15" />
+            <circle className="game-loading__pupil" cx="105" cy="62" r="8" />
+            <circle className="game-loading__glint" cx="102" cy="59" r="1.5" />
+
+            <path className="game-loading__eye-track" d={eyePath} pathLength="100" />
+            <path
+              className="game-loading__eye-progress"
+              d={eyePath}
+              pathLength="100"
+              style={{ strokeDasharray: `${value} ${100 - value}` }}
+            />
+            <path className="game-loading__eye-sweep" d={eyePath} pathLength="100" />
+          </svg>
+        </div>
+        <div className="game-loading__status">
+          <span>{status.replace(/\.+$/, '')}…</span>
+          <span>{value}%</span>
+        </div>
+      </div>
+
+      <div className="game-loading__brand">
+        <img src={LOGO_SRC} alt="Kolequant" className="game-loading__logo" draggable={false} decoding="async" />
+        <span className="game-loading__tagline">Life&apos;s short, let&apos;s change that</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GameLoadingSplash/__tests__/GameLoadingSplash.test.tsx
+++ b/src/components/GameLoadingSplash/__tests__/GameLoadingSplash.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import GameLoadingSplash from '../GameLoadingSplash';
+
+describe('GameLoadingSplash', () => {
+  it('renders the eye loader with determinate progress', () => {
+    const { container } = render(
+      <GameLoadingSplash progress={42} status="Preparing the houseguest portraits." />,
+    );
+
+    expect(screen.getByRole('status')).toHaveAccessibleName(
+      'Preparing the houseguest portraits. 42%',
+    );
+    expect(screen.getByAltText('Kolequant')).toBeInTheDocument();
+    expect(container.querySelector('.game-loading__eye-svg')).toHaveAttribute(
+      'viewBox',
+      '0 0 210 124',
+    );
+    expect(container.querySelectorAll('.game-loading__iris-rotor')).toHaveLength(1);
+    expect(container.querySelectorAll('.game-loading__eye-progress')).toHaveLength(1);
+    expect(container.querySelector('.kq-splash')).toBeNull();
+  });
+
+  it('clamps progress to the supported range', () => {
+    render(<GameLoadingSplash progress={140} status="Entering the house." />);
+    expect(screen.getByRole('status')).toHaveAccessibleName('Entering the house. 100%');
+  });
+});


### PR DESCRIPTION
## Summary

- reset the branch to the latest main
- leave the existing Kolequant launch splash completely unchanged
- add a separate eye-based loading screen used only after Play → Classic or Play → Survival
- keep the existing preload and direct navigation behavior unchanged
- isolate all new styles under game-loading class names so they cannot affect the launch splash or game UI

## Validation

- launch splash has no diff from main
- typecheck passed
- 13 focused tests passed
- ESLint passed for changed TypeScript files
- production build passed
- git diff check passed