### PR TITLE
Improve minigame and social decision realism

### DIFF
--- a/src/bb/secretMission.ts
+++ b/src/bb/secretMission.ts
@@ -187,6 +187,7 @@ export interface MissionBuildContext {
   triggeredDay: number;
   templateId: string;
   targetCandidateIds?: string[];
+  variant?: number;
 }
 
 export interface MissionTemplate {
@@ -453,7 +454,9 @@ function buildWeightedTaskStack(
   weights: Record<WeightedRequirementType, number>,
 ): Omit<MissionTask, 'completed' | 'current'>[] {
   const endDay = context.triggeredDay + daySpan;
-  const rng = createSeededRng(hashString(`${context.templateId}:${context.triggeredDay}:${endDay}`));
+  const rng = createSeededRng(
+    hashString(`${context.templateId}:${context.triggeredDay}:${endDay}:${context.variant ?? 0}`),
+  );
   const chosenTypes = weightedPickDistinct(weights, 4, rng);
   return [
     buildRequirementTask('survive_days', context, endDay, rng),
@@ -547,18 +550,85 @@ export const MISSION_TEMPLATES: MissionTemplate[] = [
 export function buildMissionTasks(
   template: MissionTemplate,
   triggeredDay: number,
-  options?: Omit<MissionBuildContext, 'triggeredDay' | 'templateId'>,
+  options?: {
+    targetCandidateIds?: string[];
+    missionNumber?: number;
+    excludedTaskSetSignatures?: string[];
+  },
 ): MissionTask[] {
-  const context: MissionBuildContext = {
-    triggeredDay,
-    templateId: template.id,
-    targetCandidateIds: options?.targetCandidateIds,
-  };
-  return buildWeightedTaskStack(context, template.daySpan, template.requirementWeights).map((task) => ({
-    ...task,
-    current: 0,
-    completed: false,
-  }));
+  const excluded = new Set(options?.excludedTaskSetSignatures ?? []);
+  let candidate: MissionTask[] = [];
+
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const context: MissionBuildContext = {
+      triggeredDay,
+      templateId: template.id,
+      targetCandidateIds: options?.targetCandidateIds,
+      variant: (options?.missionNumber ?? 1) * 101 + attempt,
+    };
+    candidate = buildWeightedTaskStack(context, template.daySpan, template.requirementWeights)
+      .map((task) => ({ ...task, current: 0, completed: false }));
+    if (!excluded.has(getMissionTaskSetSignature(candidate))) return candidate;
+  }
+
+  return candidate;
+}
+
+export function getMissionTaskSetSignature(tasks: readonly Pick<MissionTask, 'type'>[]): string {
+  return tasks.map((task) => task.type).sort().join('|');
+}
+
+const ORDINAL_TASK_REFERENCES: Readonly<Record<string, number>> = {
+  first: 1,
+  second: 2,
+  third: 3,
+  fourth: 4,
+  fifth: 5,
+};
+
+export function findSecretMissionTaskReference(
+  input: string,
+  tasks: readonly MissionTask[],
+): { task: MissionTask; taskNumber: number } | null {
+  const normalized = input.toLowerCase();
+  const numeric = normalized.match(/(?:task|mission|number|#)\s*(\d+)/i)
+    ?? normalized.match(/\b(\d+)\b/);
+  let taskNumber = numeric ? Number(numeric[1]) : 0;
+  if (!taskNumber) {
+    const ordinal = Object.entries(ORDINAL_TASK_REFERENCES)
+      .find(([word]) => normalized.includes(word));
+    taskNumber = ordinal?.[1] ?? 0;
+  }
+  const task = tasks[taskNumber - 1];
+  return task ? { task, taskNumber } : null;
+}
+
+export function getSecretMissionTaskHint(task: MissionTask, taskNumber: number): string {
+  const prefix = `To complete task ${taskNumber}`;
+  switch (task.type) {
+    case 'social_energy_empty_streak':
+      return `${prefix}, use the Social module until your Social Energy badge (⚡) reaches 0 on each required day. The checklist updates when that day ends.`;
+    case 'social_action_count':
+      return task.requiredActionIds?.length
+        ? `${prefix}, open the Social module and perform each listed interaction once: ${task.requiredActionIds.join(', ')}. Repeating the same listed action does not replace a missing one.`
+        : `${prefix}, use the Social module for the requested number of successful interactions before the deadline.`;
+    case 'incoming_response_streak':
+      return `${prefix}, open Incoming Requests and answer every request on each required day. Ignoring even one request breaks that day's streak.`;
+    case 'competition_placement':
+      return `${prefix}, finish ${task.placementThreshold === 1 ? 'first' : `in the top ${task.placementThreshold}`} in any competition before the deadline.`;
+    case 'avoid_last_place':
+      return `${prefix}, complete the required number of competitions without finishing last. Each qualifying competition adds one.`;
+    case 'public_approval_gain':
+      return `${prefix}, raise your Public Meter approval by ${task.requiredDelta ?? task.target} percentage points above the rating you had when you accepted the mission.`;
+    case 'target_nominated':
+      return `${prefix}, use social strategy such as Pitch Target or Vote Rally to help put your marked player on the block before the deadline.`;
+    case 'easter_egg_discovery':
+      return `${prefix}, talk naturally with the Big Eye and explore unusual topics or phrases. Hidden discoveries count automatically when you uncover them.`;
+    case 'survive_days':
+      return `${prefix}, remain in the house through Day ${task.endDay ?? task.target}. It updates automatically as the game advances.`;
+    default:
+      return `${prefix}, follow this checklist requirement before its deadline: ${task.description}`;
+  }
 }
 
 export function isSecretMissionSuccessful(tasks: readonly MissionTask[]): boolean {

--- a/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
+++ b/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
@@ -24,7 +24,6 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import type { RootState } from '../../store/store';
 import {
-  FINAL_TARGET_SCORE,
   initBlackjackTournament,
   resolveSpinner,
   selectPair,
@@ -67,7 +66,11 @@ const SPECTATOR_ADVANCE_MS = 600;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function avatarForId(id: string): string {
+function resolveTournamentAvatar(id: string, participants?: ParticipantProp[]): string {
+  const participant = participants?.find((entry) => entry.id === id);
+  if (participant?.avatar) {
+    return resolveAvatar({ id, name: participant.name, avatar: participant.avatar });
+  }
   const hg = HOUSEGUESTS.find((h) => h.id === id);
   if (hg) return resolveAvatar({ id: hg.id, name: hg.name, avatar: '' });
   return getDicebear(id);
@@ -121,6 +124,7 @@ interface ParticipantProp {
   id: string;
   name: string;
   isHuman: boolean;
+  avatar?: string;
 }
 
 interface Props {
@@ -137,6 +141,7 @@ interface RosterBarProps {
   controllingId: string | null;
   humanId: string | null;
   getName: (id: string) => string;
+  getAvatar: (id: string) => string;
   playerScores?: Record<string, number>;
   finalistIds?: [string, string] | null;
 }
@@ -149,8 +154,8 @@ function RosterBar({
   controllingId,
   humanId,
   getName,
+  getAvatar,
   playerScores = {},
-  finalistIds = null,
 }: RosterBarProps) {
   return (
     <div className="bjt-roster-wrap" aria-label="Remaining players">
@@ -160,12 +165,9 @@ function RosterBar({
           const isController = id === controllingId;
           const isYou = id === humanId;
           const score = playerScores[id];
-          const scoreLabel =
-            score == null || isElim
-              ? null
-              : finalistIds?.includes(id)
-                ? `${score}/${FINAL_TARGET_SCORE}`
-                : `${score} pts`;
+          const scoreLabel = score == null || isElim
+            ? null
+            : `${score} ${score === 1 ? 'life' : 'lives'}`;
           const classes = [
             'bjt-roster-item',
             isElim ? 'bjt-roster-item--eliminated' : '',
@@ -177,7 +179,7 @@ function RosterBar({
           return (
             <div key={id} className={classes}>
               <img
-                src={avatarForId(id)}
+                src={getAvatar(id)}
                 alt={getName(id)}
                 className="bjt-roster-avatar"
                 onError={(e) => {
@@ -209,6 +211,10 @@ export default function BlackjackTournamentComp({
 }: Props) {
   const dispatch = useAppDispatch();
   const bt = useAppSelector((s: RootState) => s.blackjackTournament);
+  const avatarForId = useCallback(
+    (id: string) => resolveTournamentAvatar(id, participants),
+    [participants],
+  );
 
   // Pre-computed card lengths used as stable dep-array values (avoid optional-chain in deps).
   const fighterACardCount = bt.currentDuel?.fighterACards.length ?? 0;
@@ -564,6 +570,7 @@ export default function BlackjackTournamentComp({
           controllingId={null}
           humanId={bt.humanPlayerId}
           getName={getName}
+          getAvatar={avatarForId}
           playerScores={bt.playerScores}
           finalistIds={bt.finalistIds}
         />
@@ -602,7 +609,7 @@ export default function BlackjackTournamentComp({
         <div className="bjt-players-remaining" role="status" aria-live="polite">
           <span className="bjt-badge">
             {isFinalDuelActive
-              ? `Final duel: first to ${FINAL_TARGET_SCORE}`
+              ? 'Final duel: every loss costs one life'
               : `${bt.remainingPlayerIds.length} remaining`}
           </span>
           {bt.eliminatedPlayerIds.length > 0 && (
@@ -712,6 +719,7 @@ export default function BlackjackTournamentComp({
           controllingId={controllerId}
           humanId={bt.humanPlayerId}
           getName={getName}
+          getAvatar={avatarForId}
           playerScores={bt.playerScores}
           finalistIds={bt.finalistIds}
         />
@@ -744,7 +752,7 @@ export default function BlackjackTournamentComp({
         </h2>
         {isFinalDuelActive && (
           <p className="bjt-final-score">
-            First to {FINAL_TARGET_SCORE}: {aName} {bt.playerScores[duel.fighterAId] ?? 0} -
+            Final lives: {aName} {bt.playerScores[duel.fighterAId] ?? 0} -
             {bt.playerScores[duel.fighterBId] ?? 0} {bName}
           </p>
         )}
@@ -854,6 +862,7 @@ export default function BlackjackTournamentComp({
           controllingId={bt.controllingPlayerId}
           humanId={bt.humanPlayerId}
           getName={getName}
+          getAvatar={avatarForId}
           playerScores={bt.playerScores}
           finalistIds={bt.finalistIds}
         />
@@ -894,6 +903,7 @@ export default function BlackjackTournamentComp({
             controllingId={bt.controllingPlayerId}
             humanId={bt.humanPlayerId}
             getName={getName}
+            getAvatar={avatarForId}
             playerScores={bt.playerScores}
             finalistIds={bt.finalistIds}
           />
@@ -904,13 +914,9 @@ export default function BlackjackTournamentComp({
     const winnerName = bt.duelWinnerId ? getName(bt.duelWinnerId) : '';
     const loserName = bt.duelLoserId ? getName(bt.duelLoserId) : '';
     const loserEliminated = bt.duelEliminatedId === bt.duelLoserId;
-    const winnerPreviewScore = bt.duelWinnerId
-      ? (bt.playerScores[bt.duelWinnerId] ?? 0) + 1
-      : 0;
     const loserPreviewScore = bt.duelLoserId
       ? Math.max(0, (bt.playerScores[bt.duelLoserId] ?? 0) - 1)
       : 0;
-    const finalWinPending = isFinalDuelActive && winnerPreviewScore >= FINAL_TARGET_SCORE;
 
     return (
       <div className="bjt-container bjt-result" role="status" aria-live="assertive">
@@ -957,20 +963,14 @@ export default function BlackjackTournamentComp({
         </div>
 
         <p className="bjt-eliminated-msg">
-          {isFinalDuelActive
-            ? finalWinPending
-              ? `🏁 ${winnerName} reaches ${FINAL_TARGET_SCORE} and wins the final duel!`
-              : `${winnerName} scores! ${winnerPreviewScore}/${FINAL_TARGET_SCORE}`
-            : loserEliminated
-              ? `💀 ${loserName} has been eliminated!`
-              : `${winnerName} gains 1 point; ${loserName} drops to ${loserPreviewScore}.`}
+          {loserEliminated
+            ? `💀 ${loserName} has been eliminated!`
+            : `${loserName} loses one life and drops to ${loserPreviewScore}. ${winnerName} keeps their current total.`}
         </p>
         <p className="bjt-remaining-msg">
-          {isFinalDuelActive
-            ? `Final score preview: ${winnerName} ${winnerPreviewScore}/${FINAL_TARGET_SCORE}`
-            : loserEliminated
-              ? `${bt.remainingPlayerIds.filter((id) => id !== bt.duelLoserId).length} players remain`
-              : `${bt.remainingPlayerIds.length} players remain`}
+          {loserEliminated
+            ? `${bt.remainingPlayerIds.filter((id) => id !== bt.duelLoserId).length} players remain`
+            : `${bt.remainingPlayerIds.length} players remain`}
         </p>
 
         <RosterBar
@@ -982,6 +982,7 @@ export default function BlackjackTournamentComp({
           controllingId={null}
           humanId={bt.humanPlayerId}
           getName={getName}
+          getAvatar={avatarForId}
           playerScores={bt.playerScores}
           finalistIds={bt.finalistIds}
         />
@@ -1019,6 +1020,7 @@ export default function BlackjackTournamentComp({
                 controllingId={bt.winnerId ?? null}
                 humanId={bt.humanPlayerId}
                 getName={getName}
+                getAvatar={avatarForId}
                 playerScores={bt.playerScores}
                 finalistIds={bt.finalistIds}
               />

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -69,6 +69,8 @@ export interface MinigameParticipant {
 
 export interface ReactMinigameCompletion {
   authoritativeWinnerId?: string | null;
+  /** Authoritative worst finisher when the minigame owns its full standings. */
+  authoritativeLastPlaceId?: string | null;
   rawValue?: number;
   rawResults?: Record<string, number>;
   /** Optional time-based tie-breaker in ms (lower = faster = better rank). */
@@ -667,6 +669,13 @@ export default function MinigameHost({
 
           {leaderboard ? (
             <>
+              {wasPartial && (
+                <p className="minigame-host-results-alternate-timeline">
+                  You left early and scrambled the time-space continuum. In this alternative
+                  universe, {leaderboard[0]?.name ?? 'someone unexpected'} won the competition —
+                  even if the timeline you saw was heading somewhere else.
+                </p>
+              )}
               <p className="minigame-host-results-winner">
                 🏆 {leaderboard[0]?.name ?? 'Unknown'} wins
                 {leaderboard[0]?.isHuman ? " — that's you!" : '!'}

--- a/src/components/TrapAuction/TrapAuction.tsx
+++ b/src/components/TrapAuction/TrapAuction.tsx
@@ -254,7 +254,21 @@ export default function TrapAuction({
   function handleGameComplete() {
     if (!state.winner) return;
     if (onComplete) {
-      onComplete({ authoritativeWinnerId: state.winner.id });
+      const ordered = [...state.players].sort(
+        (a, b) => (a.placement ?? Number.MAX_SAFE_INTEGER) - (b.placement ?? Number.MAX_SAFE_INTEGER),
+      );
+      const lastPlaceId = ordered[ordered.length - 1]?.id ?? null;
+      const playerCount = ordered.length;
+      onComplete({
+        authoritativeWinnerId: state.winner.id,
+        authoritativeLastPlaceId: lastPlaceId,
+        rawResults: Object.fromEntries(
+          ordered.map((player) => [
+            player.id,
+            playerCount - (player.placement ?? playerCount) + 1,
+          ]),
+        ),
+      });
     } else if (onFinish) {
       onFinish(1);
     }

--- a/src/components/TrapAuction/trapAuctionHelpers.ts
+++ b/src/components/TrapAuction/trapAuctionHelpers.ts
@@ -335,17 +335,34 @@ export function eliminatePlayers(
   ids: string[],
   round: number,
   nextPlacement: number,
+  tieBreakSeed = round,
 ): TrapAuctionPlayer[] {
-  let placementCounter = nextPlacement;
+  const hashTieBreaker = (playerId: string): number => {
+    let hash = (tieBreakSeed ^ 0x811c9dc5) >>> 0;
+    for (let i = 0; i < playerId.length; i++) {
+      hash ^= playerId.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash;
+  };
+  const tiedPlayers = players
+    .filter((player) => ids.includes(player.id) && player.isAlive)
+    // Less money after paying the tied bid ranks worse. Exact bank ties use a
+    // deterministic draw so roster order never silently decides last place.
+    .sort((a, b) => a.bank - b.bank || hashTieBreaker(a.id) - hashTieBreaker(b.id));
+  const placementById = new Map<string, number>();
+  tiedPlayers.forEach((player, index) => {
+    placementById.set(player.id, nextPlacement - index);
+  });
+
   return players.map((p) => {
-    if (ids.includes(p.id) && p.isAlive) {
-      const pl = placementCounter;
-      placementCounter--;
+    const placement = placementById.get(p.id);
+    if (placement !== undefined) {
       return {
         ...p,
         isAlive: false,
         eliminatedRound: round,
-        placement: pl,
+        placement,
       };
     }
     return p;

--- a/src/components/TrapAuction/trapAuctionReducer.ts
+++ b/src/components/TrapAuction/trapAuctionReducer.ts
@@ -264,7 +264,13 @@ export function trapAuctionReducer(
 
       // Eliminate lowest bidders
       const placement = nextPlacementFor(afterCosts);
-      const afterElimination = eliminatePlayers(afterCosts, lowestIds, state.round, placement);
+      const afterElimination = eliminatePlayers(
+        afterCosts,
+        lowestIds,
+        state.round,
+        placement,
+        state.seed ^ state.round,
+      );
 
       const humanEliminated = lowestIds.some((id) =>
         state.players.find((p) => p.id === id)?.isHuman,
@@ -421,7 +427,13 @@ function simulateToCompletion(state: TrapAuctionState): TrapAuctionState {
     const withExposure = exposeHighestBidder(withBids, highestId, s.round + 1);
     const afterCosts = applyBidCosts(withExposure, s.round);
     const placement = nextPlacementFor(afterCosts);
-    const afterElimination = eliminatePlayers(afterCosts, lowestIds, s.round, placement);
+    const afterElimination = eliminatePlayers(
+      afterCosts,
+      lowestIds,
+      s.round,
+      placement,
+      s.seed ^ s.round,
+    );
 
     s = {
       ...s,

--- a/src/features/blackjackTournament/blackjackTournamentSlice.ts
+++ b/src/features/blackjackTournament/blackjackTournamentSlice.ts
@@ -20,7 +20,8 @@
  *  - Both fighters receive two cards and alternately hit or stand.
  *  - Closest to 21 without going over wins. Bust (>21) = loss.
  *  - Exact tie (equal totals) or both-bust → TIE: rematch same pair.
- *  - After a decisive duel, loser is eliminated; duel winner becomes next controller.
+ *  - After a decisive duel, the loser loses one life; the winner becomes next controller.
+ *  - Winning never adds a life. A player is eliminated only when a loss takes them to zero.
  *  - Last player remaining wins the competition.
  *
  * Tie / rematch:
@@ -77,9 +78,9 @@ export interface BlackjackTournamentState {
   allPlayerIds: string[];
   remainingPlayerIds: string[];
   eliminatedPlayerIds: string[];
-  /** Main tournament starts each player at 3 points/lives. Finalists reset to 0. */
+  /** Every player starts with 3 lives. Only duel losses change this value. */
   playerScores: Record<string, number>;
-  /** Set when the final duel begins; finalists race from 0 to FINAL_TARGET_SCORE. */
+  /** Set when only two players remain; their existing lives carry into the final. */
   finalistIds: [string, string] | null;
 
   humanPlayerId: string | null;
@@ -128,7 +129,6 @@ const REMATCH_CAP_RNG_OFFSET = 128;
 /** Maximum number of rematches before forcing a deterministic fallback winner. */
 export const REMATCH_CAP = 100;
 export const STARTING_PLAYER_SCORE = 3;
-export const FINAL_TARGET_SCORE = 3;
 
 /** AI stands on this total or higher (standard soft-17 rule). */
 export const AI_STAND_THRESHOLD = 17;
@@ -398,8 +398,6 @@ function enterFinalDuel(state: BlackjackTournamentState): void {
   if (state.remainingPlayerIds.length !== 2) return;
   const finalists = [state.remainingPlayerIds[0], state.remainingPlayerIds[1]] as [string, string];
   state.finalistIds = finalists;
-  state.playerScores[finalists[0]] = 0;
-  state.playerScores[finalists[1]] = 0;
 }
 
 /**
@@ -666,32 +664,6 @@ const blackjackTournamentSlice = createSlice({
 
       const winner = state.duelWinnerId;
       const loser = state.duelLoserId;
-      const isFinalDuel = state.finalistIds !== null;
-
-      if (isFinalDuel) {
-        const nextWinnerScore = (state.playerScores[winner] ?? 0) + 1;
-        state.playerScores[winner] = nextWinnerScore;
-
-        state.controllingPlayerId = winner;
-        state.fighterAId = null;
-        state.fighterBId = null;
-        state.currentDuel = null;
-        state.duelEliminatedId = null;
-        state.rematchCount = 0;
-        state.duelIndex++;
-
-        if (nextWinnerScore >= FINAL_TARGET_SCORE) {
-          state.winnerId = winner;
-          state.phase = 'complete';
-          return;
-        }
-
-        autoSetFighters(state);
-        state.phase = 'pick_opponent';
-        return;
-      }
-
-      state.playerScores[winner] = (state.playerScores[winner] ?? STARTING_PLAYER_SCORE) + 1;
       const nextLoserScore = Math.max(0, (state.playerScores[loser] ?? STARTING_PLAYER_SCORE) - 1);
       state.playerScores[loser] = nextLoserScore;
 

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -985,7 +985,9 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     instructions: [
       'By a random draw selection, the first players chooses the pair to duel',
       'Both players receive 2 cards. Choose to Hit (draw a card) or Stand.',
-      'Closest to 21 without going over wins. Bust (over 21) = elimination.',
+      'Closest to 21 without going over wins the duel. A bust loses the duel.',
+      'Every player starts with 3 lives. Losing a duel costs 1 life; winning does not add one.',
+      'Reach 0 lives and you are eliminated. Remaining lives carry into the Final 2.',
       'The duel winner stays in control and picks the next pair to duel.',
       'Last player standing wins the competition!',
     ],

--- a/src/screens/DiaryRoom/DiaryRoom.tsx
+++ b/src/screens/DiaryRoom/DiaryRoom.tsx
@@ -18,7 +18,6 @@ import {
   selfEvict,
   offerSecretMission,
   acceptSecretMission,
-  reshuffleSecretMission,
   declineSecretMission,
   claimMissionReward,
   recordSecretMissionEasterEgg,
@@ -32,6 +31,8 @@ import { getSecretMissionEasterEggByIntent } from '../../bb/secretMissionEasterE
 import {
   SECRET_MISSION_BOX_REWARDS,
   getSecretMissionBoxRewards,
+  findSecretMissionTaskReference,
+  getSecretMissionTaskHint,
   pickMissionImmunityDuration,
   type SecretMissionBoxRewardType,
 } from '../../bb/secretMission';
@@ -751,6 +752,32 @@ export default function DiaryRoom() {
       return;
     }
 
+    const isMissionHintRequest =
+      secretMission?.status === 'accepted' &&
+      /(?:how|hint|help|explain|more info|what (?:do|is)|gimme|give me|complete\s+(?:task|mission))/i.test(text);
+    const missionTaskReference = isMissionHintRequest
+      ? findSecretMissionTaskReference(text, secretMission.tasks)
+      : null;
+    if (missionTaskReference) {
+      setMessages((prev) => {
+        const withSeen = prev.map((message) =>
+          message.role === 'user' && message.status !== 'seen'
+            ? { ...message, status: 'seen' as MessageStatus }
+            : message,
+        );
+        saveChat(playerId, withSeen);
+        return withSeen;
+      });
+      await appendBigEyeMessagesSequentially([
+        getSecretMissionTaskHint(
+          missionTaskReference.task,
+          missionTaskReference.taskNumber,
+        ),
+      ]);
+      setLoading(false);
+      return;
+    }
+
     try {
       const resp = await generateBigBrotherReply({
         diaryText: text,
@@ -1296,17 +1323,6 @@ export default function DiaryRoom() {
               <div className="diary-room__footer">
                 <span className="diary-room__charcount">{entry.length}/280</span>
                 <div className="diary-room__footer-actions">
-                  {secretMission?.status === 'accepted' && (
-                    <button
-                      className="diary-room__submit diary-room__submit--secondary"
-                      type="button"
-                      onClick={() => dispatch(reshuffleSecretMission())}
-                      disabled={loading}
-                      aria-label="Shuffle mission"
-                    >
-                      🔀 Shuffle
-                    </button>
-                  )}
                   <button
                     className="diary-room__submit"
                     type="submit"

--- a/src/screens/DiaryRoom/__tests__/DiaryRoom.test.tsx
+++ b/src/screens/DiaryRoom/__tests__/DiaryRoom.test.tsx
@@ -300,7 +300,7 @@ describe('DiaryRoom', () => {
     expect(screen.getByTestId('diary-room-shell')).not.toHaveClass('diary-room__shell--masked');
   });
 
-  it('shows the shuffle mission button for accepted secret missions', () => {
+  it('does not show a shuffle control for accepted secret missions', () => {
     renderDiaryRoom(['/game', '/diary-room'], {
       setupStore: (store) => {
         store.dispatch(triggerSecretMission(5));
@@ -309,10 +309,10 @@ describe('DiaryRoom', () => {
       },
     });
 
-    expect(screen.getByRole('button', { name: /shuffle mission/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /shuffle mission/i })).toBeNull();
   });
 
-  it('reshuffles accepted secret mission tasks from the confessional footer', () => {
+  it('answers task-number hint requests from the active mission checklist', async () => {
     const { store } = renderDiaryRoom(['/game', '/diary-room'], {
       setupStore: (store) => {
         store.dispatch(triggerSecretMission(5));
@@ -321,15 +321,21 @@ describe('DiaryRoom', () => {
       },
     });
 
-    const before = store.getState().game.secretMission!.tasks.map((task) => task.description);
-    expect(screen.getByRole('button', { name: /shuffle mission/i })).toBeTruthy();
+    const tasks = store.getState().game.secretMission!.tasks;
+    const taskIndex = tasks.findIndex((task) => task.type === 'social_energy_empty_streak');
+    const requestedIndex = taskIndex >= 0 ? taskIndex : 0;
 
-    fireEvent.click(screen.getByRole('button', { name: /shuffle mission/i }));
+    fireEvent.change(screen.getByLabelText(/diary entry/i), {
+      target: { value: `How do I complete task ${requestedIndex + 1}?` },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+    await flushConversationTimers();
 
-    const after = store.getState().game.secretMission!.tasks.map((task) => task.description);
-    expect(after).not.toEqual(before);
-    expect(after).toHaveLength(5);
-    expect(after.some((description) => /Survive until Day/i.test(description))).toBe(true);
+    if (taskIndex >= 0) {
+      expect(screen.getByText(/Social Energy badge.*reaches 0/i)).toBeTruthy();
+    } else {
+      expect(screen.getByText(new RegExp(`To complete task ${requestedIndex + 1}`, 'i'))).toBeTruthy();
+    }
   });
 
   it('shows four mystery reward boxes once a secret mission is completed', () => {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -3625,6 +3625,7 @@ export default function GameScreen() {
       {/* ── MinigameHost (challenge flow) ────────────────────────────────── */}
       {showMinigameHost && pendingChallenge && (
         <MinigameHost
+          key={pendingChallenge.id}
           game={pendingChallenge.game}
           gameOptions={{
             seed: pendingChallenge.seed,
@@ -3718,6 +3719,12 @@ export default function GameScreen() {
               reactCompletion?.authoritativeWinnerId != null &&
               capturedParticipants.includes(reactCompletion.authoritativeWinnerId)
                 ? reactCompletion.authoritativeWinnerId
+                : null;
+            const explicitLastPlaceId =
+              reactCompletion?.authoritativeLastPlaceId != null &&
+              capturedParticipants.includes(reactCompletion.authoritativeLastPlaceId) &&
+              reactCompletion.authoritativeLastPlaceId !== explicitWinnerId
+                ? reactCompletion.authoritativeLastPlaceId
                 : null;
 
             if (import.meta.env.DEV) {
@@ -3820,6 +3827,7 @@ export default function GameScreen() {
                 }
                 return humanPlayer.id
               }
+              if (explicitLastPlaceId) return explicitLastPlaceId;
               const ranked = computeScores(
                 pendingChallenge.game.scoringAdapter,
                 rawResults,

--- a/src/social/SocialManeuvers.ts
+++ b/src/social/SocialManeuvers.ts
@@ -49,6 +49,11 @@ interface StateForManeuvers {
 }
 
 let _store: StoreAPI | null = null;
+const FIRST_POSITIVE_MIN_DELTA = 1;
+const FIRST_POSITIVE_MAX_DELTA = 5;
+const REPEATED_POSITIVE_MIN_DELTA = 1;
+const REPEATED_POSITIVE_MAX_DELTA = 3;
+const REPEATED_BACKFIRE_DELTA = -5;
 const REPETITION_BACKFIRE_THRESHOLD = 2;
 const REPETITION_BACKFIRE_CHANCE = 0.5;
 const ALLIANCE_REJECTION_DELTA = -6;
@@ -80,6 +85,53 @@ function isRepeatSensitiveAction(
   }
 
   return delta > 0 || yields.influence > 0 || yields.info > 0;
+}
+
+function randomIntegerInclusive(min: number, max: number, random: () => number): number {
+  const normalized = Math.max(0, Math.min(0.999999999, random()));
+  return min + Math.floor(normalized * (max - min + 1));
+}
+
+/**
+ * Friendly actions feel strongest the first time, soften on the second use,
+ * and become risky from the third use onward.  Keeping this in one helper
+ * makes every positive interaction follow the same rule instead of special
+ * casing Compliment in the UI.
+ */
+export function computeRepeatedPositiveDelta(
+  priorRepeats: number,
+  random: () => number = Math.random,
+): { delta: number; didBackfire: boolean } {
+  if (priorRepeats <= 0) {
+    return {
+      delta: randomIntegerInclusive(FIRST_POSITIVE_MIN_DELTA, FIRST_POSITIVE_MAX_DELTA, random),
+      didBackfire: false,
+    };
+  }
+
+  if (priorRepeats === 1) {
+    return {
+      delta: randomIntegerInclusive(
+        REPEATED_POSITIVE_MIN_DELTA,
+        REPEATED_POSITIVE_MAX_DELTA,
+        random,
+      ),
+      didBackfire: false,
+    };
+  }
+
+  if (random() < REPETITION_BACKFIRE_CHANCE) {
+    return { delta: REPEATED_BACKFIRE_DELTA, didBackfire: true };
+  }
+
+  return {
+    delta: randomIntegerInclusive(
+      REPEATED_POSITIVE_MIN_DELTA,
+      REPEATED_POSITIVE_MAX_DELTA,
+      random,
+    ),
+    didBackfire: false,
+  };
 }
 
 function scoreToLabel(score: number): 'Bad' | 'Unmoved' | 'Good' | 'Great' {
@@ -240,6 +292,8 @@ export interface ExecuteActionOptions {
    * primary target → subject relationship to reflect the conversation.
    */
   subjectId?: string;
+  /** Optional RNG override for deterministic simulations and tests. */
+  random?: () => number;
 }
 
 export interface ExecuteActionResult {
@@ -307,6 +361,7 @@ export function executeAction(
   }
 
   const scaledYields = normalizeActionYields(action);
+  const random = options?.random ?? Math.random;
   const priorRepeats = countPriorRepeatedActions(state.social.sessionLogs, actorId, targetId, actionId);
   const existingAffinity = state.social.relationships[actorId]?.[targetId]?.affinity ?? 0;
   let outcome = options?.outcome ?? 'success';
@@ -314,25 +369,32 @@ export function executeAction(
   let gaslightOccurred = false;
   if (actionId === 'proposeAlliance' && !options?.outcome) {
     const acceptChance = getAllianceAcceptChance(existingAffinity, priorRepeats);
-    const accepted = Math.random() < acceptChance;
+    const accepted = random() < acceptChance;
     if (!accepted) {
       outcome = 'failure';
       gaslightOccurred =
         existingAffinity < ALLIANCE_GASLIGHT_AFFINITY_THRESHOLD && priorRepeats > 0;
     } else {
-      betrayalOccurred = Math.random() < getAllianceBetrayalChance(existingAffinity);
+      betrayalOccurred = random() < getAllianceBetrayalChance(existingAffinity);
     }
   }
   const baseDelta =
     actionId === 'proposeAlliance' && outcome === 'failure'
       ? getAllianceFailureDelta(gaslightOccurred)
       : computeOutcomeDelta(actionId, actorId, targetId, outcome);
-  const didBackfire =
-    outcome === 'success' &&
-    priorRepeats >= REPETITION_BACKFIRE_THRESHOLD &&
-    isRepeatSensitiveAction(action, baseDelta, scaledYields) &&
-    Math.random() < REPETITION_BACKFIRE_CHANCE;
-  const delta = didBackfire ? -Math.abs(baseDelta) : baseDelta;
+  const repeatSensitive =
+    outcome === 'success' && isRepeatSensitiveAction(action, baseDelta, scaledYields);
+  const repeatedPositive = repeatSensitive && baseDelta > 0
+    ? computeRepeatedPositiveDelta(priorRepeats, random)
+    : {
+        delta: baseDelta,
+        didBackfire:
+          repeatSensitive &&
+          priorRepeats >= REPETITION_BACKFIRE_THRESHOLD &&
+          random() < REPETITION_BACKFIRE_CHANCE,
+      };
+  const didBackfire = repeatedPositive.didBackfire;
+  const delta = repeatedPositive.delta;
 
   // Evaluate outcome score and label using the SocialPolicy evaluator.
   const mode = options?.previewOnly ? 'preview' : 'execute';

--- a/src/social/socialMiddleware.ts
+++ b/src/social/socialMiddleware.ts
@@ -69,6 +69,7 @@ interface StateWithGame {
   game: GameState;
   social?: {
     energyBank?: Record<string, number>;
+    relationships?: import('./types').RelationshipsMap;
     incomingInteractions?: IncomingInteraction[];
     scheduledIncomingInteractions?: ScheduledIncomingInteraction[];
   };
@@ -326,6 +327,10 @@ export const socialMiddleware: Middleware = (api) => (next) => (action) => {
   // ── Advance action (phase determined by comparing before/after state) ───────
   if (type === 'game/advance') {
     const prevState = api.getState() as StateWithGame;
+    api.dispatch({
+      type: 'game/syncStrategicRelationships',
+      payload: prevState.social?.relationships ?? {},
+    });
     const prevPhase = prevState.game?.phase;
     const prevHohId = prevState.game?.lohId ?? null;
     const prevPovId = prevState.game?.posWinnerId ?? null;

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -66,6 +66,7 @@ import {
   canOfferMissionImmunity,
   canUseVoteDeduction,
   isSecretMissionSuccessful,
+  getMissionTaskSetSignature,
   pickMissionImmunityDuration,
   type MissionTask,
   type LegacyMissionRewardType,
@@ -257,6 +258,8 @@ function buildSecretMissionTasksForTemplate(
     templateId: template.id,
     tasks: buildMissionTasks(template, triggeredDay, {
       targetCandidateIds: buildSecretMissionTargetCandidates(state),
+      missionNumber: state.secretMission?.missionNumber,
+      excludedTaskSetSignatures: state.secretMissionTaskSetHistory ?? [],
     }),
   };
 }
@@ -379,6 +382,7 @@ export function createInitialGameState(options?: { twinShockConsumed?: boolean }
     tiedNomineeIds: null,
     awaitingMissionImmunityOffer: false,
     secretMissionCount: 0,
+    secretMissionTaskSetHistory: [],
     secretMissionSecondChanceResolved: false,
     awaitingFinal3Eviction: false,
     awaitingFinal3Plea: false,
@@ -605,6 +609,20 @@ function getAiThreatScore(
   return score;
 }
 
+function getStrategicRelationship(state: GameState, actorId: string, targetId: string) {
+  return state.strategicRelationships?.[actorId]?.[targetId] ?? null;
+}
+
+function getSafetyRelationshipScore(state: GameState, holderId: string, nominee: Player): number {
+  const relationship = getStrategicRelationship(state, holderId, nominee.id);
+  if (!relationship) return -getAiThreatScore(state, nominee) * 3;
+  let score = relationship.affinity - getAiThreatScore(state, nominee) * 3;
+  if (relationship.tags.includes('alliance')) score += 55;
+  if (relationship.tags.includes('protection') || relationship.tags.includes('shield')) score += 25;
+  if (relationship.tags.includes('betrayal')) score -= 35;
+  return score;
+}
+
 function pickStrategicAiPlayer(
   state: GameState,
   candidates: Player[],
@@ -647,10 +665,12 @@ function pickStrategicAiPlayers(
 
 function shouldAiUseTargetedSafetyPower(
   state: GameState,
+  holderId: string | null | undefined,
   currentNominees: Player[],
   eligibleReplacements: Player[],
   options: { replacementCount?: number; preferLoh?: boolean } = {},
 ): boolean {
+  if (!holderId) return false;
   const replacementCount = Math.max(1, options.replacementCount ?? 1);
   if (eligibleReplacements.length === 0 || currentNominees.length === 0) return false;
   const currentScores = currentNominees
@@ -665,7 +685,19 @@ function shouldAiUseTargetedSafetyPower(
   const replacementValue = replacementScores
     .slice(0, Math.min(replacementCount, replacementScores.length))
     .reduce((sum, score) => sum + score, 0);
-  return replacementValue > currentValue;
+  const strategicUpgrade = replacementValue > currentValue;
+  const bestRelationship = Math.max(
+    ...currentNominees.map((nominee) => getSafetyRelationshipScore(state, holderId, nominee)),
+  );
+  let useChance = strategicUpgrade ? 0.35 : 0.05;
+  if (bestRelationship >= 75) useChance += 0.5;
+  else if (bestRelationship >= 45) useChance += 0.35;
+  else if (bestRelationship >= 20) useChance += 0.18;
+  useChance = Math.max(0.03, Math.min(0.92, useChance));
+  const rng = mulberry32(
+    (state.seed ^ hashString(`safety:${state.week}:${holderId}:${currentNominees.map((p) => p.id).join('|')}`)) >>> 0,
+  );
+  return rng() < useChance;
 }
 
 function ensureMinimumNominees(
@@ -886,8 +918,18 @@ function pickSafetySaveTarget(
   nominees: Player[],
   rng: () => number,
 ): Player | null {
-  return getTwinNomineeToSave(state, holderId, nominees)
-    ?? pickStrategicAiPlayer(state, nominees, rng, 'lowest');
+  const twin = getTwinNomineeToSave(state, holderId, nominees);
+  if (twin) return twin;
+  if (!holderId || nominees.length === 0) return null;
+  const scored = nominees.map((nominee) => ({
+    nominee,
+    score: getSafetyRelationshipScore(state, holderId, nominee),
+  }));
+  const bestScore = Math.max(...scored.map((entry) => entry.score));
+  return seededPick(
+    rng,
+    scored.filter((entry) => entry.score === bestScore).map((entry) => entry.nominee),
+  );
 }
 
 function shouldUseSafetyForTwin(state: GameState, holderId: string | null | undefined, nominees: Player[]): boolean {
@@ -1346,23 +1388,47 @@ function hashString(s: string): number {
 }
 
 /**
- * Isolated AI voting logic.
- * Deterministic placeholder — replace this function with relationship-based
- * logic once the social module is installed.
+ * Relationship-aware AI voting logic. Allies are normally protected, while
+ * threat, explicit targets, betrayal history, and rare backstabs can override.
  *
  * @param voterId     ID of the AI voter casting their vote
  * @param nomineeIds  IDs of eligible nominees (must have ≥1 entry)
  * @param gameSeed    Current game seed (keeps results varied across weeks)
  * @returns           The nominee ID that this AI voter chooses to evict
  */
-function chooseAiEvictionVote(
+export function chooseAiEvictionVote(
+  state: GameState,
   voterId: string,
   nomineeIds: string[],
   gameSeed: number,
 ): string {
-  const voterSeed = (gameSeed ^ hashString(voterId)) >>> 0;
-  const rng = mulberry32(voterSeed);
-  return nomineeIds[Math.floor(rng() * nomineeIds.length)];
+  if (nomineeIds.length <= 1) return nomineeIds[0];
+
+  const scored = nomineeIds.map((nomineeId) => {
+    const nominee = state.players.find((player) => player.id === nomineeId);
+    const relationship = getStrategicRelationship(state, voterId, nomineeId);
+    const tags = new Set(relationship?.tags ?? []);
+    const affinity = relationship?.affinity ?? 0;
+    const threat = nominee ? getAiThreatScore(state, nominee) : 0;
+    const rng = mulberry32(
+      (gameSeed ^ hashString(`vote:${state.week}:${voterId}:${nomineeId}`)) >>> 0,
+    );
+
+    let score = (threat * 8) - affinity + (rng() * 4);
+    if (tags.has('target')) score += 25;
+    if (tags.has('betrayal')) score += 35;
+    if (tags.has('protection') || tags.has('shield')) score -= 20;
+    if (tags.has('alliance')) {
+      const backstabChance = Math.min(0.22, 0.05 + (threat * 0.015));
+      if (rng() < backstabChance) score += 95;
+      else score -= 90;
+    }
+
+    return { nomineeId, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score || a.nomineeId.localeCompare(b.nomineeId));
+  return scored[0].nomineeId;
 }
 
 const gameSlice = createSlice({
@@ -1379,6 +1445,12 @@ const gameSlice = createSlice({
     updatePlayer(state, action: PayloadAction<Player>) {
       const idx = state.players.findIndex((p) => p.id === action.payload.id);
       if (idx !== -1) state.players[idx] = action.payload;
+    },
+    syncStrategicRelationships(
+      state,
+      action: PayloadAction<NonNullable<GameState['strategicRelationships']>>,
+    ) {
+      state.strategicRelationships = action.payload;
     },
     addTvEvent(state, action: PayloadAction<Omit<TvEvent, 'id' | 'timestamp'>>) {
       const event: TvEvent = {
@@ -4068,7 +4140,7 @@ const gameSlice = createSlice({
             state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury'),
           );
           const useSecond = shouldUseSafetyForTwin(state, povHolder?.id, nominees)
-            || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+            || shouldAiUseTargetedSafetyPower(state, povHolder?.id, nominees, eligible);
           if (useSecond && nominees.length > 0) {
             const nominee2 = pickSafetySaveTarget(state, povHolder?.id, nominees, rng2);
             if (!nominee2) {
@@ -4737,7 +4809,7 @@ const gameSlice = createSlice({
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
               const eligible = getReplacementEligiblePlayers(state, alive, 1, { actorId: posWinner?.id });
               const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
-                || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+                || shouldAiUseTargetedSafetyPower(state, posWinner?.id, nominees, eligible);
               if (useIt) {
                 if (nominees.length > 0) {
                   const nomineeToSave = pickSafetySaveTarget(state, posWinner?.id, nominees, rng);
@@ -4807,7 +4879,7 @@ const gameSlice = createSlice({
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
               const eligible = getReplacementEligiblePlayers(state, alive, 2, { allowLoh: true, actorId: posWinner?.id });
               const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
-                || shouldAiUseTargetedSafetyPower(state, nominees, eligible, {
+                || shouldAiUseTargetedSafetyPower(state, posWinner?.id, nominees, eligible, {
                 replacementCount: Math.min(2, nominees.length),
                 preferLoh: true,
               });
@@ -4868,7 +4940,7 @@ const gameSlice = createSlice({
               const nominees = state.players.filter((p) => state.nomineeIds.includes(p.id));
               const eligible = getReplacementEligiblePlayers(state, alive);
               const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
-                || shouldAiUseTargetedSafetyPower(state, nominees, eligible);
+                || shouldAiUseTargetedSafetyPower(state, posWinner?.id, nominees, eligible);
               if (useIt) {
                 if (nominees.length > 0) {
                   const nomineeToSave = pickSafetySaveTarget(state, posWinner?.id, nominees, rng);
@@ -4937,13 +5009,35 @@ const gameSlice = createSlice({
               'game',
             );
           } else {
-            // AI POS holder who is not a nominee: does not use the veto
-            const povName = posWinner?.name ?? 'The safety holder';
-            pushEvent(
-              state,
-              `${povName} has decided NOT to use the Power of Safety. The nominations remain the same. ⚡`,
-              'game',
-            );
+            const nominees = state.players.filter((player) => state.nomineeIds.includes(player.id));
+            const eligible = getReplacementEligiblePlayers(state, alive);
+            const useIt = shouldUseSafetyForTwin(state, posWinner?.id, nominees)
+              || shouldAiUseTargetedSafetyPower(state, posWinner?.id, nominees, eligible);
+            const saveTarget = useIt
+              ? pickSafetySaveTarget(state, posWinner?.id, nominees, rng)
+              : null;
+
+            if (saveTarget) {
+              state.nomineeIds = state.nomineeIds.filter((id) => id !== saveTarget.id);
+              saveTarget.status = 'active';
+              state.povSavedId = saveTarget.id;
+              addPovProtectedId(state, saveTarget.id);
+              pushEvent(
+                state,
+                `${posWinner?.name ?? 'The safety holder'} used the Power of Safety on ${saveTarget.name}. ⚡`,
+                'game',
+              );
+              const lohPlayer = state.players.find((player) => player.id === state.lohId);
+              if (lohPlayer?.isUser) state.replacementNeeded = true;
+              else state.aiReplacementStep = 1;
+            } else {
+              const povName = posWinner?.name ?? 'The safety holder';
+              pushEvent(
+                state,
+                `${povName} has decided NOT to use the Power of Safety. The nominations remain the same. ⚡`,
+                'game',
+              );
+            }
           }
           break;
         }
@@ -4965,6 +5059,7 @@ const gameSlice = createSlice({
                 canPlayerTargetPlayer(state, voter.id, nomineeId),
               );
               state.votes[voter.id] = chooseAiEvictionVote(
+                state,
                 voter.id,
                 eligibleNomineeIds.length > 0 ? eligibleNomineeIds : state.nomineeIds,
                 state.seed,
@@ -5238,26 +5333,10 @@ const gameSlice = createSlice({
       sm.status = 'accepted';
       sm.templateId = nextMission.templateId;
       sm.tasks = nextMission.tasks;
-    },
-
-    /**
-     * Rotate an accepted mission to the next template in the pool and rebuild
-     * its checklist from scratch for the original trigger day.
-     */
-    reshuffleSecretMission(state) {
-      const sm = state.secretMission;
-      if (!sm || sm.status !== 'accepted') return;
-      const currentIndex = MISSION_TEMPLATES.findIndex((t) => t.id === sm.templateId);
-      const nextIndex = currentIndex >= 0
-        ? (currentIndex + 1) % MISSION_TEMPLATES.length
-        : 0;
-      const nextMission = buildSecretMissionTasksForTemplate(
-        state,
-        MISSION_TEMPLATES[nextIndex]?.id ?? MISSION_TEMPLATES[0].id,
-        sm.triggeredDay,
+      const signature = getMissionTaskSetSignature(nextMission.tasks);
+      state.secretMissionTaskSetHistory = Array.from(
+        new Set([...(state.secretMissionTaskSetHistory ?? []), signature]),
       );
-      sm.templateId = nextMission.templateId;
-      sm.tasks = nextMission.tasks;
     },
 
     /**
@@ -5623,6 +5702,7 @@ export const {
   setPhase,
   advanceWeek,
   updatePlayer,
+  syncStrategicRelationships,
   addTvEvent,
   addSocialSummary,
   setLive,
@@ -5707,7 +5787,6 @@ export const {
   markSecondSecretMissionChanceResolved,
   offerSecretMission,
   acceptSecretMission,
-  reshuffleSecretMission,
   declineSecretMission,
   updateMissionTaskProgress,
   syncMissionTask,
@@ -6059,7 +6138,7 @@ function resolveDebugBlockers(
       { allowLoh: true },
     );
     const usePower = shouldUseSafetyForTwin(game, game.posWinnerId, nominees)
-      || shouldAiUseTargetedSafetyPower(game, nominees, eligible, {
+      || shouldAiUseTargetedSafetyPower(game, game.posWinnerId, nominees, eligible, {
       replacementCount: game.specialVeto?.activeType === 'coup' ? 2 : 1,
       preferLoh: true,
     });
@@ -6107,7 +6186,7 @@ function resolveDebugBlockers(
     const nominees = game.players.filter((player) => game.nomineeIds.includes(player.id));
     const eligible = getReplacementEligiblePlayers(game, alive);
     const useSecond = shouldUseSafetyForTwin(game, game.posWinnerId, nominees)
-      || shouldAiUseTargetedSafetyPower(game, nominees, eligible, { preferLoh: true });
+      || shouldAiUseTargetedSafetyPower(game, game.posWinnerId, nominees, eligible, { preferLoh: true });
     dispatch(submitVipSecondUseDecision(useSecond));
     return true;
   }

--- a/src/store/secretMissionMiddleware.ts
+++ b/src/store/secretMissionMiddleware.ts
@@ -207,19 +207,19 @@ export const secretMissionMiddleware: Middleware = (store) => (next) => (action)
 
   if (
     (actionType === 'game/advance' || actionType === 'game/setPhase' || actionType === 'game/forcePhase') &&
-    game.phase === 'week_start' &&
-    (prevPhase !== 'week_start' || prevWeek !== game.week)
+    game.phase === 'week_end' &&
+    (prevPhase !== 'week_end' || prevWeek !== game.week)
   ) {
-    const completedDay = game.week - 1;
+    const completedDay = game.week;
     for (const task of tasks) {
       if (task.type === 'survive_days') {
-        const current = Math.min(game.week, task.target);
+        const current = Math.min(completedDay, task.target);
         store.dispatch(updateMissionTaskProgress({
           taskId: task.id,
           current,
-          lastProgressDay: game.week,
-          firstSatisfiedDay: current >= task.target ? game.week : undefined,
-          auditEntry: `Reached day ${game.week}`,
+          lastProgressDay: completedDay,
+          firstSatisfiedDay: current >= task.target ? completedDay : undefined,
+          auditEntry: `Reached day ${completedDay}`,
         }));
       }
 
@@ -267,6 +267,13 @@ export const secretMissionMiddleware: Middleware = (store) => (next) => (action)
           completed: maxStreak >= task.target,
         });
       }
+    }
+    const latest = store.getState() as RootLike;
+    if (
+      completedDay >= game.secretMission.endDay &&
+      latest.game.secretMission?.status === 'accepted'
+    ) {
+      store.dispatch(expireSecretMission());
     }
     return result;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -914,6 +914,10 @@ export interface GameState {
   secretMission?: import('../bb/secretMission').SecretMissionState;
   /** Number of secret missions started this season (capped at 2). */
   secretMissionCount?: number;
+  /** Task-set signatures already generated this season; prevents repeat checklists. */
+  secretMissionTaskSetHistory?: string[];
+  /** Latest social graph snapshot used by synchronous POS and eviction AI decisions. */
+  strategicRelationships?: import('../social/types').RelationshipsMap;
   /** Tracks whether the optional second-mission 50% roll has already been resolved. */
   secretMissionSecondChanceResolved?: boolean;
   /**

--- a/tests/integration/social.maneuvers.test.ts
+++ b/tests/integration/social.maneuvers.test.ts
@@ -39,10 +39,36 @@ import {
   getActionById,
   getAvailableActions,
   canAfford,
+  computeRepeatedPositiveDelta,
   executeAction,
 } from '../../src/social/SocialManeuvers';
 import { socialMiddleware } from '../../src/social/socialMiddleware';
 import { socialConfig } from '../../src/social/socialConfig';
+
+describe('positive interaction repetition curve', () => {
+  it('uses the full +1..+5 range on first use', () => {
+    expect(computeRepeatedPositiveDelta(0, () => 0).delta).toBe(1);
+    expect(computeRepeatedPositiveDelta(0, () => 0.999).delta).toBe(5);
+  });
+
+  it('uses +1..+3 on second use', () => {
+    expect(computeRepeatedPositiveDelta(1, () => 0).delta).toBe(1);
+    expect(computeRepeatedPositiveDelta(1, () => 0.999).delta).toBe(3);
+  });
+
+  it('gives every third-or-later use a 50% -5 / 50% +1..+3 split', () => {
+    expect(computeRepeatedPositiveDelta(2, () => 0.49)).toEqual({
+      delta: -5,
+      didBackfire: true,
+    });
+
+    const rolls = [0.5, 0.999];
+    expect(computeRepeatedPositiveDelta(8, () => rolls.shift() ?? 0)).toEqual({
+      delta: 3,
+      didBackfire: false,
+    });
+  });
+});
 import type { SocialActionLogEntry } from '../../src/social/types';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -417,7 +443,7 @@ describe('executeAction – happy path', () => {
     store.dispatch(setEnergyBankEntry({ playerId: 'p1', value: 10 }));
 
     // Use 'ally' which produces a non-zero delta via socialConfig.friendlyActions
-    executeAction('p1', 'p2', 'ally');
+    executeAction('p1', 'p2', 'ally', { random: () => 0.999 });
     const rel = store.getState().social.relationships['p1']?.['p2'];
     expect(rel).toBeDefined();
     expect(rel!.affinity).toBe(socialConfig.affinityDeltas.friendlySuccess);
@@ -477,9 +503,9 @@ describe('executeAction – happy path', () => {
     store.dispatch(setEnergyBankEntry({ playerId: 'p1', value: 5 }));
     store.dispatch(setInfluenceBankEntry({ playerId: 'p1', value: 0 }));
 
-    executeAction('p1', 'p2', 'compliment', { outcome: 'success' });
-    executeAction('p1', 'p2', 'compliment', { outcome: 'success' });
-    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(10);
+    executeAction('p1', 'p2', 'compliment', { outcome: 'success', random: () => 0.999 });
+    executeAction('p1', 'p2', 'compliment', { outcome: 'success', random: () => 0.999 });
+    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(8);
     expect(store.getState().social.influenceBank['p1']).toBe(4);
 
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.1);
@@ -488,7 +514,7 @@ describe('executeAction – happy path', () => {
 
     expect(result.delta).toBe(-socialConfig.affinityDeltas.friendlySuccess);
     expect(result.summary).toBe('Compliment backfired (-5 affinity)');
-    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(5);
+    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(3);
     expect(store.getState().social.influenceBank['p1']).toBe(2);
     expect((store.getState().social.sessionLogs[2] as SocialActionLogEntry).yieldsApplied).toEqual({
       influence: -2,
@@ -501,16 +527,16 @@ describe('executeAction – happy path', () => {
     store.dispatch(setEnergyBankEntry({ playerId: 'p1', value: 5 }));
     store.dispatch(setInfluenceBankEntry({ playerId: 'p1', value: 0 }));
 
-    executeAction('p1', 'p2', 'compliment', { outcome: 'success' });
-    executeAction('p1', 'p2', 'compliment', { outcome: 'success' });
+    executeAction('p1', 'p2', 'compliment', { outcome: 'success', random: () => 0.999 });
+    executeAction('p1', 'p2', 'compliment', { outcome: 'success', random: () => 0.999 });
 
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.9);
     const result = executeAction('p1', 'p2', 'compliment', { outcome: 'success' });
     randomSpy.mockRestore();
 
-    expect(result.delta).toBe(socialConfig.affinityDeltas.friendlySuccess);
-    expect(result.summary).toBe('Compliment succeeded (+5 affinity)');
-    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(15);
+    expect(result.delta).toBe(3);
+    expect(result.summary).toBe('Compliment succeeded (+3 affinity)');
+    expect(store.getState().social.relationships['p1']?.['p2']?.affinity).toBe(11);
     expect(store.getState().social.influenceBank['p1']).toBe(6);
   });
 });
@@ -582,9 +608,10 @@ describe('executeAction – outcome delta from SocialPolicy', () => {
     initManeuvers(store);
     store.dispatch(setEnergyBankEntry({ playerId: 'p1', value: 10 }));
 
-    const result = executeAction('p1', 'p2', 'ally');
+    const result = executeAction('p1', 'p2', 'ally', { random: () => 0.999 });
     expect(result.success).toBe(true);
-    expect(result.delta).toBe(socialConfig.affinityDeltas.friendlySuccess);
+    expect(result.delta).toBeGreaterThanOrEqual(1);
+    expect(result.delta).toBeLessThanOrEqual(socialConfig.affinityDeltas.friendlySuccess);
   });
 
   it('delta for betray (aggressive, socialConfig) is negative on success', () => {
@@ -604,7 +631,8 @@ describe('executeAction – outcome delta from SocialPolicy', () => {
 
     const result = executeAction('p1', 'p2', 'compliment');
     // compliment is now in socialConfig.actionCategories.friendlyActions
-    expect(result.delta).toBe(socialConfig.affinityDeltas.friendlySuccess);
+    expect(result.delta).toBeGreaterThanOrEqual(1);
+    expect(result.delta).toBeLessThanOrEqual(socialConfig.affinityDeltas.friendlySuccess);
   });
 });
 

--- a/tests/minigames.trapAuction.rules.test.ts
+++ b/tests/minigames.trapAuction.rules.test.ts
@@ -12,10 +12,11 @@ import {
   getAllowedBidRange,
   isCompleteTie,
   isUnbreakableTie,
+  MOCK_PARTICIPANTS,
   nextPlacementFor,
   resolveTieWinner,
 } from '../src/components/TrapAuction/trapAuctionHelpers';
-import { MOCK_PARTICIPANTS, TRAP_AUCTION_CONFIG } from '../src/components/TrapAuction/trapAuctionTypes';
+import { TRAP_AUCTION_CONFIG } from '../src/components/TrapAuction/trapAuctionTypes';
 
 describe('Trap Auction rules', () => {
   it('assigns stable players and allowed bid ranges', () => {
@@ -69,9 +70,9 @@ describe('Trap Auction rules', () => {
     expect(reveals.slice(1).every((entry) => entry.isLowest)).toBe(true);
 
     const tieReveals = buildRoundReveals(players.map((player) => ({ ...player, currentBid: 5 })));
-    expect(tieReveals).toHaveLength(1);
+    expect(tieReveals).toHaveLength(players.length);
     expect(tieReveals[0].isHighest).toBe(true);
-    expect(tieReveals[0].isLowest).toBe(true);
+    expect(tieReveals.every((entry) => entry.isLowest)).toBe(true);
   });
 
   it('applies round outcomes and tie safeguards deterministically', () => {

--- a/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
+++ b/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
@@ -716,11 +716,14 @@ describe('advanceFromDuelResult', () => {
     reachResult(store);
     const before = getState(store);
     const loser = before.duelLoserId!;
+    const winner = before.duelWinnerId!;
     const scoreBefore = before.playerScores[loser];
+    const winnerScoreBefore = before.playerScores[winner];
     store.dispatch(advanceFromDuelResult());
     expect(getState(store).remainingPlayerIds).toContain(loser);
     expect(getState(store).eliminatedPlayerIds).not.toContain(loser);
     expect(getState(store).playerScores[loser]).toBe(scoreBefore - 1);
+    expect(getState(store).playerScores[winner]).toBe(winnerScoreBefore);
   });
 
   it('transitions to pick_opponent when ≥2 remain', () => {
@@ -803,11 +806,11 @@ describe('Full 3-player tournament', () => {
     expect(['alice', 'bob', 'carol']).toContain(getState(store).winnerId);
   });
 
-  it('eliminates one player before the final duel in a 3-player game', () => {
+  it('eliminates every player except the winner in a 3-player game', () => {
     const store = makeStore();
     initStore(store, ['alice', 'bob', 'carol'], 42);
     runUntilComplete(store);
-    expect(getState(store).eliminatedPlayerIds).toHaveLength(1);
+    expect(getState(store).eliminatedPlayerIds).toHaveLength(2);
     expect(getState(store).finalistIds).toHaveLength(2);
   });
 });
@@ -853,7 +856,7 @@ describe('Deterministic tournament simulation', () => {
     expect(winners.size).toBeGreaterThanOrEqual(1);
   });
 
-  it('5-player tournament eventually completes with 4 eliminations', () => {
+  it('5-player tournament eventually completes with only the winner remaining', () => {
     const store = makeStore();
     initStore(store, ['a', 'b', 'c', 'd', 'e'], 999);
     let safety = 500;
@@ -874,7 +877,7 @@ describe('Deterministic tournament simulation', () => {
       else if (ph === 'duel_result') store.dispatch(advanceFromDuelResult());
     }
     expect(getState(store).phase).toBe('complete');
-    expect(getState(store).eliminatedPlayerIds).toHaveLength(3);
+    expect(getState(store).eliminatedPlayerIds).toHaveLength(4);
     expect(getState(store).duelIndex).toBeGreaterThan(4);
   });
 });

--- a/tests/unit/gameSlice.relationshipDecisions.test.ts
+++ b/tests/unit/gameSlice.relationshipDecisions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { chooseAiEvictionVote } from '../../src/store/gameSlice';
+import type { GameState, Player } from '../../src/types';
+
+function player(id: string): Player {
+  return {
+    id,
+    name: id,
+    isUser: false,
+    status: 'active',
+    stats: { lohWins: 0, posWins: 0, timesNominated: 1 },
+  } as Player;
+}
+
+describe('relationship-aware AI eviction decisions', () => {
+  it('normally protects an ally instead of voting randomly', () => {
+    const state = {
+      week: 4,
+      lohId: 'loh',
+      players: [player('voter'), player('ally'), player('other')],
+      strategicRelationships: {
+        voter: {
+          ally: { affinity: 75, tags: ['alliance'] },
+          other: { affinity: 0, tags: [] },
+        },
+      },
+    } as GameState;
+
+    const votesAgainstAlly = Array.from({ length: 100 }, (_, seed) =>
+      chooseAiEvictionVote(state, 'voter', ['ally', 'other'], seed),
+    ).filter((vote) => vote === 'ally').length;
+
+    expect(votesAgainstAlly).toBeGreaterThan(0);
+    expect(votesAgainstAlly).toBeLessThanOrEqual(22);
+  });
+
+  it('protects the stronger relationship when neither nominee is tagged as an ally', () => {
+    const state = {
+      week: 4,
+      lohId: 'loh',
+      players: [player('voter'), player('close'), player('distant')],
+      strategicRelationships: {
+        voter: {
+          close: { affinity: 80, tags: [] },
+          distant: { affinity: 5, tags: [] },
+        },
+      },
+    } as GameState;
+
+    expect(chooseAiEvictionVote(state, 'voter', ['close', 'distant'], 42)).toBe('distant');
+  });
+});

--- a/tests/unit/minigameHost.dismissal.test.tsx
+++ b/tests/unit/minigameHost.dismissal.test.tsx
@@ -191,6 +191,8 @@ describe('MinigameHost — dismiss / close buttons route through results screen'
 
     // Results screen with "Exited Early" heading should now appear
     expect(screen.getByText('🚪 Exited Early')).toBeTruthy();
+    expect(screen.getByText(/scrambled the time-space continuum/i)).toBeInTheDocument();
+    expect(screen.getByText(/AI-1 won the competition/i)).toBeInTheDocument();
     // Continue button should be present
     expect(screen.getByRole('button', { name: /continue/i })).toBeTruthy();
   });

--- a/tests/unit/secretMission/secretMission.logic.test.ts
+++ b/tests/unit/secretMission/secretMission.logic.test.ts
@@ -16,6 +16,9 @@ import {
   checkSecretMissionTrigger,
   createSecretMissionState,
   getSecretMissionBoxRewards,
+  getMissionTaskSetSignature,
+  findSecretMissionTaskReference,
+  getSecretMissionTaskHint,
   getSecretMissionTriggerChance,
   isSecretMissionSuccessful,
   MISSION_TEMPLATES,
@@ -144,6 +147,33 @@ describe('mission generation', () => {
     const taskTypes = tasks.map((task) => task.type);
     expect(taskTypes).toContain('survive_days');
     expect(new Set(taskTypes).size).toBe(5);
+  });
+
+  it('generates a different checklist when the prior task-set signature is excluded', () => {
+    const template = pickMissionTemplate(5);
+    const first = buildMissionTasks(template, 5, { missionNumber: 1 });
+    const firstSignature = getMissionTaskSetSignature(first);
+    const second = buildMissionTasks(template, 5, {
+      missionNumber: 2,
+      excludedTaskSetSignatures: [firstSignature],
+    });
+
+    expect(getMissionTaskSetSignature(second)).not.toBe(firstSignature);
+  });
+
+  it('recognizes numeric and ordinal task references and gives actionable energy hints', () => {
+    const tasks = buildMissionTasks(pickMissionTemplate(5), 5, { missionNumber: 1 });
+    const energyTask = {
+      ...tasks[0],
+      type: 'social_energy_empty_streak' as const,
+    };
+    const hintTasks = [tasks[0], tasks[1], energyTask, tasks[3], tasks[4]];
+
+    expect(findSecretMissionTaskReference('How do I complete task 3?', hintTasks)?.task)
+      .toBe(energyTask);
+    expect(findSecretMissionTaskReference('Give me more info on the third task', hintTasks)?.task)
+      .toBe(energyTask);
+    expect(getSecretMissionTaskHint(energyTask, 3)).toMatch(/Social Energy badge \(⚡\).*0/i);
   });
 
   it('builds target-nominated tasks with a concrete target when selected', () => {

--- a/tests/unit/secretMission/secretMission.pr4.test.ts
+++ b/tests/unit/secretMission/secretMission.pr4.test.ts
@@ -7,6 +7,7 @@ import gameReducer, {
   expireMissionReward,
   offerSecretMission,
   recordSecretMissionEasterEgg,
+  setPhase,
   setMissionTaskBaselineApproval,
   syncMissionTask,
   triggerSecretMission,
@@ -45,6 +46,20 @@ function setupAcceptedMission() {
 }
 
 describe('secret mission v2 follow-up', () => {
+  it('removes an incomplete mission when its final day ends', () => {
+    const store = setupAcceptedMission();
+    const mission = store.getState().game.secretMission!;
+    store.dispatch(hydrateGame({
+      ...store.getState().game,
+      week: mission.endDay,
+      phase: 'social_2',
+    }));
+
+    store.dispatch(setPhase('week_end'));
+
+    expect(store.getState().game.secretMission?.status).toBe('expired');
+  });
+
   it('picks a deterministic immunity duration in the 1–3 day range', () => {
     const duration = pickMissionImmunityDuration(5, 'silent_witness');
     expect([1, 2, 3]).toContain(duration);

--- a/tests/unit/trapAuction/trapAuction.logic.test.ts
+++ b/tests/unit/trapAuction/trapAuction.logic.test.ts
@@ -429,6 +429,20 @@ describe('applyBidCosts', () => {
 // ─── eliminatePlayers ────────────────────────────────────────────────────────
 
 describe('eliminatePlayers', () => {
+  it('uses remaining bank before a deterministic draw to rank tied-low eliminations', () => {
+    const players = makePlayers(4, [
+      { id: 'safe', bank: 60 },
+      { id: 'poor', bank: 8 },
+      { id: 'rich', bank: 35 },
+      { id: 'other', bank: 50 },
+    ]);
+
+    const result = eliminatePlayers(players, ['poor', 'rich'], 2, 4, 1234);
+
+    expect(result.find((player) => player.id === 'poor')?.placement).toBe(4);
+    expect(result.find((player) => player.id === 'rich')?.placement).toBe(3);
+  });
+
   it('marks specified players as eliminated', () => {
     const players = makePlayers(4);
     const result = eliminatePlayers(players, ['p1', 'p2'], 2, 4);


### PR DESCRIPTION
## Summary
- make positive social interactions diminish and become risky from the third use
- make AI safety and eviction decisions relationship-aware, including protection requests and rare backstabs
- preserve authoritative minigame results, explain early exits, reset repeat challenge instances, and resolve Trap Auction ties deterministically
- update Blackjack Tournament to loss-only lives and use participant avatars
- remove Secret Mission shuffle, prevent repeated task sets, add Big Eye task hints, and expire failed checklists at day end

## Validation
- npm run lint:ci
- npm run typecheck
- npm run build
- 471 focused/regression tests passed (1 existing todo)

## Test-suite note
The all-at-once npm test command exhausted Vitest worker memory in this environment and also surfaced unrelated fixture failures in suites whose test stores omit the profiles reducer. The affected changed areas were rerun with constrained workers and passed.