### PR TITLE
Fix Famous Figures round flow

### DIFF
--- a/src/components/FamousFiguresComp/FamousFiguresComp.css
+++ b/src/components/FamousFiguresComp/FamousFiguresComp.css
@@ -11,9 +11,9 @@
   background: linear-gradient(160deg, #0a1a2e 0%, #0d2240 60%, #0a1a2e 100%);
   color: #e8f4ff;
   font-family: inherit;
-  padding: 1rem;
+  padding: 0.65rem;
   box-sizing: border-box;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 /* ── Header ─────────────────────────────────────────────────────────────── */
@@ -103,7 +103,7 @@
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(60, 160, 255, 0.35);
   border-radius: 12px;
-  padding: 1rem;
+  padding: 0.75rem;
   box-sizing: border-box;
 }
 
@@ -131,21 +131,26 @@
   margin: 0;
   padding: 0;
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.3rem;
 }
 
 .ff-hint-item {
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
-  padding: 0.5rem 0.6rem;
+  padding: 0.35rem 0.5rem;
   background: rgba(60, 160, 255, 0.08);
   border: 1px solid rgba(60, 160, 255, 0.2);
   border-radius: 6px;
   font-size: 0.88rem;
   color: #b0d8f8;
   animation: ff-hint-appear 0.35s ease-out;
+}
+
+@media (max-width: 520px) {
+  .ff-hint-list { grid-template-columns: 1fr; }
 }
 
 .ff-hint-num {

--- a/src/components/FamousFiguresComp/FamousFiguresComp.tsx
+++ b/src/components/FamousFiguresComp/FamousFiguresComp.tsx
@@ -444,6 +444,7 @@ export default function FamousFiguresComp({
     if (ff.status !== 'round_active') return;
     // Block if human has finished all personal rounds
     if (humanCursor >= ff.totalRounds) return;
+    if (humanCursor !== ff.currentRound) return;
     // Block if human already answered this personal round
     if (humanCursor !== (ff.playerRoundCursor[humanId] ?? 0)) return;
 
@@ -590,13 +591,15 @@ export default function FamousFiguresComp({
   // shared matchFigureOrder all players see the same figure per global round,
   // but the human can advance ahead of the global round immediately after
   // answering correctly.
-  const humanIsAhead = humanId !== null && humanCursor > ff.currentRound;
+  // Do not show the next personal figure while the shared round timer and AI
+  // are still resolving the current one.
+  const humanIsAhead = false;
   // Resolve the human's current figure from the shared matchFigureOrder.
   const humanFigureIdx =
-    humanId !== null && ff.matchFigureOrder.length > humanCursor
-      ? ff.matchFigureOrder[humanCursor]
+    humanId !== null && ff.matchFigureOrder.length > ff.currentRound
+      ? ff.matchFigureOrder[ff.currentRound]
       : humanId !== null
-        ? getPlayerFigureIndex(ff, humanId, humanCursor)
+        ? getPlayerFigureIndex(ff, humanId, ff.currentRound)
         : ff.currentFigureIndex;
   // Always show the human's own figure — on round_reveal this is the figure
   // they were actually being tested on. When there is no local human player,
@@ -604,7 +607,7 @@ export default function FamousFiguresComp({
   const figure = FAMOUS_FIGURES[humanFigureIdx] ?? null;
   // For hints: when ahead of the global round use the local counter so we
   // don't mutate the global hintsRevealed for the ongoing AI round.
-  const effectiveHintsRevealed = humanIsAhead ? humanAheadHints : ff.hintsRevealed;
+  const effectiveHintsRevealed = ff.hintsRevealed;
   // humanCorrect: true only if the human has already answered their CURRENT
   // personal round. When the human is ahead, they are on a fresh round (cursor
   // has already moved) so correct = false until they answer the new figure.
@@ -834,7 +837,7 @@ export default function FamousFiguresComp({
 
   // Show the human's personal round number (cursor + 1) when they are ahead,
   // otherwise show the global round number.
-  const displayRound = humanIsAhead ? humanCursor + 1 : ff.currentRound + 1;
+  const displayRound = ff.currentRound + 1;
 
   return (
     <div className="ff-container" data-status="round_active">
@@ -847,7 +850,7 @@ export default function FamousFiguresComp({
 
       {/* Narration */}
       <p className="ff-narration" aria-live="polite">
-        {pickLine(NARRATION.roundStart, humanCursor)}
+        {humanCorrect ? 'Correct — waiting for the other housemates.' : pickLine(NARRATION.roundStart, ff.currentRound)}
       </p>
 
       {/* Timer — stay visible during active rounds, including ahead-play. */}

--- a/src/features/famousFigures/famousFiguresSlice.ts
+++ b/src/features/famousFigures/famousFiguresSlice.ts
@@ -91,7 +91,7 @@ const initialState: FamousFiguresState = {
   competitionType: 'LOH',
   status: 'idle',
   currentRound: 0,
-  totalRounds: 3,
+  totalRounds: 6,
   currentFigureIndex: 0,
   hintsRevealed: 0,
   playerScores: {},
@@ -311,7 +311,7 @@ const famousFiguresSlice = createSlice({
       state.status = 'round_active';
       state.currentRound = 0;
       state.round = 0;
-      state.totalRounds = 3;
+      state.totalRounds = 6;
       state.hintsRevealed = 0;
       state.figureOrder = order;
       // Select exactly totalRounds figures from the shuffle — shared by all

--- a/tests/unit/famous-figures/famousFiguresSlice.test.ts
+++ b/tests/unit/famous-figures/famousFiguresSlice.test.ts
@@ -50,7 +50,7 @@ describe('famousFiguresSlice', () => {
     const s = getState(store);
     expect(s.status).toBe('round_active');
     expect(s.currentRound).toBe(0);
-    expect(s.totalRounds).toBe(3);
+    expect(s.totalRounds).toBe(6);
     expect(s.playerScores[PLAYER_A]).toBe(0);
     expect(s.playerScores[PLAYER_B]).toBe(0);
     expect(s.figureOrder.length).toBe(FAMOUS_FIGURES.length);
@@ -262,11 +262,11 @@ describe('famousFiguresSlice', () => {
     expect(s.status).toBe('round_active');
   });
 
-  it('after 3 rounds nextRound transitions to complete', () => {
+  it('after 6 rounds nextRound transitions to complete', () => {
     const store = makeStore();
     store.dispatch(startFamousFigures({ participantIds: [PLAYER_A, PLAYER_B], competitionType: 'LOH', seed: 1 }));
 
-    for (let round = 0; round < 3; round++) {
+    for (let round = 0; round < 6; round++) {
       expect(getState(store).status).toBe('round_active');
       store.dispatch(endRound());
       expect(getState(store).status).toBe('round_reveal');
@@ -293,6 +293,11 @@ describe('famousFiguresSlice', () => {
     // Round 3: no one answers
     store.dispatch(endRound());
     store.dispatch(nextRound());
+
+    for (let round = 3; round < 6; round++) {
+      store.dispatch(endRound());
+      store.dispatch(nextRound());
+    }
 
     const s = getState(store);
     expect(s.status).toBe('complete');
@@ -345,23 +350,23 @@ describe('famousFiguresSlice', () => {
     expect(getState(store).playerRoundCursor[PLAYER_A]).toBe(0);
   });
 
-  it('playerRoundCursor reaches totalRounds after 3 correct guesses + advancePlayerCursor calls', () => {
+  it('playerRoundCursor reaches totalRounds after 6 correct guesses + advancePlayerCursor calls', () => {
     const store = makeStore();
     store.dispatch(startFamousFigures({ participantIds: [PLAYER_A], competitionType: 'LOH', seed: 1 }));
 
-    for (let round = 0; round < 3; round++) {
+    for (let round = 0; round < 6; round++) {
       const s = getState(store);
       const fig = FAMOUS_FIGURES[getPlayerFigureIndex(s, PLAYER_A, s.currentRound)];
       store.dispatch(submitPlayerGuess({ playerId: PLAYER_A, guess: fig.canonicalName }));
       store.dispatch(advancePlayerCursor({ playerId: PLAYER_A, targetRound: round }));
       // After the last correct guess the round auto-closes (single participant),
       // advance to next round if not yet complete.
-      if (round < 2) {
+      if (round < 5) {
         store.dispatch(nextRound());
       }
     }
 
-    expect(getState(store).playerRoundCursor[PLAYER_A]).toBe(3);
+    expect(getState(store).playerRoundCursor[PLAYER_A]).toBe(6);
   });
 
   it('all players see the same figures (shared matchFigureOrder)', () => {

--- a/tests/unit/famous-figures/match-flow.integration.test.ts
+++ b/tests/unit/famous-figures/match-flow.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration test: simulate a full 3-round Famous Figures match
+ * Integration test: simulate a full 6-round Famous Figures match
  * with one human player and one AI player.
  */
 import { describe, it, expect } from 'vitest';
@@ -29,7 +29,7 @@ const AI = 'ai-player';
 const SEED = 42;
 
 describe('match-flow integration', () => {
-  it('simulates a full 3-round match', () => {
+  it('simulates a full 6-round match', () => {
     const store = makeStore();
 
     // ── Start match ──────────────────────────────────────────────────────
@@ -57,6 +57,7 @@ describe('match-flow integration', () => {
     expect(ff(store).playerRoundScores[HUMAN][0]).toBe(10);
 
     store.dispatch(nextRound());
+
     expect(ff(store).status).toBe('round_active');
     expect(ff(store).currentRound).toBe(1);
 
@@ -99,14 +100,25 @@ describe('match-flow integration', () => {
 
     store.dispatch(nextRound());
 
+    // Rounds 4-6: human solves each figure while AI misses.
+    for (let round = 3; round < 6; round++) {
+      const state = ff(store);
+      const humanFigure = FAMOUS_FIGURES[getPlayerFigureIndex(state, HUMAN, round)];
+      store.dispatch(submitPlayerGuess({ playerId: HUMAN, guess: humanFigure.canonicalName }));
+      store.dispatch(advancePlayerCursor({ playerId: HUMAN, targetRound: round }));
+      store.dispatch(submitPlayerGuess({ playerId: AI, guess: 'wrong answer xyzzy' }));
+      store.dispatch(endRound());
+      store.dispatch(nextRound());
+    }
+
     // ── Final state ───────────────────────────────────────────────────────
     const final = ff(store);
     expect(final.status).toBe('complete');
 
-    // Human has 17 pts; AI has points from round 3 only
+    // Human has 47 pts; AI has points from round 3 only
     const humanTotal = final.playerScores[HUMAN];
     const aiTotal = final.playerScores[AI];
-    expect(humanTotal).toBe(17);
+    expect(humanTotal).toBe(47);
     expect(aiTotal).toBeGreaterThan(0);
 
     // Human won overall (17 > AI's single-round score of at most 10)
@@ -150,14 +162,14 @@ describe('match-flow integration', () => {
     expect(ff(store).status).toBe('round_active');
   });
 
-  it('human can complete all 3 rounds before global endRound', () => {
+  it('human can complete all 6 rounds before global endRound', () => {
     const store = makeStore();
     store.dispatch(startFamousFigures({ participantIds: [HUMAN, AI], competitionType: 'LOH', seed: SEED }));
 
-    // Human solves all 3 rounds; AI never answers.
+    // Human solves all 6 rounds; AI never answers.
     // After endRound/nextRound each round becomes the current global round,
     // so each human answer is a current-round answer requiring advancePlayerCursor.
-    for (let round = 0; round < 3; round++) {
+    for (let round = 0; round < 6; round++) {
       const s = ff(store);
       expect(s.status).toBe('round_active');
       expect(s.currentRound).toBe(round);
@@ -171,13 +183,13 @@ describe('match-flow integration', () => {
       expect(ff(store).status).toBe('round_active');
       // Advance round via endRound/nextRound to proceed (AI still inactive)
       store.dispatch(endRound());
-      if (round < 2) store.dispatch(nextRound());
+      if (round < 5) store.dispatch(nextRound());
     }
 
     store.dispatch(nextRound());
-    // After all 3 rounds, match is complete
+    // After all 6 rounds, match is complete
     expect(ff(store).status).toBe('complete');
-    // Human cursor is 3 (completed all rounds)
-    expect(ff(store).playerRoundCursor[HUMAN]).toBe(3);
+    // Human cursor is 6 (completed all rounds)
+    expect(ff(store).playerRoundCursor[HUMAN]).toBe(6);
   });
 });

--- a/tests/unit/famous-figures/scoring.test.ts
+++ b/tests/unit/famous-figures/scoring.test.ts
@@ -40,7 +40,7 @@ describe('getPointsForHintsUsed', () => {
 // ─── Scoring across rounds ────────────────────────────────────────────────────
 
 describe('scoring across rounds', () => {
-  it('accumulates scores across 3 rounds correctly', () => {
+  it('accumulates scores across 6 rounds correctly', () => {
     const store = makeStore();
     store.dispatch(startFamousFigures({ participantIds: [PLAYER], competitionType: 'LOH', seed: 7 }));
 
@@ -65,6 +65,11 @@ describe('scoring across rounds', () => {
     // Round 3: no correct answer → 0 pts
     store.dispatch(endRound());
     store.dispatch(nextRound());
+
+    for (let round = 3; round < 6; round++) {
+      store.dispatch(endRound());
+      store.dispatch(nextRound());
+    }
 
     expect(getState(store).status).toBe('complete');
     expect(getState(store).playerScores[PLAYER]).toBe(17);
@@ -104,6 +109,11 @@ describe('tiebreaker logic', () => {
     store.dispatch(endRound());
     store.dispatch(nextRound());
 
+    for (let round = 3; round < 6; round++) {
+      store.dispatch(endRound());
+      store.dispatch(nextRound());
+    }
+
     const s = getState(store);
     expect(s.status).toBe('complete');
     // PA: 10 + 10 + 0 = 20 (2 correct rounds)
@@ -132,6 +142,11 @@ describe('tiebreaker logic', () => {
     // Round 3: neither correct
     store.dispatch(endRound());
     store.dispatch(nextRound());
+
+    for (let round = 3; round < 6; round++) {
+      store.dispatch(endRound());
+      store.dispatch(nextRound());
+    }
 
     const s = getState(store);
     expect(s.winnerId).toBe(PA);


### PR DESCRIPTION
## Summary
- increase Famous Figures from three to six figures
- keep the human UI, timer, hints, and AI on the same shared round
- show a clear waiting message after a correct answer instead of prematurely displaying the next figure
- compact the active layout and hint list to reduce redundant vertical space

## Validation
- npm run typecheck
- all 89 Famous Figures tests passed
- git diff --check