### PR TITLE
Implement temporal rupture early-exit screen

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -261,6 +261,7 @@
 }
 
 .minigame-host-results {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -278,6 +279,26 @@
   box-sizing: border-box;
   overflow: hidden;
   animation: fadeIn 0.3s ease;
+}
+
+.minigame-host-results--timeline {
+  isolation: isolate;
+}
+
+.minigame-host-results-rift {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.minigame-host-results-close {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  padding: 0 0 2px;
+  border-radius: 50%;
+  line-height: 1;
+  cursor: pointer;
 }
 
 .minigame-host-results-title {
@@ -315,6 +336,15 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+}
+
+.minigame-host-leaderboard--preview {
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.minigame-host-leaderboard--preview .minigame-host-leaderboard-entry:nth-child(n + 4) {
+  display: none;
 }
 
 .minigame-host-results-actions {

--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -539,6 +539,279 @@
   .minigame-host-results--timeline, .minigame-host-results-rift { animation: none; }
 }
 
+/* Early-exit timeline: intentionally mirrors the cinematic concept mockup. */
+.minigame-host-results--timeline {
+  --timeline-violet: #8d63ff;
+  --timeline-coral: #f15370;
+  gap: clamp(10px, 1.6vh, 16px);
+  max-width: 480px;
+  padding:
+    var(--minigame-stage-top-padding)
+    max(26px, var(--minigame-safe-padding-right))
+    max(26px, var(--minigame-safe-padding-bottom))
+    max(26px, var(--minigame-safe-padding-left));
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background:
+    radial-gradient(circle at 92% 18%, rgba(87, 51, 183, .2), transparent 30%),
+    radial-gradient(circle at 8% 76%, rgba(29, 44, 91, .2), transparent 34%),
+    linear-gradient(180deg, #030817 0%, #050a1b 54%, #030716 100%);
+}
+
+.minigame-host-results--timeline::-webkit-scrollbar { display: none; }
+
+.minigame-host-results--timeline::before {
+  content: '';
+  position: absolute;
+  z-index: -2;
+  inset: 0;
+  opacity: .46;
+  background-image:
+    radial-gradient(circle, rgba(198, 181, 255, .9) 0 1px, transparent 1.5px),
+    radial-gradient(circle, rgba(108, 87, 255, .75) 0 1px, transparent 1.5px);
+  background-position: 17px 29px, 81px 113px;
+  background-size: 97px 131px, 137px 173px;
+  pointer-events: none;
+}
+
+.minigame-host-results--timeline .minigame-host-results-rift {
+  z-index: -1;
+  top: -68px;
+  right: -148px;
+  width: 430px;
+  height: 430px;
+  opacity: .95;
+  background:
+    radial-gradient(circle at 58% 49%, #05091a 0 9%, #7454ee 10%, #d4c8ff 11%, rgba(113, 78, 237, .78) 14%, transparent 21%),
+    radial-gradient(ellipse at 58% 49%, rgba(115, 72, 235, .58), rgba(18, 25, 77, .12) 48%, transparent 68%);
+  filter: drop-shadow(0 0 20px rgba(105, 73, 255, .5));
+  animation: none;
+}
+
+.minigame-host-results--timeline .minigame-host-results-close {
+  z-index: 3;
+  top: max(18px, calc(var(--minigame-safe-top) + 14px));
+  right: max(20px, calc(var(--minigame-safe-right) + 18px));
+  width: 42px;
+  height: 42px;
+  border-color: rgba(244, 74, 105, .82);
+  color: var(--timeline-coral);
+  background: rgba(12, 17, 40, .84);
+  box-shadow: 0 0 22px rgba(241, 83, 112, .15);
+  font-size: 1.8rem;
+  font-weight: 500;
+}
+
+.minigame-host-results-kicker {
+  z-index: 1;
+  margin: 0;
+  color: #a578ff;
+  font-size: clamp(.68rem, 2.6vw, .78rem);
+  font-weight: 650;
+  letter-spacing: .27em;
+  line-height: 1;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.minigame-host-results--timeline .minigame-host-results-title {
+  z-index: 1;
+  max-width: none;
+  margin: -1px 0 0;
+  color: var(--timeline-coral);
+  font-size: clamp(3.15rem, 13.8vw, 4.45rem);
+  font-weight: 760;
+  letter-spacing: -.055em;
+  line-height: .98;
+  text-shadow: 0 0 30px rgba(241, 83, 112, .14);
+}
+
+.minigame-host-results-divider {
+  position: relative;
+  width: 72%;
+  height: 18px;
+  margin: -2px 0 0;
+  flex-shrink: 0;
+}
+
+.minigame-host-results-divider::before,
+.minigame-host-results-divider::after {
+  content: '';
+  position: absolute;
+  top: 8px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(126, 84, 255, .88));
+}
+
+.minigame-host-results-divider::before { left: 0; right: 50%; }
+.minigame-host-results-divider::after { left: 50%; right: 0; transform: scaleX(-1); }
+
+.minigame-host-results-divider span {
+  position: absolute;
+  z-index: 1;
+  top: 3px;
+  left: calc(50% - 6px);
+  width: 12px;
+  height: 12px;
+  border: 1px solid #8b61ff;
+  border-radius: 50%;
+  background: #070b20;
+  box-shadow: 0 0 0 4px rgba(96, 67, 214, .18), inset 0 0 0 3px #070b20;
+}
+
+.minigame-host-results--timeline .minigame-host-results-alternate-timeline {
+  max-width: 410px;
+  margin: 0 0 clamp(2px, .5vh, 6px);
+  color: #f0eef7;
+  font-size: clamp(1rem, 4.25vw, 1.22rem);
+  line-height: 1.42;
+  letter-spacing: -.015em;
+}
+
+.minigame-host-results--timeline .minigame-host-results-winner--timeline {
+  display: flex;
+  min-height: clamp(82px, 13.5vh, 112px);
+  align-items: center;
+  justify-content: flex-start;
+  gap: clamp(18px, 5vw, 28px);
+  padding: 12px clamp(22px, 6vw, 32px);
+  border: 1.5px solid rgba(255, 104, 121, .88);
+  border-radius: 12px;
+  color: #fff9f2;
+  background:
+    radial-gradient(circle at 15% 50%, rgba(246, 153, 45, .15), transparent 28%),
+    linear-gradient(100deg, rgba(68, 24, 39, .64), rgba(15, 15, 39, .88));
+  box-shadow: 0 0 26px rgba(245, 72, 102, .15), inset 0 0 30px rgba(231, 83, 110, .07);
+  font-size: clamp(1.65rem, 7vw, 2.2rem);
+  letter-spacing: -.025em;
+  text-align: left;
+}
+
+.minigame-host-results-trophy {
+  font-size: clamp(3rem, 13vw, 4.15rem);
+  line-height: 1;
+  filter: drop-shadow(0 0 10px rgba(255, 183, 45, .35));
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard {
+  gap: 7px;
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard--preview {
+  flex: 0 0 auto;
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard-entry {
+  min-height: clamp(52px, 7.5vh, 66px);
+  gap: 10px;
+  padding: 8px clamp(13px, 4vw, 20px);
+  border: 1px solid rgba(99, 111, 159, .18);
+  border-radius: 10px;
+  background: linear-gradient(100deg, rgba(21, 28, 56, .95), rgba(12, 18, 40, .92));
+  font-size: clamp(.88rem, 3.7vw, 1rem);
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard-entry--winner,
+.minigame-host-results--timeline .minigame-host-leaderboard-entry--you {
+  background: linear-gradient(100deg, rgba(21, 28, 56, .95), rgba(12, 18, 40, .92));
+  border-color: rgba(99, 111, 159, .18);
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard-rank {
+  width: 34px;
+  font-size: 1.45rem;
+}
+
+.minigame-host-results--timeline .minigame-host-leaderboard-name { font-size: 1.05em; }
+.minigame-host-results--timeline .minigame-host-leaderboard-score { color: #9fa5c0; }
+.minigame-host-results--timeline .minigame-host-leaderboard-score strong { color: #f8f7ff; font-size: 1.08em; }
+
+.minigame-host-results--timeline .minigame-host-results-actions {
+  gap: clamp(9px, 1.4vh, 13px);
+  margin-top: 0;
+}
+
+.minigame-host-results--timeline .minigame-host-results-btn--ranking {
+  display: grid;
+  grid-template-columns: 32px 1fr 24px;
+  align-items: center;
+  min-height: clamp(52px, 7.2vh, 62px);
+  padding: 10px 18px;
+  border: 1.5px solid #8956ff;
+  border-radius: 11px;
+  color: #fbf9ff;
+  background: rgba(7, 10, 29, .72);
+  font-size: clamp(.95rem, 4vw, 1.1rem);
+}
+
+.minigame-host-results-ranking-icon {
+  display: flex;
+  height: 22px;
+  align-items: end;
+  gap: 3px;
+}
+
+.minigame-host-results-ranking-icon i { width: 5px; border-radius: 2px 2px 0 0; background: #f2efff; }
+.minigame-host-results-ranking-icon i:nth-child(1) { height: 12px; }
+.minigame-host-results-ranking-icon i:nth-child(2) { height: 20px; }
+.minigame-host-results-ranking-icon i:nth-child(3) { height: 15px; }
+.minigame-host-results-ranking-chevron { font-size: 1.8rem; font-weight: 300; line-height: 1; }
+
+.minigame-host-results--timeline .minigame-host-results-retry {
+  gap: clamp(9px, 1.35vh, 13px);
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.minigame-host-results--timeline .minigame-host-results-btn--retry {
+  display: flex;
+  min-height: clamp(62px, 8.2vh, 76px);
+  align-items: center;
+  justify-content: center;
+  gap: clamp(14px, 4vw, 22px);
+  padding: 11px 20px;
+  border: 1.5px solid #da86ff;
+  border-radius: 11px;
+  background:
+    radial-gradient(circle at 50% 120%, rgba(163, 100, 255, .68), transparent 60%),
+    linear-gradient(100deg, #5134c6, #5930d0 52%, #7247df);
+  box-shadow: 0 0 22px rgba(132, 76, 255, .52), inset 0 0 22px rgba(255, 255, 255, .11);
+  font-size: clamp(1.3rem, 5.6vw, 1.65rem);
+}
+
+.minigame-host-results-rewind {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 2px solid #c8b2ff;
+  border-radius: 50%;
+  color: #fff;
+  font-size: .82rem;
+  letter-spacing: -4px;
+  padding-right: 4px;
+}
+
+.minigame-host-results--timeline .minigame-host-results-retry-copy {
+  max-width: 300px;
+  align-self: center;
+  margin: 0;
+  color: #a8a8bb;
+  font-size: clamp(.82rem, 3.5vw, .96rem);
+  line-height: 1.38;
+}
+
+@media (max-height: 700px) {
+  .minigame-host-results--timeline { gap: 8px; }
+  .minigame-host-results--timeline .minigame-host-results-title { font-size: 2.8rem; }
+  .minigame-host-results--timeline .minigame-host-results-alternate-timeline { font-size: .96rem; }
+  .minigame-host-results--timeline .minigame-host-results-winner--timeline { min-height: 70px; }
+  .minigame-host-results--timeline .minigame-host-results-trophy { font-size: 2.7rem; }
+  .minigame-host-results--timeline .minigame-host-leaderboard-entry { min-height: 46px; }
+}
+
 @keyframes fadeIn {
   from { opacity: 0; transform: scale(0.95); }
   to   { opacity: 1; transform: scale(1); }

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -668,27 +668,38 @@ export default function MinigameHost({
         <div className={`minigame-host-results ${wasPartial ? 'minigame-host-results--timeline' : ''}`}>
           {wasPartial && <div className="minigame-host-results-rift" aria-hidden="true" />}
           {wasPartial && (
-            <button type="button" className="minigame-host-results-close" aria-label="Close results" onClick={() => {
-              if (showCompetitionRetry) competitionRetry?.onContinueWithoutRetry?.();
-              handleContinue();
-            }}>×</button>
+            <button
+              type="button"
+              className="minigame-host-results-close"
+              aria-label="Close results"
+              onClick={() => {
+                if (showCompetitionRetry) competitionRetry?.onContinueWithoutRetry?.();
+                handleContinue();
+              }}
+            >
+              ×
+            </button>
           )}
+          {wasPartial && <p className="minigame-host-results-kicker">Temporal rupture</p>}
           <h2 className="minigame-host-results-title">
-            {wasPartial ? '🚪 Exited Early' : '🏁 Finished!'}
+            {wasPartial ? 'Exited early' : '🏁 Finished!'}
           </h2>
+          {wasPartial && <div className="minigame-host-results-divider" aria-hidden="true"><span /></div>}
 
           {leaderboard ? (
             <>
               {wasPartial && (
                 <p className="minigame-host-results-alternate-timeline">
-                  You left early and scrambled the time-space continuum. In this alternative
-                  universe, {leaderboard[0]?.name ?? 'someone unexpected'} won the competition —
-                  even if the timeline you saw was heading somewhere else.
+                  You slipped out of the timeline. While you were gone, the competition resolved in
+                  an alternate universe.
                 </p>
               )}
               <p className={`minigame-host-results-winner ${wasPartial ? 'minigame-host-results-winner--timeline' : ''}`}>
-                🏆 {leaderboard[0]?.name ?? 'Unknown'} wins
-                {leaderboard[0]?.isHuman ? " — that's you!" : '!'}
+                {wasPartial && <span className="minigame-host-results-trophy" aria-hidden="true">🏆</span>}
+                <span>
+                  {leaderboard[0]?.name ?? 'Unknown'} wins
+                  {leaderboard[0]?.isHuman ? " — that's you!" : '!'}
+                </span>
               </p>
               <ol className={`minigame-host-leaderboard ${wasPartial && !showFullRanking ? 'minigame-host-leaderboard--preview' : ''}`}>
                 {leaderboard.map((entry, i) => (
@@ -740,38 +751,48 @@ export default function MinigameHost({
 
           <div className="minigame-host-results-actions">
             {wasPartial && leaderboard && (
-              <button type="button" className="minigame-host-results-btn minigame-host-results-btn--ranking" onClick={() => setShowFullRanking((isShowing) => !isShowing)}>
-                {showFullRanking ? 'Hide full ranking' : 'See full ranking'}
+              <button
+                type="button"
+                className="minigame-host-results-btn minigame-host-results-btn--ranking"
+                onClick={() => setShowFullRanking((isShowing) => !isShowing)}
+              >
+                <span className="minigame-host-results-ranking-icon" aria-hidden="true"><i /><i /><i /></span>
+                <span>{showFullRanking ? 'Hide full ranking' : 'See full ranking'}</span>
+                <span className="minigame-host-results-ranking-chevron" aria-hidden="true">›</span>
               </button>
             )}
             {activeCompetitionRetry && (
               <div className="minigame-host-results-retry" role="group" aria-label="Competition retry">
-                <p className="minigame-host-results-retry-copy">
-                  One short ad can rewind this round before the result is locked in.
-                </p>
                 <button
                   className="minigame-host-results-btn minigame-host-results-btn--retry"
                   onClick={() => activeCompetitionRetry.onWatch(handleRetryRestart)}
                   disabled={activeCompetitionRetry.pending}
                   autoFocus
                 >
-                  {activeCompetitionRetry.pending ? 'Opening Ad…' : '↶ Reverse time'}
+                  {activeCompetitionRetry.pending ? (
+                    'Opening Ad…'
+                  ) : (
+                    <><span className="minigame-host-results-rewind" aria-hidden="true">◀◀</span>Reverse time</>
+                  )}
                 </button>
+                <p className="minigame-host-results-retry-copy">
+                  Watch a short ad to retry before this result is locked in.
+                </p>
               </div>
             )}
 
-            <button
-              className="minigame-host-results-btn"
-              onClick={() => {
-                if (showCompetitionRetry) {
-                  competitionRetry?.onContinueWithoutRetry?.();
-                }
-                handleContinue();
-              }}
-              {...(!showCompetitionRetry ? { autoFocus: true } : {})}
-            >
-              {showCompetitionRetry ? 'No Thanks — Continue ▶' : 'Continue ▶'}
-            </button>
+            {(!wasPartial || !showCompetitionRetry) && (
+              <button
+                className="minigame-host-results-btn"
+                onClick={() => {
+                  if (showCompetitionRetry) competitionRetry?.onContinueWithoutRetry?.();
+                  handleContinue();
+                }}
+                {...(!showCompetitionRetry ? { autoFocus: true } : {})}
+              >
+                {showCompetitionRetry ? 'No Thanks — Continue ▶' : 'Continue ▶'}
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -138,6 +138,7 @@ export default function MinigameHost({
   const [finalValue, setFinalValue] = useState<number | null>(null);
   const [finalTiebreakerMs, setFinalTiebreakerMs] = useState<number | null>(null);
   const [wasPartial, setWasPartial] = useState(false);
+  const [showFullRanking, setShowFullRanking] = useState(false);
   const rankingOnly = isPlacementRankingGame(game);
   const competitionRetryEnabled = competitionRetry?.enabled ?? false;
   const rulesGame = useMemo(
@@ -163,6 +164,7 @@ export default function MinigameHost({
   const handleRulesDismiss = useCallback(() => {
     setFinalValue(0);
     setWasPartial(true);
+    setShowFullRanking(false);
     setPhase('results');
   }, []);
 
@@ -199,6 +201,7 @@ export default function MinigameHost({
   const handleQuit = useCallback((partial: LegacyRawResult) => {
     setFinalValue(partial.value);
     setWasPartial(true);
+    setShowFullRanking(false);
     setPhase('results');
   }, []);
 

--- a/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
+++ b/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
@@ -94,9 +94,9 @@ describe('MinigameHost competition retry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Exit minigame' }))
 
-    expect(screen.getByText('One short ad can rewind this round before the result is locked in.')).toBeInTheDocument()
+    expect(screen.getByText('Watch a short ad to retry before this result is locked in.')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: '↶ Reverse time' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reverse time' }))
 
     expect(onWatch).toHaveBeenCalledTimes(1)
     expect(screen.getByRole('button', { name: 'Exit minigame' })).toBeInTheDocument()

--- a/tests/unit/minigameHost.dismissal.test.tsx
+++ b/tests/unit/minigameHost.dismissal.test.tsx
@@ -8,7 +8,7 @@
  * a winner without user awareness.
  *
  * Fix: both buttons now route through `setPhase('results')` so the player
- * sees the "🚪 Exited Early" screen and must click "Continue ▶" to confirm.
+ * sees the "Exited early" screen and must click "Continue ▶" to confirm.
  *
  * Tests verify:
  *  1. Clicking ✕ on the rules modal transitions to results screen (does NOT
@@ -190,9 +190,9 @@ describe('MinigameHost — dismiss / close buttons route through results screen'
     });
 
     // Results screen with "Exited Early" heading should now appear
-    expect(screen.getByText('🚪 Exited Early')).toBeTruthy();
-    expect(screen.getByText(/scrambled the time-space continuum/i)).toBeInTheDocument();
-    expect(screen.getByText(/AI-1 won the competition/i)).toBeInTheDocument();
+    expect(screen.getByText('Exited early')).toBeTruthy();
+    expect(screen.getByText(/slipped out of the timeline/i)).toBeInTheDocument();
+    expect(screen.getByText(/AI-1 wins/i)).toBeInTheDocument();
     // Continue button should be present
     expect(screen.getByRole('button', { name: /continue/i })).toBeTruthy();
   });
@@ -274,7 +274,7 @@ describe('MinigameHost — dismiss / close buttons route through results screen'
       fireEvent.click(screen.getByRole('button', { name: /exit minigame/i }));
     });
 
-    expect(screen.getByText('🚪 Exited Early')).toBeTruthy();
+    expect(screen.getByText('Exited early')).toBeTruthy();
   });
 
   it('clicking Continue after playing-phase exit calls onDone(0, true)', async () => {


### PR DESCRIPTION
## What changed
- recreates the approved Temporal Rupture early-exit design in the game
- adds the black-hole halo without radial rays
- presents the winner hero card and a three-player ranking preview
- adds expandable full rankings, the Reverse time ad-retry action, and the close action
- removes the redundant Continue action when retry is available
- preserves reduced-motion and short-screen behavior

## Why
The previous early-exit results view did not match the approved visual direction. This implementation follows the reviewed preview and keeps the decision flow clear.

## Validation
- npm run typecheck
- npx vitest run src/components/MinigameHost/__tests__/MinigameHost.test.tsx tests/unit/minigameHost.dismissal.test.tsx