### PR TITLE
Stagger Crystal Path late entries

### DIFF
--- a/src/components/GlassBridgeComp/GlassBridgeComp.tsx
+++ b/src/components/GlassBridgeComp/GlassBridgeComp.tsx
@@ -45,6 +45,9 @@ import {
   MAX_HINTS_PER_RUN,
   shouldStartParallelPlayers,
   chooseParallelAiSide,
+  COLLISION_OVERRIDE_THRESHOLD_MS,
+  MAX_PARALLEL_MOVERS,
+  PARALLEL_RELEASE_INTERVAL_MS,
   type BridgeRow,
   type TileSide,
 } from '../../features/glassBridge/glassBridgeSlice';
@@ -515,6 +518,7 @@ export default function GlassBridgeComp({
   const timerDisplayRef = useRef(timerDisplay);
   const aiStepTimerRef = useRef<number | null>(null);
   const parallelStepTimersRef = useRef<Map<string, number>>(new Map());
+  const parallelReleaseTimerRef = useRef<number | null>(null);
   const autoAdvanceRef = useRef<number | null>(null);
   const revealTimerRef = useRef<number | null>(null);
   const pendingStepRef = useRef<number | null>(null);
@@ -944,8 +948,35 @@ export default function GlassBridgeComp({
   // ── 6. AI step automation ──────────────────────────────────────────────────
   useEffect(() => {
     if (gb.phase !== 'playing' || gb.timerExpired) return;
-    if (!shouldStartParallelPlayers(timerDisplay) || gb.parallelPlayerIds.length > 0) return;
+    if (!shouldStartParallelPlayers(timerDisplay)) return;
     const activeId = selectActivePlayerId(gb);
+    const waiting = gb.turnOrder.filter((playerId) =>
+      playerId !== activeId
+      && !gb.parallelPlayerIds.includes(playerId)
+      && gb.progress[playerId]?.firstStepAtMs === undefined,
+    );
+    if (waiting.length === 0) return;
+    if (timerDisplay <= COLLISION_OVERRIDE_THRESHOLD_MS) {
+      dispatch(startParallelPlayers({ releaseAll: true }));
+      return;
+    }
+    const activeParallelCount = gb.parallelPlayerIds.filter((playerId) => {
+      const progress = gb.progress[playerId];
+      return progress && !progress.eliminated && progress.finishTimeMs === undefined;
+    }).length;
+    if (activeParallelCount >= MAX_PARALLEL_MOVERS) return;
+    if (gb.parallelPlayerIds.length > 0) {
+      parallelReleaseTimerRef.current = window.setTimeout(() => {
+        dispatch(startParallelPlayers());
+        parallelReleaseTimerRef.current = null;
+      }, PARALLEL_RELEASE_INTERVAL_MS);
+      return () => {
+        if (parallelReleaseTimerRef.current !== null) {
+          window.clearTimeout(parallelReleaseTimerRef.current);
+          parallelReleaseTimerRef.current = null;
+        }
+      };
+    }
     const hasUnstartedPlayers = gb.turnOrder.some((playerId) =>
       playerId !== activeId && gb.progress[playerId]?.firstStepAtMs === undefined,
     );

--- a/src/features/glassBridge/glassBridgeSlice.ts
+++ b/src/features/glassBridge/glassBridgeSlice.ts
@@ -157,6 +157,8 @@ export function buildGlassBridgeTimeLimitMs(participantCount: number): number {
 
 export const PARALLEL_START_THRESHOLD_MS = 60_000;
 export const COLLISION_OVERRIDE_THRESHOLD_MS = 15_000;
+export const MAX_PARALLEL_MOVERS = 3;
+export const PARALLEL_RELEASE_INTERVAL_MS = 4_000;
 
 export function shouldStartParallelPlayers(remainingMs: number): boolean {
   return remainingMs <= PARALLEL_START_THRESHOLD_MS;
@@ -499,17 +501,26 @@ const glassBridgeSlice = createSlice({
       state.currentPlayerRow = 1;
     },
 
-    /** Release only players who have not yet stepped onto the bridge. */
-    startParallelPlayers(state) {
+    /** Release waiting players gradually; the final scramble may release everyone. */
+    startParallelPlayers(state, action: PayloadAction<{ releaseAll?: boolean } | undefined>) {
       if (state.phase !== 'playing' || state.timerExpired) return;
       const activeId = state.turnOrder[state.currentTurnIndex];
-      state.parallelPlayerIds = state.turnOrder.filter((playerId) => {
+      const waiting = state.turnOrder.filter((playerId) => {
         const progress = state.progress[playerId];
         return playerId !== activeId
+          && !state.parallelPlayerIds.includes(playerId)
           && progress?.firstStepAtMs === undefined
           && !progress.eliminated
           && progress.finishTimeMs === undefined;
       });
+      const activeParallelCount = state.parallelPlayerIds.filter((playerId) => {
+        const progress = state.progress[playerId];
+        return progress && !progress.eliminated && progress.finishTimeMs === undefined;
+      }).length;
+      const capacity = action.payload?.releaseAll
+        ? waiting.length
+        : Math.max(0, MAX_PARALLEL_MOVERS - activeParallelCount);
+      state.parallelPlayerIds.push(...waiting.slice(0, capacity));
     },
 
     /** Resolve an independently active player's next row without changing the main turn. */

--- a/tests/unit/glass-bridge/glassBridge.parallel.test.ts
+++ b/tests/unit/glass-bridge/glassBridge.parallel.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 import glassBridgeReducer, {
   COLLISION_OVERRIDE_THRESHOLD_MS,
+  MAX_PARALLEL_MOVERS,
   chooseParallelAiSide,
   finaliseOrderSelection,
   initGlassBridge,
@@ -36,13 +37,14 @@ describe('Glass Bridge low-time parallel play', () => {
     expect(shouldStartParallelPlayers(60_000)).toBe(true);
   });
 
-  it('starts every waiting player without duplicating the current player', () => {
+  it('releases waiting players gradually without duplicating the current player', () => {
     const store = startedStore();
     const activeId = store.getState().glassBridge.turnOrder[0];
     store.dispatch(startParallelPlayers());
-    expect(store.getState().glassBridge.parallelPlayerIds).toEqual(
-      store.getState().glassBridge.turnOrder.filter((id) => id !== activeId),
+    expect(store.getState().glassBridge.parallelPlayerIds).toHaveLength(
+      Math.min(MAX_PARALLEL_MOVERS, store.getState().glassBridge.turnOrder.length - 1),
     );
+    expect(store.getState().glassBridge.parallelPlayerIds).not.toContain(activeId);
   });
 
   it('advances a released player independently of the main turn', () => {


### PR DESCRIPTION
## Summary
- release one waiting player at the one-minute mark
- add entrants every four seconds, capped at three active movers
- release all remaining players only during the final 15-second scramble
- keep occupied-tile avoidance until that final scramble

## Validation
- git diff --check
- focused test command could not run because the isolated checkout has no local dependencies