### PR TITLE
Reuse time-machine results for organic last place

### DIFF
--- a/src/components/MinigameHost/MinigameHost.css
+++ b/src/components/MinigameHost/MinigameHost.css
@@ -338,15 +338,6 @@
   min-height: 0;
 }
 
-.minigame-host-leaderboard--preview {
-  flex: 0 0 auto;
-  overflow: hidden;
-}
-
-.minigame-host-leaderboard--preview .minigame-host-leaderboard-entry:nth-child(n + 4) {
-  display: none;
-}
-
 .minigame-host-results-actions {
   width: 100%;
   display: flex;
@@ -474,8 +465,6 @@
 .minigame-host-results-btn--retry:hover {
   background: #5551e3;
 }
-
-.minigame-host-results-btn--ranking:hover { background: rgba(110, 103, 245, .26); }
 
 @keyframes timeline-arrival {
   0% { opacity: 0; transform: translate3d(-9px, 0, 0) scale(1.04); filter: blur(2px); }
@@ -650,10 +639,6 @@
   gap: 7px;
 }
 
-.minigame-host-results--timeline .minigame-host-leaderboard--preview {
-  flex: 0 0 auto;
-}
-
 .minigame-host-results--timeline .minigame-host-leaderboard-entry {
   min-height: clamp(52px, 7.5vh, 66px);
   gap: 10px;
@@ -683,32 +668,6 @@
   gap: clamp(9px, 1.4vh, 13px);
   margin-top: 0;
 }
-
-.minigame-host-results--timeline .minigame-host-results-btn--ranking {
-  display: grid;
-  grid-template-columns: 32px 1fr 24px;
-  align-items: center;
-  min-height: clamp(52px, 7.2vh, 62px);
-  padding: 10px 18px;
-  border: 1.5px solid #8956ff;
-  border-radius: 11px;
-  color: #fbf9ff;
-  background: rgba(7, 10, 29, .72);
-  font-size: clamp(.95rem, 4vw, 1.1rem);
-}
-
-.minigame-host-results-ranking-icon {
-  display: flex;
-  height: 22px;
-  align-items: end;
-  gap: 3px;
-}
-
-.minigame-host-results-ranking-icon i { width: 5px; border-radius: 2px 2px 0 0; background: #f2efff; }
-.minigame-host-results-ranking-icon i:nth-child(1) { height: 12px; }
-.minigame-host-results-ranking-icon i:nth-child(2) { height: 20px; }
-.minigame-host-results-ranking-icon i:nth-child(3) { height: 15px; }
-.minigame-host-results-ranking-chevron { font-size: 1.8rem; font-weight: 300; line-height: 1; }
 
 .minigame-host-results--timeline .minigame-host-results-retry {
   gap: clamp(9px, 1.35vh, 13px);

--- a/src/components/MinigameHost/MinigameHost.tsx
+++ b/src/components/MinigameHost/MinigameHost.tsx
@@ -138,7 +138,6 @@ export default function MinigameHost({
   const [finalValue, setFinalValue] = useState<number | null>(null);
   const [finalTiebreakerMs, setFinalTiebreakerMs] = useState<number | null>(null);
   const [wasPartial, setWasPartial] = useState(false);
-  const [showFullRanking, setShowFullRanking] = useState(false);
   const rankingOnly = isPlacementRankingGame(game);
   const competitionRetryEnabled = competitionRetry?.enabled ?? false;
   const rulesGame = useMemo(
@@ -164,7 +163,6 @@ export default function MinigameHost({
   const handleRulesDismiss = useCallback(() => {
     setFinalValue(0);
     setWasPartial(true);
-    setShowFullRanking(false);
     setPhase('results');
   }, []);
 
@@ -201,7 +199,6 @@ export default function MinigameHost({
   const handleQuit = useCallback((partial: LegacyRawResult) => {
     setFinalValue(partial.value);
     setWasPartial(true);
-    setShowFullRanking(false);
     setPhase('results');
   }, []);
 
@@ -257,6 +254,8 @@ export default function MinigameHost({
     competitionRetryEnabled && !!humanLastPlaceEntry?.isHuman;
   const activeCompetitionRetry =
     showCompetitionRetry && competitionRetry ? competitionRetry : null;
+  const showOrganicLastPlace = showCompetitionRetry && !wasPartial;
+  const showTimeMachineResults = wasPartial || showOrganicLastPlace;
 
   const handleRetryRestart = useCallback(() => {
     setFinalValue(null);
@@ -665,9 +664,9 @@ export default function MinigameHost({
       )}
 
       {phase === 'results' && (
-        <div className={`minigame-host-results ${wasPartial ? 'minigame-host-results--timeline' : ''}`}>
-          {wasPartial && <div className="minigame-host-results-rift" aria-hidden="true" />}
-          {wasPartial && (
+        <div className={`minigame-host-results ${showTimeMachineResults ? 'minigame-host-results--timeline' : ''}`}>
+          {showTimeMachineResults && <div className="minigame-host-results-rift" aria-hidden="true" />}
+          {showTimeMachineResults && (
             <button
               type="button"
               className="minigame-host-results-close"
@@ -680,22 +679,27 @@ export default function MinigameHost({
               ×
             </button>
           )}
-          {wasPartial && <p className="minigame-host-results-kicker">Temporal rupture</p>}
+          {showTimeMachineResults && (
+            <p className="minigame-host-results-kicker">
+              {showOrganicLastPlace ? 'Alternative universe' : 'Temporal rupture'}
+            </p>
+          )}
           <h2 className="minigame-host-results-title">
-            {wasPartial ? 'Exited early' : '🏁 Finished!'}
+            {showOrganicLastPlace ? 'Is this real?' : wasPartial ? 'Exited early' : '🏁 Finished!'}
           </h2>
-          {wasPartial && <div className="minigame-host-results-divider" aria-hidden="true"><span /></div>}
+          {showTimeMachineResults && <div className="minigame-host-results-divider" aria-hidden="true"><span /></div>}
 
           {leaderboard ? (
             <>
-              {wasPartial && (
+              {showTimeMachineResults && (
                 <p className="minigame-host-results-alternate-timeline">
-                  You slipped out of the timeline. While you were gone, the competition resolved in
-                  an alternate universe.
+                  {showOrganicLastPlace
+                    ? "A time shift seems to have opened an alternative universe, because somehow you finished last. You're definitely not a loser, so this must be a temporal rift. Use the time machine to set things straight."
+                    : 'You slipped out of the timeline. While you were gone, the competition resolved in an alternate universe.'}
                 </p>
               )}
-              <p className={`minigame-host-results-winner ${wasPartial ? 'minigame-host-results-winner--timeline' : ''}`}>
-                {wasPartial && <span className="minigame-host-results-trophy" aria-hidden="true">🏆</span>}
+              <p className={`minigame-host-results-winner ${showTimeMachineResults ? 'minigame-host-results-winner--timeline' : ''}`}>
+                {showTimeMachineResults && <span className="minigame-host-results-trophy" aria-hidden="true">🏆</span>}
                 <span>
                   {leaderboard[0]?.name ?? 'Unknown'} wins
                   {leaderboard[0]?.isHuman ? " — that's you!" : '!'}
@@ -750,17 +754,6 @@ export default function MinigameHost({
           )}
 
           <div className="minigame-host-results-actions">
-            {wasPartial && leaderboard && (
-              <button
-                type="button"
-                className="minigame-host-results-btn minigame-host-results-btn--ranking"
-                onClick={() => setShowFullRanking((isShowing) => !isShowing)}
-              >
-                <span className="minigame-host-results-ranking-icon" aria-hidden="true"><i /><i /><i /></span>
-                <span>{showFullRanking ? 'Hide full ranking' : 'See full ranking'}</span>
-                <span className="minigame-host-results-ranking-chevron" aria-hidden="true">›</span>
-              </button>
-            )}
             {activeCompetitionRetry && (
               <div className="minigame-host-results-retry" role="group" aria-label="Competition retry">
                 <button
@@ -781,7 +774,7 @@ export default function MinigameHost({
               </div>
             )}
 
-            {(!wasPartial || !showCompetitionRetry) && (
+            {(!showTimeMachineResults || !showCompetitionRetry) && (
               <button
                 className="minigame-host-results-btn"
                 onClick={() => {

--- a/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
+++ b/src/components/MinigameHost/__tests__/MinigameHost.test.tsx
@@ -95,6 +95,7 @@ describe('MinigameHost competition retry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Exit minigame' }))
 
     expect(screen.getByText('Watch a short ad to retry before this result is locked in.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'See full ranking' })).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Reverse time' }))
 
@@ -125,7 +126,32 @@ describe('MinigameHost competition retry', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Finish Test Game' }))
 
-    expect(screen.queryByRole('button', { name: 'Watch Ad to Retry' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reverse time' })).toBeNull()
     expect(screen.getByRole('button', { name: 'Continue ▶' })).toBeInTheDocument()
+  })
+
+  it('uses the alternative-universe treatment when the human organically finishes last', () => {
+    render(
+      <MinigameHost
+        game={baseGame}
+        onDone={vi.fn()}
+        skipRules
+        skipCountdown
+        participants={makeParticipants(0, 50)}
+        competitionRetry={{ enabled: true, onWatch: vi.fn() }}
+      />,
+    )
+
+    act(() => {
+      vi.runAllTimers()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finish Test Game' }))
+
+    expect(screen.getByText('Alternative universe')).toBeInTheDocument()
+    expect(screen.getByText('Is this real?')).toBeInTheDocument()
+    expect(screen.getByText(/somehow you finished last/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reverse time' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /continue/i })).toBeNull()
   })
 })


### PR DESCRIPTION
## What changed
- removes the redundant See full ranking button and keeps the standings as the single scrollable list
- reuses the time-machine result treatment when the player organically finishes last
- uses Alternative universe, Is this real?, and dedicated last-place copy for that scenario
- keeps Temporal rupture and Exited early for early exits

## Validation
- npm run typecheck
- npx vitest run src/components/MinigameHost/__tests__/MinigameHost.test.tsx tests/unit/minigameHost.dismissal.test.tsx
- 15 targeted tests passed