### PR TITLE
Map classic campaign minigames

### DIFF
--- a/src/ai/competition/bracketTemplate.ts
+++ b/src/ai/competition/bracketTemplate.ts
@@ -1,204 +1,275 @@
-/**
- * bracketTemplate.ts — Default competition scheduling template.
- *
- * Organises minigame keys into player-count brackets, each with a separate
- * LOH pool and POS pool.  Games may only be swapped within the same bracket
- * and the same competition type (LOH or POS).
- *
- * The DEFAULT_BRACKET_TEMPLATE constant is the single source of truth and is
- * deliberately easy to edit: to adjust a bracket, change the keys array for
- * the relevant band/type entry.  To add a new bracket, insert a new band
- * object and keep the array sorted from highest to lowest player-count band
- * (highest `maxPlayers` first) so that `getBracketPoolForContext` resolves
- * the correct band quickly.
- *
- * Bracket definitions:
- *  - 16–13 players
- *  - 12–10 players
- *  - 9–8  players
- *  - 7–5  players
- *  - 4    players
- *  - 3    players (Final Trilogy — LOH only, no POS)
- */
-
-// ── Types ─────────────────────────────────────────────────────────────────────
+import type { Phase } from '../../types';
 
 /**
- * A single bracket band.  `minPlayers` and `maxPlayers` are both inclusive.
- * Pools list registry game keys.  An empty `pos` array means no POS games
- * are played in this band (e.g. the Final Trilogy bracket).
+ * Classic campaign competition map.
+ *
+ * The most specific rule matching the current day, alive-housemate count, and
+ * Final 3 phase owns the random-selection pool. Keeping LOH and POS lists separate prevents
+ * a short luck game from accidentally becoming the week's main competition.
  */
+
 export interface BracketBand {
-  /** Human-readable label used for debugging and display. */
+  /** Human-readable label used by tests, diagnostics, and design reviews. */
   label: string;
-  /** Inclusive lower bound (fewest players in the bracket). */
+  /** Inclusive alive-housemate bounds. */
   minPlayers: number;
-  /** Inclusive upper bound (most players in the bracket). */
   maxPlayers: number;
-  /** Registry keys for LOH competitions in this bracket. */
+  /** Optional inclusive campaign-day bounds. */
+  minDay?: number;
+  maxDay?: number;
+  /** Optional exact phases, used to make the Final 3 trilogy escalate. */
+  phases?: Phase[];
   loh: string[];
-  /** Registry keys for POS competitions in this bracket. Empty = no POS. */
   pos: string[];
 }
 
-/**
- * The full bracket template: an ordered list of bands (highest to lowest
- * player count).  Mutate or replace this constant to reconfigure the season.
- */
 export type BracketTemplate = BracketBand[];
 
+export interface ClassicCampaignContext {
+  day: number;
+  playerCount: number;
+  compType: 'LOH' | 'POS';
+  phase?: Phase;
+}
+
 /**
- * Return the unique set of all competition game keys approved in the default
- * classical bracket template.
+ * Explicitly approved normal-campaign games. Registry activation alone is not
+ * enough: entries only belong here after gameplay QA and campaign approval.
+ * Special-purpose games such as Capitalization are intentionally absent.
  */
+export const CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS = [
+  'quickTap',
+  'memoryMatch',
+  'holdWall',
+  'famousFigures',
+  'silentSaboteur',
+  'majorityRules',
+  'colorMatch',
+  'logicLocks',
+  'snake',
+  'cardClash',
+  'hangman',
+  'tiltLabyrinth',
+  'threeDigitsQuiz',
+  'tetris',
+  'minesweeps',
+  'dontGoOver',
+  'blackjackTournament',
+  'riskWheel',
+  'wildcardWestern',
+  'castleRescue',
+  'glass_bridge_brutal',
+  'crystal_path_shattered',
+  'trapAuction',
+  'gridOfLuck',
+  'bigSpender',
+  'chainOfGreed',
+  'batteryLow',
+] as const;
+
+/** Per-game story prerequisites that apply in addition to the roster map. */
+export const CLASSIC_CAMPAIGN_GAME_MIN_DAY: Partial<
+  Record<(typeof CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS)[number], number>
+> = {
+  // Social reads only feel earned after several days with the housemates.
+  silentSaboteur: 4,
+};
+
 export function getApprovedCompetitionGameKeys(
   template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE,
 ): string[] {
   return [...new Set(template.flatMap((band) => [...band.loh, ...band.pos]))];
 }
 
-// ── Default template ──────────────────────────────────────────────────────────
-
 /**
- * Default season template derived from engagement-based bracket analysis.
+ * Design rules represented below:
  *
- * LOH / POS games are chosen so that:
- *  - Large-group phases (16–10) favour fast, social, or mass-participation games.
- *  - Mid-game phases (9–5) shift toward individual skill and precision.
- *  - Endgame phases (4 and below) use spotlight-heavy, high-drama games.
- *  - Final Trilogy (3 players) is LOH-only with an escalating three-comp arc.
- *
- * Swaps are only valid within the same bracket AND the same comp type.
+ * - Day 1 uses immediately readable, parallel-play games at every normal
+ *   cast size, so a smaller configured starting cast still gets a strong hook.
+ * - With many housemates, LOH uses fixed-round or simultaneous games and POS
+ *   stays short. Sequential/turn-heavy formats wait until the cast is smaller.
+ * - LOH becomes longer and more technical as the season progresses.
+ * - POS increasingly permits shorter, simpler, and chance-driven formats.
+ * - Final 4 only uses games that make sense with four players.
+ * - Each Final 3 part has a distinct style and an escalating difficulty curve.
  */
 export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
   {
-    label: '16–13 players',
+    label: 'Day 1 hook',
+    minPlayers: 5,
+    maxPlayers: 16,
+    minDay: 1,
+    maxDay: 1,
+    loh: ['holdWall', 'majorityRules', 'memoryMatch'],
+    pos: ['quickTap', 'colorMatch', 'dontGoOver'],
+  },
+  {
+    label: '16-13 players',
     minPlayers: 13,
     maxPlayers: 16,
     loh: [
-      'majorityRules',      // Majority Rules   — social deduction; best with a full house
-      'glass_bridge_brutal', // The Crystal Path — high-stakes sequential choice
-      'riskWheel',          // Risk Wheel       — multi-round elimination wheel
-      'trapAuction',        // Trap Auction     — secret bidding; best when many bluff
+      'holdWall',
+      'memoryMatch',
+      'famousFigures',
+      'majorityRules',
+      'batteryLow',
     ],
-    pos: [
-      'quickTap',   // Quick Tap Race — fast, fair, packed leaderboard
-      'holdWall',   // Hold the Wall  — endurance; every dropout is visible
-      'colorMatch', // Color Match    — precision slider; easy to compare across cast
-    ],
+    pos: ['quickTap', 'colorMatch', 'cardClash', 'hangman', 'dontGoOver', 'tiltLabyrinth'],
   },
   {
-    label: '12–10 players',
+    label: '12-10 players',
     minPlayers: 10,
     maxPlayers: 12,
-    loh: [
-      'blackjackTournament', // Blackjack Tournament — duel structure; tighter cast
-      'dontGoOver',          // Don't Go Over        — numeric guessing; tournament pressure
-      'silentSaboteur',      // Silent Saboteur      — deduction peaks at 10–12 players
-    ],
+    loh: ['memoryMatch', 'famousFigures', 'majorityRules', 'silentSaboteur', 'batteryLow'],
     pos: [
-      'castleRescue',  // Find Your Twin  — platformer; spotlight per run at mid-size
-      'logicLocks',    // Vault Cracker   — logic puzzle; watchable at mid-cast
+      'quickTap',
+      'colorMatch',
+      'cardClash',
+      'hangman',
+      'dontGoOver',
+      'tiltLabyrinth',
+      'threeDigitsQuiz',
+      'logicLocks',
     ],
   },
   {
-    label: '9–8 players',
+    label: '9-8 players',
     minPlayers: 8,
     maxPlayers: 9,
-    loh: [
-      'famousFigures',  // Famous Figures  — clue-based; each run gets real focus
-      'wildcardWestern', // Wildcard Western — showdown format; focused and dramatic
-    ],
-    pos: [
-      'minesweeps',    // Minesweeps    — high-focus puzzle; best with small field
-      'tiltLabyrinth', // Tilt Labyrinth — route precision; better with few players
-    ],
+    loh: ['snake', 'memoryMatch', 'famousFigures', 'silentSaboteur', 'batteryLow', 'chainOfGreed'],
+    pos: ['logicLocks', 'hangman', 'tiltLabyrinth', 'minesweeps', 'dontGoOver', 'bigSpender', 'threeDigitsQuiz', 'tetris'],
   },
   {
-    label: '7–5 players',
+    label: '7-5 players',
     minPlayers: 5,
     maxPlayers: 7,
     loh: [
-      'snake',        // Serpentine (Snake) — arcade mastery; each mistake magnified
-      'tetris',       // Fit Me In (Tetris) — serious skill; mid-late game feel
-      'chainOfGreed', // Chain of Greed     — higher-lower chain; good for ≤7 players
+      'castleRescue',
+      'glass_bridge_brutal',
+      'chainOfGreed',
+      'trapAuction',
+      'silentSaboteur',
+      'batteryLow',
     ],
-    pos: [
-      'cardClash',      // House of Cards — memory race; great at 5–7
-      'threeDigitsQuiz', // Number Trivia  — elimination trivia; sharper with fewer
-    ],
+    pos: ['riskWheel', 'blackjackTournament', 'bigSpender', 'logicLocks', 'hangman', 'minesweeps', 'tetris'],
   },
   {
     label: '4 players',
     minPlayers: 4,
     maxPlayers: 4,
-    loh: [
-      'gridOfLuck', // Grid of Luck  — cinematic box-opening; scales to 4
-      'logicLocks', // Vault Cracker — elite endgame puzzle pressure
-    ],
-    pos: [
-      'gridOfLuck', // Grid of Luck  — turn-based; fine at final 4
-      'logicLocks', // Vault Cracker — alternate high-stakes option
-    ],
+    loh: ['crystal_path_shattered', 'chainOfGreed', 'batteryLow', 'trapAuction', 'holdWall'],
+    pos: ['gridOfLuck', 'riskWheel', 'blackjackTournament', 'bigSpender', 'tetris'],
   },
   {
+    label: 'Final 3 - Part 1 endurance',
+    minPlayers: 3,
+    maxPlayers: 3,
+    phases: ['final3_comp1', 'final3_comp1_minigame'],
+    loh: ['holdWall', 'glass_bridge_brutal'],
+    pos: [],
+  },
+  {
+    label: 'Final 3 - Part 2 precision and memory',
+    minPlayers: 3,
+    maxPlayers: 3,
+    phases: ['final3_comp2', 'final3_comp2_minigame'],
+    loh: ['memoryMatch', 'famousFigures', 'castleRescue', 'batteryLow'],
+    pos: [],
+  },
+  {
+    label: 'Final 3 - Part 3 championship',
+    minPlayers: 3,
+    maxPlayers: 3,
+    phases: ['final3_comp3', 'final3_comp3_minigame'],
+    loh: ['crystal_path_shattered', 'chainOfGreed', 'wildcardWestern', 'trapAuction'],
+    pos: [],
+  },
+  {
+    // Phase-less compatibility pool for tools that only know the player count.
     label: '3 players (Final Trilogy)',
     minPlayers: 3,
     maxPlayers: 3,
     loh: [
-      'glass_bridge_brutal', // Crystal Path: Infinity — high-stakes sequential choice; strong opening comp of the trilogy
-      'chainOfGreed',   // Chain of Greed  — pressure chain; escalating second comp
-      'gridOfLuck',     // Grid of Luck    — cinematic finale; dramatic conclusion
+      'holdWall',
+      'glass_bridge_brutal',
+      'memoryMatch',
+      'famousFigures',
+      'castleRescue',
+      'batteryLow',
+      'crystal_path_shattered',
+      'chainOfGreed',
+      'wildcardWestern',
+      'trapAuction',
     ],
-    // Final Trilogy is LOH-only — no POS comps at final 3.
     pos: [],
   },
 ];
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+function matchesCampaignContext(band: BracketBand, context: ClassicCampaignContext): boolean {
+  if (context.playerCount < band.minPlayers || context.playerCount > band.maxPlayers) return false;
+  if (band.minDay !== undefined && context.day < band.minDay) return false;
+  if (band.maxDay !== undefined && context.day > band.maxDay) return false;
+  if (band.phases && (!context.phase || !band.phases.includes(context.phase))) return false;
+  return true;
+}
+
+function applyGameStoryPrerequisites(pool: string[], day: number): string[] {
+  return pool.filter((key) => {
+    const minDay = CLASSIC_CAMPAIGN_GAME_MIN_DAY[
+      key as (typeof CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS)[number]
+    ];
+    return minDay === undefined || day >= minDay;
+  });
+}
 
 /**
- * Return the list of registry keys eligible for the next competition, given
- * the current alive-player count and competition type.
- *
- * Rules:
- *  - The bracket is determined by the first band (highest `maxPlayers` first)
- *    whose range includes `playerCount`.
- *  - If `playerCount` is above every bracket's `maxPlayers` (unusual edge case)
- *    the first band is returned.
- *  - If `playerCount` is below every bracket's `minPlayers` (e.g. 1–2 players
- *    when the narrowest bracket starts at 3), an empty pool is returned so the
- *    caller can fall back to the standard scheduler.
- *
- * @param playerCount - Number of currently alive players (>= 1).
- * @param compType    - 'LOH' or 'POS'.
- * @param template    - Template to query; defaults to DEFAULT_BRACKET_TEMPLATE.
+ * Resolve the exact classic-campaign pool for a day/housemate/phase context.
+ * Counts above the supported cast size use the widest large-house band. Counts
+ * below Final 3 intentionally return no pool.
+ */
+export function getClassicCampaignPoolForContext(
+  context: ClassicCampaignContext,
+  template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE,
+): string[] {
+  const matched = template
+    .filter((band) => matchesCampaignContext(band, context))
+    .sort((left, right) => {
+      const specificity = (band: BracketBand) =>
+        (band.phases ? 100 : 0) +
+        (band.minDay !== undefined || band.maxDay !== undefined ? 10 : 0);
+      return specificity(right) - specificity(left);
+    })[0];
+  if (matched) {
+    const pool = context.compType === 'POS' ? matched.pos : matched.loh;
+    return applyGameStoryPrerequisites(pool, context.day);
+  }
+
+  if (context.playerCount > 16) {
+    const widest = template.find(
+      (band) => band.minPlayers === 13 && band.maxPlayers === 16 && !band.minDay && !band.phases,
+    );
+    if (widest) {
+      const pool = context.compType === 'POS' ? widest.pos : widest.loh;
+      return applyGameStoryPrerequisites(pool, context.day);
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Backwards-compatible count-only resolver used by admin tools and existing
+ * callers. Day-specific and Final 3 phase-specific rows are skipped because
+ * those callers do not have enough context to select them safely.
  */
 export function getBracketPoolForContext(
   playerCount: number,
   compType: 'LOH' | 'POS',
   template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE,
 ): string[] {
-  // Walk bands from widest (first) to narrowest to find the correct bracket.
-  // Bands are stored in descending order so this is a simple linear scan.
-  let matched: BracketBand | undefined;
-  for (const band of template) {
-    if (playerCount >= band.minPlayers && playerCount <= band.maxPlayers) {
-      matched = band;
-      break;
-    }
-  }
-
-  // Edge case: player count is above every bracket's maxPlayers — use the
-  // widest band.  Do NOT fall back for below-range counts (e.g. 1–2 players
-  // when the smallest bracket starts at 3): return an empty pool so the
-  // caller can fall back to the standard scheduler.
-  if (!matched && template.length > 0 && playerCount > template[0].maxPlayers) {
-    matched = template[0];
-  }
-
-  if (!matched) return [];
-
-  const pool = compType === 'POS' ? matched.pos : matched.loh;
-  return pool.length > 0 ? [...pool] : [];
+  const genericTemplate = template.filter((band) => !band.minDay && !band.maxDay && !band.phases);
+  return getClassicCampaignPoolForContext(
+    { day: Number.MAX_SAFE_INTEGER, playerCount, compType },
+    genericTemplate,
+  );
 }

--- a/src/components/compSelectionUtils.ts
+++ b/src/components/compSelectionUtils.ts
@@ -21,9 +21,9 @@
  * - `logic-only`         – restrict to the `logic` registry category.
  * - `retired`            – pick from retired games only.
  * - `misc`               – games not matching any of the main categories (fallback).
- * - `unique`             – default mapped mode; uses the order/type bracket template
- *                          when available, avoids recent repeats within that mapped pool,
- *                          and only falls back to broader scheduling when no mapping applies.
+ * - `unique`             – default mapped mode; uses the day/housemate/type campaign map
+ *                          and avoids every played LOH/POS game while the current eligible
+ *                          pool still contains an unused game.
  * - `bracket-template`   – select from the default bracket template pool for the
  *                          current player count and competition type (LOH/POS).
  *                          Falls back to random selection when the bracket pool is empty.

--- a/src/minigames/registry.ts
+++ b/src/minigames/registry.ts
@@ -268,7 +268,7 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     legacy: false,
     weight: 1,
     category: 'arcade',
-    retired: false,
+    retired: true,
   },
 
   estimationGame: {

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -15,7 +15,9 @@ import {
   simulateMinigameAiScore,
 } from '../ai/competition';
 import { selectNextCompetitionGame } from '../ai/competition/scheduling';
-import { getApprovedCompetitionGameKeys, getBracketPoolForContext } from '../ai/competition/bracketTemplate';
+import {
+  getClassicCampaignPoolForContext,
+} from '../ai/competition/bracketTemplate';
 import { applyCompetitionSeasonUpdate, hydrateGame, selectAlivePlayers } from './gameSlice';
 import { pickRandomGame, getGame, getPoolByFilter, supportsPlayerCount } from '../minigames/registry';
 import type { GameRegistryEntry, GameCategory } from '../minigames/registry';
@@ -98,7 +100,6 @@ const initialState: ChallengeState = {
 const LATE_SEASON_PLAYER_THRESHOLD = 6;
 // Keep a modest history buffer in case the scheduler window expands.
 const RECENT_HISTORY_LIMIT = 10;
-const SURVIVOR_APPROVED_GAME_KEYS = new Set(getApprovedCompetitionGameKeys());
 
 // ─── Slice ───────────────────────────────────────────────────────────────────
 
@@ -199,9 +200,8 @@ export const startChallenge =
           `${state.game.runId ?? state.game.gameId ?? 'game'}:${nextNonce}`,
         );
 
-    const historyGameKeys = (state.challenge?.history ?? [])
-      .slice(0, RECENT_HISTORY_LIMIT)
-      .map((run) => run.gameKey);
+    const allHistoryGameKeys = (state.challenge?.history ?? []).map((run) => run.gameKey);
+    const historyGameKeys = allHistoryGameKeys.slice(0, RECENT_HISTORY_LIMIT);
     // Late-season bias is based on active competitors (jury members no longer play comps).
     const activeCompetitorCount = selectAlivePlayers(state).length;
     const scheduledPlayerCount = participants.length || activeCompetitorCount;
@@ -226,15 +226,17 @@ export const startChallenge =
         : null;
       if (!modeSpecific) return pickFromRegistry(category, excludeKeys);
 
-      const approvedPool = getPoolByFilter({ retired: false, excludeKeys })
-        .filter(eligibleForRoster)
-        .filter((game) => SURVIVOR_APPROVED_GAME_KEYS.has(game.key));
+      // Survivor has its own free-form rotation. The curated Classic campaign
+      // map must not constrain it; only retirement, roster safety, explicit
+      // exclusions, and an optional category filter apply.
+      const availablePool = getPoolByFilter({ retired: false, excludeKeys })
+        .filter(eligibleForRoster);
       const pool = category
-        ? approvedPool.filter((game) => game.category === category)
-        : approvedPool;
-      const selectionPool = pool.length > 0 ? pool : approvedPool;
+        ? availablePool.filter((game) => game.category === category)
+        : availablePool;
+      const selectionPool = pool.length > 0 ? pool : availablePool;
       if (selectionPool.length === 0) {
-        throw new Error('[challengeSlice] No approved Survival games are available');
+        throw new Error('[challengeSlice] No non-retired Survival games are available');
       }
 
       const usedKeys = modeSpecific.competitionRotation.usedKeys ?? [];
@@ -264,15 +266,29 @@ export const startChallenge =
       return selected;
     };
     const getBracketTemplatePool = (excludeKeys?: string[]) => {
+      const isFinal3Competition =
+        state.game.phase === 'final3_comp1' ||
+        state.game.phase === 'final3_comp1_minigame' ||
+        state.game.phase === 'final3_comp2' ||
+        state.game.phase === 'final3_comp2_minigame' ||
+        state.game.phase === 'final3_comp3' ||
+        state.game.phase === 'final3_comp3_minigame';
       const bracketCompType =
         opts.prizeType === 'LOH' || opts.prizeType === 'POS'
           ? opts.prizeType
-          : undefined;
+          : isFinal3Competition
+            ? 'LOH'
+            : undefined;
       if (!bracketCompType) return [];
 
       const bracketPlayerCount =
         activeCompetitorCount > 0 ? activeCompetitorCount : participants.length;
-      const bracketKeys = getBracketPoolForContext(bracketPlayerCount, bracketCompType);
+      const bracketKeys = getClassicCampaignPoolForContext({
+        day: state.game.week,
+        playerCount: bracketPlayerCount,
+        compType: bracketCompType,
+        phase: state.game.phase,
+      });
       if (bracketKeys.length === 0) return [];
 
       const excluded = new Set(excludeKeys ?? []);
@@ -362,8 +378,12 @@ export const startChallenge =
 
         case 'unique': {
           const recentKeys = new Set(historyGameKeys);
+          const seasonUsedKeys = new Set(allHistoryGameKeys);
           const bracketPool = getBracketTemplatePool(opts.excludeKeys);
-          const uniqueBracketPool = bracketPool.filter((game) => !recentKeys.has(game.key));
+          // Classic campaign selection is without replacement across both LOH
+          // and POS. Only repeat after every game in the current eligible pool
+          // has already appeared this season.
+          const uniqueBracketPool = bracketPool.filter((game) => !seasonUsedKeys.has(game.key));
           if (uniqueBracketPool.length > 0) {
             gameEntry = selectFromPool(uniqueBracketPool);
             break;
@@ -390,7 +410,9 @@ export const startChallenge =
         case 'bracket-template': {
           const bracketPool = getBracketTemplatePool(opts.excludeKeys);
           if (bracketPool.length > 0) {
-            gameEntry = selectFromPool(bracketPool);
+            const seasonUsedKeys = new Set(allHistoryGameKeys);
+            const unusedPool = bracketPool.filter((game) => !seasonUsedKeys.has(game.key));
+            gameEntry = selectFromPool(unusedPool.length > 0 ? unusedPool : bracketPool);
             break;
           }
           gameEntry = pickFromRegistry(opts.category, opts.excludeKeys);

--- a/tests/integration/challenge.flow.dispatch.test.tsx
+++ b/tests/integration/challenge.flow.dispatch.test.tsx
@@ -20,7 +20,12 @@ import profilesReducer, { type ProfilesState } from '../../src/store/profilesSli
 import settingsReducer, { DEFAULT_SETTINGS } from '../../src/store/settingsSlice';
 import publicOpinionReducer from '../../src/publicOpinion/publicOpinionSlice';
 import GameScreen from '../../src/screens/GameScreen/GameScreen';
-import { getApprovedCompetitionGameKeys, getBracketPoolForContext } from '../../src/ai/competition/bracketTemplate';
+import {
+  getApprovedCompetitionGameKeys,
+  getBracketPoolForContext,
+  getClassicCampaignPoolForContext,
+} from '../../src/ai/competition/bracketTemplate';
+import { getPoolByFilter, supportsPlayerCount } from '../../src/minigames/registry';
 import { createSurvivorRun } from '../../src/modes/survivorRun';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
@@ -383,6 +388,78 @@ describe('startChallenge – compSelection modes', () => {
     expect(expectedPool).toContain(pending?.game.key);
   });
 
+  it('unique: does not reuse an eligible game until the current pool is exhausted', () => {
+    const store = makeStoreWithCompSelection({ mode: 'unique', enabledIds: [] });
+    const state = store.getState();
+    const alivePlayerCount = state.game.players.filter(
+      (player) => player.status !== 'evicted' && player.status !== 'jury',
+    ).length;
+    const eligibleKeys = getClassicCampaignPoolForContext({
+      day: state.game.week,
+      playerCount: alivePlayerCount,
+      compType: 'POS',
+      phase: 'pos_comp',
+    });
+    const onlyUnusedKey = eligibleKeys.at(-1);
+    expect(onlyUnusedKey).toBeDefined();
+
+    eligibleKeys.slice(0, -1).forEach((gameKey, index) => {
+      store.dispatch(recordRun({
+        id: `used-by-earlier-loh-or-pos-${index}`,
+        gameKey,
+        seed: index,
+        participants: [],
+        rawScores: {},
+        canonicalScores: {},
+        winnerId: 'p1',
+        timestamp: index,
+        authoritative: false,
+      }));
+    });
+
+    dispatchThunk(store, startChallenge(91, state.game.players.map((player) => player.id), { prizeType: 'POS' }));
+    expect(store.getState().challenge.pending?.game.key).toBe(onlyUnusedKey);
+
+    store.dispatch(recordRun({
+      id: 'used-final-eligible-game',
+      gameKey: onlyUnusedKey!,
+      seed: 99,
+      participants: [],
+      rawScores: {},
+      canonicalScores: {},
+      winnerId: 'p1',
+      timestamp: 99,
+      authoritative: false,
+    }));
+    store.dispatch(setPendingChallenge(null));
+
+    dispatchThunk(store, startChallenge(92, state.game.players.map((player) => player.id), { prizeType: 'POS' }));
+    expect(eligibleKeys).toContain(store.getState().challenge.pending?.game.key);
+  });
+
+  it('unique: routes Final 3 parts through their phase-specific LOH pools', () => {
+    const players = [
+      { id: 'p1', name: 'Ari', avatar: '🙂', status: 'active' as const, isUser: true },
+      { id: 'p2', name: 'Bo', avatar: '🙂', status: 'active' as const, isUser: false },
+      { id: 'p3', name: 'Cy', avatar: '🙂', status: 'active' as const, isUser: false },
+    ];
+    const store = makeStoreWithGame({
+      week: 14,
+      phase: 'final3_comp2_minigame',
+      players,
+    });
+    const expectedPool = getClassicCampaignPoolForContext({
+      day: 14,
+      playerCount: 3,
+      compType: 'LOH',
+      phase: 'final3_comp2_minigame',
+    });
+
+    dispatchThunk(store, startChallenge(144, players.map((player) => player.id)));
+
+    expect(expectedPool).toContain(store.getState().challenge.pending?.game.key);
+  });
+
   it('random-games: falls back to the existing random selection', () => {
     const store = makeStoreWithCompSelection({ mode: 'random-games', enabledIds: [] });
 
@@ -393,16 +470,29 @@ describe('startChallenge – compSelection modes', () => {
     expect(typeof pending?.game.key).toBe('string');
   });
 
-  it('survivor mode only selects games approved in the classical template', () => {
+  it('survivor mode rotates through all roster-safe non-retired games, independently of Classic', () => {
     const store = makeSurvivorStore();
-    const approvedKeys = new Set(getApprovedCompetitionGameKeys());
+    const playerCount = store.getState().game.players.filter(
+      (player) => player.status !== 'evicted' && player.status !== 'jury',
+    ).length;
+    const availableKeys = getPoolByFilter({ retired: false })
+      .filter((game) => supportsPlayerCount(game, playerCount))
+      .map((game) => game.key);
+    const classicKeys = new Set(getApprovedCompetitionGameKeys());
+    const survivorOnlyKeys = availableKeys.filter((key) => !classicKeys.has(key));
+    const selectedKeys = new Set<string>();
 
-    dispatchThunk(store, startChallenge(42, ['p1', 'p2']));
+    expect(survivorOnlyKeys.length).toBeGreaterThan(0);
+    availableKeys.forEach((_, index) => {
+      dispatchThunk(store, startChallenge(42 + index, store.getState().game.players.map((player) => player.id)));
+      const pending = store.getState().challenge.pending;
+      expect(pending?.game.retired).toBe(false);
+      selectedKeys.add(pending?.game.key ?? '');
+      store.dispatch(setPendingChallenge(null));
+    });
 
-    const pending = store.getState().challenge.pending;
-    expect(pending).not.toBeNull();
-    expect(pending?.game.retired).toBe(false);
-    expect(approvedKeys.has(pending?.game.key ?? '')).toBe(true);
+    expect([...selectedKeys].some((key) => survivorOnlyKeys.includes(key))).toBe(true);
+    expect(selectedKeys.size).toBe(availableKeys.length);
   });
 
   it('debug forceGameKey overrides compSelection mode', () => {

--- a/tests/unit/competition-ai/bracketTemplate.test.ts
+++ b/tests/unit/competition-ai/bracketTemplate.test.ts
@@ -1,135 +1,194 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS,
   DEFAULT_BRACKET_TEMPLATE,
   getBracketPoolForContext,
+  getClassicCampaignPoolForContext,
   type BracketTemplate,
 } from '../../../src/ai/competition/bracketTemplate';
 import { getGame } from '../../../src/minigames/registry';
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function allKeys(template: BracketTemplate): string[] {
   return template.flatMap((band) => [...band.loh, ...band.pos]);
 }
 
-// ── Registry integrity ────────────────────────────────────────────────────────
-
-describe('DEFAULT_BRACKET_TEMPLATE — registry integrity', () => {
-  it('every game key in the template resolves to a known registry entry', () => {
-    const unknown = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((k) => !getGame(k));
+describe('classic campaign map registry integrity', () => {
+  it('only references active registry games', () => {
+    const unknown = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => !getGame(key));
+    const retired = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => getGame(key)?.retired);
     expect(unknown).toEqual([]);
-  });
-
-  it('every game key in the template is non-retired', () => {
-    const retired = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((k) => {
-      const g = getGame(k);
-      return g?.retired === true;
-    });
     expect(retired).toEqual([]);
   });
 
-  it('bands are ordered from highest maxPlayers to lowest', () => {
-    const maxValues = DEFAULT_BRACKET_TEMPLATE.map((b) => b.maxPlayers);
-    for (let i = 1; i < maxValues.length; i++) {
-      expect(maxValues[i]).toBeLessThanOrEqual(maxValues[i - 1]);
+  it('only schedules explicitly QA-approved campaign games', () => {
+    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE));
+    const approved = new Set<string>(CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS);
+    expect([...scheduled].filter((key) => !approved.has(key))).toEqual([]);
+    expect([...approved].filter((key) => !scheduled.has(key))).toEqual([]);
+  });
+
+  it('excludes unavailable and special-purpose games from normal campaign pools', () => {
+    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE));
+    expect(scheduled).not.toContain('timingBar');
+    expect(scheduled).not.toContain('estimationGame');
+    expect(scheduled).not.toContain('pressurePlank');
+    expect(scheduled).not.toContain('rescueTheKing');
+    expect(scheduled).not.toContain('capitalization');
+    expect(scheduled).not.toContain('targetPractice');
+    expect(getGame('targetPractice')?.retired).toBe(true);
+  });
+
+  it('keeps Vault Cracker, Verdict Board, and Fit Me In POS-only and Battery Low LOH-only', () => {
+    const allLoh = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.loh);
+    const allPos = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.pos);
+    expect(allLoh).not.toContain('logicLocks');
+    expect(allLoh).not.toContain('hangman');
+    expect(allLoh).not.toContain('tetris');
+    expect(allPos).not.toContain('batteryLow');
+    expect(allPos).toContain('logicLocks');
+    expect(allPos).toContain('hangman');
+    expect(allPos).toContain('tetris');
+    expect(allLoh).toContain('batteryLow');
+  });
+
+  it('delays Silent Saboteur until housemates have had time to get acquainted', () => {
+    const tooEarly = getClassicCampaignPoolForContext({
+      day: 2,
+      playerCount: 10,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    });
+    const laterHouse = getClassicCampaignPoolForContext({
+      day: 4,
+      playerCount: 7,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    });
+    expect(tooEarly).not.toContain('silentSaboteur');
+    expect(laterHouse).toContain('silentSaboteur');
+  });
+
+  it('keeps bands ordered from the largest roster to Final 3', () => {
+    const maxValues = DEFAULT_BRACKET_TEMPLATE.map((band) => band.maxPlayers);
+    for (let index = 1; index < maxValues.length; index += 1) {
+      expect(maxValues[index]).toBeLessThanOrEqual(maxValues[index - 1]);
     }
   });
 
-  it('every LOH band has at least one game', () => {
-    const empty = DEFAULT_BRACKET_TEMPLATE.filter((b) => b.loh.length === 0);
-    expect(empty).toEqual([]);
-  });
-
-  it('final 3 band has an empty POS pool', () => {
-    const f3 = DEFAULT_BRACKET_TEMPLATE.find(
-      (b) => b.minPlayers === 3 && b.maxPlayers === 3,
+  it('has LOH games in every band and no Final 3 POS games', () => {
+    expect(DEFAULT_BRACKET_TEMPLATE.every((band) => band.loh.length > 0)).toBe(true);
+    const final3Bands = DEFAULT_BRACKET_TEMPLATE.filter(
+      (band) => band.minPlayers === 3 && band.maxPlayers === 3,
     );
-    expect(f3).toBeDefined();
-    expect(f3?.pos).toEqual([]);
+    expect(final3Bands.length).toBeGreaterThan(0);
+    expect(final3Bands.every((band) => band.pos.length === 0)).toBe(true);
   });
 });
 
-// ── getBracketPoolForContext ───────────────────────────────────────────────────
-
-describe('getBracketPoolForContext', () => {
-  it('returns the 16–13 LOH pool for 16 players', () => {
-    const pool = getBracketPoolForContext(16, 'LOH');
-    expect(pool).toContain('majorityRules');
-    expect(pool).toContain('trapAuction');
-    expect(pool.length).toBeGreaterThan(0);
+describe('getBracketPoolForContext compatibility resolver', () => {
+  it.each([
+    [16, 'LOH', 'holdWall'],
+    [13, 'POS', 'quickTap'],
+    [10, 'LOH', 'memoryMatch'],
+    [9, 'POS', 'tetris'],
+    [5, 'POS', 'riskWheel'],
+    [4, 'LOH', 'batteryLow'],
+    [3, 'LOH', 'wildcardWestern'],
+  ] as const)('maps %i players / %s to %s', (playerCount, compType, expectedKey) => {
+    expect(getBracketPoolForContext(playerCount, compType)).toContain(expectedKey);
   });
 
-  it('returns the 16–13 POS pool for 13 players', () => {
-    const pool = getBracketPoolForContext(13, 'POS');
-    expect(pool).toContain('quickTap');
-    expect(pool).toContain('holdWall');
+  it('returns no POS pool at Final 3 or pool below Final 3', () => {
+    expect(getBracketPoolForContext(3, 'POS')).toEqual([]);
+    expect(getBracketPoolForContext(2, 'POS')).toEqual([]);
+    expect(getBracketPoolForContext(1, 'LOH')).toEqual([]);
   });
 
-  it('returns the 12–10 LOH pool for 10 players', () => {
-    const pool = getBracketPoolForContext(10, 'LOH');
-    expect(pool).toContain('blackjackTournament');
-    expect(pool).toContain('silentSaboteur');
+  it('uses the widest safe band for oversized casts', () => {
+    expect(getBracketPoolForContext(99, 'LOH')).toContain('holdWall');
   });
 
-  it('returns the 9–8 LOH pool for 9 players', () => {
-    const pool = getBracketPoolForContext(9, 'LOH');
-    expect(pool).toContain('famousFigures');
-    expect(pool).toContain('wildcardWestern');
-  });
+  it('returns fresh arrays and supports custom templates', () => {
+    const first = getBracketPoolForContext(16, 'LOH');
+    const second = getBracketPoolForContext(16, 'LOH');
+    first.push('EXTRA');
+    expect(second).not.toContain('EXTRA');
 
-  it('returns the 7–5 POS pool for 5 players', () => {
-    const pool = getBracketPoolForContext(5, 'POS');
-    expect(pool).toContain('cardClash');
-    expect(pool).toContain('threeDigitsQuiz');
-  });
-
-  it('returns the 4-player LOH pool for 4 players', () => {
-    const pool = getBracketPoolForContext(4, 'LOH');
-    expect(pool).toContain('gridOfLuck');
-    expect(pool).toContain('logicLocks');
-  });
-
-  it('returns an empty pool for final-3 POS (no POS at final 3)', () => {
-    const pool = getBracketPoolForContext(3, 'POS');
-    expect(pool).toEqual([]);
-  });
-
-  it('returns the final-3 LOH pool for 3 players', () => {
-    const pool = getBracketPoolForContext(3, 'LOH');
-    expect(pool).toContain('glass_bridge_brutal');
-    expect(pool).toContain('chainOfGreed');
-    expect(pool).toContain('gridOfLuck');
-  });
-
-  it('returns the widest band when player count exceeds all brackets', () => {
-    const pool = getBracketPoolForContext(99, 'LOH');
-    // Should match the 16–13 band (highest maxPlayers)
-    expect(pool).toContain('majorityRules');
-  });
-
-  it('returns an empty pool when player count is below the smallest bracket (e.g. 1 player)', () => {
-    // Below the narrowest bracket (3 players) — no fallback to template[0]
-    const pool = getBracketPoolForContext(1, 'LOH');
-    expect(pool).toEqual([]);
-  });
-
-  it('returns an empty pool when player count is 2 (below the narrowest bracket)', () => {
-    const pool = getBracketPoolForContext(2, 'POS');
-    expect(pool).toEqual([]);
-  });
-
-  it('returns a fresh copy each call (mutations do not bleed between calls)', () => {
-    const a = getBracketPoolForContext(16, 'LOH');
-    const b = getBracketPoolForContext(16, 'LOH');
-    a.push('EXTRA');
-    expect(b).not.toContain('EXTRA');
-  });
-
-  it('supports a custom template override', () => {
     const custom: BracketTemplate = [
       { label: 'test', minPlayers: 1, maxPlayers: 99, loh: ['quickTap'], pos: ['laneRacers'] },
     ];
     expect(getBracketPoolForContext(10, 'LOH', custom)).toEqual(['quickTap']);
     expect(getBracketPoolForContext(10, 'POS', custom)).toEqual(['laneRacers']);
+  });
+});
+
+describe('getClassicCampaignPoolForContext', () => {
+  it('uses the hook pool on day 1 even for a smaller starting cast', () => {
+    expect(getClassicCampaignPoolForContext({
+      day: 1,
+      playerCount: 10,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    })).toEqual(['holdWall', 'majorityRules', 'memoryMatch']);
+  });
+
+  it('widens the eligible pool after day 1 so fresh games keep entering', () => {
+    const day1 = getClassicCampaignPoolForContext({
+      day: 1,
+      playerCount: 16,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    });
+    const day2 = getClassicCampaignPoolForContext({
+      day: 2,
+      playerCount: 16,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    });
+    expect(day2.length).toBeGreaterThan(day1.length);
+    expect(day2).toEqual(expect.arrayContaining(day1));
+  });
+
+  it('moves to the roster-specific pool after the opening hook', () => {
+    const pool = getClassicCampaignPoolForContext({
+      day: 3,
+      playerCount: 10,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    });
+    expect(pool).toContain('memoryMatch');
+    expect(pool).not.toContain('targetPractice');
+  });
+
+  it('keeps turn-heavy Grid of Luck to the 2-4 compatible endgame context', () => {
+    const final4 = getClassicCampaignPoolForContext({
+      day: 13,
+      playerCount: 4,
+      compType: 'POS',
+      phase: 'pos_comp',
+    });
+    const final5 = getClassicCampaignPoolForContext({
+      day: 12,
+      playerCount: 5,
+      compType: 'POS',
+      phase: 'pos_comp',
+    });
+    expect(final4).toContain('gridOfLuck');
+    expect(final5).not.toContain('gridOfLuck');
+  });
+
+  it('uses a disjoint, escalating pool for each Final 3 part', () => {
+    const resolve = (phase: 'final3_comp1_minigame' | 'final3_comp2_minigame' | 'final3_comp3_minigame') =>
+      getClassicCampaignPoolForContext({ day: 14, playerCount: 3, compType: 'LOH', phase });
+    const part1 = resolve('final3_comp1_minigame');
+    const part2 = resolve('final3_comp2_minigame');
+    const part3 = resolve('final3_comp3_minigame');
+
+    expect(part1).toContain('holdWall');
+    expect(part2).toContain('memoryMatch');
+    expect(part3).toContain('wildcardWestern');
+    expect(new Set([...part1, ...part2, ...part3]).size).toBe(
+      part1.length + part2.length + part3.length,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add a curated classic-campaign LOH/POS map by day, housemate count, and Final 3 phase
- avoid repeats across LOH and POS until the currently eligible pool is exhausted
- retire Bullseye and enforce game-role rules such as Silent Saboteur from day 4, Fit Me In for POS, Verdict Board for POS, and Battery Low for LOH
- keep Survivor independent, rotating through all non-retired, roster-safe games

## Why

Classic campaign selection previously relied on broad registry activation and player-count filtering. That allowed retired or special-purpose games into rotation and did not account for pacing, challenge role, or campaign phase.

## Impact

Classic campaigns now get curated early-game pacing and stronger late/final competitions. Survivor remains free-form apart from retired and roster-incompatible games.

## Validation

- `npm run typecheck`
- ESLint on all six changed files
- focused Vitest selection coverage: 24 passed, 20 unrelated tests skipped

## Note

The broader integration file also passed 43 tests but hit its existing 15-second spectator/UI timeout in one unrelated test.
