### PR TITLE
Fix badge reveal timing and Pixel layout

### DIFF
--- a/src/components/FloatingActionBar/FloatingActionBar.css
+++ b/src/components/FloatingActionBar/FloatingActionBar.css
@@ -1,7 +1,7 @@
 /* ── Floating Action Bar ────────────────────────────────────────────────── */
 .fab {
   position: absolute;
-  bottom: 16px;
+  bottom: var(--game-action-dock-gap, 12px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -469,6 +469,7 @@ export default function GameScreen() {
   // pendingWinnerDispatchRef stores the deferred thunk so handleCeremonyDone
   // can call it without stale-closure issues.
   const [pendingWinnerCeremony, setPendingWinnerCeremony] = useState<{
+    winnerId: string
     tiles: CeremonyTile[]
     caption: string
     subtitle?: string
@@ -734,6 +735,9 @@ export default function GameScreen() {
     const isAnimatingSaveTarget = pendingSaveCeremony?.savedId === p.id
     const isPublicSaveWinner = pendingPublicSaveResult?.savedId === p.id
     const isAnimatingReplacementNominee = activeReplacementAnimationTargetId === p.id
+    const isAnimatingAwardWinner =
+      pendingWinnerCeremony?.winnerId === p.id ||
+      (showAdvanceHohCeremony && game.lohId === p.id)
     if (
       Array.isArray(game.nomineeIds) &&
       game.nomineeIds.includes(p.id) &&
@@ -771,7 +775,10 @@ export default function GameScreen() {
       finalRank: (p.finalRank ?? null) as 1 | 2 | 3 | null,
       isEvicted,
       isYou: p.isUser,
-      showPermanentBadge: !isAnimatingNominee,
+      // The landing badge is the only award badge visible during a winner
+      // ceremony. This also covers the outgoing-LOH path, where the reducer has
+      // already committed the winner before the overlay starts.
+      showPermanentBadge: !isAnimatingNominee && !isAnimatingAwardWinner,
       nominationCeremonyState,
       layoutId: `avatar-tile-${p.id}`,
       isEvicting: (showEvictionSplash && pendingEvictionPlayer?.id === p.id) || game.evictionOverlayPlayerId === p.id || isReturning,
@@ -3887,6 +3894,7 @@ export default function GameScreen() {
             pendingWinnerDispatchRef.current = () =>
               dispatch(applyMinigameWinner({ winnerId: finalWinnerId, lastPlaceId: compLastPlaceId, skipSeasonUpdate: true }));
             setPendingWinnerCeremony({
+              winnerId: finalWinnerId,
               tiles,
               caption: `${winnerPlayer.name} wins ${winLabel}!`,
               subtitle: winSymbol,

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -50,15 +50,15 @@ export interface ResponsiveGameLayoutInput {
   revision?: number
 }
 
-const ANDROID_TOP_SAFE_FALLBACK = 24
+const ANDROID_TOP_SAFE_FALLBACK = 30
 const DEFAULT_NAV_HEIGHT = 60
 const COMPACT_NAV_HEIGHT = 46
 const DEFAULT_PHONE_WIDTH = 390
 const DEFAULT_PHONE_HEIGHT = 780
 const DEFAULT_DOCK_RATIO = 220 / 980
 const COMPACT_DOCK_SCALE = 0.9
-const NORMAL_DOCK_GAP = 6
-const COMPACT_DOCK_GAP = 3
+const NORMAL_DOCK_GAP = 12
+const COMPACT_DOCK_GAP = 8
 const ROSTER_COLUMNS = 4
 const ROSTER_GAP = 5
 const GAME_INLINE_PADDING = 24
@@ -205,8 +205,11 @@ export function computeResponsiveGameLayout(input: ResponsiveGameLayoutInput): R
   const baselineDockHeight = Math.max(measuredDockHeight, estimatedDockHeight)
   const normalDockHeight = input.hasDock ? baselineDockHeight : 0
   const compactDockHeight = input.hasDock ? Math.max(56, baselineDockHeight * COMPACT_DOCK_SCALE) : 0
-  const normalDockClearance = input.hasDock ? normalDockHeight + NORMAL_DOCK_GAP : 0
-  const compactDockClearance = input.hasDock ? compactDockHeight + COMPACT_DOCK_GAP : 0
+  // Reserve the same whitespace above and below the floating dock. The CSS
+  // positions the dock by actionDockGap from the nav edge; the second gap here
+  // keeps the fourth roster row equally far from the dock's upper edge.
+  const normalDockClearance = input.hasDock ? normalDockHeight + NORMAL_DOCK_GAP * 2 : 0
+  const compactDockClearance = input.hasDock ? compactDockHeight + COMPACT_DOCK_GAP * 2 : 0
   const measuredStageAndNavHeight = stageHeight + measuredNavHeight
   const normalStageHeight = Math.max(0, measuredStageAndNavHeight - normalNavHeight)
   const compactStageHeight = Math.max(0, measuredStageAndNavHeight - compactNavHeight)

--- a/tests/integration/spotlight.animation.test.tsx
+++ b/tests/integration/spotlight.animation.test.tsx
@@ -19,6 +19,7 @@ import challengeReducer from '../../src/store/challengeSlice';
 import socialReducer from '../../src/social/socialSlice';
 import uiReducer from '../../src/store/uiSlice';
 import settingsReducer from '../../src/store/settingsSlice';
+import profilesReducer from '../../src/store/profilesSlice';
 import publicOpinionReducer from '../../src/publicOpinion/publicOpinionSlice';
 import type { GameState, Player } from '../../src/types';
 import CeremonyOverlay from '../../src/components/CeremonyOverlay/CeremonyOverlay';
@@ -94,6 +95,7 @@ function makeStore(overrides: Partial<GameState> = {}) {
       social: socialReducer,
       ui: uiReducer,
       settings: settingsReducer,
+      profiles: profilesReducer,
       publicOpinion: publicOpinionReducer,
     },
     preloadedState: { game: { ...base, ...overrides } },
@@ -202,6 +204,31 @@ describe('GameScreen – CeremonyOverlay defers LOH/POS store mutations', () => 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it('hides the committed tile badge until an advance-picked LOH ceremony finishes', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 50, y: 100, width: 60, height: 80,
+      top: 100, left: 50, bottom: 180, right: 110,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const store = makeStore({
+      phase: 'loh_results',
+      lohId: 'p1',
+      prevHohId: 'p0',
+    });
+    renderWithStore(store);
+
+    const ceremonyBadges = document.querySelectorAll<HTMLImageElement>('img[src*="loh_badge.png"]');
+    expect(ceremonyBadges).toHaveLength(1);
+    expect(ceremonyBadges[0]).toHaveClass('ceremony-overlay__badge-image');
+
+    await act(async () => { vi.advanceTimersByTime(2800 + 400); });
+
+    const landedBadges = document.querySelectorAll<HTMLImageElement>('img[src*="loh_badge.png"]');
+    expect(landedBadges).toHaveLength(1);
+    expect(landedBadges[0]).not.toHaveClass('ceremony-overlay__badge-image');
   });
 
   it('commits applyMinigameWinner immediately when DOMRects are unavailable (defensive fallback)', async () => {

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -37,7 +37,7 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '24px',
+      '--game-safe-top': '30px',
     })
   })
 
@@ -147,12 +147,16 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '24px',
+      '--game-safe-top': '30px',
     })
     expect(['normal', 'compact']).toContain(budget.bottomControlsMode)
     expect(budget.rosterMode).toBe('normal')
     expect(budget.compactRoster).toBe(false)
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
+    const dockGap = readCssPx(budget, '--game-action-dock-gap')
+    const dockHeight = readCssPx(budget, '--game-action-dock-height')
+    const dockClearance = readCssPx(budget, '--game-screen-floating-dock-clearance')
+    expect(dockClearance).toBe(dockHeight + dockGap * 2)
   })
 
   it('tries compact bottom controls before compact roster fallback on small old phones', () => {


### PR DESCRIPTION
## What changed

- Hide the permanent LOH/POS tile badge while its winner ceremony is playing, including the advance-picked outgoing-LOH path.
- Reveal the permanent badge only after the animated badge lands.
- Increase the Android top-safe fallback slightly so Pixel-class layouts clear the camera area.
- Balance the spacing above and below the floating action bar for the classical four-row roster.
- Add regression coverage for badge timing and Pixel-style responsive spacing.

## Why

Award state could already be committed before some ceremony paths started, causing the destination badge to appear underneath the flying badge. Pixel 6-class screens also needed a little more top clearance and more consistent vertical spacing around the roster, action bar, and navigation.

## Validation

- `npm test -- --run tests/unit/layout/responsiveGameLayout.test.ts tests/integration/spotlight.animation.test.tsx tests/unit/ui/playerAvatar.badges.test.tsx` (31 tests passed)
- `npm run typecheck`
