### PR TITLE
Fix Pixel cutout and action dock spacing

### DIFF
--- a/src/components/FloatingActionBar/FloatingActionBar.css
+++ b/src/components/FloatingActionBar/FloatingActionBar.css
@@ -1,7 +1,7 @@
 /* ── Floating Action Bar ────────────────────────────────────────────────── */
 .fab {
   position: absolute;
-  bottom: var(--game-action-dock-gap, 12px);
+  bottom: 16px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -28,6 +28,7 @@ import { createSurvivorRun, getSurvivorCurrentDay, isSurvivorRunTerminal } from 
 import ConfirmExitModal from '../ConfirmExitModal/ConfirmExitModal';
 import GameControlDock from '../GameControlDock/GameControlDock';
 import ConfessionalSpotlightOverlay from './ConfessionalSpotlightOverlay';
+import { resolveBalancedDockBottom } from './floatingActionBarLayout';
 
 const CONFESSIONAL_FLASH_DURATION_MS = 1800;
 const SURVIVOR_DISABLED_MESSAGE_MS = 5000;
@@ -39,24 +40,6 @@ type FloatingActionBarProps = {
   /** Called when the player activates a blocked social module. */
   onSocialModuleBlocked?: (availability: SocialModuleAvailability) => void;
 };
-
-export function resolveBalancedDockBottom({
-  gameBottom,
-  lowerBoundary,
-  rosterBottom,
-  dockHeight,
-  minimumGap,
-}: {
-  gameBottom: number;
-  lowerBoundary: number;
-  rosterBottom: number;
-  dockHeight: number;
-  minimumGap: number;
-}) {
-  const openSpace = lowerBoundary - rosterBottom - dockHeight;
-  const balancedGap = Math.max(minimumGap, openSpace / 2);
-  return Math.max(minimumGap, gameBottom - lowerBoundary + balancedGap);
-}
 
 /**
  * FloatingActionBar — BitLife-style mobile FAB for the Game screen.

--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -40,6 +40,24 @@ type FloatingActionBarProps = {
   onSocialModuleBlocked?: (availability: SocialModuleAvailability) => void;
 };
 
+export function resolveBalancedDockBottom({
+  gameBottom,
+  lowerBoundary,
+  rosterBottom,
+  dockHeight,
+  minimumGap,
+}: {
+  gameBottom: number;
+  lowerBoundary: number;
+  rosterBottom: number;
+  dockHeight: number;
+  minimumGap: number;
+}) {
+  const openSpace = lowerBoundary - rosterBottom - dockHeight;
+  const balancedGap = Math.max(minimumGap, openSpace / 2);
+  return Math.max(minimumGap, gameBottom - lowerBoundary + balancedGap);
+}
+
 /**
  * FloatingActionBar — BitLife-style mobile FAB for the Game screen.
  *
@@ -131,6 +149,7 @@ export default function FloatingActionBar({
   const [triggeredConfessionalDecisionKey, setTriggeredConfessionalDecisionKey] = useState<string | null>(null);
   const [showConfessionalSpotlight, setShowConfessionalSpotlight] = useState(false);
   const confessionalIconRef = useRef<HTMLImageElement | null>(null);
+  const dockRef = useRef<HTMLDivElement | null>(null);
   const prevConfessionalCountRef = useRef(confessionalAlertCount);
   const hasPendingConfessionalDecision = activeConfessionalDecision !== null;
   const hasSeenConfessionalSpotlight = game.hasSeenConfessionalSpotlight === true;
@@ -299,6 +318,70 @@ export default function FloatingActionBar({
     navigate('/');
   }, [dispatch, navigate]);
 
+  // Center the dock in the real rendered space between the roster's last row
+  // and the navbar. Device scaling and tile rounding can make nominally equal
+  // budget gaps render at noticeably different sizes.
+  useEffect(() => {
+    const dock = dockRef.current;
+    const gameScreen = dock?.closest<HTMLElement>('.game-screen');
+    if (!dock || !gameScreen) return undefined;
+
+    let frameId = 0;
+    const balanceDock = () => {
+      const roster = gameScreen.querySelector<HTMLElement>(
+        'section[aria-labelledby="houseguests-heading"] ul[role="list"]',
+      );
+      const nav = document.querySelector<HTMLElement>('.nav-bar');
+      if (!roster || !nav) return;
+
+      const gameRect = gameScreen.getBoundingClientRect();
+      const rosterRect = roster.getBoundingClientRect();
+      const dockRect = dock.getBoundingClientRect();
+      const navRect = nav.getBoundingClientRect();
+      if (dockRect.height <= 0) return;
+
+      const lowerBoundary = Math.min(gameRect.bottom, navRect.top);
+      const configuredGap = Number.parseFloat(
+        getComputedStyle(gameScreen).getPropertyValue('--game-action-dock-gap'),
+      );
+      const minimumGap = Number.isFinite(configuredGap) ? configuredGap : 8;
+      const bottomOffset = resolveBalancedDockBottom({
+        gameBottom: gameRect.bottom,
+        lowerBoundary,
+        rosterBottom: rosterRect.bottom,
+        dockHeight: dockRect.height,
+        minimumGap,
+      });
+      dock.style.bottom = `${Math.round(bottomOffset)}px`;
+    };
+    const scheduleBalance = () => {
+      window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(balanceDock);
+    };
+
+    scheduleBalance();
+    window.addEventListener('resize', scheduleBalance);
+    window.visualViewport?.addEventListener('resize', scheduleBalance);
+    const observed = [
+      gameScreen,
+      dock,
+      gameScreen.querySelector<HTMLElement>('.tv-zone'),
+      gameScreen.querySelector<HTMLElement>('section[aria-labelledby="houseguests-heading"]'),
+      document.querySelector<HTMLElement>('.nav-bar'),
+    ].filter((element): element is HTMLElement => element instanceof HTMLElement);
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(scheduleBalance);
+    observed.forEach((element) => resizeObserver?.observe(element));
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', scheduleBalance);
+      window.visualViewport?.removeEventListener('resize', scheduleBalance);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
   return (
     <>
       {blockedAnnouncement && (
@@ -316,6 +399,7 @@ export default function FloatingActionBar({
         onCancel={handleReturnHome}
       />
       <GameControlDock
+        dockRef={dockRef}
         onChatClick={handleChatClick}
         onIncomingRequestsClick={handleIncomingRequestsClick}
         onPrimaryActionClick={handlePrimaryActionClick}

--- a/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
@@ -27,7 +27,8 @@ import socialReducer, {
 import profilesReducer from '../../../store/profilesSlice';
 import challengeReducer from '../../../store/challengeSlice';
 import publicOpinionReducer, { addDirection } from '../../../publicOpinion/publicOpinionSlice';
-import FloatingActionBar, { resolveBalancedDockBottom } from '../FloatingActionBar';
+import FloatingActionBar from '../FloatingActionBar';
+import { resolveBalancedDockBottom } from '../floatingActionBarLayout';
 import type { RootState } from '../../../store/store';
 import type { PublicDirection } from '../../../publicOpinion/types';
 import { createSecretMissionState } from '../../../bb/secretMission';

--- a/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
@@ -27,7 +27,7 @@ import socialReducer, {
 import profilesReducer from '../../../store/profilesSlice';
 import challengeReducer from '../../../store/challengeSlice';
 import publicOpinionReducer, { addDirection } from '../../../publicOpinion/publicOpinionSlice';
-import FloatingActionBar from '../FloatingActionBar';
+import FloatingActionBar, { resolveBalancedDockBottom } from '../FloatingActionBar';
 import type { RootState } from '../../../store/store';
 import type { PublicDirection } from '../../../publicOpinion/types';
 import { createSecretMissionState } from '../../../bb/secretMission';
@@ -105,6 +105,18 @@ function renderFAB(
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('FloatingActionBar – responsive placement', () => {
+  it('centers the dock between the fourth roster row and navbar', () => {
+    expect(resolveBalancedDockBottom({
+      gameBottom: 800,
+      lowerBoundary: 800,
+      rosterBottom: 600,
+      dockHeight: 80,
+      minimumGap: 8,
+    })).toBe(60);
+  });
+});
 
 describe('FloatingActionBar – social energy badge', () => {
   it('shows a badge with the human player energy value', () => {

--- a/src/components/FloatingActionBar/floatingActionBarLayout.ts
+++ b/src/components/FloatingActionBar/floatingActionBarLayout.ts
@@ -1,0 +1,17 @@
+export function resolveBalancedDockBottom({
+  gameBottom,
+  lowerBoundary,
+  rosterBottom,
+  dockHeight,
+  minimumGap,
+}: {
+  gameBottom: number;
+  lowerBoundary: number;
+  rosterBottom: number;
+  dockHeight: number;
+  minimumGap: number;
+}) {
+  const openSpace = lowerBoundary - rosterBottom - dockHeight;
+  const balancedGap = Math.max(minimumGap, openSpace / 2);
+  return Math.max(minimumGap, gameBottom - lowerBoundary + balancedGap);
+}

--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -1,7 +1,7 @@
 /* ── GameControlDock ────────────────────────────────────────────────────── */
 .game-control-dock {
   position: absolute;
-  bottom: 2px;
+  bottom: var(--game-action-dock-gap, 8px);
   left: 50%;
   z-index: 100;
   width: min(calc(80% * var(--game-action-dock-scale, 1)), calc(340px * var(--game-action-dock-scale, 1)));

--- a/src/components/GameControlDock/GameControlDock.tsx
+++ b/src/components/GameControlDock/GameControlDock.tsx
@@ -8,6 +8,8 @@ function assetUrl(file: string): string {
 }
 
 export interface GameControlDockProps {
+  /** Ref to the dock shell for responsive placement within the game screen. */
+  dockRef?: Ref<HTMLDivElement>;
   onChatClick?: () => void;
   onIncomingRequestsClick?: () => void;
   onPrimaryActionClick?: () => void;
@@ -40,6 +42,7 @@ export interface GameControlDockProps {
 }
 
 export default function GameControlDock({
+  dockRef,
   onChatClick,
   onIncomingRequestsClick,
   onPrimaryActionClick,
@@ -69,6 +72,7 @@ export default function GameControlDock({
 
   return (
     <div
+      ref={dockRef}
       className="game-control-dock fab-clean"
       role="toolbar"
       aria-label="Game actions"

--- a/src/index.css
+++ b/src/index.css
@@ -99,7 +99,8 @@ html.is-capacitor {
 }
 
 html.is-chrome-android {
-  --app-safe-area-top-fallback: 24px;
+  /* Clear centered punch-hole cameras before drawing the TV header edge. */
+  --app-safe-area-top-fallback: 44px;
 }
 
 /* ── Base elements ────────────────────────────────────────────────────────── */

--- a/src/publicOpinion/publicOpinionMiddleware.ts
+++ b/src/publicOpinion/publicOpinionMiddleware.ts
@@ -77,12 +77,12 @@ function dispatchReactionDeltas(
 
 interface StateWithGame {
   game: GameState;
-  social?: { relationships?: import('../social/types').RelationshipsMap };
   publicOpinion?: {
     profiles: Record<string, unknown>;
     directions: PublicDirection[];
   };
   social?: {
+    relationships?: import('../social/types').RelationshipsMap;
     sessionLogs?: Array<{
       actorId?: string;
       source?: 'manual' | 'system';

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -50,7 +50,7 @@ export interface ResponsiveGameLayoutInput {
   revision?: number
 }
 
-const ANDROID_TOP_SAFE_FALLBACK = 30
+const ANDROID_TOP_SAFE_FALLBACK = 44
 const DEFAULT_NAV_HEIGHT = 60
 const COMPACT_NAV_HEIGHT = 46
 const DEFAULT_PHONE_WIDTH = 390

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -37,7 +37,7 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '30px',
+      '--game-safe-top': '44px',
     })
   })
 
@@ -147,7 +147,7 @@ describe('responsive game layout budget', () => {
     }))
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '30px',
+      '--game-safe-top': '44px',
     })
     expect(['normal', 'compact']).toContain(budget.bottomControlsMode)
     expect(budget.rosterMode).toBe('normal')

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -19,7 +19,7 @@ describe('safe-area layout styles', () => {
 
     expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);');
     expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);');
-    expect(globalCss).toContain('html.is-chrome-android { --app-safe-area-top-fallback: 24px; }');
+    expect(globalCss).toContain('html.is-chrome-android { /* Clear centered punch-hole cameras before drawing the TV header edge. */ --app-safe-area-top-fallback: 44px; }');
     expect(existsSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.tsx'))).toBe(false);
     expect(existsSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.css'))).toBe(false);
     expect(appShellTsx).not.toContain('SafeGameViewport');
@@ -47,7 +47,7 @@ describe('safe-area layout styles', () => {
     expect(bottomNavCss).toContain('padding-bottom: var(--safe-bottom);');
     expect(bottomNavCss).not.toContain('env(safe-area-inset-bottom');
     expect(dockCss).toContain('.game-control-dock { position: absolute;');
-    expect(dockCss).toContain('bottom: 2px;');
+    expect(dockCss).toContain('bottom: var(--game-action-dock-gap, 8px);');
     expect(dockCss).not.toContain('position: fixed;');
     expect(dockCss).not.toContain('env(safe-area-inset-bottom');
     expect(gameScreenCss).toContain('.game-screen:has(.game-control-dock)');


### PR DESCRIPTION
## What changed

- Increase the Chrome Android app-shell top inset so the TV header edge clears centered punch-hole cameras such as Pixel 6.
- Measure the rendered fourth roster row, action dock, game boundary, and navbar.
- Center the action dock in the actual remaining vertical space so the roster-to-dock and dock-to-navbar gaps match.
- Rebalance placement after viewport or relevant panel-size changes.
- Add direct coverage for the equal-gap calculation and update Android safe-area contracts.

## Root cause

The previous follow-up changed a responsive `--game-safe-top` value that the gameplay shell did not consume, so it could not move the TV header below the camera. It also changed a legacy `.fab` rule while the visible control is positioned by `.game-control-dock`. Static budget values additionally could not account for device scaling and rounded avatar-tile measurements.

## Validation

- 41 focused responsive layout, action-bar, and dock tests passed.
- 2 targeted safe-area contract tests passed.
- `npm run typecheck` passed.

The full `safeArea.styles.test.ts` currently has one unrelated stale assertion about the existing `GameRoute` implementation on `main`.
