### PR TITLE
Fix Crystal Path concurrent starts

### DIFF
--- a/src/components/GlassBridgeComp/GlassBridgeComp.tsx
+++ b/src/components/GlassBridgeComp/GlassBridgeComp.tsx
@@ -514,7 +514,7 @@ export default function GlassBridgeComp({
   const timerIntervalRef = useRef<number | null>(null);
   const timerDisplayRef = useRef(timerDisplay);
   const aiStepTimerRef = useRef<number | null>(null);
-  const parallelStepTimerRef = useRef<number | null>(null);
+  const parallelStepTimersRef = useRef<Map<string, number>>(new Map());
   const autoAdvanceRef = useRef<number | null>(null);
   const revealTimerRef = useRef<number | null>(null);
   const pendingStepRef = useRef<number | null>(null);
@@ -583,10 +583,10 @@ export default function GlassBridgeComp({
       window.clearTimeout(aiStepTimerRef.current);
       aiStepTimerRef.current = null;
     }
-    if (parallelStepTimerRef.current !== null) {
-      window.clearTimeout(parallelStepTimerRef.current);
-      parallelStepTimerRef.current = null;
+    for (const timer of parallelStepTimersRef.current.values()) {
+      window.clearTimeout(timer);
     }
+    parallelStepTimersRef.current.clear();
     if (autoAdvanceRef.current !== null) {
       window.clearTimeout(autoAdvanceRef.current);
       autoAdvanceRef.current = null;
@@ -955,51 +955,71 @@ export default function GlassBridgeComp({
     }
   }, [dispatch, flashStatusBanner, gb, timerDisplay]);
 
-  // Independently advance released AI players while the original active turn continues.
+  // Independently advance every released AI while the original active turn continues.
   useEffect(() => {
-    if (gb.phase !== 'playing' || gb.timerExpired || gb.parallelPlayerIds.length === 0) return;
+    const waitingForHumanSpectatorDecision = Boolean(
+      humanId && !gb.humanSpectating && (
+        gb.progress[humanId]?.eliminated
+        || (pendingStep?.actorId === humanId && pendingStep.isBreak)
+      ),
+    );
+    if (
+      gb.phase !== 'playing'
+      || gb.timerExpired
+      || gb.parallelPlayerIds.length === 0
+      || waitingForHumanSpectatorDecision
+    ) {
+      for (const timer of parallelStepTimersRef.current.values()) window.clearTimeout(timer);
+      parallelStepTimersRef.current.clear();
+      return;
+    }
     const candidates = gb.parallelPlayerIds
       .filter((playerId) => playerId !== humanId)
       .map((playerId) => ({ playerId, progress: gb.progress[playerId] }))
-      .filter(({ progress }) => progress && !progress.eliminated && progress.finishTimeMs === undefined)
-      .sort((a, b) => a.progress.furthestRowReached - b.progress.furthestRowReached);
-    const candidate = candidates[0];
-    if (!candidate) return;
-    const rowNumber = candidate.progress.furthestRowReached + 1;
-    const row = gb.rows[rowNumber - 1];
-    if (!row) return;
-    const occupiedSides = Object.entries(gb.progress)
-      .filter(([playerId, progress]) =>
-        playerId !== candidate.playerId
-        && !progress.eliminated
-        && progress.finishTimeMs === undefined
-        && progress.furthestRowReached === rowNumber
-        && progress.currentSide,
-      )
-      .map(([, progress]) => progress.currentSide!);
-    const participant = gb.participants.find((entry) => entry.id === candidate.playerId);
-    const chosenSide = chooseParallelAiSide(
-      row,
-      occupiedSides,
-      timerDisplayRef.current,
-      aiRngRef.current,
-      participant?.competitionProfile,
-    );
-    parallelStepTimerRef.current = window.setTimeout(() => {
-      dispatch(resolveParallelStep({
-        playerId: candidate.playerId,
-        chosenSide,
-        now: getEffectiveNowMs(),
-      }));
-      parallelStepTimerRef.current = null;
-    }, scaleSpectatorDelay(1_500));
-    return () => {
-      if (parallelStepTimerRef.current !== null) {
-        window.clearTimeout(parallelStepTimerRef.current);
-        parallelStepTimerRef.current = null;
+      .filter(({ progress }) => progress && !progress.eliminated && progress.finishTimeMs === undefined);
+    const candidateIds = new Set(candidates.map(({ playerId }) => playerId));
+    for (const [playerId, timer] of parallelStepTimersRef.current) {
+      if (!candidateIds.has(playerId)) {
+        window.clearTimeout(timer);
+        parallelStepTimersRef.current.delete(playerId);
       }
-    };
-  }, [dispatch, gb, getEffectiveNowMs, humanId, scaleSpectatorDelay]);
+    }
+
+    candidates.forEach((candidate, index) => {
+      if (parallelStepTimersRef.current.has(candidate.playerId)) return;
+      const rowNumber = candidate.progress.furthestRowReached + 1;
+      const row = gb.rows[rowNumber - 1];
+      if (!row) return;
+      const occupiedSides = Object.entries(gb.progress)
+        .filter(([playerId, progress]) =>
+          playerId !== candidate.playerId
+          && !progress.eliminated
+          && progress.finishTimeMs === undefined
+          && progress.furthestRowReached === rowNumber
+          && progress.currentSide,
+        )
+        .map(([, progress]) => progress.currentSide!);
+      const participant = gb.participants.find((entry) => entry.id === candidate.playerId);
+      const chosenSide = chooseParallelAiSide(
+        row,
+        occupiedSides,
+        timerDisplayRef.current,
+        aiRngRef.current,
+        participant?.competitionProfile,
+      );
+      const delay = scaleSpectatorDelay(900 + (index * 90));
+      const timer = window.setTimeout(() => {
+        parallelStepTimersRef.current.delete(candidate.playerId);
+        dispatch(resolveParallelStep({
+          playerId: candidate.playerId,
+          chosenSide,
+          now: getEffectiveNowMs(),
+          remainingMs: timerDisplayRef.current,
+        }));
+      }, delay);
+      parallelStepTimersRef.current.set(candidate.playerId, timer);
+    });
+  }, [dispatch, gb, getEffectiveNowMs, humanId, pendingStep, scaleSpectatorDelay]);
 
   useEffect(() => {
     if (gb.phase !== 'playing') return;
@@ -1648,16 +1668,23 @@ export default function GlassBridgeComp({
               // Find players on this row (those who have reached exactly this row and are active).
               const playersOnRow = gb.turnOrder.filter(pid => {
                 const p = gb.progress[pid];
+                const isParallelPlayer = gb.parallelPlayerIds.includes(pid);
+                const parallelPlayerOnRow = Boolean(
+                  isParallelPlayer
+                  && p?.firstStepAtMs !== undefined
+                  && Math.max(1, p.furthestRowReached) === rowNum,
+                );
+                const mainPlayerOnRow = activeId === pid
+                  && !isParallelPlayer
+                  && gb.currentPlayerRow === rowNum;
                 const timedOutOnBridge =
                   timeoutCollapseActive &&
                   isTimeoutPlayer(pid) &&
-                  (activeId === pid || gb.parallelPlayerIds.includes(pid)) &&
-                  isCurrentRow;
+                  (mainPlayerOnRow || parallelPlayerOnRow);
                 return (
                   p &&
                   p.finishTimeMs === undefined &&
-                  activeId === pid &&
-                  isCurrentRow &&
+                  (mainPlayerOnRow || parallelPlayerOnRow) &&
                   (!p.eliminated || timedOutOnBridge)
                 );
               });

--- a/src/components/GlassBridgeComp/__tests__/GlassBridgeComp.test.tsx
+++ b/src/components/GlassBridgeComp/__tests__/GlassBridgeComp.test.tsx
@@ -4,12 +4,14 @@ import { Provider } from 'react-redux';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import glassBridgeReducer, {
   finaliseOrderSelection,
+  initGlassBridge,
   recordNumberChoice,
   startPlaying,
   resolveStep,
   HINT_PENALTY_MS,
 } from '../../../features/glassBridge/glassBridgeSlice';
 import GlassBridgeComp from '../GlassBridgeComp';
+import { mulberry32 } from '../../../store/rng';
 
 const playSafeStep = vi.fn();
 const playDeath = vi.fn();
@@ -72,6 +74,59 @@ describe('GlassBridgeComp', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('starts every waiting AI concurrently when a stalled human reaches one minute', async () => {
+    const ids = ['user', 'ai-1', 'ai-2', 'ai-3', 'ai-4', 'ai-5'];
+    const seed = 42;
+    const store = makeStore();
+    render(
+      <Provider store={store}>
+        <GlassBridgeComp
+          participantIds={ids}
+          participants={ids.map((id) => ({ id, name: id, isHuman: id === 'user' }))}
+          seed={seed}
+        />
+      </Provider>,
+    );
+    await advance(0);
+
+    // Assign the user the number that the seeded reveal will place first.
+    const shuffledNumbers = ids.map((_, index) => index + 1);
+    const rng = mulberry32(seed + 1);
+    for (let i = shuffledNumbers.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [shuffledNumbers[i], shuffledNumbers[j]] = [shuffledNumbers[j], shuffledNumbers[i]];
+    }
+    const firstNumber = shuffledNumbers[0];
+    const remainingNumbers = ids.map((_, index) => index + 1).filter((n) => n !== firstNumber);
+
+    await act(async () => {
+      store.dispatch(initGlassBridge({
+        participantIds: ids,
+        participants: ids.map((id) => ({ id, name: id, isHuman: id === 'user' })),
+        competitionType: 'LOH',
+        seed,
+        humanPlayerId: 'user',
+      }));
+      store.dispatch(recordNumberChoice({ playerId: 'user', number: firstNumber }));
+      ids.slice(1).forEach((id, index) => {
+        store.dispatch(recordNumberChoice({ playerId: id, number: remainingNumbers[index] }));
+      });
+      store.dispatch(finaliseOrderSelection());
+      store.dispatch(startPlaying({ now: Date.now() }));
+    });
+
+    expect(store.getState().glassBridge.turnOrder[0]).toBe('user');
+    expect(store.getState().glassBridge.globalTimeLimitMs).toBe(96_000);
+    await advance(36_250);
+    await advance(2_250);
+
+    const progress = store.getState().glassBridge.progress;
+    for (const id of ids.slice(1)) {
+      expect(progress[id].firstStepAtMs, `${id} should have started`).toBeDefined();
+    }
+    expect(progress.user.furthestRowReached).toBe(0);
   });
 
   it('waits for the bridge-collapse timeout sequence before showing results', async () => {

--- a/src/features/glassBridge/glassBridgeSlice.ts
+++ b/src/features/glassBridge/glassBridgeSlice.ts
@@ -515,10 +515,15 @@ const glassBridgeSlice = createSlice({
     /** Resolve an independently active player's next row without changing the main turn. */
     resolveParallelStep(
       state,
-      action: PayloadAction<{ playerId: string; chosenSide: TileSide; now: number }>,
+      action: PayloadAction<{
+        playerId: string;
+        chosenSide: TileSide;
+        now: number;
+        remainingMs?: number;
+      }>,
     ) {
       if (state.phase !== 'playing' || state.timerExpired) return;
-      const { playerId, chosenSide, now } = action.payload;
+      const { playerId, chosenSide, now, remainingMs = 0 } = action.payload;
       if (!state.parallelPlayerIds.includes(playerId)) return;
       const progress = state.progress[playerId];
       if (!progress || progress.eliminated || progress.finishTimeMs !== undefined) return;
@@ -527,18 +532,36 @@ const glassBridgeSlice = createSlice({
       if (!row) return;
       if (progress.firstStepAtMs === undefined) progress.firstStepAtMs = now;
       const elapsed = state.challengeStartTimeMs === null ? 0 : now - state.challengeStartTimeMs;
+      const occupiedSides = Object.entries(state.progress)
+        .filter(([otherId, other]) =>
+          otherId !== playerId
+          && !other.eliminated
+          && other.finishTimeMs === undefined
+          && other.furthestRowReached === rowNumber
+          && other.currentSide,
+        )
+        .map(([, other]) => other.currentSide!);
+      let resolvedSide = chosenSide;
+      if (
+        remainingMs >= COLLISION_OVERRIDE_THRESHOLD_MS
+        && occupiedSides.includes(resolvedSide)
+      ) {
+        const alternative: TileSide = resolvedSide === 'left' ? 'right' : 'left';
+        const alternativeBroken = alternative === 'left' ? row.leftBroken : row.rightBroken;
+        if (!alternativeBroken && !occupiedSides.includes(alternative)) resolvedSide = alternative;
+      }
 
-      if (chosenSide === row.safeSide) {
+      if (resolvedSide === row.safeSide) {
         progress.furthestRowReached = rowNumber;
         progress.timeReachedFurthestRowMs = elapsed;
-        progress.currentSide = chosenSide;
-        row.revealedSafeSide = chosenSide;
+        progress.currentSide = resolvedSide;
+        row.revealedSafeSide = resolvedSide;
         if (rowNumber >= state.rowsCount) {
           progress.finishTimeMs = elapsed;
           progress.currentSide = undefined;
         }
       } else {
-        if (chosenSide === 'left') row.leftBroken = true;
+        if (resolvedSide === 'left') row.leftBroken = true;
         else row.rightBroken = true;
         progress.eliminated = true;
         progress.currentSide = undefined;

--- a/tests/unit/glass-bridge/glassBridge.parallel.test.ts
+++ b/tests/unit/glass-bridge/glassBridge.parallel.test.ts
@@ -72,4 +72,27 @@ describe('Glass Bridge low-time parallel play', () => {
       () => 0,
     )).toBe('left');
   });
+
+  it('enforces occupied-tile avoidance when simultaneous steps resolve', () => {
+    const store = startedStore();
+    store.dispatch(startParallelPlayers());
+    const [firstId, secondId] = store.getState().glassBridge.parallelPlayerIds;
+    const safeSide = store.getState().glassBridge.rows[0].safeSide;
+    store.dispatch(resolveParallelStep({
+      playerId: firstId,
+      chosenSide: safeSide,
+      now: T0 + 1_000,
+      remainingMs: 30_000,
+    }));
+    store.dispatch(resolveParallelStep({
+      playerId: secondId,
+      chosenSide: safeSide,
+      now: T0 + 1_001,
+      remainingMs: 30_000,
+    }));
+
+    const progress = store.getState().glassBridge.progress;
+    expect(progress[firstId].currentSide).toBe(safeSide);
+    expect(progress[secondId].currentSide).not.toBe(safeSide);
+  });
 });


### PR DESCRIPTION
## What changed
- give every waiting AI its own movement timer when one minute remains
- show parallel players on their real bridge rows
- pause movement while an eliminated human chooses whether to spectate
- enforce occupied-tile avoidance atomically until the final 15 seconds

## Root cause
The first implementation marked all waiting players as released, but advanced only one of them every 1.5 seconds. With several players, their turns were still effectively serialized and most could not play before time expired. Parallel avatars were also filtered out of the bridge display.

## Regression covered
A human in first position can stall without moving. At 1:00, five waiting AIs must all record their first step within about two seconds while the human remains stationary.

## Validation
- npm run typecheck
- npm run lint:ci
- npm run build
- 90 Crystal Path and AI-audit tests passed