### PR TITLE
Start Crystal Path players in parallel at low time

### DIFF
--- a/src/components/GlassBridgeComp/GlassBridgeComp.tsx
+++ b/src/components/GlassBridgeComp/GlassBridgeComp.tsx
@@ -30,6 +30,8 @@ import {
   recordNumberChoice,
   finaliseOrderSelection,
   startPlaying,
+  startParallelPlayers,
+  resolveParallelStep,
   resolveStep,
   expireTimer,
   completeGame,
@@ -41,6 +43,8 @@ import {
   selectIsGameOver,
   HINT_PENALTY_MS,
   MAX_HINTS_PER_RUN,
+  shouldStartParallelPlayers,
+  chooseParallelAiSide,
   type BridgeRow,
   type TileSide,
 } from '../../features/glassBridge/glassBridgeSlice';
@@ -508,7 +512,9 @@ export default function GlassBridgeComp({
 
   // ── Refs ──────────────────────────────────────────────────────────────────
   const timerIntervalRef = useRef<number | null>(null);
+  const timerDisplayRef = useRef(timerDisplay);
   const aiStepTimerRef = useRef<number | null>(null);
+  const parallelStepTimerRef = useRef<number | null>(null);
   const autoAdvanceRef = useRef<number | null>(null);
   const revealTimerRef = useRef<number | null>(null);
   const pendingStepRef = useRef<number | null>(null);
@@ -564,6 +570,10 @@ export default function GlassBridgeComp({
   // Stable RNG for AI step timing (different sub-seed so it doesn't affect bridge layout).
   const aiRngRef = useRef(mulberry32(sessionSeed + 9999));
 
+  useEffect(() => {
+    timerDisplayRef.current = timerDisplay;
+  }, [timerDisplay]);
+
   function clearAllTimers() {
     if (timerIntervalRef.current !== null) {
       window.clearInterval(timerIntervalRef.current);
@@ -572,6 +582,10 @@ export default function GlassBridgeComp({
     if (aiStepTimerRef.current !== null) {
       window.clearTimeout(aiStepTimerRef.current);
       aiStepTimerRef.current = null;
+    }
+    if (parallelStepTimerRef.current !== null) {
+      window.clearTimeout(parallelStepTimerRef.current);
+      parallelStepTimerRef.current = null;
     }
     if (autoAdvanceRef.current !== null) {
       window.clearTimeout(autoAdvanceRef.current);
@@ -929,10 +943,70 @@ export default function GlassBridgeComp({
 
   // ── 6. AI step automation ──────────────────────────────────────────────────
   useEffect(() => {
+    if (gb.phase !== 'playing' || gb.timerExpired) return;
+    if (!shouldStartParallelPlayers(timerDisplay) || gb.parallelPlayerIds.length > 0) return;
+    const activeId = selectActivePlayerId(gb);
+    const hasUnstartedPlayers = gb.turnOrder.some((playerId) =>
+      playerId !== activeId && gb.progress[playerId]?.firstStepAtMs === undefined,
+    );
+    if (hasUnstartedPlayers) {
+      dispatch(startParallelPlayers());
+      flashStatusBanner('Less than a minute remains — waiting players are entering the path now!', 'warning');
+    }
+  }, [dispatch, flashStatusBanner, gb, timerDisplay]);
+
+  // Independently advance released AI players while the original active turn continues.
+  useEffect(() => {
+    if (gb.phase !== 'playing' || gb.timerExpired || gb.parallelPlayerIds.length === 0) return;
+    const candidates = gb.parallelPlayerIds
+      .filter((playerId) => playerId !== humanId)
+      .map((playerId) => ({ playerId, progress: gb.progress[playerId] }))
+      .filter(({ progress }) => progress && !progress.eliminated && progress.finishTimeMs === undefined)
+      .sort((a, b) => a.progress.furthestRowReached - b.progress.furthestRowReached);
+    const candidate = candidates[0];
+    if (!candidate) return;
+    const rowNumber = candidate.progress.furthestRowReached + 1;
+    const row = gb.rows[rowNumber - 1];
+    if (!row) return;
+    const occupiedSides = Object.entries(gb.progress)
+      .filter(([playerId, progress]) =>
+        playerId !== candidate.playerId
+        && !progress.eliminated
+        && progress.finishTimeMs === undefined
+        && progress.furthestRowReached === rowNumber
+        && progress.currentSide,
+      )
+      .map(([, progress]) => progress.currentSide!);
+    const participant = gb.participants.find((entry) => entry.id === candidate.playerId);
+    const chosenSide = chooseParallelAiSide(
+      row,
+      occupiedSides,
+      timerDisplayRef.current,
+      aiRngRef.current,
+      participant?.competitionProfile,
+    );
+    parallelStepTimerRef.current = window.setTimeout(() => {
+      dispatch(resolveParallelStep({
+        playerId: candidate.playerId,
+        chosenSide,
+        now: getEffectiveNowMs(),
+      }));
+      parallelStepTimerRef.current = null;
+    }, scaleSpectatorDelay(1_500));
+    return () => {
+      if (parallelStepTimerRef.current !== null) {
+        window.clearTimeout(parallelStepTimerRef.current);
+        parallelStepTimerRef.current = null;
+      }
+    };
+  }, [dispatch, gb, getEffectiveNowMs, humanId, scaleSpectatorDelay]);
+
+  useEffect(() => {
     if (gb.phase !== 'playing') return;
 
     const activeId = selectActivePlayerId(gb);
     if (!activeId) return;
+    if (gb.parallelPlayerIds.includes(activeId)) return;
 
     const isHumanTurn = activeId === humanId && !gb.humanSpectating;
     if (isHumanTurn) return; // human controls their own steps
@@ -1066,7 +1140,12 @@ export default function GlassBridgeComp({
     setShowEliminationFlash(true);
     setShowScreenShake(true);
     playDeath();
-    if (activeId && activeRow && hasOneBrokenTile(activeRow)) {
+    if (
+      activeId
+      && activeRow
+      && gb.progress[activeId]?.firstStepAtMs !== undefined
+      && hasOneBrokenTile(activeRow)
+    ) {
       flashStatusBanner(
         getBrokenPlatformFallMessage(activeId === humanId, getName(activeId)),
         'danger',
@@ -1088,6 +1167,7 @@ export default function GlassBridgeComp({
     gb.currentPlayerRow,
     gb.currentTurnIndex,
     gb.phase,
+    gb.progress,
     gb.rows,
     gb.timerExpired,
     gb.turnOrder,
@@ -1241,9 +1321,12 @@ export default function GlassBridgeComp({
       if (pendingStep) return;
 
       const activeId = selectActivePlayerId(gb);
-      if (activeId !== humanId) return;
+      const isParallelHuman = gb.parallelPlayerIds.includes(humanId);
+      if (activeId !== humanId && !isParallelHuman) return;
 
-      const rowIdx = gb.currentPlayerRow - 1;
+      const rowIdx = isParallelHuman
+        ? (gb.progress[humanId]?.furthestRowReached ?? 0)
+        : gb.currentPlayerRow - 1;
       if (rowIdx < 0 || rowIdx >= gb.rows.length) return;
       const row = gb.rows[rowIdx];
 
@@ -1281,7 +1364,9 @@ export default function GlassBridgeComp({
           shatterResolveRef.current = window.setTimeout(() => {
             setShatteringTile(null);
             setPendingStep(null);
-            dispatch(resolveStep({ chosenSide: side, now: chosenAt }));
+            dispatch(isParallelHuman
+              ? resolveParallelStep({ playerId: humanId, chosenSide: side, now: chosenAt })
+              : resolveStep({ chosenSide: side, now: chosenAt }));
           }, shatterDelay);
           return;
         }
@@ -1291,7 +1376,9 @@ export default function GlassBridgeComp({
         if (rowIdx + 1 < gb.rowsCount) {
           flashStatusBanner(pickRandom(humanClearMessages)(rowIdx + 1), 'success');
         }
-        dispatch(resolveStep({ chosenSide: side, now: chosenAt }));
+        dispatch(isParallelHuman
+          ? resolveParallelStep({ playerId: humanId, chosenSide: side, now: chosenAt })
+          : resolveStep({ chosenSide: side, now: chosenAt }));
       }, suspenseDelay);
     },
     [humanId, gb, dispatch, pendingStep, playSafeStep, playDeath, flashStatusBanner, getEffectiveNowMs],
@@ -1318,7 +1405,9 @@ export default function GlassBridgeComp({
     const hintsUsed = getHintUses(humanProgress.hintPenaltyMs);
     if (hintsUsed >= MAX_HINTS_PER_RUN) return;
 
-    const rowIdx = gb.currentPlayerRow - 1;
+    const rowIdx = gb.parallelPlayerIds.includes(humanId)
+      ? humanProgress.furthestRowReached
+      : gb.currentPlayerRow - 1;
     if (rowIdx < 0 || rowIdx >= gb.rows.length) return;
     const row = gb.rows[rowIdx];
 
@@ -1336,13 +1425,17 @@ export default function GlassBridgeComp({
     setCurrentHintMessage(pickRandom(hintMessages)(chance));
     setHintRequestsForCurrentRow(sameRowHintCount);
     dispatch(recordHintUsed({ playerId: humanId }));
-  }, [humanId, gb.progress, gb.currentPlayerRow, gb.rows, dispatch, hintRequestsForCurrentRow]);
+  }, [humanId, gb.progress, gb.currentPlayerRow, gb.parallelPlayerIds, gb.rows, dispatch, hintRequestsForCurrentRow]);
 
   // ── Derived values ────────────────────────────────────────────────────────
 
   const activeId = selectActivePlayerId(gb);
-  const isHumanTurn = activeId === humanId && !gb.humanSpectating;
+  const humanIsParallel = humanId ? gb.parallelPlayerIds.includes(humanId) : false;
+  const isHumanTurn = (activeId === humanId || humanIsParallel) && !gb.humanSpectating;
   const humanProgress = humanId ? gb.progress[humanId] : null;
+  const currentRowForDisplay = humanIsParallel && humanProgress
+    ? humanProgress.furthestRowReached + 1
+    : gb.currentPlayerRow;
   const isHumanEliminated = !!humanProgress?.eliminated;
   const pendingActorId = pendingStep?.actorId ?? null;
   const hintsUsed = getHintUses(humanProgress?.hintPenaltyMs);
@@ -1549,7 +1642,7 @@ export default function GlassBridgeComp({
             <div className="gb-led-rail gb-led-rail-right gb-side-led" aria-hidden="true" />
             {gb.rows.map((row, rowIdx) => {
               const rowNum = rowIdx + 1;
-              const isCurrentRow = gb.currentPlayerRow === rowNum;
+              const isCurrentRow = currentRowForDisplay === rowNum;
               const rowDepthScale = Math.max(0.82, 1 - rowIdx * 0.015);
 
               // Find players on this row (those who have reached exactly this row and are active).
@@ -1558,7 +1651,7 @@ export default function GlassBridgeComp({
                 const timedOutOnBridge =
                   timeoutCollapseActive &&
                   isTimeoutPlayer(pid) &&
-                  activeId === pid &&
+                  (activeId === pid || gb.parallelPlayerIds.includes(pid)) &&
                   isCurrentRow;
                 return (
                   p &&

--- a/src/features/glassBridge/glassBridgeSlice.ts
+++ b/src/features/glassBridge/glassBridgeSlice.ts
@@ -57,6 +57,8 @@ export interface GlassBridgePlayerProgress {
   finishTimeMs?: number;
   /** Cumulative penalty in ms added for hint usage (30 000 ms per hint). */
   hintPenaltyMs: number;
+  /** Tile currently occupied after the player's latest safe step. */
+  currentSide?: TileSide;
 }
 
 export type GlassBridgePhase =
@@ -133,6 +135,9 @@ export interface GlassBridgeState {
 
   /** Whether the human is currently spectating (eliminated but watching). */
   humanSpectating: boolean;
+
+  /** Unstarted players released onto the bridge once less than a minute remains. */
+  parallelPlayerIds: string[];
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -148,6 +153,30 @@ export const MAX_HINTS_PER_RUN = 3;
 
 export function buildGlassBridgeTimeLimitMs(participantCount: number): number {
   return Math.max(1, participantCount) * TIME_LIMIT_PER_PLAYER_MS;
+}
+
+export const PARALLEL_START_THRESHOLD_MS = 60_000;
+export const COLLISION_OVERRIDE_THRESHOLD_MS = 15_000;
+
+export function shouldStartParallelPlayers(remainingMs: number): boolean {
+  return remainingMs <= PARALLEL_START_THRESHOLD_MS;
+}
+
+/** Respect occupied tiles while time permits, but stop waiting in the final 15 seconds. */
+export function chooseParallelAiSide(
+  row: BridgeRow,
+  occupiedSides: TileSide[],
+  remainingMs: number,
+  rng: () => number,
+  profile?: CompetitionSkillProfile,
+): TileSide {
+  const preferred = aiDecideStep(row, rng, profile);
+  if (remainingMs < COLLISION_OVERRIDE_THRESHOLD_MS || !occupiedSides.includes(preferred)) {
+    return preferred;
+  }
+  const alternative: TileSide = preferred === 'left' ? 'right' : 'left';
+  const alternativeBroken = alternative === 'left' ? row.leftBroken : row.rightBroken;
+  return !alternativeBroken && !occupiedSides.includes(alternative) ? alternative : preferred;
 }
 
 /**
@@ -317,6 +346,7 @@ const initialState: GlassBridgeState = {
   timerExpired: false,
   humanPlayerId: null,
   humanSpectating: false,
+  parallelPlayerIds: [],
 };
 
 // ─── Slice ────────────────────────────────────────────────────────────────────
@@ -374,6 +404,7 @@ const glassBridgeSlice = createSlice({
           timeReachedFurthestRowMs: 0,
           eliminated: false,
           hintPenaltyMs: 0,
+          currentSide: undefined,
         };
       }
 
@@ -468,6 +499,53 @@ const glassBridgeSlice = createSlice({
       state.currentPlayerRow = 1;
     },
 
+    /** Release only players who have not yet stepped onto the bridge. */
+    startParallelPlayers(state) {
+      if (state.phase !== 'playing' || state.timerExpired) return;
+      const activeId = state.turnOrder[state.currentTurnIndex];
+      state.parallelPlayerIds = state.turnOrder.filter((playerId) => {
+        const progress = state.progress[playerId];
+        return playerId !== activeId
+          && progress?.firstStepAtMs === undefined
+          && !progress.eliminated
+          && progress.finishTimeMs === undefined;
+      });
+    },
+
+    /** Resolve an independently active player's next row without changing the main turn. */
+    resolveParallelStep(
+      state,
+      action: PayloadAction<{ playerId: string; chosenSide: TileSide; now: number }>,
+    ) {
+      if (state.phase !== 'playing' || state.timerExpired) return;
+      const { playerId, chosenSide, now } = action.payload;
+      if (!state.parallelPlayerIds.includes(playerId)) return;
+      const progress = state.progress[playerId];
+      if (!progress || progress.eliminated || progress.finishTimeMs !== undefined) return;
+      const rowNumber = progress.furthestRowReached + 1;
+      const row = state.rows[rowNumber - 1];
+      if (!row) return;
+      if (progress.firstStepAtMs === undefined) progress.firstStepAtMs = now;
+      const elapsed = state.challengeStartTimeMs === null ? 0 : now - state.challengeStartTimeMs;
+
+      if (chosenSide === row.safeSide) {
+        progress.furthestRowReached = rowNumber;
+        progress.timeReachedFurthestRowMs = elapsed;
+        progress.currentSide = chosenSide;
+        row.revealedSafeSide = chosenSide;
+        if (rowNumber >= state.rowsCount) {
+          progress.finishTimeMs = elapsed;
+          progress.currentSide = undefined;
+        }
+      } else {
+        if (chosenSide === 'left') row.leftBroken = true;
+        else row.rightBroken = true;
+        progress.eliminated = true;
+        progress.currentSide = undefined;
+        if (!state.eliminationOrder.includes(playerId)) state.eliminationOrder.push(playerId);
+      }
+    },
+
     /**
      * Resolve a single step: the active player steps onto `chosenSide`.
      *
@@ -521,6 +599,7 @@ const glassBridgeSlice = createSlice({
         // Safe — advance.
         progress.furthestRowReached = state.currentPlayerRow;
         progress.timeReachedFurthestRowMs = elapsed;
+        progress.currentSide = chosenSide;
 
         // Mark this row's safe side as revealed so subsequent AI players can use it.
         row.revealedSafeSide = chosenSide;
@@ -528,6 +607,7 @@ const glassBridgeSlice = createSlice({
         if (state.currentPlayerRow >= state.rowsCount) {
           // Player has crossed the final row — they finished!
           progress.finishTimeMs = elapsed;
+          progress.currentSide = undefined;
           // Advance to next turn.
           state.currentTurnIndex += 1;
           state.currentPlayerRow = 1;
@@ -542,6 +622,7 @@ const glassBridgeSlice = createSlice({
           row.rightBroken = true;
         }
         progress.eliminated = true;
+        progress.currentSide = undefined;
         state.eliminationOrder.push(activeId);
 
         // Advance to next turn.
@@ -628,6 +709,8 @@ export const {
   recordNumberChoice,
   finaliseOrderSelection,
   startPlaying,
+  startParallelPlayers,
+  resolveParallelStep,
   resolveStep,
   advanceTurn,
   expireTimer,

--- a/tests/unit/glass-bridge/glassBridge.parallel.test.ts
+++ b/tests/unit/glass-bridge/glassBridge.parallel.test.ts
@@ -1,0 +1,75 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { describe, expect, it } from 'vitest';
+import glassBridgeReducer, {
+  COLLISION_OVERRIDE_THRESHOLD_MS,
+  chooseParallelAiSide,
+  finaliseOrderSelection,
+  initGlassBridge,
+  recordNumberChoice,
+  resolveParallelStep,
+  startParallelPlayers,
+  startPlaying,
+  shouldStartParallelPlayers,
+  type BridgeRow,
+} from '../../../src/features/glassBridge/glassBridgeSlice';
+
+const T0 = 1_700_000_000_000;
+
+function startedStore() {
+  const store = configureStore({ reducer: { glassBridge: glassBridgeReducer } });
+  store.dispatch(initGlassBridge({
+    participantIds: ['a', 'b', 'c'],
+    competitionType: 'LOH',
+    seed: 7,
+  }));
+  store.dispatch(recordNumberChoice({ playerId: 'a', number: 1 }));
+  store.dispatch(recordNumberChoice({ playerId: 'b', number: 2 }));
+  store.dispatch(recordNumberChoice({ playerId: 'c', number: 3 }));
+  store.dispatch(finaliseOrderSelection());
+  store.dispatch(startPlaying({ now: T0 }));
+  return store;
+}
+
+describe('Glass Bridge low-time parallel play', () => {
+  it('starts at one minute, but not above it', () => {
+    expect(shouldStartParallelPlayers(60_001)).toBe(false);
+    expect(shouldStartParallelPlayers(60_000)).toBe(true);
+  });
+
+  it('starts every waiting player without duplicating the current player', () => {
+    const store = startedStore();
+    const activeId = store.getState().glassBridge.turnOrder[0];
+    store.dispatch(startParallelPlayers());
+    expect(store.getState().glassBridge.parallelPlayerIds).toEqual(
+      store.getState().glassBridge.turnOrder.filter((id) => id !== activeId),
+    );
+  });
+
+  it('advances a released player independently of the main turn', () => {
+    const store = startedStore();
+    store.dispatch(startParallelPlayers());
+    const before = store.getState().glassBridge;
+    const parallelId = before.parallelPlayerIds[0];
+    const safeSide = before.rows[0].safeSide;
+    store.dispatch(resolveParallelStep({ playerId: parallelId, chosenSide: safeSide, now: T0 + 1_000 }));
+    const after = store.getState().glassBridge;
+    expect(after.progress[parallelId].furthestRowReached).toBe(1);
+    expect(after.currentTurnIndex).toBe(before.currentTurnIndex);
+  });
+
+  it('avoids an occupied preferred tile until the final 15 seconds', () => {
+    const row: BridgeRow = {
+      safeSide: 'left',
+      leftBroken: false,
+      rightBroken: false,
+      revealedSafeSide: 'left',
+    };
+    expect(chooseParallelAiSide(row, ['left'], 15_000, () => 0)).toBe('right');
+    expect(chooseParallelAiSide(
+      row,
+      ['left'],
+      COLLISION_OVERRIDE_THRESHOLD_MS - 1,
+      () => 0,
+    )).toBe('left');
+  });
+});


### PR DESCRIPTION
## Summary
- release every not-yet-started player when one minute remains
- let released players progress independently alongside the original active player
- include the human player in the parallel control path when applicable
- avoid tiles occupied by another active player until less than 15 seconds remain
- preserve timeout-collapse and spectator behavior

## Validation
- npm run lint:ci
- npm run build
- 88 Glass Bridge and AI-audit tests passed