### PR TITLE
Fix Survival action bar spacing

### DIFF
--- a/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -301,9 +301,9 @@ export default function FloatingActionBar({
     navigate('/');
   }, [dispatch, navigate]);
 
-  // Center the dock in the real rendered space between the roster's last row
-  // and the navbar. Device scaling and tile rounding can make nominally equal
-  // budget gaps render at noticeably different sizes.
+  // Center the dock in the real rendered space between the content immediately
+  // above it and the navbar. The whole houseguest section is the upper boundary
+  // because modes may append content after the roster list.
   useEffect(() => {
     const dock = dockRef.current;
     const gameScreen = dock?.closest<HTMLElement>('.game-screen');
@@ -311,14 +311,14 @@ export default function FloatingActionBar({
 
     let frameId = 0;
     const balanceDock = () => {
-      const roster = gameScreen.querySelector<HTMLElement>(
-        'section[aria-labelledby="houseguests-heading"] ul[role="list"]',
+      const contentAbove = gameScreen.querySelector<HTMLElement>(
+        'section[aria-labelledby="houseguests-heading"]',
       );
       const nav = document.querySelector<HTMLElement>('.nav-bar');
-      if (!roster || !nav) return;
+      if (!contentAbove || !nav) return;
 
       const gameRect = gameScreen.getBoundingClientRect();
-      const rosterRect = roster.getBoundingClientRect();
+      const contentRect = contentAbove.getBoundingClientRect();
       const dockRect = dock.getBoundingClientRect();
       const navRect = nav.getBoundingClientRect();
       if (dockRect.height <= 0) return;
@@ -331,7 +331,7 @@ export default function FloatingActionBar({
       const bottomOffset = resolveBalancedDockBottom({
         gameBottom: gameRect.bottom,
         lowerBoundary,
-        rosterBottom: rosterRect.bottom,
+        contentBottom: contentRect.bottom,
         dockHeight: dockRect.height,
         minimumGap,
       });

--- a/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
+++ b/src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx
@@ -108,14 +108,24 @@ function renderFAB(
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('FloatingActionBar – responsive placement', () => {
-  it('centers the dock between the fourth roster row and navbar', () => {
+  it('centers the dock between the content above it and navbar', () => {
     expect(resolveBalancedDockBottom({
       gameBottom: 800,
       lowerBoundary: 800,
-      rosterBottom: 600,
+      contentBottom: 600,
       dockHeight: 80,
       minimumGap: 8,
     })).toBe(60);
+  });
+
+  it('accounts for mode-specific content appended below the roster', () => {
+    expect(resolveBalancedDockBottom({
+      gameBottom: 800,
+      lowerBoundary: 800,
+      contentBottom: 660,
+      dockHeight: 80,
+      minimumGap: 8,
+    })).toBe(30);
   });
 });
 

--- a/src/components/FloatingActionBar/floatingActionBarLayout.ts
+++ b/src/components/FloatingActionBar/floatingActionBarLayout.ts
@@ -1,17 +1,17 @@
 export function resolveBalancedDockBottom({
   gameBottom,
   lowerBoundary,
-  rosterBottom,
+  contentBottom,
   dockHeight,
   minimumGap,
 }: {
   gameBottom: number;
   lowerBoundary: number;
-  rosterBottom: number;
+  contentBottom: number;
   dockHeight: number;
   minimumGap: number;
 }) {
-  const openSpace = lowerBoundary - rosterBottom - dockHeight;
+  const openSpace = lowerBoundary - contentBottom - dockHeight;
   const balancedGap = Math.max(minimumGap, openSpace / 2);
   return Math.max(minimumGap, gameBottom - lowerBoundary + balancedGap);
 }


### PR DESCRIPTION
## Summary

- position the action bar against the complete content section above it
- include Survival's standout card when calculating balanced navbar spacing
- add regression coverage for mode-specific content below the roster

## Root cause

PR #1166 measured the upper spacing boundary at the roster list. Survival renders a standout card after that list, so the action bar could overlap the card even though its spacing relative to the navbar was balanced.

## Impact

The action bar now maintains equal clearance between the nearest content above it and the navbar below it, including in Survival mode.

## Validation

- `npm test -- --run src/components/FloatingActionBar/__tests__/FloatingActionBar.test.tsx` (26 tests passed)
- `npm run typecheck`
- `git diff --check`
