### PR TITLE
Include Blackjack cutoff ties in finals

### DIFF
--- a/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
+++ b/src/components/BlackjackTournamentComp/BlackjackTournamentComp.tsx
@@ -510,29 +510,37 @@ export default function BlackjackTournamentComp({
   const { phase } = bt;
 
   if (phase === 'league_results') {
+    const finalistIds = bt.finalistIds ?? [];
+    const finalistCount = finalistIds.length;
     return (
       <div className="bjt-container bjt-result" role="region" aria-label="League rankings">
         <h2 className="bjt-title">📊 League Complete</h2>
         <p className="bjt-subtitle">
-          Every player has completed the round robin. The top three advance with 3 lives each.
+          The top three scores advance, and every tie at the cutoff qualifies. {finalistCount} players enter the finals with 3 lives each.
         </p>
         <div className="minigame-placement-list bjt-placement-list" role="list" aria-label="League standings">
-          {bt.leagueRankings.map((id, index) => (
+          {bt.leagueRankings.map((id) => {
+            const score = bt.leagueScores[id] ?? 0;
+            const sharedRank = bt.leagueRankings.findIndex(
+              (rankedId) => (bt.leagueScores[rankedId] ?? 0) === score,
+            ) + 1;
+            return (
             <div key={id} className="bjt-placement-item" role="listitem">
-              <span className="bjt-placement-rank">#{index + 1}</span>
+              <span className="bjt-placement-rank">#{sharedRank}</span>
               <img src={avatarForId(id)} alt={getName(id)} className="bjt-roster-avatar" />
               <span className="bjt-placement-name">{getName(id)}</span>
               <span className="bjt-placement-detail">{bt.leagueScores[id] ?? 0} pts</span>
-              {index < 3 && <span className="bjt-badge">FINALIST</span>}
+              {finalistIds.includes(id) && <span className="bjt-badge">FINALIST</span>}
             </div>
-          ))}
+            );
+          })}
         </div>
         <button
           type="button"
           className="bjt-btn bjt-btn--continue"
           onClick={() => dispatch(startFinalStage())}
         >
-          Start Final Three →
+          Start Finals →
         </button>
       </div>
     );
@@ -782,7 +790,7 @@ export default function BlackjackTournamentComp({
       <div className="bjt-container bjt-duel" role="region" aria-label="Blackjack duel">
         <h2 className="bjt-title">
           ⚔️ {isFinalDuelActive
-            ? 'Final Three Duel'
+            ? 'Finals Duel'
             : `League Match ${bt.leagueOpponentIndex + 1}/${bt.leagueOpponentIds.length}`}: {aName} vs {bName}
         </h2>
         {isFinalDuelActive && (

--- a/src/features/blackjackTournament/blackjackTournamentSlice.ts
+++ b/src/features/blackjackTournament/blackjackTournamentSlice.ts
@@ -87,7 +87,7 @@ export interface BlackjackTournamentState {
   leagueRankings: string[];
   leagueOpponentIds: string[];
   leagueOpponentIndex: number;
-  /** Top-three finalists, in league ranking order. */
+  /** Finalists in league ranking order, including every tie at the top-three cutoff. */
   finalistIds: string[] | null;
 
   humanPlayerId: string | null;
@@ -381,6 +381,18 @@ export function rankLeaguePlayers(
   );
 }
 
+/** Select the top three scores without using an invisible tiebreaker at the cutoff. */
+export function selectLeagueFinalists(
+  leagueRankings: string[],
+  scores: Record<string, number>,
+  guaranteedPlaces = 3,
+): string[] {
+  if (leagueRankings.length <= guaranteedPlaces) return [...leagueRankings];
+  const cutoffId = leagueRankings[guaranteedPlaces - 1];
+  const cutoffScore = scores[cutoffId] ?? 0;
+  return leagueRankings.filter((id) => (scores[id] ?? 0) >= cutoffScore);
+}
+
 function shuffleLeagueOpponents(ids: string[], seed: number): string[] {
   const result = [...ids];
   const rng = mulberry32((seed ^ 0x1ea6e001) >>> 0);
@@ -494,10 +506,11 @@ function dealDuelCards(
 function finishLeague(state: BlackjackTournamentState): void {
   state.leagueScores = { ...state.playerScores };
   state.leagueRankings = rankLeaguePlayers(state.allPlayerIds, state.leagueScores, state.seed);
-  const finalists = state.leagueRankings.slice(0, Math.min(3, state.leagueRankings.length));
+  const finalists = selectLeagueFinalists(state.leagueRankings, state.leagueScores);
   state.finalistIds = finalists;
   state.remainingPlayerIds = finalists;
-  state.eliminatedPlayerIds = state.leagueRankings.slice(finalists.length);
+  const finalistSet = new Set(finalists);
+  state.eliminatedPlayerIds = state.leagueRankings.filter((id) => !finalistSet.has(id));
   state.fighterAId = null;
   state.fighterBId = null;
   state.currentDuel = null;

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -992,8 +992,8 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     instructions: [
       'League: play one blackjack duel against every opponent while AI league matches resolve in the background.',
       'A league win adds 1 point and a league loss removes 1 point. Scores may go below zero.',
-      'After all league matches, only the top three players advance.',
-      'Final Three: all finalists reset to 3 lives. Winners keep their total; losers lose 1 life.',
+      'After all league matches, the top three scores advance. Everyone tied at the cutoff also qualifies.',
+      'Finals: all qualifiers reset to 3 lives. Winners keep their total; losers lose 1 life.',
       'The duel winner controls the next pairing. Reach 0 lives and you are eliminated.',
       'The last finalist with lives remaining wins the competition!',
     ],

--- a/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
+++ b/tests/unit/blackjackTournament/blackjackTournamentSlice.test.ts
@@ -29,6 +29,7 @@ import reducer, {
   resolveDuel,
   advanceFromDuelResult,
   markBlackjackTournamentOutcomeResolved,
+  selectLeagueFinalists,
   resetBlackjackTournament,
   computeTotal,
   cardRank,
@@ -385,7 +386,7 @@ describe('league to Final Three flow', () => {
     expect(Object.values(first.playerScores).some((score) => score < 0)).toBe(true);
   });
 
-  it('ranks everyone, cuts to three, and resets finalists to 3 lives', () => {
+  it('ranks everyone, includes cutoff ties, and resets finalists to 3 lives', () => {
     const store = initLeague(['user', 'a', 'b', 'c', 'd']);
     let safety = 500;
     while (getState(store).phase !== 'league_results' && safety-- > 0) {
@@ -399,15 +400,30 @@ describe('league to Final Three flow', () => {
     }
     const league = getState(store);
     expect(league.leagueRankings).toHaveLength(5);
-    expect(league.remainingPlayerIds).toEqual(league.leagueRankings.slice(0, 3));
-    expect(league.eliminatedPlayerIds).toEqual(league.leagueRankings.slice(3));
+    const expectedFinalists = selectLeagueFinalists(league.leagueRankings, league.leagueScores);
+    expect(league.remainingPlayerIds).toEqual(expectedFinalists);
+    expect(league.eliminatedPlayerIds).toEqual(
+      league.leagueRankings.filter((id) => !expectedFinalists.includes(id)),
+    );
 
     store.dispatch(startFinalStage());
     const final = getState(store);
     expect(final.stage).toBe('final');
     expect(final.phase).toBe('spin');
-    expect(final.remainingPlayerIds).toHaveLength(3);
+    expect(final.remainingPlayerIds).toHaveLength(expectedFinalists.length);
     final.remainingPlayerIds.forEach((id) => expect(final.playerScores[id]).toBe(3));
+  });
+
+  it('advances everyone tied with the third-place score', () => {
+    const rankings = ['lira', 'kang', 'sora', 'venn', 'zari', 'user'];
+    const scores = { lira: 2, kang: 0, sora: 0, venn: 0, zari: 0, user: 0 };
+    expect(selectLeagueFinalists(rankings, scores)).toEqual(rankings);
+  });
+
+  it('does not expand the finals when fourth place has a lower score', () => {
+    const rankings = ['a', 'b', 'c', 'd', 'e'];
+    const scores = { a: 3, b: 2, c: 1, d: 0, e: -1 };
+    expect(selectLeagueFinalists(rankings, scores)).toEqual(['a', 'b', 'c']);
   });
 });
 


### PR DESCRIPTION
## What changed
- advance every player tied at the third-place league score instead of slicing an invisibly ordered top three
- allow the existing life-based finals to begin with more than three qualifiers
- show shared ranks for tied league scores and mark every actual qualifier
- update the rules and UI wording from Final Three to Finals

## Root cause
League standings used a seeded hash to order equal scores, then selected the first three entries. The hash made the result deterministic but had no visible or gameplay justification, so equally scoring players were treated differently.

## Example
For scores 2, 0, 0, 0, 0, 0, the third-place cutoff is 0, so all six players now advance with three lives.

## Validation
- npm run typecheck
- 113 focused Blackjack Tournament tests