### PR TITLE
Redesign early exit results

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -261,6 +261,7 @@
 }
 
 .minigame-host-results {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -280,11 +281,63 @@
   animation: fadeIn 0.3s ease;
 }
 
+.minigame-host-results--timeline {
+  gap: 14px;
+  isolation: isolate;
+  animation: timeline-arrival 640ms cubic-bezier(.2, .75, .2, 1);
+}
+
+.minigame-host-results-rift {
+  position: absolute;
+  z-index: -1;
+  top: -110px;
+  right: -120px;
+  width: 310px;
+  height: 310px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(246, 74, 115, .24) 0 2%, transparent 3% 11%, rgba(118, 103, 255, .18) 12% 13%, transparent 14% 22%, rgba(65, 211, 255, .1) 23% 24%, transparent 25%), radial-gradient(circle, rgba(108, 92, 246, .18), transparent 66%);
+  animation: rift-spin 12s linear infinite;
+  pointer-events: none;
+}
+
+.minigame-host-results-close {
+  position: absolute;
+  top: var(--minigame-stage-top-padding);
+  right: max(24px, var(--minigame-safe-padding-right));
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  padding: 0 0 2px;
+  border: 1px solid rgba(255, 255, 255, .16);
+  border-radius: 50%;
+  color: #f5f4ff;
+  background: rgba(18, 17, 38, .76);
+  font-size: 1.55rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
 .minigame-host-results-title {
   font-size: 1.6rem;
   font-weight: 700;
   color: #e94560;
   margin: 0;
+  flex-shrink: 0;
+}
+
+.minigame-host-results--timeline .minigame-host-results-title {
+  max-width: calc(100% - 50px);
+  color: #ff5a78;
+  letter-spacing: -.02em;
+}
+
+.minigame-host-results-alternate-timeline {
+  margin: 0;
+  max-width: 360px;
+  color: #dedced;
+  font-size: 1rem;
+  line-height: 1.48;
   flex-shrink: 0;
 }
 
@@ -304,6 +357,15 @@
   flex-shrink: 0;
 }
 
+.minigame-host-results-winner--timeline {
+  padding: 11px 14px;
+  border: 1px solid rgba(255, 206, 91, .3);
+  border-radius: 14px;
+  color: #fff9e7;
+  background: linear-gradient(100deg, rgba(255, 178, 55, .13), rgba(233, 69, 96, .12));
+  box-shadow: 0 10px 30px rgba(0, 0, 0, .16);
+}
+
 .minigame-host-leaderboard {
   list-style: none;
   margin: 0;
@@ -315,6 +377,15 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+}
+
+.minigame-host-leaderboard--preview {
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.minigame-host-leaderboard--preview .minigame-host-leaderboard-entry:nth-child(n + 4) {
+  display: none;
 }
 
 .minigame-host-results-actions {
@@ -432,6 +503,13 @@
   background: #6a67f5;
 }
 
+.minigame-host-results-btn--ranking {
+  padding: 12px 24px;
+  border: 1px solid rgba(153, 145, 255, .5);
+  color: #dcd9ff;
+  background: rgba(110, 103, 245, .14);
+}
+
 .minigame-host-results-btn:disabled {
   cursor: wait;
   opacity: 0.72;
@@ -443,6 +521,22 @@
 
 .minigame-host-results-btn--retry:hover {
   background: #5551e3;
+}
+
+.minigame-host-results-btn--ranking:hover { background: rgba(110, 103, 245, .26); }
+
+@keyframes timeline-arrival {
+  0% { opacity: 0; transform: translate3d(-9px, 0, 0) scale(1.04); filter: blur(2px); }
+  18% { transform: translate3d(8px, -1px, 0) scale(1.01); }
+  34% { transform: translate3d(-5px, 1px, 0); }
+  52% { transform: translate3d(3px, 0, 0); filter: blur(0); }
+  100% { opacity: 1; transform: translate3d(0, 0, 0) scale(1); }
+}
+
+@keyframes rift-spin { to { transform: rotate(360deg) scale(1.08); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .minigame-host-results--timeline, .minigame-host-results-rift { animation: none; }
 }
 
 @keyframes fadeIn {

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -138,6 +138,7 @@ export default function MinigameHost({
   const [finalValue, setFinalValue] = useState<number | null>(null);
   const [finalTiebreakerMs, setFinalTiebreakerMs] = useState<number | null>(null);
   const [wasPartial, setWasPartial] = useState(false);
+  const [showFullRanking, setShowFullRanking] = useState(false);
   const rankingOnly = isPlacementRankingGame(game);
   const competitionRetryEnabled = competitionRetry?.enabled ?? false;
   const rulesGame = useMemo(
@@ -163,6 +164,7 @@ export default function MinigameHost({
   const handleRulesDismiss = useCallback(() => {
     setFinalValue(0);
     setWasPartial(true);
+    setShowFullRanking(false);
     setPhase('results');
   }, []);
 
@@ -199,6 +201,7 @@ export default function MinigameHost({
   const handleQuit = useCallback((partial: LegacyRawResult) => {
     setFinalValue(partial.value);
     setWasPartial(true);
+    setShowFullRanking(false);
     setPhase('results');
   }, []);
 
@@ -662,7 +665,14 @@ export default function MinigameHost({
       )}
 
       {phase === 'results' && (
-        <div className="minigame-host-results">
+        <div className={`minigame-host-results ${wasPartial ? 'minigame-host-results--timeline' : ''}`}>
+          {wasPartial && <div className="minigame-host-results-rift" aria-hidden="true" />}
+          {wasPartial && (
+            <button type="button" className="minigame-host-results-close" aria-label="Close results" onClick={() => {
+              if (showCompetitionRetry) competitionRetry?.onContinueWithoutRetry?.();
+              handleContinue();
+            }}>×</button>
+          )}
           <h2 className="minigame-host-results-title">
             {wasPartial ? '🚪 Exited Early' : '🏁 Finished!'}
           </h2>
@@ -676,11 +686,11 @@ export default function MinigameHost({
                   even if the timeline you saw was heading somewhere else.
                 </p>
               )}
-              <p className="minigame-host-results-winner">
+              <p className={`minigame-host-results-winner ${wasPartial ? 'minigame-host-results-winner--timeline' : ''}`}>
                 🏆 {leaderboard[0]?.name ?? 'Unknown'} wins
                 {leaderboard[0]?.isHuman ? " — that's you!" : '!'}
               </p>
-              <ol className="minigame-host-leaderboard">
+              <ol className={`minigame-host-leaderboard ${wasPartial && !showFullRanking ? 'minigame-host-leaderboard--preview' : ''}`}>
                 {leaderboard.map((entry, i) => (
                   <li
                     key={entry.id}
@@ -729,10 +739,15 @@ export default function MinigameHost({
           )}
 
           <div className="minigame-host-results-actions">
+            {wasPartial && leaderboard && (
+              <button type="button" className="minigame-host-results-btn minigame-host-results-btn--ranking" onClick={() => setShowFullRanking((isShowing) => !isShowing)}>
+                {showFullRanking ? 'Hide full ranking' : 'See full ranking'}
+              </button>
+            )}
             {activeCompetitionRetry && (
               <div className="minigame-host-results-retry" role="group" aria-label="Competition retry">
                 <p className="minigame-host-results-retry-copy">
-                  Finished last? Watch a short ad to retry before the result is locked in.
+                  One short ad can rewind this round before the result is locked in.
                 </p>
                 <button
                   className="minigame-host-results-btn minigame-host-results-btn--retry"
@@ -740,7 +755,7 @@ export default function MinigameHost({
                   disabled={activeCompetitionRetry.pending}
                   autoFocus
                 >
-                  {activeCompetitionRetry.pending ? 'Opening Ad…' : 'Watch Ad to Retry'}
+                  {activeCompetitionRetry.pending ? 'Opening Ad…' : '↶ Reverse time'}
                 </button>
               </div>
             )}

--- a/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
+++ b/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
@@ -94,9 +94,9 @@ describe('MinigameHost competition retry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Exit minigame' }))
 
-    expect(screen.getByText('Finished last? Watch a short ad to retry before the result is locked in.')).toBeInTheDocument()
+    expect(screen.getByText('One short ad can rewind this round before the result is locked in.')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Watch Ad to Retry' }))
+    fireEvent.click(screen.getByRole('button', { name: '↶ Reverse time' }))
 
     expect(onWatch).toHaveBeenCalledTimes(1)
     expect(screen.getByRole('button', { name: 'Exit minigame' })).toBeInTheDocument()


### PR DESCRIPTION
## What changed
- turns early exit into a cinematic temporal-rupture state with a controlled shake and animated rift
- adds a close control, compact ranking preview, and full-ranking toggle
- spotlights the alternate-timeline winner and renames the ad retry action to Reverse time
- respects reduced-motion preferences

## Why
The previous result screen felt rigid and presented too much information at once. This redesign gives quitting early a game-native moment while keeping the ranking and retry choices clear.

## Validation
- npm run typecheck
- npx vitest run src/components/MinigameHost/__tests__/MinigameHost.test.tsx