### PR TITLE
Polish Grid of Luck, Big Spender, and Crystal rewards

### DIFF
--- a/src/components/BigSpender/BigSpender.css
+++ b/src/components/BigSpender/BigSpender.css
@@ -49,12 +49,22 @@
 
 .big-spender__status-panel {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 0.65rem;
   min-height: 0;
   padding: 0.55rem 0.65rem;
   border-radius: 0.8rem;
+}
+
+.big-spender__info {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid rgba(213, 226, 255, 0.24);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f8fbff;
+  font-weight: 900;
 }
 
 .big-spender__status-panel > div {
@@ -461,6 +471,10 @@
 
 .big-spender__modal--round {
   width: min(100%, 32rem);
+}
+
+.big-spender__modal--rules {
+  width: min(100%, 24rem);
 }
 
 .big-spender__modal h2 {

--- a/src/components/BigSpender/BigSpender.tsx
+++ b/src/components/BigSpender/BigSpender.tsx
@@ -64,7 +64,6 @@ function chooseAiWallet(state: BigSpenderState, playerId: string, rng: () => num
 
 function isBroadcastEvent(event: BigSpenderState['events'][number]) {
   return (
-    event.type === 'walletOpened' ||
     event.type === 'playerLocked' ||
     event.type === 'playerBombed' ||
     event.type === 'playerZeroFinished' ||
@@ -90,6 +89,7 @@ export default function BigSpender(props: GenericMinigameProps) {
   const [zeroDramaVisible, setZeroDramaVisible] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [fastForwarding, setFastForwarding] = useState(false);
+  const [showRules, setShowRules] = useState(false);
   const aiRngRef = useRef(mulberry32((seed ^ 0x5eedcafe) >>> 0));
   const aiTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   const broadcastQueueRef = useRef<string[]>([]);
@@ -230,9 +230,9 @@ export default function BigSpender(props: GenericMinigameProps) {
     const drain = () => {
       const nextMessage = broadcastQueueRef.current.shift();
       if (nextMessage) {
-        setBroadcasts((previous) => [nextMessage, ...previous].slice(0, 3));
+        setBroadcasts((previous) => [nextMessage, ...previous].slice(0, 2));
       }
-      broadcastTimerRef.current = broadcastQueueRef.current.length > 0 ? setTimeout(drain, 1350) : null;
+      broadcastTimerRef.current = broadcastQueueRef.current.length > 0 ? setTimeout(drain, 2_200) : null;
     };
     broadcastTimerRef.current = setTimeout(drain, 450);
   }, [state.events]);
@@ -378,6 +378,9 @@ export default function BigSpender(props: GenericMinigameProps) {
             {fastForwarding ? 'Forwarding' : 'Fast forward'}
           </button>
         )}
+        <button type="button" className="big-spender__info" onClick={() => setShowRules(true)} aria-label="Show rules">
+          i
+        </button>
         {state.status === 'running' && !humanFinishedWhileRunning && (
           <button type="button" className="big-spender__action big-spender__action--lock" onClick={lockHuman} disabled={!canHumanLock}>
             Lock in
@@ -428,6 +431,18 @@ export default function BigSpender(props: GenericMinigameProps) {
             <p key={message}>{message}</p>
           ))}
         </section>
+      )}
+
+      {showRules && (
+        <div className="big-spender__overlay" role="dialog" aria-modal="true" aria-label="Big Spender rules">
+          <div className="big-spender__modal big-spender__modal--rules">
+            <span className="big-spender__eyebrow">Quick rules</span>
+            <h2>Broke or Boom</h2>
+            <p>Start at 1,200. Open at least 8 wallets, then lock in as close to 0 as you dare. Bombed players rank last.</p>
+            <p>Rounds 1–4 use private boards. The final two alternate on one shared board.</p>
+            <button type="button" onClick={() => setShowRules(false)}>Got it</button>
+          </div>
+        </div>
       )}
 
       {humanAdRescuePending && bombDramaStage && bombDramaStage !== 'prompt' && (

--- a/src/components/GridOfLuck/GridOfLuck.css
+++ b/src/components/GridOfLuck/GridOfLuck.css
@@ -86,6 +86,18 @@
   flex-wrap: wrap;
 }
 
+.grid-of-luck__autoplay {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  color: rgba(235, 226, 255, 0.9);
+}
+
+.grid-of-luck__autoplay input {
+  accent-color: #9d75ff;
+}
+
 .grid-of-luck__boxes-remaining {
   background: rgba(120, 80, 255, 0.2);
   border: 1px solid rgba(160, 120, 255, 0.3);

--- a/src/components/GridOfLuck/GridOfLuck.tsx
+++ b/src/components/GridOfLuck/GridOfLuck.tsx
@@ -1184,6 +1184,7 @@ export default function GridOfLuck(props: GenericMinigameProps) {
   const [completed, setCompleted] = useState(false);
   const [isSpectatorMode, setIsSpectatorMode] = useState(false);
   const [showSpectatorChoice, setShowSpectatorChoice] = useState(false);
+  const [autoplay, setAutoplay] = useState(false);
 
   const activePlayer = getCurrentPlayer(state);
   const humanPlayer = useMemo(
@@ -1445,15 +1446,24 @@ export default function GridOfLuck(props: GenericMinigameProps) {
   }, [pendingSelection, resolveOutcome, state, validTargets]);
 
   useEffect(() => {
+    if (!autoplay || !pendingSelection || validTargets.length === 0) return undefined;
+    const timer = setTimeout(() => {
+      const target = validTargets[Math.floor(rngRef.current() * validTargets.length)] ?? validTargets[0];
+      if (target) handleTargetSelection(target.id);
+    }, 650);
+    return () => clearTimeout(timer);
+  }, [autoplay, handleTargetSelection, pendingSelection, validTargets]);
+
+  useEffect(() => {
     if (turnMode !== 'box') return undefined;
     if (state.gamePhase === 'finished') return undefined;
-    if (activePlayer.isHuman) return undefined;
+    if (activePlayer.isHuman && !autoplay) return undefined;
     const timer = setTimeout(() => {
       const box = chooseAiBox(state, activePlayer.id, rngRef.current);
       stageBoxReveal(state, activePlayer, box.id);
     }, state.gamePhase === 'final' ? 700 : state.players.length >= 5 ? 850 : HUMAN_PICK_DELAY_MS);
     return () => clearTimeout(timer);
-  }, [activePlayer, stageBoxReveal, state, turnMode]);
+  }, [activePlayer, autoplay, stageBoxReveal, state, turnMode]);
 
   useEffect(() => {
     if (floatingBursts.length === 0) return undefined;
@@ -1534,6 +1544,10 @@ export default function GridOfLuck(props: GenericMinigameProps) {
               {state.gamePhase === 'finished' ? 'Ritual Complete' : state.gamePhase === 'final' ? 'Final Phase' : 'Mystic Chamber'}
             </motion.h2>
             <motion.div className="grid-of-luck__turn-meta">
+              <label className="grid-of-luck__autoplay">
+                <input type="checkbox" checked={autoplay} onChange={(event) => setAutoplay(event.target.checked)} />
+                Autoplay
+              </label>
               <span className="grid-of-luck__boxes-remaining">{boxesRemaining} boxes</span>
               {state.gamePhase === 'final' && <span className="grid-of-luck__phase-badge">Final</span>}
             </motion.div>
@@ -1604,7 +1618,7 @@ export default function GridOfLuck(props: GenericMinigameProps) {
                 const effectMeta = BOX_META[box.type];
                 const glow = opened ? getBoxTone(box.type) : 'rgba(185, 150, 255, 0.75)';
                 const isCurrentReveal = revealState?.boxId === box.id;
-                const isClickable = turnMode === 'box' && activePlayer.isHuman && !opened && !box.isLocked && state.gamePhase !== 'finished';
+                const isClickable = turnMode === 'box' && activePlayer.isHuman && !autoplay && !opened && !box.isLocked && state.gamePhase !== 'finished';
                 return (
                   <motion.button
                     key={box.id}

--- a/src/minigames/crystalPathShattered/CrystalPathShatteredGame.tsx
+++ b/src/minigames/crystalPathShattered/CrystalPathShatteredGame.tsx
@@ -198,7 +198,7 @@ export default function CrystalPathShatteredGame({
   const [activeAnimation, setActiveAnimation] = useState<Animation | null>(null);
   const [hintRowIndex, setHintRowIndex] = useState<number | null>(null);
   const [messageLog, setMessageLog] = useState<string[]>([]);
-  const [mysteryModal, setMysteryModal] = useState<{ effectLabel: string; positive: boolean } | null>(null);
+  const [mysteryModal, setMysteryModal] = useState<{ effectLabel: string; detail: string; positive: boolean } | null>(null);
   const [secretWinBanner, setSecretWinBanner] = useState(false);
   const [liveFeed, setLiveFeed] = useState<string[]>([]);
   const [resolvedRows, setResolvedRows] = useState<Record<number, { side: TileSide; wrong: boolean }>>({});
@@ -546,7 +546,14 @@ export default function CrystalPathShatteredGame({
     if (eliminatedByMystery) playDeath();
 
     if (targetPlayer?.isHuman) {
-      setMysteryModal({ effectLabel: applied.label, positive });
+      const detail = applied.spDelta !== 0
+        ? `${applied.spDelta > 0 ? 'Restore' : 'Lose'} ${Math.abs(applied.spDelta)} SP.`
+        : applied.hintDelta !== 0
+          ? `${applied.hintDelta > 0 ? 'Gain' : 'Lose'} ${Math.abs(applied.hintDelta)} hint.`
+          : applied.addedEffect
+            ? `${applied.label} is active briefly.`
+            : 'The effect applies immediately.';
+      setMysteryModal({ effectLabel: applied.label, detail, positive });
       queueTimeout(() => setMysteryModal(null), MYSTERY_REVEAL_MS);
     }
     queueTimeout(() => {
@@ -920,7 +927,7 @@ export default function CrystalPathShatteredGame({
           <div className={`cps-modal-card ${mysteryModal.positive ? 'is-pos' : 'is-neg'}`}>
             <div className="cps-modal-icon" aria-hidden="true">{mysteryModal.positive ? '✨' : '⚠️'}</div>
             <h3>{mysteryModal.effectLabel}</h3>
-            <p>{mysteryModal.positive ? 'The chamber smiles on you.' : 'The chamber tests you.'}</p>
+            <p>{mysteryModal.detail}</p>
           </div>
         </div>
       )}

--- a/src/minigames/crystalPathShattered/shatteredLogic.ts
+++ b/src/minigames/crystalPathShattered/shatteredLogic.ts
@@ -46,7 +46,7 @@ export const VISIBLE_ROW_WINDOW = 8;
 /** Turn pacing. */
 export const SAFE_STEP_MS = 420;
 export const WRONG_STEP_MS = 720;
-export const MYSTERY_REVEAL_MS = 900;
+export const MYSTERY_REVEAL_MS = 2_400;
 export const AI_MIN_THINK_MS = 320;
 export const AI_MAX_THINK_MS = 1_300;
 export const NEW_TURN_DELAY_MS = 520;

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -60,8 +60,15 @@ export interface GameRegistryEntry {
   category: GameCategory;
   /** True if this entry should not be selected for new challenges. */
   retired: boolean;
+  /** Optional safe participant-count bounds for random scheduling. */
+  minPlayers?: number;
+  maxPlayers?: number;
   /** Key of the game that supersedes this one (for retired games). */
   replacedBy?: string;
+}
+
+export function supportsPlayerCount(game: GameRegistryEntry, playerCount: number): boolean {
+  return playerCount >= (game.minPlayers ?? 1) && playerCount <= (game.maxPlayers ?? Number.POSITIVE_INFINITY);
 }
 
 export function isPlacementRankingGame(
@@ -1212,6 +1219,8 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     weight: 2,
     category: 'logic',
     retired: false,
+    minPlayers: 2,
+    maxPlayers: 4,
   },
 
   bigSpender: {
@@ -1219,17 +1228,10 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     title: 'Big Spender: Broke or Boom',
     description: 'Open private wallets, spend down your Eyeoleans, and lock in before a bomb ruins the run.',
     instructions: [
-      'The game runs across 5 rounds. Rounds 1-4 use private boards, then Round 5 is a shared-board finale.',
-      'Every active player starts each round with 1,200 Eyeoleans and plays live on a 32-wallet board.',
-      'Most wallets subtract Eyeoleans, some add Eyeoleans, and a few hide bombs.',
-      'Open at least 8 wallets to unlock Lock in, then stop whenever your balance feels good.',
-      'Reach 0 to make the strongest possible finish. The closer to 0 you are, the better you rank.',
-      'Rounds 1-3 eliminate the lowest-ranked player. Round 4 cuts the field down to the final 2.',
-      'In Round 5, the finalists take turns picking from the same board with both balances visible.',
-      'If you open a bomb before the finale, the blast reveals first, then you may use up to two ad saves and personally pick a mandatory Second Chance Wallet.',
-      'A finale bomb drops that finalist to 0, ends the game immediately, and the other finalist wins.',
-      'Scores stay hidden before the finale and reveal fully on the results screen.',
-      'Bombed players rank below everyone who survives, even if their balance was low.',
+      'Start each round with 1,200 Eyeoleans. Open wallets and finish as close to 0 as possible; bombs rank below every survivor.',
+      'After 8 wallets you may Lock in. Rounds 1-3 remove one player and Round 4 selects the final two.',
+      'Rounds 1-4 use private boards. The finalists share one board and alternate picks in Round 5.',
+      'Before the finale, a bomb may be rescued twice by an ad and one mandatory Second Chance Wallet.',
     ],
     resultMode: 'placement',
     metricKind: 'points',

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -17,7 +17,7 @@ import {
 import { selectNextCompetitionGame } from '../ai/competition/scheduling';
 import { getApprovedCompetitionGameKeys, getBracketPoolForContext } from '../ai/competition/bracketTemplate';
 import { applyCompetitionSeasonUpdate, hydrateGame, selectAlivePlayers } from './gameSlice';
-import { pickRandomGame, getGame, getPoolByFilter } from '../minigames/registry';
+import { pickRandomGame, getGame, getPoolByFilter, supportsPlayerCount } from '../minigames/registry';
 import type { GameRegistryEntry, GameCategory } from '../minigames/registry';
 import { computeScores } from '../minigames/scoring';
 import type { RawResult } from '../minigames/scoring';
@@ -183,6 +183,8 @@ export const startChallenge =
       .map((run) => run.gameKey);
     // Late-season bias is based on active competitors (jury members no longer play comps).
     const activeCompetitorCount = selectAlivePlayers(state).length;
+    const scheduledPlayerCount = participants.length || activeCompetitorCount;
+    const eligibleForRoster = (game: GameRegistryEntry) => supportsPlayerCount(game, scheduledPlayerCount);
     const lateSeasonBias =
       activeCompetitorCount > 0 && activeCompetitorCount <= LATE_SEASON_PLAYER_THRESHOLD;
     const selectFromPool = (pool: GameRegistryEntry[]) =>
@@ -193,7 +195,7 @@ export const startChallenge =
         lateSeasonBias,
       });
     const pickFromRegistry = (category?: GameCategory, excludeKeys?: string[]) => {
-      const pool = getPoolByFilter({ retired: false, category, excludeKeys });
+      const pool = getPoolByFilter({ retired: false, category, excludeKeys }).filter(eligibleForRoster);
       if (pool.length > 0) return selectFromPool(pool);
       return pickRandomGame(gameSeed, { category, excludeKeys });
     };
@@ -204,6 +206,7 @@ export const startChallenge =
       if (!modeSpecific) return pickFromRegistry(category, excludeKeys);
 
       const approvedPool = getPoolByFilter({ retired: false, excludeKeys })
+        .filter(eligibleForRoster)
         .filter((game) => SURVIVOR_APPROVED_GAME_KEYS.has(game.key));
       const pool = category
         ? approvedPool.filter((game) => game.category === category)
@@ -254,7 +257,7 @@ export const startChallenge =
       const excluded = new Set(excludeKeys ?? []);
       return bracketKeys
         .map((k) => getGame(k))
-        .filter((g): g is GameRegistryEntry => g !== undefined && !g.retired && !excluded.has(g.key));
+        .filter((g): g is GameRegistryEntry => g !== undefined && !g.retired && !excluded.has(g.key) && eligibleForRoster(g));
     };
 
     let gameEntry: GameRegistryEntry;
@@ -276,7 +279,7 @@ export const startChallenge =
           // Remote key takes priority over the user's selectedGameId.
           const key = remoteChallenge?.weeklyGameKey ?? compSel?.selectedGameId;
           const found = key ? getGame(key) : undefined;
-          if (found) {
+          if (found && eligibleForRoster(found)) {
             gameEntry = found;
           } else {
             // Unknown or missing key — fall back to random selection.
@@ -290,7 +293,7 @@ export const startChallenge =
           const keys = remoteChallenge?.weeklyGameKeys ?? compSel?.selectedGameIds ?? [];
           const pool = keys
             .map((k) => getGame(k))
-            .filter((g): g is GameRegistryEntry => g !== undefined && !g.retired);
+            .filter((g): g is GameRegistryEntry => g !== undefined && !g.retired && eligibleForRoster(g));
           if (pool.length > 0) {
             gameEntry = selectFromPool(pool);
           } else {
@@ -354,7 +357,7 @@ export const startChallenge =
             retired: false,
             category: opts.category,
             excludeKeys: exclude,
-          });
+          }).filter(eligibleForRoster);
           if (uniquePool.length > 0) {
             gameEntry = selectFromPool(uniquePool);
           } else {


### PR DESCRIPTION
## Summary
- add opt-in Grid of Luck autoplay and keep random scheduling to 2-4 player rosters
- shorten Big Spender rules, add an in-game info control, and reduce repetitive live broadcasts
- keep Crystal Path mystery rewards visible for 2.4 seconds with a concise effect explanation

## Validation
- npm run typecheck
- 69 focused tests across Grid of Luck, Big Spender, and Crystal Path

## Note
- One pre-existing Grid of Luck copy-power assertion remains red when run separately; this branch does not modify that resolution logic.