### PR TITLE
Add distinctive IntroHub button icons

### DIFF
--- a/public/assets/intro_hub_icons/back.svg
+++ b/public/assets/intro_hub_icons/back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="7" y1="8" x2="25" y2="24" gradientUnits="userSpaceOnUse"><stop stop-color="#D9FAFF"/><stop offset=".55" stop-color="#87E2FF"/><stop offset="1" stop-color="#A17CFF"/></linearGradient></defs>
+  <path d="M12 8 5 14.2l7 6.2v-3.6h7.2c3.2 0 5 1.5 6.8 5.1-.1-7.4-2.7-10.4-7.3-10.4H12V8Z" fill="#5548B2" stroke="url(#a)" stroke-width="1.6" stroke-linejoin="round"/><path d="M18 22.6c2.1-2.3 5.4-2.3 7.5 0-2.1 2.3-5.4 2.3-7.5 0Z" fill="#322D68" stroke="#EAFBFF" stroke-width="1"/><circle cx="21.8" cy="22.6" r="1.25" fill="#8EE6FF"/>
+</svg>

--- a/public/assets/intro_hub_icons/campaign.svg
+++ b/public/assets/intro_hub_icons/campaign.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="8" y1="6" x2="24" y2="27" gradientUnits="userSpaceOnUse"><stop stop-color="#DDFBFF"/><stop offset=".5" stop-color="#86E3FF"/><stop offset="1" stop-color="#A47DFF"/></linearGradient></defs>
+  <path d="m4.5 14.2 11.5-9 11.5 9" stroke="#F1FCFF" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7.5 12.4v13.3h17V12.4L16 6l-8.5 6.4Z" fill="#40397E" fill-opacity=".86" stroke="url(#a)" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M10.4 16c2.8-3.1 8.4-3.1 11.2 0-2.8 3.1-8.4 3.1-11.2 0Z" fill="#292655" stroke="#C9F7FF" stroke-width="1.1"/>
+  <circle cx="16" cy="16" r="2.15" fill="#8C73FF" stroke="#F3FDFF" stroke-width=".75"/>
+  <path d="M12 25.7v-5h8v5M9.8 9.7l2.1-3.4 2 1.2" stroke="#8EE7FF" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/assets/intro_hub_icons/credits.svg
+++ b/public/assets/intro_hub_icons/credits.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="8" y1="7" x2="24" y2="26" gradientUnits="userSpaceOnUse"><stop stop-color="#D9FAFF"/><stop offset=".52" stop-color="#84E0FF"/><stop offset="1" stop-color="#A27AFF"/></linearGradient></defs>
+  <path d="M6.2 11.7h20v14.1h-20z" fill="#3F397C" stroke="url(#a)" stroke-width="1.5" stroke-linejoin="round"/><path d="m5.4 7.7 20.2-2.5.7 5.2-20.2 2.5-.7-5.2Z" fill="#6859CD" stroke="#F3FDFF" stroke-width="1.4" stroke-linejoin="round"/><path d="m9.7 7.2 3.2 4.2M17.3 6.3l3.2 4.2" stroke="#9DEBFF" stroke-width="1.3"/><path d="M10.5 18.5c2.8-3.2 8.2-3.2 11 0-2.8 3.2-8.2 3.2-11 0Z" fill="#292654" stroke="url(#a)" stroke-width="1.2"/><circle cx="16" cy="18.5" r="2.1" fill="#8A73FF" stroke="#E9FBFF" stroke-width=".8"/>
+</svg>

--- a/public/assets/intro_hub_icons/housemates.svg
+++ b/public/assets/intro_hub_icons/housemates.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="7" y1="6" x2="25" y2="27" gradientUnits="userSpaceOnUse"><stop stop-color="#DDFBFF"/><stop offset=".5" stop-color="#85E3FF"/><stop offset="1" stop-color="#A37CFF"/></linearGradient></defs>
+  <path d="M4.7 13.4 16 5l11.3 8.4" stroke="#F2FDFF" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7.6 11.5v14.3h16.8V11.5L16 5.3l-8.4 6.2Z" fill="#3D3778" fill-opacity=".88" stroke="url(#a)" stroke-width="1.45" stroke-linejoin="round"/>
+  <circle cx="12.7" cy="15" r="2.35" fill="#8170E8" stroke="#DDFBFF" stroke-width="1"/>
+  <circle cx="19.3" cy="15" r="2.35" fill="#8170E8" stroke="#DDFBFF" stroke-width="1"/>
+  <path d="M8.9 22.8c.35-3 1.65-4.6 3.8-4.6 1.4 0 2.45.7 3.15 2.05.75-1.35 1.8-2.05 3.45-2.05 2.15 0 3.45 1.6 3.8 4.6" fill="#5B4EC3" fill-opacity=".72" stroke="url(#a)" stroke-width="1.35" stroke-linecap="round"/>
+  <path d="M10.4 15c1.15-1.3 3.45-1.3 4.6 0M17 15c1.15-1.3 3.45-1.3 4.6 0" stroke="#9CEEFF" stroke-width=".8" stroke-linecap="round"/>
+</svg>

--- a/public/assets/intro_hub_icons/leaderboard.svg
+++ b/public/assets/intro_hub_icons/leaderboard.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="9" y1="7" x2="23" y2="26" gradientUnits="userSpaceOnUse"><stop stop-color="#DDFBFF"/><stop offset=".5" stop-color="#86E1FF"/><stop offset="1" stop-color="#A27CFF"/></linearGradient></defs>
+  <path d="M4.5 25.8V19h7.2v6.8M11.7 25.8V15.2h8.6v10.6M20.3 25.8v-8.3h7.2v8.3" fill="#4E459B" fill-opacity=".72" stroke="url(#a)" stroke-width="1.5" stroke-linejoin="round"/><path d="M3.3 26h25.4" stroke="#fff" stroke-width="1.5" stroke-linecap="round"/><path d="m16 4.7 1.5 2.2 2.6.7-1.7 2.1.1 2.7-2.5-.9-2.5.9.1-2.7-1.7-2.1 2.6-.7L16 4.7Z" fill="url(#a)" stroke="#fff" stroke-width=".9" stroke-linejoin="round"/><path d="M13.4 8.6c1.3-1.3 3.9-1.3 5.2 0-1.3 1.3-3.9 1.3-5.2 0Z" fill="#6252D8"/><circle cx="16" cy="8.6" r=".72" fill="#D8FAFF"/>
+</svg>

--- a/public/assets/intro_hub_icons/play.svg
+++ b/public/assets/intro_hub_icons/play.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="11" y1="9" x2="22" y2="24" gradientUnits="userSpaceOnUse"><stop stop-color="#D9F8FF"/><stop offset=".46" stop-color="#8DDCFF"/><stop offset="1" stop-color="#A98AFF"/></linearGradient></defs>
+  <path d="M2.8 16s4.9-7.3 13.2-7.3S29.2 16 29.2 16 24.3 23.3 16 23.3 2.8 16 2.8 16Z" fill="#7864E8" fill-opacity=".34" stroke="#EFFCFF" stroke-width="1.7"/>
+  <path d="m13.4 11.9 7.4 4.1-7.4 4.1v-8.2Z" fill="url(#a)" stroke="#fff" stroke-width=".8" stroke-linejoin="round"/>
+  <path d="M4.8 16h2.4M24.8 16h2.4" stroke="#8FE9FF" stroke-width="1.3" stroke-linecap="round"/>
+</svg>

--- a/public/assets/intro_hub_icons/profile.svg
+++ b/public/assets/intro_hub_icons/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="10" y1="8" x2="22" y2="25" gradientUnits="userSpaceOnUse"><stop stop-color="#B9F4FF"/><stop offset="1" stop-color="#9B76FF"/></linearGradient></defs>
+  <path d="M6 11V6h5M21 6h5v5M26 21v5h-5M11 26H6v-5" stroke="#EAFBFF" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><circle cx="16" cy="13" r="4" fill="#403B83" stroke="url(#a)" stroke-width="1.7"/><path d="M8.8 24c.7-4.1 3.2-6.3 7.2-6.3s6.5 2.2 7.2 6.3" fill="#5B4EC5" fill-opacity=".68" stroke="url(#a)" stroke-width="1.7" stroke-linecap="round"/><path d="M12.8 13c1.6-1.8 4.8-1.8 6.4 0-1.6 1.8-4.8 1.8-6.4 0Z" fill="#BDF6FF"/><circle cx="16" cy="13" r="1" fill="#6453DF"/>
+</svg>

--- a/public/assets/intro_hub_icons/rules.svg
+++ b/public/assets/intro_hub_icons/rules.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="9" y1="5" x2="23" y2="27" gradientUnits="userSpaceOnUse"><stop stop-color="#9FEAFF"/><stop offset="1" stop-color="#8A6EFF"/></linearGradient></defs>
+  <path d="M8.2 5.1h12.6l3 3v18.1H8.2V5.1Z" fill="#34336D" stroke="#F4FDFF" stroke-width="1.5" stroke-linejoin="round"/><path d="M20.8 5.1v3.2h3" fill="#7399F2" stroke="#F4FDFF" stroke-width="1.2" stroke-linejoin="round"/>
+  <path d="M11.5 11.4h7.8M11.5 15.2h9M11.5 19h5.7" stroke="url(#a)" stroke-width="1.6" stroke-linecap="round"/><path d="M17.8 22.3c1.2-1.5 3.6-1.5 4.8 0-1.2 1.5-3.6 1.5-4.8 0Z" fill="#9CEBFF" stroke="#fff" stroke-width=".65"/><circle cx="20.2" cy="22.3" r=".8" fill="#604DE1"/><path d="M5.3 9v13.6" stroke="#8EDFFF" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/public/assets/intro_hub_icons/survival.svg
+++ b/public/assets/intro_hub_icons/survival.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <defs><linearGradient id="a" x1="9" y1="5" x2="24" y2="27" gradientUnits="userSpaceOnUse"><stop stop-color="#DFFBFF"/><stop offset=".48" stop-color="#83E7FF"/><stop offset="1" stop-color="#A578FF"/></linearGradient></defs>
+  <path d="M16 4.7 25.1 8v7.2c0 5.8-3.3 9.7-9.1 12.1-5.8-2.4-9.1-6.3-9.1-12.1V8L16 4.7Z" fill="#3C3776" stroke="url(#a)" stroke-width="1.65" stroke-linejoin="round"/>
+  <path d="M9.9 16h3l1.5-4.1 2.6 8.2 1.8-5 1.1 2.2h2.3" stroke="#EAFDFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11.2 10.2c2.4-2.5 7.2-2.5 9.6 0-2.4 2.5-7.2 2.5-9.6 0Z" fill="#8CEAFF" fill-opacity=".3" stroke="#9CEEFF" stroke-width=".9"/>
+  <circle cx="16" cy="10.2" r="1.35" fill="#987BFF" stroke="#F4FDFF" stroke-width=".55"/>
+</svg>

--- a/src/screens/HomeHub/HomeHub.css
+++ b/src/screens/HomeHub/HomeHub.css
@@ -125,6 +125,19 @@ body:has(.homehub-shell) .app-shell {
   animation: hub-nav-enter 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
+.home-hub__button-icon {
+  display: block;
+  width: 27px;
+  height: 27px;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 4px rgba(20, 16, 72, 0.5));
+}
+
+.game-btn--secondary_small .home-hub__button-icon {
+  width: 25px;
+  height: 25px;
+}
+
 @keyframes hub-nav-enter {
   from {
     opacity: 0;

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
@@ -46,6 +46,29 @@ import {
 import { buildAchievementSummary } from '../../store/achievementSummary';
 import './HomeHub.css';
 
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+type HomeHubIconName =
+  | 'play'
+  | 'rules'
+  | 'profile'
+  | 'leaderboard'
+  | 'credits'
+  | 'campaign'
+  | 'survival'
+  | 'back';
+
+function HomeHubButtonIcon({ name }: { name: HomeHubIconName }) {
+  return (
+    <img
+      className="home-hub__button-icon"
+      src={`${BASE}/assets/intro_hub_icons/${name}.svg`}
+      alt=""
+      draggable={false}
+    />
+  );
+}
+
 /**
  * HomeHub — entry screen with BB hero branding and button stack.
  *
@@ -62,12 +85,12 @@ import './HomeHub.css';
  *   5. When Play is pressed AssetPreloaderOverlay runs then navigates to /game.
  */
 const HUB_BUTTONS = [
-  { to: '/game',         label: 'Play',        icon: '▶',  variant: 'primary_large'    },
-  { to: '/rules',        label: 'Rules',       icon: '📋', variant: 'secondary_medium' },
-  { to: '/profile',      label: 'Profile',     icon: '👤', variant: 'secondary_medium' },
-  { to: '/leaderboard',  label: 'Leaderboard', icon: '🏆', variant: 'secondary_wide'   },
-  { to: '/credits',      label: 'Credits',     icon: '🎬', variant: 'secondary_small'  },
-] as const satisfies ReadonlyArray<{ to: string; label: string; icon: string; variant: GameButtonVariant }>;
+  { to: '/game',         label: 'Play',        icon: 'play',        variant: 'primary_large'    },
+  { to: '/rules',        label: 'Rules',       icon: 'rules',       variant: 'secondary_medium' },
+  { to: '/profile',      label: 'Profile',     icon: 'profile',     variant: 'secondary_medium' },
+  { to: '/leaderboard',  label: 'Leaderboard', icon: 'leaderboard', variant: 'secondary_wide'   },
+  { to: '/credits',      label: 'Credits',     icon: 'credits',     variant: 'secondary_small'  },
+] as const satisfies ReadonlyArray<{ to: string; label: string; icon: HomeHubIconName; variant: GameButtonVariant }>;
 
 type ClassicPrompt = 'resume-or-new' | 'confirm-new' | null;
 type SurvivorPrompt = 'resume-or-new' | 'ended' | 'confirm-new' | null;
@@ -78,26 +101,10 @@ interface HubAssetState {
   status: string;
 }
 
-function snapshotDay(snapshot: SavedSeasonSnapshot | null | undefined): number | null {
-  const day = snapshot?.game?.week;
-  return typeof day === 'number' && Number.isFinite(day) ? day : null;
-}
-
-function buildModeLabel(mode: GameMode, snapshot: SavedSeasonSnapshot | null | undefined): string {
-  const day = snapshotDay(snapshot);
-  if (mode === 'classic') return day ? `Classic Day ${day}` : 'Classic Campaign';
-  const survivorState = snapshot?.game?.modeSpecific?.kind === 'survival'
-    ? snapshot.game.modeSpecific
-    : null;
-  if (day) return `Survival Day ${day}`;
-  if (survivorState?.bestDayReached) return `Survival Best ${survivorState.bestDayReached}`;
-  return 'Survival Mode';
-}
-
 interface PlaySelectionButton {
   key: string;
   label: string;
-  icon: string;
+  icon: ReactNode;
   variant: GameButtonVariant;
   onClick: () => void;
 }
@@ -166,7 +173,7 @@ function HomeHubAssetLayer({
                   <GameButton
                     key={to}
                     label={label}
-                    icon={icon}
+                    icon={<HomeHubButtonIcon name={icon} />}
                     variant={variant}
                     onClick={to === '/game' ? onPlay : () => onNavigate(to, to === '/profile' ? { state: { from: '/' } } : undefined)}
                   />
@@ -384,7 +391,7 @@ export default function HomeHub() {
     playSelectionButtons.push({
       key: 'continue-last',
       label: 'Continue Last',
-      icon: '▶',
+      icon: <HomeHubButtonIcon name="play" />,
       variant: 'primary_large',
       onClick: continueLastRun,
     });
@@ -392,22 +399,22 @@ export default function HomeHub() {
   playSelectionButtons.push(
     {
       key: 'classic',
-      label: buildModeLabel('classic', classicSnapshot),
-      icon: '🎬',
+      label: 'Campaign',
+      icon: <HomeHubButtonIcon name="campaign" />,
       variant: 'secondary_wide',
       onClick: () => startOrResumeMode('classic'),
     },
     {
       key: 'survival',
-      label: buildModeLabel('survival', survivorSnapshot),
-      icon: '◆',
+      label: 'Survival',
+      icon: <HomeHubButtonIcon name="survival" />,
       variant: 'secondary_wide',
       onClick: () => startOrResumeMode('survival'),
     },
     {
       key: 'back',
       label: 'Back',
-      icon: '↩',
+      icon: <HomeHubButtonIcon name="back" />,
       variant: 'secondary_medium',
       onClick: () => setPlaySelectionOpen(false),
     },

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -364,7 +364,7 @@ describe('HomeHub', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Play' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Survival Mode' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Survival' }));
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText(/don't show this again/i));

--- a/src/screens/HomeHub/homeHubAssets.ts
+++ b/src/screens/HomeHub/homeHubAssets.ts
@@ -24,6 +24,17 @@ const INTRO_HUB_ICONS = [
   'shop',
 ] as const;
 
+const HOME_HUB_BUTTON_ICONS = [
+  'play',
+  'rules',
+  'profile',
+  'leaderboard',
+  'credits',
+  'campaign',
+  'survival',
+  'back',
+] as const;
+
 function assetUrl(path: string): string {
   return `${BASE}${path}`;
 }
@@ -53,6 +64,10 @@ export function getHomeHubAssetUrls(effectiveBgUrl: string | null): string[] {
 
   INTRO_HUB_ICONS.forEach((icon) => {
     urls.push(assetUrl(`/assets/side_utilities_button/${icon}_v2.svg`));
+  });
+
+  HOME_HUB_BUTTON_ICONS.forEach((icon) => {
+    urls.push(assetUrl(`/assets/intro_hub_icons/${icon}.svg`));
   });
 
   return unique(urls);


### PR DESCRIPTION
## What changed

- Added a cohesive set of custom SVG icons for Play, Rules, Profile, Leaderboard, Credits, Campaign, Survival, Back, and Housemates.
- Replaced the generic emoji/symbol glyphs used by the active IntroHub buttons.
- Renamed the Play submenu entries to the shorter **Campaign** and **Survival** labels.
- Added the active icon assets to the HomeHub preload bundle and sized them consistently beside button labels.
- Included the matching Housemates SVG for the separate Housemates menu work without pulling that unfinished feature into this PR.

## Impact

The IntroHub now has a distinctive broadcast-eye visual identity while preserving the existing button artwork, states, layout behavior, and navigation.

## Validation

- TypeScript build (`tsc -b`)
- HomeHub test suite: 9/9 passing
- SVG XML validation
- `git diff --check`