### PR TITLE
Diversify Trap Auction opening bids

### DIFF
--- a/src/components/TrapAuction/trapAuctionHelpers.ts
+++ b/src/components/TrapAuction/trapAuctionHelpers.ts
@@ -27,6 +27,24 @@ function deriveSeed(base: number, salt: number): number {
   return (mulberry32((base ^ salt ^ 0xdeadbeef) >>> 0)() * 0x100000000) >>> 0;
 }
 
+function hashPlayerId(id: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    hash ^= id.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/** Stable continuous traits keep two AIs with the same broad personality distinct. */
+function getIndividualBidStyle(playerId: string) {
+  const rng = mulberry32(hashPlayerId(playerId) ^ 0x9e3779b9);
+  return {
+    riskBias: (rng() - 0.5) * 0.5,
+    volatility: 0.7 + rng() * 0.6,
+  };
+}
+
 // ─── Personality assignment ───────────────────────────────────────────────────
 
 const AI_PERSONALITIES: AiPersonality[] = [
@@ -179,7 +197,9 @@ export function chooseAiBid(
         Math.max(
           2,                         // hard minimum when bank > 1
           endgameFloor(aliveCount),  // late-game lift
-          Math.floor(player.bank * (aliveCount <= 3 ? 0.12 : 0.08)),
+          // Only the endgame needs a bank-relative floor. Applying an 8% floor
+          // to a full 16-player opening forced most strategies to exactly 8.
+          aliveCount <= 3 ? Math.floor(player.bank * 0.12) : 0,
           Math.floor(2 + roundPressure * 4),  // round pressure: up to +4 by round 8
         ),
       );
@@ -227,7 +247,10 @@ export function chooseAiBid(
       multiplier = 0.5 + rng();
   }
 
-  const raw = Math.round(sustainable * Math.max(0, multiplier));
+  const individualStyle = getIndividualBidStyle(player.id);
+  const individualNoise = (rng() - 0.5) * 0.22 * individualStyle.volatility;
+  const individualizedMultiplier = multiplier + individualStyle.riskBias + individualNoise;
+  const raw = Math.round(sustainable * Math.max(0, individualizedMultiplier));
 
   const clamped = Math.max(min, Math.min(max, raw));
   return Math.max(min, Math.min(max, Math.max(survivalFloor, clamped)));
@@ -502,7 +525,9 @@ export function computeAiBids(
 ): TrapAuctionPlayer[] {
   return players.map((p, idx) => {
     if (!p.isAlive || p.isHuman || p.currentBid !== null) return p;
-    const playerSeed = deriveSeed(roundSeed, idx);
+    // Player identity participates in the seed so roster order is not the AI's
+    // hidden strategy and two contestants never share the same random stream.
+    const playerSeed = deriveSeed(roundSeed, idx ^ hashPlayerId(p.id));
     const bid = chooseAiBid(p, state, playerSeed);
     return { ...p, currentBid: bid };
   });

--- a/tests/unit/trapAuction/trapAuction.logic.test.ts
+++ b/tests/unit/trapAuction/trapAuction.logic.test.ts
@@ -17,6 +17,7 @@ import {
   eliminatePlayers,
   getWinner,
   buildRoundReveals,
+  computeAiBids,
   nextPlacementFor,
   shouldRevealPlayerBank,
   MOCK_PARTICIPANTS,
@@ -258,6 +259,27 @@ describe('chooseAiBid', () => {
       // round 1 of a 6-player field (sustainable budget ≈ bank / 5).
       expect(avg).toBeLessThan(TRAP_AUCTION_CONFIG.startingBank * 0.5);
     });
+  });
+
+  it('does not collapse a 16-player opening round onto one shared bid', () => {
+    const participants = [
+      { id: 'human', name: 'You', isHuman: true, precomputedScore: 0, previousPR: null },
+      ...['Lia', 'Dex', 'Zed', 'Vee', 'Aria', 'Blue', 'Sol', 'Kai', 'Rae', 'Kian', 'Echo', 'Nova', 'Jax', 'Ivy', 'Ash']
+        .map((name) => ({ id: name.toLowerCase(), name, isHuman: false, precomputedScore: 0, previousPR: null })),
+    ];
+
+    for (let seed = 1; seed <= 25; seed++) {
+      const players = createInitialPlayers(participants, seed);
+      const withBids = computeAiBids(players, { round: 1, players }, seed * 7919);
+      const bids = withBids.filter((player) => !player.isHuman).map((player) => player.currentBid as number);
+      const frequencies = bids.reduce<Record<number, number>>((counts, bid) => {
+        counts[bid] = (counts[bid] ?? 0) + 1;
+        return counts;
+      }, {});
+
+      expect(new Set(bids).size).toBeGreaterThanOrEqual(4);
+      expect(Math.max(...Object.values(frequencies))).toBeLessThan(bids.length / 2);
+    }
   });
 });
 


### PR DESCRIPTION
## What changed
- removed the shared 8% opening survival floor that collapsed most AI bids to exactly 8
- gave every AI stable individual risk and volatility traits in addition to its broad personality
- mixed player identity into each bidding random stream so roster order cannot define strategy
- retained the stronger bank-relative survival floor only for the final three

## Root cause
With 16 players and a full 100-Eyeolen bank, the common survival floor evaluated to 8. Most personality calculations naturally produced bids below 8, so the final clamp overrode those strategies and turned them all into identical bids.

## Validation
- npm run typecheck
- 94 Trap Auction component and logic tests
- new 16-player regression runs 25 seeds, requires at least four distinct opening bids, and rejects any bid shared by half the AI field