### PR TITLE
Require user opt-in for compact game layout

### DIFF
--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -78,6 +78,15 @@
   min-width: 0;
 }
 
+.scrollRoster .grid {
+  height: auto;
+  max-height: var(--game-roster-max-height, 40vh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+}
+
 .container[data-header-mode='persistent'] .headerRow {
   position: static;
   max-width: 100%;

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -237,9 +237,10 @@ export function computeResponsiveGameLayout(
   const minTvHeight = minTvViewportHeight + TV_CHROME_HEIGHT + TV_LOG_ROW_HEIGHT
   const normalWithoutHeader = normalRosterHeight - ROSTER_HEADER_HEIGHT
   const compactWithoutHeader = compactRosterHeight - ROSTER_HEADER_HEIGHT
-  const normalControlsFullRosterFits =
-    !shouldUseCompactBase && normalRosterHeight + minTvHeight <= normalAvailableAfterTv
-  const bottomControlsMode: BottomControlsMode = normalControlsFullRosterFits ? 'normal' : 'compact'
+  // Compact presentation is an explicit accessibility/display preference. A
+  // cramped viewport may scroll the roster, but must not silently opt the user
+  // into smaller tiles or controls.
+  const bottomControlsMode: BottomControlsMode = input.userCompactRoster ? 'compact' : 'normal'
   const availableAfterTv =
     bottomControlsMode === 'normal' ? normalAvailableAfterTv : compactAvailableAfterTv
   const selectedNavHeight = bottomControlsMode === 'normal' ? normalNavHeight : compactNavHeight
@@ -247,11 +248,12 @@ export function computeResponsiveGameLayout(
     bottomControlsMode === 'normal' ? normalNavContentHeight : compactNavContentHeight
   const selectedDockHeight = bottomControlsMode === 'normal' ? normalDockHeight : compactDockHeight
   const dockClearance = bottomControlsMode === 'normal' ? normalDockClearance : compactDockClearance
-  const normalStaticFitsAfterCompactControls =
-    !shouldUseCompactBase && normalWithoutHeader + minTvHeight <= compactAvailableAfterTv
   const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> =
-    input.userCompactRoster || !normalStaticFitsAfterCompactControls ? 'compact-small' : 'normal'
-  const rosterMode: ResponsiveRosterMode = baseRosterMode
+    input.userCompactRoster ? 'compact-small' : 'normal'
+  const normalStaticFits =
+    !shouldUseCompactBase && normalWithoutHeader + minTvHeight <= normalAvailableAfterTv
+  const rosterMode: ResponsiveRosterMode =
+    !input.userCompactRoster && !normalStaticFits ? 'scroll' : baseRosterMode
   const baseAvatarTileSize = baseRosterMode === 'compact-small' ? compactTileSize : normalTileSize
   const baseRosterHeight =
     baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
@@ -282,7 +284,9 @@ export function computeResponsiveGameLayout(
   const tvHeight = minTvHeight + extraLogRows * TV_LOG_ROW_HEIGHT + breathingRoom
   const tvViewportHeight = minTvViewportHeight + breathingRoom
   const compactRoster = baseRosterMode === 'compact-small'
-  const rosterMaxHeight = baseRosterHeightWithoutHeader
+  const rosterMaxHeight = rosterMode === 'scroll'
+    ? Math.max(normalTileSize, availableAfterTv - minTvHeight)
+    : baseRosterHeightWithoutHeader
   const avatarTileSize = baseAvatarTileSize
   const avatarTileSizePx = Math.max(0, Math.floor(avatarTileSize))
   const actionDockScale = bottomControlsMode === 'normal' ? 1 : COMPACT_DOCK_SCALE

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -43,7 +43,7 @@ describe('responsive game layout budget', () => {
     })
   })
 
-  it('uses compact bottom controls before compacting an iPhone Pro-like roster', () => {
+  it('does not enable compact mode without user consent on an iPhone Pro-like screen', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportHeight: 852,
@@ -53,23 +53,23 @@ describe('responsive game layout budget', () => {
     )
 
     expect(budget.layoutSize).toBe('phone-large')
-    expect(budget.bottomControlsMode).toBe('compact')
+    expect(budget.bottomControlsMode).toBe('normal')
     expect(budget.baseRosterMode).toBe('normal')
-    expect(budget.rosterMode).toBe('normal')
+    expect(budget.rosterMode).toBe('scroll')
     expect(budget.rosterHeaderMode).toBe('tv-chip')
     expect(budget.compactRoster).toBe(false)
     expect(budget.cssVars).toMatchObject({
-      '--game-bottom-controls-mode': 'compact',
-      '--game-action-dock-scale': '0.9',
-      '--game-nav-height': '46px',
-      '--game-nav-item-label-display': 'none',
+      '--game-bottom-controls-mode': 'normal',
+      '--game-action-dock-scale': '1',
+      '--game-nav-height': '60px',
+      '--game-nav-item-label-display': 'block',
       '--game-roster-board-height': '335px',
     })
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
     expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
   })
 
-  it('keeps iPhone Pro bottom controls stable after compact controls resize themselves', () => {
+  it('keeps user-selected normal controls stable across viewport measurements', () => {
     const normalMeasuredBudget = computeResponsiveGameLayout(
       makeInput({
         viewportHeight: 852,
@@ -89,8 +89,8 @@ describe('responsive game layout budget', () => {
       })
     )
 
-    expect(normalMeasuredBudget.bottomControlsMode).toBe('compact')
-    expect(compactMeasuredBudget.bottomControlsMode).toBe('compact')
+    expect(normalMeasuredBudget.bottomControlsMode).toBe('normal')
+    expect(compactMeasuredBudget.bottomControlsMode).toBe('normal')
     expect(compactMeasuredBudget.signature).toBe(normalMeasuredBudget.signature)
   })
 
@@ -124,7 +124,7 @@ describe('responsive game layout budget', () => {
       '--game-avatar-tile-size': `${dayEndBudget.avatarTileSize}px`,
     })
     expect(dayEndBudget.rosterMode).toBe('normal')
-    expect(liveVoteBudget.rosterMode).toBe('normal')
+    expect(liveVoteBudget.rosterMode).toBe('scroll')
   })
 
   it('keeps normal premium controls on iPhone Pro Max-like screens when full roster fits', () => {
@@ -165,8 +165,8 @@ describe('responsive game layout budget', () => {
     expect(budget.cssVars).toMatchObject({
       '--game-safe-top': '44px',
     })
-    expect(['normal', 'compact']).toContain(budget.bottomControlsMode)
-    expect(budget.rosterMode).toBe('normal')
+    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.rosterMode).toBe('scroll')
     expect(budget.compactRoster).toBe(false)
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
     const dockGap = readCssPx(budget, '--game-action-dock-gap')
@@ -175,7 +175,7 @@ describe('responsive game layout budget', () => {
     expect(dockClearance).toBe(dockHeight + dockGap * 2)
   })
 
-  it('tries compact bottom controls before compact roster fallback on small old phones', () => {
+  it('uses scrolling rather than silently enabling compact mode on small old phones', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportWidth: 320,
@@ -187,9 +187,9 @@ describe('responsive game layout budget', () => {
     )
 
     expect(budget.layoutSize).toBe('phone-small')
-    expect(budget.bottomControlsMode).toBe('compact')
-    expect(budget.rosterMode).toBe('compact-small')
-    expect(budget.compactRoster).toBe(true)
+    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.compactRoster).toBe(false)
     expect(budget.rosterHeaderMode).toBe('tv-chip')
   })
 
@@ -207,7 +207,7 @@ describe('responsive game layout budget', () => {
 
     expect(budget.layoutSize).toBe('phone-medium')
     expect(budget.shellMaxWidth).toBe(480)
-    expect(budget.rosterMode).not.toBe('scroll')
+    expect(budget.rosterMode).toBe('scroll')
     expect(budget.cssVars).toMatchObject({
       '--game-cabinet-max-width': '480px',
       '--game-shell-max-width': '480px',


### PR DESCRIPTION
## What changed
- Compact roster tiles and compact controls now activate only when the user enables Compact mode.
- Cramped screens retain the normal presentation and use a bounded scrollable roster instead.
- Responsive layout coverage now includes iPhone, Android, small-phone, and tablet cases.

## Root cause
The responsive height budget treated compact mode as an automatic overflow fallback, overriding the saved user preference.

## Validation
- `npm test -- --run tests/unit/layout/responsiveGameLayout.test.ts` (13 passed)
- `npm run typecheck`
- `git diff --check`