### PR TITLE
Allow nominees to request safety for themselves

### DIFF
--- a/src/components/SocialPanelV2/SocialPanelV2.tsx
+++ b/src/components/SocialPanelV2/SocialPanelV2.tsx
@@ -42,9 +42,13 @@ function getSubjectCandidates(
   players: Player[],
   actorId: string,
   relationships: Record<string, Record<string, { affinity: number }>> | undefined,
+  allowActorAsSubject = false,
 ): Player[] {
   const eligible = players.filter(
-    (p) => p.id !== primaryTargetId && p.id !== actorId && p.status !== 'evicted' && p.status !== 'jury',
+    (p) => p.id !== primaryTargetId
+      && (allowActorAsSubject || p.id !== actorId)
+      && p.status !== 'evicted'
+      && p.status !== 'jury',
   );
   switch (pool) {
     case 'nominees':
@@ -323,9 +327,12 @@ export default function SocialPanelV2() {
       ? getSubjectCandidates(
           selectedAction.subjectPool,
           effectivePrimaryTargetId,
-          orderedPlayers,
+          selectedAction.allowActorAsSubject
+            ? [...orderedPlayers, humanPlayer!]
+            : orderedPlayers,
           humanPlayer!.id,
           relationships as Record<string, Record<string, { affinity: number }>> | undefined,
+          selectedAction.allowActorAsSubject,
         )
       : [];
 

--- a/src/components/SocialPanelV2/__tests__/SocialPanelV2.test.tsx
+++ b/src/components/SocialPanelV2/__tests__/SocialPanelV2.test.tsx
@@ -27,7 +27,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, act, cleanup, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import gameReducer, { setPhase } from '../../../store/gameSlice';
@@ -567,5 +567,35 @@ describe('SocialPanelV2 – subject picker', () => {
 
     const subjectPicker = screen.getByLabelText('Choose subject');
     expect(subjectPicker).toHaveTextContent(nomineeWithPos.name);
+  });
+
+  it('lets a nominated user ask the POS holder to use safety on them', () => {
+    const basePlayers = store.getState().game.players.filter((p) => !p.isUser);
+    const posHolder = basePlayers[0];
+    const otherNominee = basePlayers[1];
+    cleanup();
+    store = makeStore({
+      phase: 'social_1',
+      humanStatus: 'nominated',
+      playerStatusOverrides: {
+        [posHolder.id]: 'pos',
+        [otherNominee.id]: 'nominated',
+      },
+    });
+    const human = store.getState().game.players.find((p) => p.isUser)!;
+    store.dispatch(setEnergyBankEntry({ playerId: human.id, value: 10 }));
+    store.dispatch(setInfluenceBankEntry({ playerId: human.id, value: 20 }));
+    store.dispatch(openSocialPanel());
+    initManeuvers(store);
+    renderPanel(store);
+
+    fireEvent.click(screen.getAllByRole('button', { name: new RegExp(posHolder.name, 'i') })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /Ask to Use Safety/i }));
+
+    const subjectPicker = screen.getByLabelText('Choose subject');
+    expect(subjectPicker).toHaveTextContent(human.name);
+    expect(subjectPicker).toHaveTextContent(otherNominee.name);
+    fireEvent.click(within(subjectPicker).getByRole('button', { name: human.name }));
+    expect(screen.getByRole('button', { name: 'Execute' })).toBeEnabled();
   });
 });

--- a/src/social/socialActions.ts
+++ b/src/social/socialActions.ts
@@ -126,6 +126,8 @@ export interface SocialActionDefinition {
    * as the contextual subject. Used by the UI to generate candidate chips.
    */
   subjectPool?: SubjectPool;
+  /** Allow the acting player to be chosen as the contextual subject. */
+  allowActorAsSubject?: boolean;
   /**
    * When set, this action is only available when the selected primary target
    * has one of the listed statuses.  For example, `['loh', 'loh+pos']` means
@@ -354,6 +356,7 @@ export const SOCIAL_ACTIONS: SocialActionDefinition[] = [
     baseCost: { energy: 2, influence: 1.0 },
     targetMode: 'primaryPlusSubject',
     subjectPool: 'nominees',
+    allowActorAsSubject: true,
     successWeight: 1,
     outcomeTag: 'protection',
     availabilityHint: 'Talk to POS about a nominee',


### PR DESCRIPTION
## What changed
- allow the acting player to appear in the subject picker for Ask to Use Safety
- keep self-subjecting disabled for other social actions
- cover the exact case where the user and another player are nominated and the POS holder is selected

## Root cause
The generic primary-plus-subject filter always removed the acting player, and the subject list was built from a roster that already excluded the human player.

## Impact
A nominated user can now ask the POS holder to save themself or choose the other nominee.

## Validation
- npm run typecheck
- npm run lint:ci
- 129 focused social tests passed (1 existing todo), including 41 SocialPanel tests