### PR TITLE
Fix competition outcomes and audience impact

### DIFF
--- a/src/components/SnakeGame/SnakeGame.tsx
+++ b/src/components/SnakeGame/SnakeGame.tsx
@@ -123,7 +123,16 @@ interface Props {
   /** LOH/POS minigame path: all game players (for name lookup). */
   players?: Player[];
   /** MinigameHost path: called with the human's final score. */
-  onFinish?: (value: number) => void;
+  onFinish?: (
+    value: number,
+    tiebreakerMs?: number,
+    completion?: {
+      authoritativeWinnerId?: string | null;
+      authoritativeLastPlaceId?: string | null;
+      rawResults?: Record<string, number>;
+      tiebreakerMs?: number;
+    },
+  ) => void;
   /** Competition seed (forwarded from host; reserved for future use). */
   seed?: number;
   /** When true the game starts immediately on mount. */
@@ -751,8 +760,19 @@ export default function SnakeGame({
       dispatch(completeMinigame(payload));
       return;
     }
-    if (onFinish) onFinish(humanScore);
-  }, [dispatch, onFinish, scores, session]);
+    if (onFinish) {
+      const winnerId = scores[0]?.id ?? humanId ?? null;
+      const lastPlaceId = scores[scores.length - 1]?.id ?? null;
+      const humanResult = scores.find((entry) => entry.isHuman);
+      const humanTime = humanResult?.completionMs;
+      onFinish(humanScore, humanTime, {
+        authoritativeWinnerId: winnerId,
+        authoritativeLastPlaceId: lastPlaceId,
+        rawResults: Object.fromEntries(scores.map((entry) => [entry.id, entry.score])),
+        ...(humanTime != null ? { tiebreakerMs: humanTime } : {}),
+      });
+    }
+  }, [dispatch, humanId, onFinish, scores, session]);
 
   const handleFastForward = useCallback(() => {
     if (gamePhase !== 'waiting' || isFastForwarding) return;

--- a/src/publicOpinion/publicOpinionConfig.ts
+++ b/src/publicOpinion/publicOpinionConfig.ts
@@ -8,6 +8,10 @@ export const publicOpinionConfig = {
     povWin: 4,
     nominated: -2,
     evictionVotedOut: -3,
+    strongPerformance: 1,
+    weakPerformance: -1,
+    lastPlace: -2,
+    quitEarly: -4,
   },
   socialImpact: {
     positiveInteraction: 2,

--- a/src/publicOpinion/publicOpinionConfig.ts
+++ b/src/publicOpinion/publicOpinionConfig.ts
@@ -17,6 +17,9 @@ export const publicOpinionConfig = {
     positiveInteraction: 2,
     negativeInteraction: -2,
     betrayal: -4,
+    highQualityInteraction: 1,
+    poorInteraction: -1,
+    inactiveDay: -1,
   },
   strategyImpact: {
     boldNomination: 3,

--- a/src/publicOpinion/publicOpinionMiddleware.ts
+++ b/src/publicOpinion/publicOpinionMiddleware.ts
@@ -81,6 +81,13 @@ interface StateWithGame {
     profiles: Record<string, unknown>;
     directions: PublicDirection[];
   };
+  social?: {
+    sessionLogs?: Array<{
+      actorId?: string;
+      source?: 'manual' | 'system';
+      week?: number;
+    }>;
+  };
 }
 
 const OPENING_PUBLIC_APPROVAL_MIN = 42;
@@ -411,12 +418,33 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
         actionId?: string;
         outcome?: string;
         delta?: number;
+        score?: number;
+        source?: 'manual' | 'system';
       };
     } | undefined;
     const entry = payload?.entry;
     if (entry?.actorId) {
       const week = game.week ?? 1;
       const { actorId, targetId, actionId = '', outcome = '', delta = 0 } = entry;
+
+      const human = game.players?.find((player) => player.isUser);
+      if (human?.id === actorId && entry.source === 'manual') {
+        const score = typeof entry.score === 'number' ? entry.score : 0;
+        const approvalDelta = outcome === 'success' && score >= 0.55
+          ? publicOpinionConfig.socialImpact.highQualityInteraction
+          : outcome === 'failure' || score <= -0.25
+            ? publicOpinionConfig.socialImpact.poorInteraction
+            : 0;
+        if (approvalDelta !== 0) {
+          store.dispatch(updateApproval({
+            playerId: actorId,
+            delta: approvalDelta,
+            reason: approvalDelta > 0 ? 'high_quality_social_play' : 'poor_social_play',
+            week,
+            addToFeed: false,
+          }));
+        }
+      }
 
       let missionEventType: MissionGameEvent['type'] | null = null;
       if (actionId === 'betray' && outcome === 'success') {
@@ -602,6 +630,23 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
       }
 
       if (newPhase === 'week_end') {
+        const human = game.players?.find((player) => player.isUser);
+        const socialLogs = nextState.social?.sessionLogs;
+        if (human && socialLogs) {
+          const usedSocialThisWeek = socialLogs.some(
+            (entry) => entry.actorId === human.id && entry.source === 'manual' && entry.week === week,
+          );
+          if (!usedSocialThisWeek) {
+            store.dispatch(updateApproval({
+              playerId: human.id,
+              delta: publicOpinionConfig.socialImpact.inactiveDay,
+              reason: 'social_inactivity',
+              week,
+              addToFeed: false,
+            }));
+          }
+        }
+
         store.dispatch(pruneExpiredDirections({ week: week + 1 }));
 
         const activePlayers = (game.players ?? []).filter(

--- a/src/publicOpinion/publicOpinionMiddleware.ts
+++ b/src/publicOpinion/publicOpinionMiddleware.ts
@@ -356,6 +356,50 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
     return result;
   }
 
+  if (actionType === 'challenge/recordRun') {
+    const run = actionPayload as {
+      participants?: string[];
+      canonicalScores?: Record<string, number>;
+      winnerId?: string;
+      partial?: boolean;
+    } | undefined;
+    const human = game.players?.find((player) => player.isUser);
+    if (!human || !run?.participants?.includes(human.id)) return result;
+    ensureProfiles(store, game);
+
+    let delta = 0;
+    let reason = 'competition_performance';
+    if (run.partial) {
+      delta = publicOpinionConfig.competitionImpact.quitEarly;
+      reason = 'challenge_quit_early';
+    } else {
+      const ranked = [...run.participants].sort((a, b) =>
+        (run.canonicalScores?.[b] ?? 0) - (run.canonicalScores?.[a] ?? 0),
+      );
+      const placement = ranked.indexOf(human.id) + 1;
+      if (placement === 1) {
+        delta = publicOpinionConfig.competitionImpact.strongPerformance;
+        reason = 'strong_competition_performance';
+      } else if (placement === ranked.length) {
+        delta = publicOpinionConfig.competitionImpact.lastPlace;
+        reason = 'last_place_competition';
+      } else if (placement > Math.ceil(ranked.length / 2)) {
+        delta = publicOpinionConfig.competitionImpact.weakPerformance;
+        reason = 'weak_competition_performance';
+      }
+    }
+    if (delta !== 0) {
+      store.dispatch(updateApproval({
+        playerId: human.id,
+        delta,
+        reason,
+        week: game.week ?? 1,
+        addToFeed: true,
+      }));
+    }
+    return result;
+  }
+
   if (actionType === 'social/recordSocialAction') {
     // Payload: { entry: SocialActionLogEntry }
     // entry has actorId, targetId, actionId ('ally'|'protect'|'betray'|'nominate'),

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -2076,7 +2076,7 @@ export default function GameScreen() {
     // — UNLESS this is an AI tiebreak where we want the modal to show the tie
     // banner first and call onTiebreakerRequired.
     if (game.pendingEviction) {
-      if (!humanIsHoH) {
+      if (!humanIsHoH && game.awaitingTieBreak) {
         // Check whether the tallies are actually tied (AI tiebreak case).
         let maxVotes = -1
         let topCount = 0
@@ -2107,10 +2107,10 @@ export default function GameScreen() {
     if (evicteeIds.length !== 1) return null
 
     return game.players.find((p) => p.id === evicteeIds[0]) ?? null
-  }, [game.voteResults, game.pendingEviction, game.players, humanIsHoH])
+  }, [game.voteResults, game.pendingEviction, game.players, game.awaitingTieBreak, humanIsHoH])
 
   const aiTiebreakContext = useMemo<AiTiebreakContext | null>(() => {
-    if (humanIsHoH || !game.voteResults || !game.pendingEviction?.evicteeId) return null
+    if (humanIsHoH || !game.awaitingTieBreak || !game.voteResults || !game.pendingEviction?.evicteeId) return null
     let maxVotes = -1
     let topCount = 0
     for (const count of Object.values(game.voteResults)) {
@@ -2141,7 +2141,7 @@ export default function GameScreen() {
         ? `By a vote of ${evicteeVotes + 1} to ${otherVotes}`
         : `With ${evicteeVotes + 1} vote${evicteeVotes + 1 === 1 ? '' : 's'}`,
     }
-  }, [game.lohId, game.pendingEviction?.evicteeId, game.players, game.voteResults, humanIsHoH])
+  }, [game.awaitingTieBreak, game.lohId, game.pendingEviction?.evicteeId, game.players, game.voteResults, humanIsHoH])
 
   const aiTiebreakAnnouncement = useMemo<Announcement | null>(() => {
     if (!aiTiebreakStage || !activeAiTiebreakContext) return null
@@ -3742,6 +3742,7 @@ export default function GameScreen() {
 
             const scoreWinnerId = dispatch(completeChallenge(rawResults, {
               authoritativeWinnerId: explicitWinnerId,
+              partial: partial === true,
             })) as string | null;
 
             if (import.meta.env.DEV) {

--- a/src/social/SocialManeuvers.ts
+++ b/src/social/SocialManeuvers.ts
@@ -471,7 +471,7 @@ export function executeAction(
   }
 
   // Read balances after all mutations
-  const stateAfter = _store.getState() as { social: SocialState };
+  const stateAfter = _store.getState() as { social: SocialState; game?: { week?: number } };
   const balancesAfter = {
     energy: stateAfter.social.energyBank[actorId] ?? 0,
     influence: stateAfter.social.influenceBank[actorId] ?? 0,
@@ -492,6 +492,7 @@ export function executeAction(
     newEnergy,
     balancesAfter,
     timestamp: Date.now(),
+    week: stateAfter.game?.week,
     score: finalScore,
     label: finalLabel,
     source: options?.source ?? 'system',

--- a/src/social/types.ts
+++ b/src/social/types.ts
@@ -61,6 +61,8 @@ export interface SocialActionLogEntry {
   /** Actor's energy after the action (backward-compatible; prefer `balancesAfter.energy`). */
   newEnergy: number;
   timestamp: number;
+  /** In-game week in which the action happened, used by daily engagement systems. */
+  week?: number;
   /** Normalised outcome score in [-1, +1] produced by the SocialPolicy evaluator. */
   score?: number;
   /** Human-readable outcome label (e.g. 'Good', 'Bad') produced by the evaluator. */

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -49,6 +49,8 @@ export interface ChallengeRun {
   timestamp: number;
   /** Whether the winner was determined by the game authoritatively. */
   authoritative: boolean;
+  /** True when the human dismissed the challenge before it completed. */
+  partial?: boolean;
 }
 
 export interface ChallengeState {
@@ -481,6 +483,7 @@ export const completeChallenge =
     rawResults: RawResult[],
     options?: {
       authoritativeWinnerId?: string | null;
+      partial?: boolean;
     },
   ) =>
   (dispatch: AppDispatch, getState: () => RootState): string | null => {
@@ -516,6 +519,7 @@ export const completeChallenge =
       winnerId,
       timestamp: Date.now(),
       authoritative: explicitWinnerId !== null || winner?.authoritativeWinner === true,
+      partial: options?.partial === true,
     };
 
     dispatch(recordRun(run));

--- a/tests/doubleEviction.flow.test.ts
+++ b/tests/doubleEviction.flow.test.ts
@@ -507,6 +507,43 @@ describe('advance() — eviction_results with Double Eviction', () => {
     expect(doubleEviction?.pendingSecondEviction?.evictionMessage).toContain('eliminated in tonight\'s Double Elimination');
   });
 
+  it('treats 3-3-1 as two clear evictees with no tie-break', () => {
+    const store = makeEvictionStore({
+      v0: 'p1', v1: 'p1', v2: 'p1',
+      v3: 'p2', v4: 'p2', v5: 'p2',
+      v6: 'p3',
+    });
+    store.dispatch(advance());
+    const game = store.getState().game;
+    expect(game.awaitingTieBreak).toBe(false);
+    expect(new Set([
+      game.pendingEviction?.evicteeId,
+      game.doubleEviction?.pendingSecondEviction?.evicteeId,
+    ])).toEqual(new Set(['p1', 'p2']));
+  });
+
+  it('treats 2-2-2 as a tie for both eviction slots', () => {
+    const store = makeEvictionStore({
+      v0: 'p1', v1: 'p1', v2: 'p2', v3: 'p2', v4: 'p3', v5: 'p3',
+    }, { humanLoh: true });
+    store.dispatch(advance());
+    const game = store.getState().game;
+    expect(game.awaitingTieBreak).toBe(true);
+    expect(game.pendingEviction).toBeNull();
+    expect(new Set(game.tiedNomineeIds ?? [])).toEqual(new Set(['p1', 'p2', 'p3']));
+  });
+
+  it('treats 2-1-1 as a tie only for the second eviction slot', () => {
+    const store = makeEvictionStore({
+      v0: 'p1', v1: 'p1', v2: 'p2', v3: 'p3',
+    }, { humanLoh: true });
+    store.dispatch(advance());
+    const game = store.getState().game;
+    expect(game.pendingEviction?.evicteeId).toBe('p1');
+    expect(game.awaitingTieBreak).toBe(true);
+    expect(new Set(game.tiedNomineeIds ?? [])).toEqual(new Set(['p2', 'p3']));
+  });
+
   it('stores vote results for popup reveal', () => {
     const store = makeEvictionStore({
       v0: 'p1', v1: 'p2', v2: 'p3',

--- a/tests/snakeGame.results.test.tsx
+++ b/tests/snakeGame.results.test.tsx
@@ -162,7 +162,9 @@ describe('SnakeGame competition reveal flow', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
-    expect(onFinish).toHaveBeenCalledWith(0);
+    expect(onFinish).toHaveBeenCalled();
+    expect(onFinish.mock.calls[0]?.[0]).toBe(0);
+    expect(onFinish.mock.calls[0]?.[2]?.authoritativeWinnerId).toBeTruthy();
   });
 
   it('renders a retro handheld status line for points and time', () => {

--- a/tests/unit/publicOpinion/eventDrivenReactions.test.ts
+++ b/tests/unit/publicOpinion/eventDrivenReactions.test.ts
@@ -160,6 +160,44 @@ describe('event-driven approval: loh_results', () => {
   });
 });
 
+describe('event-driven approval: challenge performance', () => {
+  it('penalizes quitting more than finishing last', () => {
+    const players = makeGameState().players.map((player, index) => ({
+      ...player,
+      isUser: index === 0,
+    }));
+    const quitStore = makeStore({ players });
+    quitStore.dispatch(initializeProfiles(players.map((player) => player.id)));
+    quitStore.dispatch({
+      type: 'challenge/recordRun',
+      payload: {
+        participants: ['p1', 'p2', 'p3'],
+        canonicalScores: { p1: 0, p2: 800, p3: 500 },
+        winnerId: 'p2',
+        partial: true,
+      },
+    });
+    expect(quitStore.getState().publicOpinion.profiles.p1.approval).toBe(
+      50 + publicOpinionConfig.competitionImpact.quitEarly,
+    );
+
+    const lastStore = makeStore({ players });
+    lastStore.dispatch(initializeProfiles(players.map((player) => player.id)));
+    lastStore.dispatch({
+      type: 'challenge/recordRun',
+      payload: {
+        participants: ['p1', 'p2', 'p3'],
+        canonicalScores: { p1: 100, p2: 800, p3: 500 },
+        winnerId: 'p2',
+        partial: false,
+      },
+    });
+    expect(lastStore.getState().publicOpinion.profiles.p1.approval).toBe(
+      50 + publicOpinionConfig.competitionImpact.lastPlace,
+    );
+  });
+});
+
 describe('event-driven approval: nomination_results', () => {
   it('applies LOH backlash immediately when a liked player (≥60%) is nominated', () => {
     const store = makeStore({ phase: 'loh_results', week: 1, lohId: 'p1' });

--- a/tests/unit/publicOpinion/eventDrivenReactions.test.ts
+++ b/tests/unit/publicOpinion/eventDrivenReactions.test.ts
@@ -198,6 +198,31 @@ describe('event-driven approval: challenge performance', () => {
   });
 });
 
+describe('event-driven approval: social quality', () => {
+  it('rewards only strong manual interactions and penalizes poor attempts', () => {
+    const players = makeGameState().players.map((player, index) => ({
+      ...player,
+      isUser: index === 0,
+    }));
+    const store = makeStore({ players });
+    store.dispatch(initializeProfiles(players.map((player) => player.id)));
+
+    store.dispatch({
+      type: 'social/recordSocialAction',
+      payload: { entry: { actorId: 'p1', targetId: 'p2', actionId: 'compliment', outcome: 'success', delta: 4, score: 0.8, source: 'manual' } },
+    });
+    expect(store.getState().publicOpinion.profiles.p1.approval).toBe(
+      50 + publicOpinionConfig.socialImpact.highQualityInteraction,
+    );
+
+    store.dispatch({
+      type: 'social/recordSocialAction',
+      payload: { entry: { actorId: 'p1', targetId: 'p2', actionId: 'compliment', outcome: 'failure', delta: -2, score: -0.5, source: 'manual' } },
+    });
+    expect(store.getState().publicOpinion.profiles.p1.approval).toBe(50);
+  });
+});
+
 describe('event-driven approval: nomination_results', () => {
   it('applies LOH backlash immediately when a liked player (≥60%) is nominated', () => {
     const store = makeStore({ phase: 'loh_results', week: 1, lohId: 'p1' });


### PR DESCRIPTION
## Summary
- preserve Serpentine's authoritative time-based winner through the host
- apply bounded public approval reactions for strong, weak, last-place, and early-exit challenge results
- make quitting more costly than completing in last place while leaving social and strategic actions as the primary approval drivers
- stop 3-3-1 double-elimination results from invoking the UI tie-break path
- lock exact 3-3-1, 2-2-2, and 2-1-1 behavior with tests

## Validation
- npm run typecheck
- 104 focused tests passed
- git diff --check