### PR TITLE
Fix run persistence and lifecycle recovery

### DIFF
--- a/src/publicOpinion/publicOpinionSlice.ts
+++ b/src/publicOpinion/publicOpinionSlice.ts
@@ -297,6 +297,10 @@ const publicOpinionSlice = createSlice({
         applyDirectionCompletionRewards(state, direction, week);
       }
     },
+
+    hydratePublicOpinion(_state, action: PayloadAction<PublicOpinionState>) {
+      return action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addMatcher(
@@ -315,6 +319,7 @@ export const {
   pruneExpiredDirections,
   resetDailyFeedBudget,
   updateMissionProgress,
+  hydratePublicOpinion,
 } = publicOpinionSlice.actions;
 
 export default publicOpinionSlice.reducer;

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -66,6 +66,8 @@ import { startChallenge, selectPendingChallenge, completeChallenge, type Pending
 import { selectLastSocialReport } from '../../social/socialSlice'
 import { setEnergyBankEntry } from '../../social/socialSlice'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { selectActiveProfileId, selectIsGuest } from '../../store/profilesSlice'
+import { clearSavedRun, clearSeasonSnapshot, savedStateKeyForProfile } from '../../store/saveStatePersistence'
 import { selectSocialSummaryOpen } from '../../store/uiSlice'
 import TvZone from '../../components/ui/TvZone'
 import HouseguestGrid from '../../components/HouseguestGrid/HouseguestGrid'
@@ -325,6 +327,8 @@ export default function GameScreen() {
   }, [store])
   const alivePlayers = useAppSelector(selectAlivePlayers)
   const game = useAppSelector((s) => s.game)
+  const activeProfileId = useAppSelector(selectActiveProfileId)
+  const isGuest = useAppSelector(selectIsGuest)
   const settings = useAppSelector(selectSettings)
   // ── Confessional ceremony decision routing ─────────────────────────────────
   // When non-null, a required player ceremony decision is pending that must be
@@ -408,15 +412,22 @@ export default function GameScreen() {
   const humanPlayer = game.players.find((p) => p.isUser)
   const humanPlayerEliminated = humanPlayer?.status === 'evicted' || humanPlayer?.status === 'jury'
   const preJuryGameOver = game.mode !== 'survival' && humanPlayer?.status === 'evicted'
+  const clearEliminatedRun = useCallback(() => {
+    if (isGuest || !activeProfileId) return
+    clearSavedRun(activeProfileId, game.mode ?? 'classic')
+    clearSeasonSnapshot(savedStateKeyForProfile(activeProfileId))
+  }, [activeProfileId, game.mode, isGuest])
   const handleStartNewSeason = useCallback(() => {
+    clearEliminatedRun()
     dispatch(resetGame())
     dispatch({ type: 'challenge/setPendingChallenge', payload: null })
-    navigate('/', { replace: true })
-  }, [dispatch, navigate])
+    navigate('/', { replace: true, state: { autoStartGame: true } })
+  }, [clearEliminatedRun, dispatch, navigate])
   const handlePreJuryReturnHome = useCallback(() => {
+    clearEliminatedRun()
     dispatch({ type: 'challenge/setPendingChallenge', payload: null })
     navigate('/', { replace: true })
-  }, [dispatch, navigate])
+  }, [clearEliminatedRun, dispatch, navigate])
   const confessionalTvAnnouncement = confessionalPromptTriggered && showConfessionalTvPrompt
     ? {
       key: 'confessional_required',

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -4,6 +4,8 @@ import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
 import { hydrateFinale } from '../../store/finaleSlice';
 import { hydrateSocial } from '../../social/socialSlice';
+import { hydratePublicOpinion } from '../../publicOpinion/publicOpinionSlice';
+import { hydrateChallenge } from '../../store/challengeSlice';
 import { loadSeasonArchives } from '../../store/archivePersistence';
 import {
   selectActiveProfileId,
@@ -267,6 +269,8 @@ export default function HomeHub() {
     dispatch(hydrateGame(snapshot.game));
     dispatch(hydrateFinale(snapshot.finale));
     dispatch(hydrateSocial(snapshot.social));
+    if (snapshot.publicOpinion) dispatch(hydratePublicOpinion(snapshot.publicOpinion));
+    if (snapshot.challenge) dispatch(hydrateChallenge(snapshot.challenge));
     navigate('/game');
   }
 

--- a/src/screens/ProfilePicker/ProfilePicker.tsx
+++ b/src/screens/ProfilePicker/ProfilePicker.tsx
@@ -16,6 +16,8 @@ import {
 import { resetGame, hydrateGame } from '../../store/gameSlice';
 import { hydrateFinale } from '../../store/finaleSlice';
 import { hydrateSocial } from '../../social/socialSlice';
+import { hydratePublicOpinion } from '../../publicOpinion/publicOpinionSlice';
+import { hydrateChallenge } from '../../store/challengeSlice';
 import { loadSeasonArchives } from '../../store/archivePersistence';
 import {
   savedStateKeyForProfile,
@@ -171,6 +173,8 @@ export default function ProfilePicker() {
       dispatch(hydrateGame(snapshot.game));
       dispatch(hydrateFinale(snapshot.finale));
       dispatch(hydrateSocial(snapshot.social));
+      if (snapshot.publicOpinion) dispatch(hydratePublicOpinion(snapshot.publicOpinion));
+      if (snapshot.challenge) dispatch(hydrateChallenge(snapshot.challenge));
       navigate('/game', { replace: true });
     } catch {
       // If hydration fails for any reason, gracefully fall back to a fresh season

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -128,6 +128,15 @@ const challengeSlice = createSlice({
     clearDebugOverrides(state) {
       state.debug = {};
     },
+    hydrateChallenge(_state, action: PayloadAction<ChallengeState>) {
+      const restored = action.payload;
+      return {
+        ...restored,
+        pending: restored.pending
+          ? { ...restored.pending, phase: 'rules' as const }
+          : null,
+      };
+    },
   },
 });
 
@@ -138,6 +147,7 @@ export const {
   recordRun,
   setDebugOverrides,
   clearDebugOverrides,
+  hydrateChallenge,
 } = challengeSlice.actions;
 
 export default challengeSlice.reducer;

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -20,6 +20,8 @@ import {
 } from '../modes/survivorAchievements';
 import type { FinaleState } from './finaleSlice';
 import type { SocialState } from '../social/types';
+import type { PublicOpinionState } from '../publicOpinion/types';
+import type { ChallengeState } from './challengeSlice';
 import type { SurvivorAchievementUnlockMap } from '../modes/survivorAchievements';
 
 /** Prefix for per-profile saved-season localStorage keys. */
@@ -40,6 +42,10 @@ export interface SavedSeasonSnapshot {
   finale: FinaleState;
   /** Social-slice state at the time of save. */
   social: SocialState;
+  /** Optional for backward compatibility with snapshots created before public-mode persistence. */
+  publicOpinion?: PublicOpinionState;
+  /** Restores the selected challenge; an in-progress game restarts from its rules screen. */
+  challenge?: ChallengeState;
 }
 
 export interface SavedRunProfileStats {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -107,6 +107,10 @@ let prevProfiles = store.getState().profiles;
 let prevAds = store.getState().ads;
 // Persist active mode runs whenever the game slice changes.
 let prevGame = store.getState().game;
+let prevFinale = store.getState().finale;
+let prevSocial = store.getState().social;
+let prevPublicOpinion = store.getState().publicOpinion;
+let prevChallenge = store.getState().challenge;
 // Persist season archives to localStorage whenever they change
 let prevSeasonArchives = store.getState().game.seasonArchives;
 // Track archive length together with the profile that owns those archives.
@@ -137,8 +141,18 @@ store.subscribe(() => {
     prevAds = current.ads;
     saveAdsState(current.ads);
   }
-  if (current.game !== prevGame) {
+  const resumableStateChanged =
+    current.game !== prevGame
+    || current.finale !== prevFinale
+    || current.social !== prevSocial
+    || current.publicOpinion !== prevPublicOpinion
+    || current.challenge !== prevChallenge;
+  if (resumableStateChanged) {
     prevGame = current.game;
+    prevFinale = current.finale;
+    prevSocial = current.social;
+    prevPublicOpinion = current.publicOpinion;
+    prevChallenge = current.challenge;
     const activeProfileId = current.profiles.activeProfileId;
     if (!current.profiles.isGuest && activeProfileId && hasMeaningfulGameProgress(current.game)) {
       saveRunSnapshot(activeProfileId, {
@@ -153,6 +167,8 @@ store.subscribe(() => {
         },
         finale: current.finale,
         social: current.social,
+        publicOpinion: current.publicOpinion,
+        challenge: current.challenge,
       });
     }
   }
@@ -183,6 +199,27 @@ store.subscribe(() => {
     prevArchiveProfileId = archivesProfileId;
   }
 });
+
+// Android may reclaim a background WebView without another Redux action. Force
+// the latest serializable campaign state to storage as soon as the app hides.
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'hidden') return;
+    const current = store.getState();
+    const activeProfileId = current.profiles.activeProfileId;
+    if (current.profiles.isGuest || !activeProfileId || !hasMeaningfulGameProgress(current.game)) return;
+    saveRunSnapshot(activeProfileId, {
+      version: 1,
+      profileId: activeProfileId,
+      savedAt: new Date().toISOString(),
+      game: { ...current.game, lastPlayedAt: Date.now() },
+      finale: current.finale,
+      social: current.social,
+      publicOpinion: current.publicOpinion,
+      challenge: current.challenge,
+    });
+  });
+}
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- clear pre-jury eliminated saves before starting a new season and launch the fresh-season flow directly
- persist and hydrate public opinion so approval no longer resets to 50%
- persist the selected challenge and restart interrupted gameplay safely from its rules screen
- checkpoint all resumable state when Android backgrounds the WebView

## Validation
- npm run typecheck
- npx vitest run src/store/saveStatePersistence.test.ts src/screens/HomeHub/__tests__/HomeHub.test.tsx --maxWorkers=2 (11 passed)
- git diff --check