### PR TITLE
Bound Majority revotes and add spectator controls

### DIFF
--- a/src/components/MajorityRulesComp/MajorityRulesComp.css
+++ b/src/components/MajorityRulesComp/MajorityRulesComp.css
@@ -444,6 +444,7 @@ button.majority-rules-player-card:hover {
 .majority-rules-follow-target,
 .majority-rules-number-button,
 .majority-rules-primary,
+.majority-rules-secondary,
 .majority-rules-pill {
   appearance: none;
   border: 1px solid rgba(148, 163, 184, 0.24);
@@ -464,6 +465,7 @@ button.majority-rules-player-card:hover {
 .majority-rules-option:hover,
 .majority-rules-number-button:hover,
 .majority-rules-primary:hover,
+.majority-rules-secondary:hover,
 .majority-rules-pill:hover {
   transform: translateY(-1px);
   border-color: rgba(191, 219, 254, 0.62);
@@ -472,6 +474,7 @@ button.majority-rules-player-card:hover {
 .majority-rules-option:disabled,
 .majority-rules-number-button:disabled,
 .majority-rules-primary:disabled,
+.majority-rules-secondary:disabled,
 .majority-rules-pill:disabled {
   opacity: 0.56;
   transform: none;
@@ -608,6 +611,75 @@ button.majority-rules-player-card:hover {
   background: linear-gradient(180deg, #f97316, #c2410c);
   border-color: rgba(251, 146, 60, 0.72);
   box-shadow: 0 12px 28px rgba(194, 65, 12, 0.2);
+}
+
+.majority-rules-secondary {
+  justify-self: stretch;
+  border-radius: 18px;
+  padding: 0.98rem 1.15rem;
+  font-weight: 900;
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(148, 163, 184, 0.34);
+}
+
+.majority-rules-spectator-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding: calc(env(safe-area-inset-top, 0px) + 1rem) 1rem calc(env(safe-area-inset-bottom, 0px) + 1rem);
+  background: rgba(2, 6, 23, 0.82);
+  backdrop-filter: blur(12px);
+}
+
+.majority-rules-spectator-card {
+  width: min(100%, 28rem);
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+  box-shadow: 0 28px 70px rgba(2, 6, 23, 0.58);
+  color: #f8fafc;
+}
+
+.majority-rules-spectator-card h2,
+.majority-rules-spectator-card p {
+  margin: 0;
+}
+
+.majority-rules-spectator-card p {
+  color: #cbd5e1;
+  line-height: 1.55;
+}
+
+.majority-rules-spectator-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.majority-rules-fast-forward {
+  position: fixed;
+  inset: 0;
+  z-index: 35;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(2, 6, 23, 0.9);
+  color: #f8fafc;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
+@media (max-width: 420px) {
+  .majority-rules-spectator-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 body.no-animations .majority-rules-ambient,

--- a/src/components/MajorityRulesComp/MajorityRulesComp.tsx
+++ b/src/components/MajorityRulesComp/MajorityRulesComp.tsx
@@ -27,6 +27,9 @@ const INTRO_DELAY_MS = 5000;
 const AI_LOCK_DELAY_MS = 950;
 const AI_DUEL_DELAY_MS = 1250;
 const SPECTATOR_REVEAL_ADVANCE_DELAY_MS = 3000;
+const FAST_FORWARD_STEP_MS = 25;
+
+type SpectatorMode = 'playing' | 'pending' | 'watching' | 'skipping';
 
 const PHASE_MOTION = {
   initial: { opacity: 0, y: 18, scale: 0.985 },
@@ -380,6 +383,7 @@ export default function MajorityRulesComp({
   const game = useAppSelector((state: RootState) => state.majorityRules);
   const gamePlayers = useAppSelector((state: RootState) => state.game.players);
   const completedRef = useRef(false);
+  const [spectatorMode, setSpectatorMode] = useState<SpectatorMode>('playing');
   const [initialConfig] = useState<{
     participantIds: string[];
     competitionType: MajorityRulesCompetitionType;
@@ -436,6 +440,20 @@ export default function MajorityRulesComp({
     };
 
   const getName = (id: string) => getPlayer(id).name;
+  const humanIsEliminated = Boolean(
+    game.humanPlayerId && game.eliminatedIds.includes(game.humanPlayerId),
+  );
+
+  useEffect(() => {
+    if (
+      humanIsEliminated &&
+      spectatorMode === 'playing' &&
+      game.phase !== 'winner' &&
+      game.phase !== 'complete'
+    ) {
+      setSpectatorMode('pending');
+    }
+  }, [game.phase, humanIsEliminated, spectatorMode]);
 
   useEffect(() => {
     dispatch(initMajorityRules(initialConfig));
@@ -450,35 +468,50 @@ export default function MajorityRulesComp({
   useEffect(() => {
     const humanIsActive =
       game.humanPlayerId != null && game.activeIds.includes(game.humanPlayerId);
-    if (game.phase !== 'question' || humanIsActive) return undefined;
-    const timeout = window.setTimeout(() => dispatch(lockRound()), AI_LOCK_DELAY_MS);
+    if (game.phase !== 'question' || humanIsActive || spectatorMode === 'pending') return undefined;
+    const timeout = window.setTimeout(
+      () => dispatch(lockRound()),
+      spectatorMode === 'skipping' ? FAST_FORWARD_STEP_MS : AI_LOCK_DELAY_MS,
+    );
     return () => window.clearTimeout(timeout);
-  }, [dispatch, game.activeIds, game.humanPlayerId, game.phase]);
+  }, [dispatch, game.activeIds, game.humanPlayerId, game.phase, spectatorMode]);
 
   useEffect(() => {
-    if (game.phase !== 'final_duel_roll' || !game.finalDuel) return undefined;
+    if (game.phase !== 'final_duel_roll' || !game.finalDuel || spectatorMode === 'pending') return undefined;
     if (game.finalDuel.currentRollerId === game.humanPlayerId) return undefined;
-    const timeout = window.setTimeout(() => dispatch(rollFinalDuel()), AI_DUEL_DELAY_MS);
+    const timeout = window.setTimeout(
+      () => dispatch(rollFinalDuel()),
+      spectatorMode === 'skipping' ? FAST_FORWARD_STEP_MS : AI_DUEL_DELAY_MS,
+    );
     return () => window.clearTimeout(timeout);
-  }, [dispatch, game.finalDuel, game.humanPlayerId, game.phase]);
+  }, [dispatch, game.finalDuel, game.humanPlayerId, game.phase, spectatorMode]);
 
   useEffect(() => {
-    if (game.phase !== 'three_way_duel_roll' || !game.threeWayDuel) return undefined;
+    if (game.phase !== 'three_way_duel_roll' || !game.threeWayDuel || spectatorMode === 'pending') return undefined;
     if (game.threeWayDuel.currentRollerId === game.humanPlayerId) return undefined;
-    const timeout = window.setTimeout(() => dispatch(rollThreeWayDuel()), AI_DUEL_DELAY_MS);
+    const timeout = window.setTimeout(
+      () => dispatch(rollThreeWayDuel()),
+      spectatorMode === 'skipping' ? FAST_FORWARD_STEP_MS : AI_DUEL_DELAY_MS,
+    );
     return () => window.clearTimeout(timeout);
-  }, [dispatch, game.humanPlayerId, game.phase, game.threeWayDuel]);
+  }, [dispatch, game.humanPlayerId, game.phase, game.threeWayDuel, spectatorMode]);
 
   useEffect(() => {
     const humanIsStillActive =
       game.humanPlayerId != null && game.activeIds.includes(game.humanPlayerId);
-    if (game.phase !== 'reveal' || humanIsStillActive) return undefined;
+    if (game.phase !== 'reveal' || humanIsStillActive || spectatorMode === 'pending') return undefined;
     const timeout = window.setTimeout(
       () => dispatch(advanceReveal()),
-      SPECTATOR_REVEAL_ADVANCE_DELAY_MS,
+      spectatorMode === 'skipping' ? FAST_FORWARD_STEP_MS : SPECTATOR_REVEAL_ADVANCE_DELAY_MS,
     );
     return () => window.clearTimeout(timeout);
-  }, [dispatch, game.activeIds, game.humanPlayerId, game.phase]);
+  }, [dispatch, game.activeIds, game.humanPlayerId, game.phase, spectatorMode]);
+
+  useEffect(() => {
+    if (game.phase !== 'winner' || spectatorMode !== 'skipping') return undefined;
+    const timeout = window.setTimeout(() => dispatch(advanceWinner()), FAST_FORWARD_STEP_MS);
+    return () => window.clearTimeout(timeout);
+  }, [dispatch, game.phase, spectatorMode]);
 
   useEffect(() => {
     if (game.phase !== 'complete' || completedRef.current) return;
@@ -766,7 +799,9 @@ export default function MajorityRulesComp({
           <span className="majority-rules-kicker">The room speaks.</span>
           <h2 className="majority-rules-question">
             {reveal?.result.kind === 'revote'
-              ? 'Split house. Nobody is safe yet.'
+              ? reveal.revoteNumber >= 1
+                ? 'Still tied. This question is over.'
+                : 'Split house. One re-vote remains.'
               : reveal?.result.kind === 'unanimous'
                 ? 'A full sweep. Nobody falls this time.'
                 : tiedMinorityLabels.length > 0
@@ -775,7 +810,9 @@ export default function MajorityRulesComp({
           </h2>
           <p className="majority-rules-copy">
             {reveal?.result.kind === 'revote'
-              ? 'Every answer tied, so the house votes again.'
+              ? reveal.revoteNumber >= 1
+                ? 'The re-vote tied again, so a fresh question will replace it.'
+                : 'Every populated answer tied, so the house votes once more.'
               : reveal?.result.kind === 'unanimous'
                 ? 'No elimination this round. The next question starts fresh.'
                 : tiedMinorityLabels.length > 0
@@ -1145,6 +1182,28 @@ export default function MajorityRulesComp({
           </motion.div>
         )}
       </AnimatePresence>
+      {spectatorMode === 'pending' && (
+        <div className="majority-rules-spectator-overlay" role="dialog" aria-modal="true" aria-labelledby="majority-rules-spectator-title">
+          <div className="majority-rules-spectator-card">
+            <span className="majority-rules-badge majority-rules-badge--danger">Eliminated</span>
+            <h2 id="majority-rules-spectator-title">Stay for the rest of the vote?</h2>
+            <p>You can watch at normal speed or fast-forward the same live game directly to its final result.</p>
+            <div className="majority-rules-spectator-actions">
+              <button type="button" className="majority-rules-primary" onClick={() => setSpectatorMode('watching')}>
+                Continue watching
+              </button>
+              <button type="button" className="majority-rules-secondary" onClick={() => setSpectatorMode('skipping')}>
+                Skip to results
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {spectatorMode === 'skipping' && game.phase !== 'complete' && (
+        <div className="majority-rules-fast-forward" role="status" aria-live="polite">
+          Fast-forwarding the live game…
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/majorityRules/majorityRulesSlice.ts
+++ b/src/features/majorityRules/majorityRulesSlice.ts
@@ -5,7 +5,6 @@ import {
   buildPollEstimate,
   countAnswerDistribution,
   initializeDiceDuel,
-  initializeThreeWayDice,
   pickAiDuelNumber,
   pickMajorityRulesQuestion,
   resolveDiceDuelRoll,
@@ -119,18 +118,6 @@ function clearRoundHintState(state: MajorityRulesState) {
   state.roundHintPeekedAnswers = null;
 }
 
-function distributionsMatch(
-  left: Record<string, number> | null,
-  right: Record<string, number>,
-): boolean {
-  if (!left) return false;
-  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
-  for (const key of keys) {
-    if ((left[key] ?? 0) !== (right[key] ?? 0)) return false;
-  }
-  return true;
-}
-
 function prepareQuestion(state: MajorityRulesState) {
   const question = pickMajorityRulesQuestion(state.seed, state.roundNumber, state.usedQuestionIds);
   state.currentQuestion = question;
@@ -208,24 +195,6 @@ function ensureAiThreeWayDuelPicks(state: MajorityRulesState) {
   if (allPicked && state.phase === 'three_way_duel_pick') {
     state.phase = 'three_way_duel_roll';
   }
-}
-
-function advanceToThreeWayDuel(state: MajorityRulesState) {
-  if (state.activeIds.length !== 3) return;
-  state.currentQuestion = null;
-  state.draftAnswers = {};
-  state.revealState = null;
-  state.blockedAnswers = {};
-  state.revoteNumber = 0;
-  clearRoundHintState(state);
-  state.finalDuel = null;
-  state.threeWayDuel = initializeThreeWayDice([
-    state.activeIds[0],
-    state.activeIds[1],
-    state.activeIds[2],
-  ]);
-  state.phase = 'three_way_duel_pick';
-  ensureAiThreeWayDuelPicks(state);
 }
 
 function seedOpeningFinalDuel(state: MajorityRulesState) {
@@ -445,16 +414,12 @@ const majorityRulesSlice = createSlice({
     advanceReveal(state) {
       if (state.phase !== 'reveal' || !state.revealState) return;
       const { result } = state.revealState;
-      const repeatedThreeWayRevote =
-        state.activeIds.length === 3 &&
-        result.kind === 'revote' &&
-        state.revoteNumber > 0 &&
-        distributionsMatch(state.previousDistribution, result.distribution);
-
       state.previousDistribution = result.distribution;
 
       if (result.kind === 'revote') {
-        if (repeatedThreeWayRevote) {
+        // A tied ballot gets exactly one re-vote. If that also ties, discard
+        // the question so deterministic AI choices cannot repeat forever.
+        if (state.revoteNumber >= 1) {
           state.roundNumber += 1;
           state.revoteNumber = 0;
           state.previousDistribution = null;
@@ -463,12 +428,8 @@ const majorityRulesSlice = createSlice({
           state.phase = 'question';
           return;
         }
-        if (state.activeIds.length === 3 && state.revoteNumber >= 2) {
-          advanceToThreeWayDuel(state);
-          return;
-        }
         state.phase = 'question';
-        state.revoteNumber += 1;
+        state.revoteNumber = 1;
         state.blockedAnswers = { ...result.answers };
         state.draftAnswers = {};
         state.revealState = null;

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -406,7 +406,7 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
       'You get 3 hints for the whole game, and each hint can only be used once.',
       'Players in the minority are eliminated.',
       'If everyone picks the same answer, nobody leaves and the next round starts fresh.',
-      "If all 3 answers are split evenly, everyone re-votes up to 3 times before a 3-way dice tiebreaker.",
+      'A tied ballot gets one re-vote. If it is still tied, that question is discarded and a new one begins.',
       'If multiple minority answers tie beneath the majority, every tied minority player is eliminated.',
       'At the Final 2, the game becomes a dice duel.',
     ],

--- a/tests/integration/minigame.majorityRules.integration.test.ts
+++ b/tests/integration/minigame.majorityRules.integration.test.ts
@@ -95,7 +95,7 @@ describe('majorityRules registry entry', () => {
       'You get 3 hints for the whole game, and each hint can only be used once.',
     );
     expect(entry?.instructions).toContain(
-      "If all 3 answers are split evenly, everyone re-votes up to 3 times before a 3-way dice tiebreaker.",
+      'A tied ballot gets one re-vote. If it is still tied, that question is discarded and a new one begins.',
     );
   });
 });
@@ -249,7 +249,7 @@ describe('majorityRules initialization flow', () => {
     expect(retriedState.roundHintPollEstimate).toBeNull();
   });
 
-  it('moves a third straight 3-player draw into the 3-way dice tiebreak', () => {
+  it('replaces the question after one tied re-vote', () => {
     const question = MAJORITY_RULES_QUESTIONS[0];
     const store = configureStore({
       reducer: {
@@ -265,7 +265,7 @@ describe('majorityRules initialization flow', () => {
           eliminatedIds: [],
           humanPlayerId: 'p1',
           roundNumber: 4,
-          revoteNumber: 2,
+          revoteNumber: 1,
           currentQuestion: question,
           usedQuestionIds: [question.id],
           draftAnswers: {},
@@ -292,7 +292,7 @@ describe('majorityRules initialization flow', () => {
               tiedOptionIds: ['a', 'b', 'c'],
               eliminationCount: 1,
             },
-            revoteNumber: 2,
+            revoteNumber: 1,
           },
           threeWayDuel: null,
           finalDuel: null,
@@ -305,11 +305,11 @@ describe('majorityRules initialization flow', () => {
     store.dispatch(advanceReveal());
 
     const majorityRules = store.getState().majorityRules;
-    expect(majorityRules.phase).toBe('three_way_duel_pick');
-    expect(majorityRules.threeWayDuel?.finalists).toEqual(['p1', 'p2', 'p3']);
-    expect(majorityRules.threeWayDuel?.chosenNumbers.p1).toBeNull();
-    expect(majorityRules.threeWayDuel?.chosenNumbers.p2).toBeTypeOf('number');
-    expect(majorityRules.threeWayDuel?.chosenNumbers.p3).toBeTypeOf('number');
+    expect(majorityRules.phase).toBe('question');
+    expect(majorityRules.roundNumber).toBe(5);
+    expect(majorityRules.revoteNumber).toBe(0);
+    expect(majorityRules.currentQuestion?.id).not.toBe(question.id);
+    expect(majorityRules.blockedAnswers).toEqual({});
   });
 
   it('eliminates the third player after a 3-way dice tie and advances to the final duel', () => {

--- a/tests/unit/majorityRules/majorityRules.component.test.tsx
+++ b/tests/unit/majorityRules/majorityRules.component.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import majorityRulesReducer, {
@@ -199,7 +199,7 @@ describe('MajorityRulesComp', () => {
     expect(store.getState().majorityRules.draftAnswers.user).toBe(chosenOptionId);
   });
 
-  it('auto-advances reveal in 3 seconds when the eliminated user keeps spectating', async () => {
+  it('pauses after elimination and resumes normal timing when the user continues watching', async () => {
     vi.useFakeTimers();
     const question = MAJORITY_RULES_QUESTIONS[0];
     const store = makeStore(undefined, {
@@ -260,6 +260,15 @@ describe('MajorityRulesComp', () => {
 
     await act(async () => {});
     expect(store.getState().majorityRules.phase).toBe('reveal');
+    expect(screen.getByRole('button', { name: 'Continue watching' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Skip to results' })).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(store.getState().majorityRules.phase).toBe('reveal');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue watching' }));
 
     act(() => {
       vi.advanceTimersByTime(2999);
@@ -270,6 +279,67 @@ describe('MajorityRulesComp', () => {
       vi.advanceTimersByTime(1);
     });
     expect(store.getState().majorityRules.phase).toBe('question');
+    vi.useRealTimers();
+  });
+
+  it('fast-forwards the existing game state when the eliminated user skips to results', async () => {
+    vi.useFakeTimers();
+    const question = MAJORITY_RULES_QUESTIONS[0];
+    const store = makeStore(undefined, {
+      phase: 'question',
+      competitionType: 'LOH',
+      seed: 42,
+      participantIds: ['user', 'finn', 'mimi', 'rae'],
+      activeIds: ['finn', 'mimi', 'rae'],
+      eliminatedIds: ['user'],
+      humanPlayerId: 'user',
+      roundNumber: 12,
+      revoteNumber: 0,
+      currentQuestion: question,
+      usedQuestionIds: [question.id],
+      draftAnswers: {},
+      previousDistribution: null,
+      blockedAnswers: {},
+      doubleEliminationArmed: false,
+      hintInventories: {},
+      roundHintUsedBy: null,
+      roundHintType: null,
+      roundHintTargetId: null,
+      roundHintPollEstimate: null,
+      roundHintPeekedAnswers: null,
+      revealState: null,
+      threeWayDuel: null,
+      finalDuel: null,
+      winnerId: null,
+      outcomeResolved: false,
+    });
+
+    render(
+      <Provider store={store}>
+        <MajorityRulesComp
+          participantIds={['user', 'finn', 'mimi', 'rae']}
+          participants={[
+            { id: 'user', name: 'You', isHuman: true, precomputedScore: 0, previousPR: null },
+            { id: 'finn', name: 'Finn', isHuman: false, precomputedScore: 0, previousPR: null },
+            { id: 'mimi', name: 'Mimi', isHuman: false, precomputedScore: 0, previousPR: null },
+            { id: 'rae', name: 'Rae', isHuman: false, precomputedScore: 0, previousPR: null },
+          ]}
+          prizeType="LOH"
+          seed={42}
+        />
+      </Provider>,
+    );
+
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Skip to results' }));
+    expect(screen.getByRole('status')).toHaveTextContent('Fast-forwarding the live game');
+
+    act(() => vi.advanceTimersByTime(24));
+    expect(store.getState().majorityRules.phase).toBe('question');
+    act(() => vi.advanceTimersByTime(1));
+    expect(store.getState().majorityRules.phase).toBe('reveal');
+    expect(store.getState().majorityRules.roundNumber).toBe(12);
+    expect(store.getState().majorityRules.currentQuestion?.id).toBe(question.id);
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## What changed
- cap tied ballots at one re-vote
- discard the question and draw a fresh one if the re-vote also ties
- update reveal copy and the rules modal to describe the new limit
- pause gameplay when the human is eliminated and offer Continue watching or Skip to results
- make Skip run the existing Redux game at 25 ms steps through questions, reveals, and dice rolls
- auto-finish the winner screen only during fast-forward

## Root cause
For fields larger than three, every tied reveal returned to the same question and incremented revoteNumber without a universal cap. AI decisions are deterministic for a question and round, so an eliminated human could no longer break the repeated vote pattern.

## Result integrity
Skip to results never reinitializes Majority Rules and does not synthesize a replacement winner. It accelerates the same lockRound, advanceReveal, dice-roll, and advanceWinner reducers until the authoritative result is reached.

## Validation
- npm run typecheck
- 19 focused Majority Rules integration, component, and style tests