### PR TITLE
Remove automatic user eviction vote bias

### DIFF
--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -109,7 +109,6 @@ const PHASE_ORDER: Phase[] = [
 const IMMUNITY_REPLACEMENT_SEED_MODIFIER = 0x51c4f1d3;
 const DAY_START_SHOCK_MIN_WEEK = 3;
 const DAY_START_SHOCK_RNG_SALT = 0x7c2f5d19;
-const AI_USER_THREAT_WEIGHT = 6;
 const AI_LOH_REVENGE_THREAT_WEIGHT = 6;
 const AI_LOH_BASE_THREAT_WEIGHT = 2;
 const AI_LOH_WIN_THREAT_WEIGHT = 4;
@@ -594,7 +593,6 @@ function getAiThreatScore(
   const posWins = player.stats?.posWins ?? 0;
   const timesNominated = player.stats?.timesNominated ?? 0;
   let score = 0;
-  if (player.isUser) score += AI_USER_THREAT_WEIGHT;
   if (player.id === state.lohId) {
     score += options.preferLoh === true
       ? AI_LOH_REVENGE_THREAT_WEIGHT

--- a/tests/unit/gameSlice.relationshipDecisions.test.ts
+++ b/tests/unit/gameSlice.relationshipDecisions.test.ts
@@ -12,7 +12,40 @@ function player(id: string): Player {
   } as Player;
 }
 
+function userPlayer(id: string): Player {
+  return { ...player(id), isUser: true };
+}
+
 describe('relationship-aware AI eviction decisions', () => {
+  it('does not treat the human as an automatic eviction threat', () => {
+    const voters = Array.from({ length: 12 }, (_, index) => player(`voter-${index}`));
+    const state = {
+      week: 4,
+      lohId: 'loh',
+      players: [...voters, userPlayer('user'), player('ai')],
+      strategicRelationships: {},
+    } as GameState;
+
+    const votes = voters.map((voter) =>
+      chooseAiEvictionVote(state, voter.id, ['user', 'ai'], 42),
+    );
+
+    expect(new Set(votes)).toEqual(new Set(['user', 'ai']));
+  });
+
+  it('uses accomplishments rather than player type to identify a threat', () => {
+    const provenThreat = player('proven-threat');
+    provenThreat.stats = { lohWins: 2, posWins: 1, timesNominated: 1 };
+    const state = {
+      week: 4,
+      lohId: 'loh',
+      players: [player('voter'), userPlayer('user'), provenThreat],
+      strategicRelationships: {},
+    } as GameState;
+
+    expect(chooseAiEvictionVote(state, 'voter', ['user', 'proven-threat'], 42))
+      .toBe('proven-threat');
+  });
   it('normally protects an ally instead of voting randomly', () => {
     const state = {
       week: 4,


### PR DESCRIPTION
## What changed
- Removed the fixed threat bonus applied solely because a nominee is the human player.
- AI eviction votes still consider actual LOH/POS wins, current power, nomination history, affinity, alliances, protection, targets, betrayal, and rare backstabs.
- Added regression coverage proving comparable human and AI nominees can both receive votes, while accomplished competitors remain valid strategic targets.

## Root cause
The human-only threat bonus was multiplied by the eviction scoring formula, creating an approximately 48-point advantage over an otherwise comparable AI nominee. Independent AI voters therefore reached the same decision and unanimously targeted the user.

## Validation
- `npm test -- --run tests/unit/gameSlice.relationshipDecisions.test.ts` (4 passed)
- `npm run typecheck`
- `git diff --check`