### PR TITLE
Improve trivia realism and hints

### DIFF
--- a/src/components/Capitalization/Capitalization.css
+++ b/src/components/Capitalization/Capitalization.css
@@ -258,6 +258,22 @@
   line-height: 1.45;
 }
 
+.capitalization__hint-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin-top: 0.55rem;
+}
+
+.capitalization__hint-options button {
+  min-height: 2.35rem;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+  border-radius: 0.65rem;
+  background: rgba(14, 116, 144, 0.2);
+  color: inherit;
+  font-weight: 700;
+}
+
 .capitalization__location {
   margin-top: auto;
   padding: 12px;

--- a/src/components/Capitalization/Capitalization.tsx
+++ b/src/components/Capitalization/Capitalization.tsx
@@ -109,6 +109,8 @@ export default function Capitalization({
   const [attempts, setAttempts] = useState(0);
   const [feedback, setFeedback] = useState('The globe is choosing the next continent.');
   const [inputError, setInputError] = useState<string | null>(null);
+  const [hintOptions, setHintOptions] = useState<string[] | null>(null);
+  const [hintUsed, setHintUsed] = useState(false);
   const [scoreboard, setScoreboard] = useState<CapitalizationScoreboard | null>(null);
   const [nowMs, setNowMs] = useState(0);
   const [questionStartedAtMs, setQuestionStartedAtMs] = useState(0);
@@ -249,8 +251,30 @@ export default function Capitalization({
       guessed: true,
       attempts: nextAttempts,
       timeMs: Date.now() - questionStartedAtRef.current,
+      hintUsed,
     });
-  }, [answerInput, attempts, currentQuestion, phase, resolveQuestion]);
+  }, [answerInput, attempts, currentQuestion, hintUsed, phase, resolveQuestion]);
+
+  const requestHint = useCallback(() => {
+    if (!currentQuestion || phase !== 'question' || hintUsed) return;
+    const distractors = Array.from(new Set(
+      questionSet.questions
+        .map((question) => question.capital)
+        .filter((capital) => capital !== currentQuestion.capital),
+    ));
+    const start = (runSeed + currentQuestion.questionNumber) % Math.max(1, distractors.length);
+    const picked = [
+      distractors[start],
+      distractors[(start + 3) % Math.max(1, distractors.length)],
+    ].filter((value): value is string => Boolean(value));
+    const options = Array.from(new Set([currentQuestion.capital, ...picked])).slice(0, 3);
+    const correctPosition = (runSeed ^ currentQuestion.questionNumber) % options.length;
+    const correct = options.shift();
+    if (correct) options.splice(correctPosition, 0, correct);
+    setHintOptions(options);
+    setHintUsed(true);
+    setFeedback('Hint used — the score for this question is now halved.');
+  }, [currentQuestion, hintUsed, phase, questionSet.questions, runSeed]);
 
   const skipQuestion = useCallback(() => {
     if (!currentQuestion || phase !== 'question') return;
@@ -272,6 +296,8 @@ export default function Capitalization({
     setAnswerInput('');
     setAttempts(0);
     setInputError(null);
+    setHintOptions(null);
+    setHintUsed(false);
     setScoreboard(null);
     setQuestionStartedAtMs(0);
     setFeedback(`The globe is landing on ${nextQuestion?.continent ?? 'the next continent'}.`);
@@ -396,7 +422,19 @@ export default function Capitalization({
                       <button type="button" disabled={inputDisabled} onClick={skipQuestion}>
                         Skip
                       </button>
+                      <button type="button" disabled={inputDisabled || hintUsed} onClick={requestHint}>
+                        Hint −50%
+                      </button>
                     </div>
+                    {hintOptions && (
+                      <div className="capitalization__hint-options" aria-label="Capital hint options">
+                        {hintOptions.map((option) => (
+                          <button key={option} type="button" onClick={() => setAnswerInput(option)}>
+                            {option}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                     {inputError && <p className="capitalization__error">{inputError}</p>}
                   </form>
                 )}

--- a/src/components/Capitalization/capitalizationUtils.ts
+++ b/src/components/Capitalization/capitalizationUtils.ts
@@ -35,6 +35,7 @@ export interface CapitalizationRoundPerformance {
   attempts: number;
   timeMs: number;
   skipped?: boolean;
+  hintUsed?: boolean;
 }
 
 export interface CapitalizationStanding {
@@ -135,7 +136,8 @@ export function computeCapitalizationQuestionScore(
   const timePenalty = Math.min(620, Math.round((performance.timeMs / 1000) * 18));
   const attemptPenalty = Math.max(0, attempts - 1) * 140;
   const firstTryBonus = attempts === 1 ? 110 : 0;
-  return Math.max(90, 1000 + firstTryBonus - timePenalty - attemptPenalty);
+  const score = Math.max(90, 1000 + firstTryBonus - timePenalty - attemptPenalty);
+  return performance.hintUsed ? Math.floor(score / 2) : score;
 }
 
 export function createCapitalizationAiRng(context: CapitalizationAiRngContext): () => number {

--- a/src/components/NumberTrivia/numberTriviaUtils.ts
+++ b/src/components/NumberTrivia/numberTriviaUtils.ts
@@ -137,7 +137,10 @@ export function simulateNumberTriviaAiPerformance(
   const profile = NUMBER_TRIVIA_AI_PROFILES[context.question.difficulty];
   const skillOffset = clamp((context.precomputedScore - 60) / 300, -0.12, 0.12);
   const fatiguePenalty = Math.max(0, context.roundNumber - 3) * 0.015;
-  const minAccuracy = clamp(profile.accuracyRange[0] + skillOffset - fatiguePenalty, 0.05, 0.995);
+  const configuredMinAccuracy = profile.accuracyRange[0] + skillOffset - fatiguePenalty;
+  const minAccuracy = context.question.difficulty === 'easy'
+    ? clamp(Math.max(0.95, configuredMinAccuracy), 0.95, 0.995)
+    : clamp(configuredMinAccuracy, 0.05, 0.995);
   const maxAccuracy = clamp(profile.accuracyRange[1] + skillOffset - fatiguePenalty, minAccuracy, 0.995);
   const accuracy = clamp(
     minAccuracy + (maxAccuracy - minAccuracy) * clamp(0.5 + skillOffset * 2.5, 0, 1),
@@ -148,7 +151,8 @@ export function simulateNumberTriviaAiPerformance(
   const guessed = rng() < accuracy;
 
   if (guessed) {
-    let attempts = 1;
+    const isExactYearQuestion = /\b(?:which|what) year\b/i.test(context.question.prompt);
+    let attempts = isExactYearQuestion ? Math.min(2, profile.maxCorrectAttempts) : 1;
     let hesitationChance = clamp(profile.hesitationChance - skillOffset * 1.2, 0.01, 0.9);
     while (attempts < profile.maxCorrectAttempts && rng() < hesitationChance) {
       attempts += 1;
@@ -206,9 +210,6 @@ export function computeNumberTriviaRoundScore(performance: TriviaRoundPerformanc
 
 export function getNumberTriviaEliminationCount(roundNumber: number, activeCount: number): number {
   if (roundNumber >= NUMBER_TRIVIA_TOTAL_ROUNDS || activeCount <= 2) return 0;
-  if (roundNumber === 4) {
-    return Math.min(activeCount - 2, Math.floor(activeCount / 2));
-  }
   return Math.min(activeCount - 2, 1);
 }
 

--- a/tests/unit/capitalization/capitalization.logic.test.ts
+++ b/tests/unit/capitalization/capitalization.logic.test.ts
@@ -85,6 +85,12 @@ describe('Capitalization answer matching and scoring', () => {
     expect(fastFirstTry).toBeGreaterThan(slowThirdTry);
     expect(slowThirdTry).toBeGreaterThan(0);
     expect(skipped).toBe(0);
+    expect(computeCapitalizationQuestionScore({
+      guessed: true,
+      attempts: 1,
+      timeMs: 2_000,
+      hintUsed: true,
+    })).toBe(Math.floor(fastFirstTry / 2));
   });
 });
 

--- a/tests/unit/number-trivia/numberTrivia.test.tsx
+++ b/tests/unit/number-trivia/numberTrivia.test.tsx
@@ -63,10 +63,10 @@ describe('NumberTrivia helpers', () => {
     expect(solvedFastButMessy).toBeGreaterThan(solvedSlowClean);
   });
 
-  it('eliminates half the field at the end of round four using the lower half', () => {
+  it('eliminates one player per round instead of wiping out half the field', () => {
     expect(getNumberTriviaEliminationCount(4, 3)).toBe(1);
-    expect(getNumberTriviaEliminationCount(4, 5)).toBe(2);
-    expect(getNumberTriviaEliminationCount(4, 6)).toBe(3);
+    expect(getNumberTriviaEliminationCount(4, 5)).toBe(1);
+    expect(getNumberTriviaEliminationCount(4, 6)).toBe(1);
   });
 
   it('keeps easy AI answers fast and confident', () => {
@@ -98,11 +98,9 @@ describe('NumberTrivia helpers', () => {
       sequenceRng([0.5, 0.2, 0.3, 0.9]),
     );
 
-    expect(performance).toMatchObject({
-      guessed: true,
-      attempts: 2,
-      closestDistance: 0,
-    });
+    expect(performance.guessed).toBe(true);
+    expect(performance.attempts).toBeGreaterThanOrEqual(2);
+    expect(performance.closestDistance).toBe(0);
     expect(performance.timeMs).toBeGreaterThan(4_000);
     expect(performance.timeMs).toBeLessThanOrEqual(6_650);
   });


### PR DESCRIPTION
## Summary
- enforce a 95% easy-question AI accuracy floor
- make exact-year AI answers require multiple attempts instead of implausible first guesses
- eliminate one Number Trivia player per round
- add a three-option Capitalization hint that halves only the current question score

## Validation
- npm run typecheck
- 22 focused Number Trivia and Capitalization tests passed
- git diff --check