### PR TITLE
Make AI Power of Safety use rare

### DIFF
--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -689,11 +689,15 @@ function shouldAiUseTargetedSafetyPower(
   const bestRelationship = Math.max(
     ...currentNominees.map((nominee) => getSafetyRelationshipScore(state, holderId, nominee)),
   );
-  let useChance = strategicUpgrade ? 0.35 : 0.05;
-  if (bestRelationship >= 75) useChance += 0.5;
-  else if (bestRelationship >= 45) useChance += 0.35;
-  else if (bestRelationship >= 20) useChance += 0.18;
-  useChance = Math.max(0.03, Math.min(0.92, useChance));
+  // A non-nominated holder should almost always keep the power.  Relationship
+  // signals make a save possible, not expected; strategy can only add a small
+  // nudge.  Mandatory self-use and the twin exception are handled by callers.
+  let useChance = 0.01;
+  if (bestRelationship >= 75) useChance = 0.09;
+  else if (bestRelationship >= 45) useChance = 0.065;
+  else if (bestRelationship >= 20) useChance = 0.04;
+  if (strategicUpgrade) useChance += 0.01;
+  useChance = Math.min(0.10, useChance);
   const rng = mulberry32(
     (state.seed ^ hashString(`safety:${state.week}:${holderId}:${currentNominees.map((p) => p.id).join('|')}`)) >>> 0,
   );


### PR DESCRIPTION
## What changed
Non-nominated AI holders now use the Power of Safety only rarely: 1–2% without a meaningful connection, 4–5% with a positive/protection signal, 6.5–7.5% for a close ally, and 10% maximum for a very close ally.

## Why
The earlier relationship-aware logic treated a strategically stronger replacement as a 35% base chance, which made use feel routine rather than exceptional.

## Impact
AI holders still self-save when nominated and twins still protect each other. Outside those exceptions, a save is now a notable social or strategic moment instead of the default outcome.

## Validation
- npm run typecheck
- 90 focused relationship and social tests passed (1 existing todo)