### PR TITLE
Make public apology missions actionable

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -19,6 +19,7 @@ import {
   startMinigame,
   queueForcedShock,
   clearForcedShock,
+  completeMission,
 } from '../../store/gameSlice';
 import {
   clearIncomingInteractionLogs,
@@ -608,6 +609,17 @@ export default function DebugPanel() {
                   title="Launch a standalone TapRace session for testing"
                 >
                   Test TapRace
+                </button>
+              </div>
+
+              <div className="dbg-row">
+                <button
+                  className="dbg-btn dbg-btn--wide"
+                  onClick={() => dispatch(completeMission())}
+                  disabled={game.secretMission?.status !== 'accepted'}
+                  title="Complete every active Secret Mission task and reveal its reward"
+                >
+                  Complete Secret Mission
                 </button>
               </div>
 

--- a/src/components/SocialPanelV2/socialNarratives.ts
+++ b/src/components/SocialPanelV2/socialNarratives.ts
@@ -35,6 +35,11 @@ const NARRATIVES: Record<string, string[]> = {
     "You told {target} they remind you of your favourite childhood TV character.",
     "You convinced {target} they are the secret fan-favourite of this season.",
   ],
+  apologize: [
+    'You gave {target} a sincere apology and cleared the air.',
+    'You owned your mistake with {target}. The tension finally eased.',
+    'You and {target} talked it through without excuses.',
+  ],
   rumor: [
     "You planted a seed in {target}'s ear about a secret trio on the other side.",
     "You told {target} someone has been throwing competitions on purpose.",

--- a/src/publicOpinion/PublicDirectionService.ts
+++ b/src/publicOpinion/PublicDirectionService.ts
@@ -2,6 +2,7 @@ import type { Player } from '../types';
 import { mulberry32, seededPick, seededPickN } from '../store/rng';
 import { publicOpinionConfig } from './publicOpinionConfig';
 import type { PublicDirection, DirectionType } from './types';
+import type { RelationshipsMap } from '../social/types';
 
 const DIRECTION_TYPES: DirectionType[] = [
   'get_closer',
@@ -84,8 +85,9 @@ export function generateDirectionsForCycle(params: {
   week: number;
   seed: number;
   count?: number;
+  relationships?: RelationshipsMap;
 }): PublicDirection[] {
-  const { players, week, seed, count = publicOpinionConfig.directionsPerCycle } = params;
+  const { players, week, seed, count = publicOpinionConfig.directionsPerCycle, relationships } = params;
 
   const activePlayers = players.filter(
     (p) => p.status !== 'evicted' && p.status !== 'jury',
@@ -99,14 +101,23 @@ export function generateDirectionsForCycle(params: {
   const selectedPlayers = seededPickN(rng, activePlayers, Math.min(count, activePlayers.length));
 
   for (const player of selectedPlayers) {
-    const dirType: DirectionType = seededPick(rng, DIRECTION_TYPES);
+    let dirType: DirectionType = seededPick(rng, DIRECTION_TYPES);
+    const repairCandidates = activePlayers.filter(
+      (candidate) => candidate.id !== player.id
+        && (relationships?.[player.id]?.[candidate.id]?.affinity ?? 0) < 15,
+    );
+    if ((dirType === 'apologize' || dirType === 'repair_relationship') && repairCandidates.length === 0) {
+      dirType = 'get_closer';
+    }
     const isSolo = SOLO_DIRECTION_TYPES.includes(dirType);
 
     let relatedPlayerId: string | undefined;
     let relatedName: string | undefined;
 
     if (!isSolo && activePlayers.length > 1) {
-      const others = activePlayers.filter((p) => p.id !== player.id);
+      const others = (dirType === 'apologize' || dirType === 'repair_relationship')
+        ? repairCandidates
+        : activePlayers.filter((p) => p.id !== player.id);
       const related = seededPick(rng, others);
       relatedPlayerId = related.id;
       relatedName = related.name;

--- a/src/publicOpinion/publicOpinionMiddleware.ts
+++ b/src/publicOpinion/publicOpinionMiddleware.ts
@@ -77,6 +77,7 @@ function dispatchReactionDeltas(
 
 interface StateWithGame {
   game: GameState;
+  social?: { relationships?: import('../social/types').RelationshipsMap };
   publicOpinion?: {
     profiles: Record<string, unknown>;
     directions: PublicDirection[];
@@ -375,7 +376,9 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
       const { actorId, targetId, actionId = '', outcome = '', delta = 0 } = entry;
 
       let missionEventType: MissionGameEvent['type'] | null = null;
-      if (actionId === 'betray' && outcome === 'success') {
+      if (actionId === 'apologize' && outcome === 'success') {
+        missionEventType = 'apologized_to';
+      } else if (actionId === 'betray' && outcome === 'success') {
         missionEventType = 'betrayal';
       } else if (actionId === 'ally' || actionId === 'protect') {
         missionEventType = outcome === 'success' ? 'positive_social' : null;
@@ -570,6 +573,7 @@ export const publicOpinionMiddleware: Middleware = (store) => (next) => (action)
             week: week + 1,
             seed: game.seed ?? 0,
             count: publicOpinionConfig.directionsPerCycle,
+            relationships: nextState.social?.relationships,
           });
           for (const direction of newDirections) {
             store.dispatch(addDirection(direction));

--- a/src/social/socialActions.ts
+++ b/src/social/socialActions.ts
@@ -241,6 +241,18 @@ export const SOCIAL_ACTIONS: SocialActionDefinition[] = [
     yields: { influence: 0.03 },
   },
   {
+    id: 'apologize',
+    title: 'Clear the Air',
+    icon: '🕊️',
+    description: 'Own a mistake and sincerely repair tension with this player.',
+    category: 'friendly',
+    kind: 'rapport',
+    baseCost: 1,
+    targetMode: 'primary',
+    successWeight: 2,
+    yields: { influence: 0.02 },
+  },
+  {
     id: 'share_intel',
     title: 'Share Intel',
     icon: '📋',

--- a/src/social/socialConfig.ts
+++ b/src/social/socialConfig.ts
@@ -39,7 +39,7 @@ export const socialConfig = {
     friendlyActions: [
       'ally', 'protect',
       // Extended friendly actions for the outgoing social module:
-      'compliment', 'proposeAlliance', 'group_chat', 'reassure', 'share_intel', 'ask_use_safety',
+      'compliment', 'proposeAlliance', 'group_chat', 'reassure', 'apologize', 'share_intel', 'ask_use_safety',
     ] as string[],
     aggressiveActions: [
       'betray', 'nominate',


### PR DESCRIPTION
## Summary
- add a real Clear the Air social action with affinity, narrative, and resource behavior
- map a successful apology directly to public mission progress
- generate apology/repair missions only for relationships with actual unresolved tension
- fall back to a get-closer mission when no repair target exists
- add a debug button that completes an accepted Secret Mission

## Validation
- npm run typecheck
- 222 focused social/public-opinion tests passed (1 existing todo)
- git diff --check