### PR TITLE
Fix and redesign Survival rules modal

### DIFF
--- a/src/components/ConfirmExitModal/SurvivorRulesModal.css
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.css
@@ -16,18 +16,22 @@
     radial-gradient(circle at bottom, rgba(15, 118, 255, 0.12), transparent 36%),
     rgba(3, 6, 14, 0.82);
   backdrop-filter: blur(16px);
+  height: 100dvh;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .survivor-rules-modal__card {
   position: relative;
   width: min(42rem, 100%);
-  max-height: min(
+  height: min(
     calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 32px),
     44rem
   );
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+  max-height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 24px;
@@ -93,12 +97,44 @@
   padding: 1.2rem 1.2rem 1rem;
 }
 
+.survivor-rules-modal__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.survivor-rules-modal__logo {
+  width: 2.75rem;
+  height: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 1px solid rgba(100, 180, 255, 0.45);
+  border-radius: 12px;
+  background: linear-gradient(135deg, #111827, #172554);
+  color: #78bfff;
+  font-size: 1.45rem;
+  font-weight: 900;
+  box-shadow: 0 0 18px rgba(100, 180, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
 .survivor-rules-modal__eyebrow {
-  margin: 0 0 0.55rem;
+  margin: 0 0 0.2rem;
   color: rgba(183, 194, 255, 0.9);
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.survivor-rules-modal__guide-label {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
@@ -123,50 +159,47 @@
   position: relative;
   z-index: 1;
   display: grid;
-  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: 0.65rem;
+  min-height: 0;
   padding: 0 1.2rem 1rem;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .survivor-rules-modal__rule {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.85rem;
-  align-items: flex-start;
-  padding: 0.9rem 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.36rem;
+  min-height: 7rem;
+  padding: 0.78rem 0.82rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 18px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.03)),
-    rgba(13, 18, 32, 0.92);
+  border-radius: 8px;
+  background: rgba(100, 180, 255, 0.055);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
-.survivor-rules-modal__rule-index {
+.survivor-rules-modal__rule-kicker {
+  align-self: flex-start;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
+  padding: 0.12rem 0.48rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.96), rgba(139, 92, 246, 0.96));
-  color: #f5f7ff;
-  font-size: 0.9rem;
-  font-weight: 900;
-  box-shadow:
-    0 10px 20px rgba(81, 83, 210, 0.22),
-    0 0 0 1px rgba(255, 255, 255, 0.1);
-}
-
-.survivor-rules-modal__rule-copy {
-  min-width: 0;
+  border: 1px solid rgba(100, 180, 255, 0.26);
+  background: rgba(100, 180, 255, 0.14);
+  color: #8ac6ff;
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
 }
 
 .survivor-rules-modal__rule-title {
   margin: 0;
-  color: #fff;
-  font-size: 0.98rem;
-  font-weight: 800;
+  color: #f4d67b;
+  font-size: 0.93rem;
+  font-weight: 700;
   line-height: 1.2;
 }
 
@@ -181,8 +214,11 @@
   position: relative;
   z-index: 1;
   display: grid;
-  gap: 0.9rem;
-  padding: 0 1.2rem 1.2rem;
+  gap: 0.7rem;
+  padding: 0.85rem 1.2rem 1.1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 11, 20, 0.98);
+  box-shadow: 0 -12px 24px rgba(3, 6, 14, 0.22);
 }
 
 .survivor-rules-modal__checkbox {
@@ -207,14 +243,15 @@
 }
 
 .survivor-rules-modal__actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.7rem;
   justify-content: flex-end;
-  flex-wrap: wrap;
 }
 
 .survivor-rules-modal__btn {
-  min-width: 11rem;
+  width: 100%;
+  min-width: 0;
 }
 
 .survivor-rules-modal__btn.game-button {
@@ -243,7 +280,7 @@
   }
 
   .survivor-rules-modal__card {
-    max-height: min(
+    height: min(
       calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 20px),
       44rem
     );
@@ -257,11 +294,11 @@
   }
 
   .survivor-rules-modal__rule {
-    padding: 0.82rem 0.85rem;
+    padding: 0.72rem 0.78rem;
   }
 
-  .survivor-rules-modal__actions {
-    flex-direction: column;
+  .survivor-rules-modal__rules {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .survivor-rules-modal__btn {
@@ -271,5 +308,29 @@
 
   .survivor-rules-modal__checkbox {
     width: 100%;
+  }
+}
+
+@media (max-width: 360px) {
+  .survivor-rules-modal__actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-height: 700px) {
+  .survivor-rules-modal__header {
+    padding-block: 0.85rem 0.7rem;
+  }
+
+  .survivor-rules-modal__brand {
+    margin-bottom: 0.55rem;
+  }
+
+  .survivor-rules-modal__desc {
+    margin-top: 0.5rem;
+  }
+
+  .survivor-rules-modal__footer {
+    padding-block: 0.65rem 0.75rem;
   }
 }

--- a/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
@@ -9,24 +9,24 @@ interface Props {
 
 const RULES = [
   {
-    title: 'Endless days',
-    description: 'Survive as long as you can. The run ends only when you are eliminated.',
+    kicker: 'RUN',
+    title: 'Endless survival',
+    description: 'There is no finale. Keep advancing through days until you are eliminated.',
   },
   {
-    title: 'Synthetic replacements',
-    description: 'AI contestants are replaced after eviction, keeping the house full.',
+    kicker: 'HOUSE',
+    title: 'The house stays full',
+    description: 'Every evicted AI is replaced, so each new day restores the pressure.',
   },
   {
-    title: 'Social mode off',
-    description: 'The AI players are not here to make friends.',
+    kicker: 'RULES',
+    title: 'Competition only',
+    description: 'Social and public modes are off. There are no alliances, audience saves, or approval shields.',
   },
   {
-    title: 'Public mode off',
-    description: 'No audience saves. No popularity shield. Only survival.',
-  },
-  {
+    kicker: 'RECORD',
     title: 'Every day counts',
-    description: 'Your highest Survival day and unlocked milestones are saved to your profile.',
+    description: 'Your best day and unlocked Survival milestones are saved to your profile.',
   },
 ] as const;
 
@@ -68,26 +68,28 @@ export default function SurvivorRulesModal({ open, onContinue, onCancel }: Props
         <div className="survivor-rules-modal__glow survivor-rules-modal__glow--right" aria-hidden="true" />
 
         <header className="survivor-rules-modal__header">
-          <p className="survivor-rules-modal__eyebrow">Survival Mode</p>
+          <div className="survivor-rules-modal__brand">
+            <span className="survivor-rules-modal__logo" aria-hidden="true">∞</span>
+            <div>
+              <p className="survivor-rules-modal__eyebrow">Survival Mode</p>
+              <p className="survivor-rules-modal__guide-label">The Big Eye — Survival Guide</p>
+            </div>
+          </div>
           <h2 id={titleId} className="survivor-rules-modal__title">
-            Before You Enter Survival
+            How Survival Works
           </h2>
           <p id={descId} className="survivor-rules-modal__desc">
-            Survival Mode is an endless pressure run. There is no finale, no public rescue,
-            and no social safety net.
+            The classical weekly structure becomes an endless elimination run. Win challenges,
+            survive each vote, and push your record as far as you can.
           </p>
         </header>
 
         <div className="survivor-rules-modal__rules" role="list" aria-label="Survival rules">
-          {RULES.map((rule, index) => (
+          {RULES.map((rule) => (
             <article className="survivor-rules-modal__rule" key={rule.title} role="listitem">
-              <div className="survivor-rules-modal__rule-index" aria-hidden="true">
-                {index + 1}
-              </div>
-              <div className="survivor-rules-modal__rule-copy">
-                <h3 className="survivor-rules-modal__rule-title">{rule.title}</h3>
-                <p className="survivor-rules-modal__rule-desc">{rule.description}</p>
-              </div>
+              <span className="survivor-rules-modal__rule-kicker">{rule.kicker}</span>
+              <h3 className="survivor-rules-modal__rule-title">{rule.title}</h3>
+              <p className="survivor-rules-modal__rule-desc">{rule.description}</p>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## What changed
- rebuilt the modal as header, independently scrollable rules, and a fixed in-flow footer
- removed the Android rule/footer overlap and added safe behavior for short non-iOS viewports
- redesigned the rules with the same kicker, gold-title, compact-card language used by the IntroHub classical guide
- consolidated five repetitive rules into four clearer Survival concepts
- placed Enter Survival and Back side by side on normal phones to reduce footer height

## Root cause
The flex layout allowed the rules child to retain an unsafe minimum content height inside a max-height card. Android WebView viewport sizing exposed the overflow, causing rule cards to continue beneath the footer. A mobile min-height override also let rule text spill between cards.

## Validation
- npm run typecheck
- 9 HomeHub tests
- visual verification at 412x915 and 360x740 Android-sized viewports
- confirmed independent scrolling, no card-to-card overlap, and the complete footer remains inside the modal