### PR TITLE
Refine mobile finale presentation

### DIFF
--- a/src/components/FinalFaceoff/FinalFaceoff.css
+++ b/src/components/FinalFaceoff/FinalFaceoff.css
@@ -657,24 +657,38 @@
   position: absolute;
   inset: 0 0 54px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   overflow: hidden;
+  padding: 12px;
 }
 
-.fo-finalist__portrait {
+.fo-finalist__portrait.pa {
   display: block;
-  width: 92%;
-  height: 100%;
-  object-fit: contain;
-  object-position: center bottom;
-  filter: drop-shadow(0 16px 24px rgba(0, 0, 0, 0.52));
+  flex: 0 0 auto;
+  width: clamp(7.75rem, 33vw, 11rem);
+  height: clamp(7.75rem, 33vw, 11rem);
+  overflow: hidden;
+  border: 2px solid rgba(232, 191, 118, 0.64);
+  border-radius: 50%;
+  background: #111725;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.52), 0 0 34px rgba(232, 191, 118, 0.18);
+  filter: none;
   animation: fo-finalist-arrive 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.fo-finalist:nth-child(2) .fo-finalist__portrait {
+.fo-finalist:nth-child(2) .fo-finalist__portrait.pa {
+  border-color: rgba(185, 166, 255, 0.68);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.52), 0 0 34px rgba(185, 166, 255, 0.2);
   animation-delay: 90ms;
 }
+
+.fo-finalist--winner .fo-finalist__portrait.pa {
+  border-color: rgba(255, 239, 185, 0.92);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.52), 0 0 42px rgba(247, 211, 132, 0.34);
+}
+
+.fo-finalist__portrait .pa__img { object-position: center 18%; }
 
 @keyframes fo-finalist-arrive {
   from { opacity: 0; transform: translateY(24px) scale(0.94); }
@@ -857,6 +871,11 @@
 
   .fo-finalists {
     flex-basis: 190px;
+  }
+
+  .fo-finalist__portrait.pa {
+    width: 6.75rem;
+    height: 6.75rem;
   }
 }
 

--- a/src/components/FinalFaceoff/FinalFaceoff.css
+++ b/src/components/FinalFaceoff/FinalFaceoff.css
@@ -625,13 +625,13 @@
 /* Verdict act: the finalists read as opposing cases, not small profile tiles. */
 .fo-finalists {
   z-index: 4;
-  flex: 0 0 clamp(210px, 34dvh, 310px);
+  flex: 0 0 clamp(260px, 40dvh, 390px);
   gap: 8px;
   padding: 2px 12px 8px;
 }
 
 .fo-finalist {
-  max-width: 250px;
+  max-width: 320px;
   min-width: 0;
   overflow: hidden;
   display: block;
@@ -666,8 +666,9 @@
 .fo-finalist__portrait.pa {
   display: block;
   flex: 0 0 auto;
-  width: clamp(7.75rem, 33vw, 11rem);
-  height: clamp(7.75rem, 33vw, 11rem);
+  width: min(94%, 15rem);
+  height: auto;
+  aspect-ratio: 1;
   overflow: hidden;
   border: 2px solid rgba(232, 191, 118, 0.64);
   border-radius: 50%;
@@ -870,12 +871,12 @@
   }
 
   .fo-finalists {
-    flex-basis: 190px;
+    flex-basis: 230px;
   }
 
   .fo-finalist__portrait.pa {
-    width: 6.75rem;
-    height: 6.75rem;
+    width: min(90%, 9.25rem);
+    height: auto;
   }
 }
 

--- a/src/components/FinalFaceoff/FinalFaceoff.tsx
+++ b/src/components/FinalFaceoff/FinalFaceoff.tsx
@@ -46,7 +46,7 @@ import { useStore } from 'react-redux';
 import JurorBubble from './JurorBubble';
 import FinalTallyPanel from './FinalTallyPanel';
 import FinaleControls from './FinaleControls';
-import FullSizeCutoutImage from '../FullSizeCutoutImage/FullSizeCutoutImage';
+import PlayerAvatar from '../PlayerAvatar/PlayerAvatar';
 import SeasonRecapCinematic from '../SeasonRecapCinematic/SeasonRecapCinematic';
 import TribunalMemberStage from '../TribunalMemberStage/TribunalMemberStage';
 import {
@@ -551,12 +551,12 @@ export default function FinalFaceoff() {
               >
                 {finale.winnerId === f.id && <span className="fo-winner-badge">Champion</span>}
                 <div className="fo-finalist__portrait-frame">
-                  <FullSizeCutoutImage
+                  <PlayerAvatar
                     player={f}
-                    attire="formal"
-                    alt={f.name}
                     className="fo-finalist__portrait"
-                    loading="eager"
+                    size="lg"
+                    showRelationshipOutline={false}
+                    showEvictedStyle={false}
                   />
                 </div>
                 <div className="fo-finalist__meta">

--- a/src/components/FinalLightsOutSequence/FinalLightsOutSequence.css
+++ b/src/components/FinalLightsOutSequence/FinalLightsOutSequence.css
@@ -185,7 +185,6 @@
 .flo-tv-frame--off {
   background: #000;
   box-shadow: none;
-  filter: brightness(0);
 }
 
 .flo-tv-shell--off {
@@ -266,31 +265,34 @@
 
 .flo-tv-message {
   margin: 0;
-  font-size: clamp(0.92rem, 3.5vw, 1.2rem);
+  max-width: 18rem;
+  font-size: clamp(1rem, 4vw, 1.35rem);
   font-weight: 700;
-  line-height: 1.45;
+  line-height: 1.32;
   color: rgba(245, 247, 250, 0.95);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.15rem;
+  gap: 0.3rem;
+  text-wrap: balance;
   text-shadow:
     0 0 16px rgba(0, 0, 0, 0.85),
     0 1px 4px rgba(0, 0, 0, 0.95);
 }
 
-.flo-tv-message-signoff {
-  color: rgba(216, 222, 232, 0.82);
-  font-size: 0.9em;
+.flo-tv-frame--off .flo-tv-screen-inner {
+  overflow: hidden;
+  background: #f7f8ff;
+  box-shadow: 0 0 34px rgba(220, 232, 255, 0.9);
+  transform-origin: center;
+  animation: flo-tv-power-down 1.55s cubic-bezier(0.76, 0, 0.24, 1) both;
 }
 
-.flo-tv-footnote {
-  margin: 0;
-  font-size: 0.7rem;
-  color: rgba(226, 232, 240, 0.66);
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-  padding-top: 0.7rem;
-  width: 100%;
+@keyframes flo-tv-power-down {
+  0% { opacity: 1; transform: scale(1); filter: brightness(1); }
+  52% { opacity: 1; transform: scaleX(1) scaleY(0.018); filter: brightness(5); }
+  76% { opacity: 1; transform: scaleX(0.14) scaleY(0.018); filter: brightness(7); }
+  100% { opacity: 0; transform: scale(0.01); filter: brightness(0); }
 }
 
 /* ── Final blackout ── */
@@ -313,6 +315,7 @@
   .flo-light,
   .flo-tv-frame,
   .flo-tv-content,
+  .flo-tv-screen-inner,
   .flo-tv-logo,
   .flo-final-black {
     animation: none;
@@ -320,8 +323,8 @@
   }
   .flo-light-row--off { opacity: 0; }
   .flo-tv-frame--off  {
-    filter: brightness(0);
     opacity: 1 !important;
   }
+  .flo-tv-frame--off .flo-tv-screen-inner { opacity: 0; }
   .flo-tv-content     { opacity: 1; }
 }

--- a/src/components/FinalLightsOutSequence/FinalLightsOutSequence.tsx
+++ b/src/components/FinalLightsOutSequence/FinalLightsOutSequence.tsx
@@ -18,6 +18,7 @@ import './FinalLightsOutSequence.css';
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 export interface FinalLightsOutSequenceProps {
+  /** Retained for call-site compatibility; the final TV card intentionally contains only the farewell. */
   publicFavoriteWinnerName?: string;
   onComplete: () => void;
 }
@@ -41,7 +42,6 @@ const LIGHT_ROWS = 5;
 const STAGE_DURATIONS = [800, 1400, 1400, 1400, 3000, 1800, 1400];
 
 export default function FinalLightsOutSequence({
-  publicFavoriteWinnerName,
   onComplete,
 }: FinalLightsOutSequenceProps) {
   const [stage, setStage] = useState(0);
@@ -267,15 +267,9 @@ export default function FinalLightsOutSequence({
               />
             </span>
             <p className="flo-tv-message">
-              <span>This is not a Goodbye,</span>
-              <span>it's see you soon</span>
-              <span className="flo-tv-message-signoff">from the Big Eye.</span>
+              <span>This is not a goodbye</span>
+              <span>It&apos;s see you soon</span>
             </p>
-            {publicFavoriteWinnerName && (
-              <p className="flo-tv-footnote">
-                Public's Favorite: <strong>{publicFavoriteWinnerName}</strong>
-              </p>
-            )}
           </div>
         </div>
       </div>

--- a/src/components/HousematesBioCinematic/HousematesBioCinematic.css
+++ b/src/components/HousematesBioCinematic/HousematesBioCinematic.css
@@ -590,14 +590,14 @@
 @media (orientation: portrait) {
   .hbc-card__portrait-wrap {
     z-index: 6;
-    bottom: -1%;
-    left: -5%;
-    width: 59vw;
-    height: 75%;
+    bottom: -2%;
+    left: -12%;
+    width: 78vw;
+    height: 86%;
   }
 
   .hbc-card--reverse .hbc-card__portrait-wrap {
-    right: -5%;
+    right: -12%;
     left: auto;
   }
 
@@ -647,8 +647,14 @@
 
 @media (max-width: 420px) and (orientation: portrait) {
   .hbc-card__portrait-wrap {
-    width: 62vw;
-    height: 72%;
+    left: -14%;
+    width: 82vw;
+    height: 84%;
+  }
+
+  .hbc-card--reverse .hbc-card__portrait-wrap {
+    right: -14%;
+    left: auto;
   }
 
   .hbc-card__copy { width: 47vw; }

--- a/src/components/HousematesBioCinematic/HousematesBioCinematic.css
+++ b/src/components/HousematesBioCinematic/HousematesBioCinematic.css
@@ -590,15 +590,24 @@
 @media (orientation: portrait) {
   .hbc-card__portrait-wrap {
     z-index: 6;
-    bottom: -2%;
-    left: -12%;
-    width: 78vw;
-    height: 86%;
+    bottom: -4%;
+    left: -28%;
+    width: 96vw;
+    height: 100%;
   }
 
   .hbc-card--reverse .hbc-card__portrait-wrap {
-    right: -12%;
+    right: -28%;
     left: auto;
+  }
+
+  .hbc-card__portrait {
+    transform: scale(1.16);
+    transform-origin: left bottom;
+  }
+
+  .hbc-card--reverse .hbc-card__portrait {
+    transform-origin: right bottom;
   }
 
   .hbc-card__copy {
@@ -647,15 +656,17 @@
 
 @media (max-width: 420px) and (orientation: portrait) {
   .hbc-card__portrait-wrap {
-    left: -14%;
-    width: 82vw;
-    height: 84%;
+    left: -31%;
+    width: 100vw;
+    height: 100%;
   }
 
   .hbc-card--reverse .hbc-card__portrait-wrap {
-    right: -14%;
+    right: -31%;
     left: auto;
   }
+
+  .hbc-card__portrait { transform: scale(1.2); }
 
   .hbc-card__copy { width: 47vw; }
 

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -903,19 +903,25 @@
   overflow: hidden;
 }
 
-.pf-overlay__leader-cutout-wrap {
+.pf-overlay__leader-avatar-wrap {
   position: absolute;
   inset: 0;
+  display: grid;
+  place-items: center;
 }
 
-.pf-overlay__leader-avatar--cutout {
-  width: 100%;
-  height: 100%;
-  border: 0;
-  border-radius: 0;
-  object-fit: contain;
-  object-position: center bottom;
-  filter: drop-shadow(0 14px 20px rgba(0, 0, 0, 0.6));
+.pf-overlay__leader-avatar--portrait {
+  width: clamp(6rem, 25vw, 7.75rem);
+  height: clamp(6rem, 25vw, 7.75rem);
+  overflow: hidden;
+  border: 2px solid rgba(121, 231, 255, 0.54);
+  border-radius: 50%;
+  background: #111725;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.52), 0 0 30px rgba(121, 231, 255, 0.2);
+}
+
+.pf-overlay__leader-avatar--portrait .pf-overlay__avatar-img {
+  object-position: center 18%;
 }
 
 .pf-overlay__leader-glow {
@@ -1069,7 +1075,7 @@
 @media (prefers-reduced-motion: reduce) {
   .pf-overlay__studio,
   .pf-overlay__highlight,
-  .pf-overlay__leader-avatar--cutout {
+  .pf-overlay__leader-avatar-wrap {
     animation: none;
   }
 }

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -868,8 +868,8 @@
 }
 
 .pf-overlay__spotlight {
-  min-height: 7.4rem;
-  grid-template-columns: minmax(0, 1fr) 7.4rem;
+  min-height: 10.75rem;
+  grid-template-columns: minmax(0, 1fr) clamp(9rem, 34vw, 14rem);
   padding: 0.75rem 0.8rem;
   border-color: rgba(121, 231, 255, 0.2);
   border-radius: 1rem;
@@ -911,8 +911,8 @@
 }
 
 .pf-overlay__leader-avatar--portrait {
-  width: clamp(6rem, 25vw, 7.75rem);
-  height: clamp(6rem, 25vw, 7.75rem);
+  width: clamp(8.5rem, 32vw, 13rem);
+  height: clamp(8.5rem, 32vw, 13rem);
   overflow: hidden;
   border: 2px solid rgba(121, 231, 255, 0.54);
   border-radius: 50%;
@@ -1038,7 +1038,7 @@
 
 @media (max-width: 420px) {
   .pf-overlay__spotlight {
-    grid-template-columns: minmax(0, 1fr) 6.8rem;
+    grid-template-columns: minmax(0, 1fr) 9rem;
   }
 
   .pf-overlay__header-copy {
@@ -1058,7 +1058,7 @@
 
 @media (max-height: 700px) {
   .pf-overlay__spotlight {
-    min-height: 5.8rem;
+    min-height: 8.75rem;
   }
 
   .pf-overlay__spotlight-fact,

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -19,7 +19,6 @@ import { AnimatePresence, motion } from 'framer-motion';
 import type { Player } from '../../types';
 import { useBattleBackVoting } from '../../hooks/useBattleBackVoting';
 import { resolveAvatar } from '../../utils/avatar';
-import FullSizeCutoutImage from '../FullSizeCutoutImage/FullSizeCutoutImage';
 import {
   buildHouseguestSpotlightItems,
   getActiveSpotlightPlayers,
@@ -357,18 +356,13 @@ function HousemateSpotlightCard({
         <AnimatePresence mode="wait">
           <motion.div
             key={player.id}
-            className="pf-overlay__leader-cutout-wrap"
+            className="pf-overlay__leader-avatar-wrap"
             initial={{ opacity: 0, x: 12 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -12 }}
             transition={{ duration: 0.32, ease: 'easeOut' }}
           >
-            <FullSizeCutoutImage
-              player={player}
-              alt={player.name}
-              className="pf-overlay__leader-avatar pf-overlay__leader-avatar--cutout"
-              loading="eager"
-            />
+            <PlayerPortrait candidate={player} className="pf-overlay__leader-avatar pf-overlay__leader-avatar--portrait" />
           </motion.div>
         </AnimatePresence>
       </div>

--- a/src/components/SeasonRecapCinematic/SeasonRecapCinematic.css
+++ b/src/components/SeasonRecapCinematic/SeasonRecapCinematic.css
@@ -1284,6 +1284,8 @@
   min-height: 0;
   object-position: center bottom;
   filter: drop-shadow(0 24px 34px rgba(0, 0, 0, 0.55));
+  transform: scale(1.28);
+  transform-origin: left bottom;
 }
 
 .src-category-cutout[data-image-state='pending'] {
@@ -1407,6 +1409,8 @@
   max-height: none;
   object-position: center bottom;
   filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.5));
+  transform: scale(1.24);
+  transform-origin: center bottom;
 }
 
 .src-finalists-equal__name {

--- a/src/screens/GameOver/GameOver.css
+++ b/src/screens/GameOver/GameOver.css
@@ -1445,12 +1445,83 @@
 
 .gameover-record-logo {
   display: block;
-  width: min(132px, 34vw);
-  max-height: 56px;
-  margin: auto auto 2px;
+  width: min(260px, 58vw);
+  max-height: 110px;
+  margin: auto auto 8px;
   object-fit: contain;
   opacity: 0.84;
   filter: drop-shadow(0 10px 22px rgba(0, 0, 0, 0.38));
+}
+
+.gameover-champion-record {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(10px, 2dvh, 20px);
+  padding: clamp(16px, 3dvh, 28px) 14px;
+}
+
+.gameover-champion-record__identity {
+  position: relative;
+  z-index: 3;
+  width: 100%;
+  text-align: center;
+}
+
+.gameover-champion-record__identity .gameover-winner__name {
+  margin-top: 4px;
+  font-size: clamp(2.45rem, 11vw, 4.5rem);
+  line-height: 0.9;
+}
+
+.gameover-champion-record__showpiece {
+  position: relative;
+  display: grid;
+  width: clamp(13rem, 52vw, 19rem);
+  aspect-ratio: 1;
+  place-items: center;
+  perspective: 700px;
+}
+
+.gameover-champion-record__portrait {
+  align-self: auto;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  border-width: 3px;
+  box-shadow: 0 20px 52px rgba(2, 6, 23, 0.54), 0 0 46px rgba(99, 102, 241, 0.32);
+}
+
+.gameover-champion-record__trophy {
+  position: absolute;
+  right: -7%;
+  bottom: 2%;
+  z-index: 4;
+  display: grid;
+  width: clamp(4.7rem, 18vw, 6.4rem);
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.36);
+  border-radius: 50%;
+  color: #fff4b8;
+  background: radial-gradient(circle at 34% 26%, #fff8d7, #f3be45 46%, #9b5b12 100%);
+  box-shadow: 0 14px 34px rgba(2, 6, 23, 0.48), 0 0 30px rgba(245, 194, 67, 0.34);
+  transform-style: preserve-3d;
+  animation: gameover-trophy-spin 3.2s linear infinite;
+}
+
+.gameover-champion-record__trophy svg {
+  width: 58%;
+  height: 58%;
+  fill: currentColor;
+  filter: drop-shadow(0 3px 4px rgba(92, 49, 4, 0.38));
+}
+
+@keyframes gameover-trophy-spin {
+  0% { transform: rotateY(0deg) rotateZ(-4deg); }
+  50% { transform: rotateY(180deg) rotateZ(4deg); }
+  100% { transform: rotateY(360deg) rotateZ(-4deg); }
 }
 
 .gameover-aftermath__paper {
@@ -1464,6 +1535,23 @@
     repeating-linear-gradient(0deg, rgba(35, 28, 48, 0.025) 0 1px, transparent 1px 4px),
     linear-gradient(145deg, #f6f4fa, #e9e5f0);
   box-shadow: 0 20px 52px rgba(2, 6, 23, 0.42), inset 0 0 0 6px rgba(255, 255, 255, 0.35);
+}
+
+.gameover-aftermath {
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+}
+
+.gameover-aftermath__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0 2px 18px;
+  overscroll-behavior: contain;
+  scroll-padding-bottom: 24px;
+  -webkit-overflow-scrolling: touch;
 }
 
 .gameover-aftermath__paper::before {
@@ -1511,8 +1599,31 @@
   background: rgba(91, 75, 183, 0.08);
 }
 
+.gameover-aftermath__actions {
+  position: relative;
+  bottom: auto;
+  z-index: 30;
+  flex: 0 0 auto;
+  margin: 8px -12px -12px;
+  padding: 11px 12px max(12px, env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid rgba(129, 140, 248, 0.2);
+  background: rgba(8, 11, 20, 0.99);
+  box-shadow: 0 -16px 34px rgba(8, 11, 20, 0.88);
+  pointer-events: auto;
+}
+
 @media (max-width: 460px) {
   .gameover-card { padding: 14px 12px 12px; border-radius: 18px 18px 8px 8px; }
   .gameover-title { font-size: clamp(2.55rem, 15vw, 4.6rem); }
   .gameover-aftermath__photo { height: min(46dvh, 430px); min-height: 340px; }
+}
+
+@media (max-height: 760px) {
+  .gameover-champion-record__showpiece {
+    width: clamp(10.5rem, 42vw, 14rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gameover-champion-record__trophy { animation: none; }
 }

--- a/src/screens/GameOver/GameOver.css
+++ b/src/screens/GameOver/GameOver.css
@@ -1421,3 +1421,98 @@
     animation: none;
   }
 }
+
+/* Full-height season record and tabloid-style aftermath refinements. */
+.gameover-shell {
+  justify-content: flex-start;
+  padding-top: max(10px, calc(var(--safe-top) + 8px));
+}
+
+.gameover-card {
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 680px);
+  height: calc(100dvh - var(--gameover-bottom-clearance) - var(--safe-top) - var(--safe-bottom) - 20px);
+  max-height: none;
+  min-height: 0;
+}
+
+.gameover-carousel { flex: 1; min-height: 0; }
+.gameover-carousel__slide--active { display: flex; flex-direction: column; }
+.gameover-carousel__slide--active .gameover-champion-record { flex: 1; }
+.gameover-scoreboard { gap: clamp(5px, 1.2dvh, 10px); }
+.gameover-scoreboard__row { flex: 0 0 auto; }
+
+.gameover-record-logo {
+  display: block;
+  width: min(132px, 34vw);
+  max-height: 56px;
+  margin: auto auto 2px;
+  object-fit: contain;
+  opacity: 0.84;
+  filter: drop-shadow(0 10px 22px rgba(0, 0, 0, 0.38));
+}
+
+.gameover-aftermath__paper {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(68, 55, 94, 0.24);
+  border-radius: 8px;
+  color: #191522;
+  background:
+    radial-gradient(circle at 14% 16%, rgba(99, 102, 241, 0.08) 0 1px, transparent 1.5px) 0 0 / 8px 8px,
+    repeating-linear-gradient(0deg, rgba(35, 28, 48, 0.025) 0 1px, transparent 1px 4px),
+    linear-gradient(145deg, #f6f4fa, #e9e5f0);
+  box-shadow: 0 20px 52px rgba(2, 6, 23, 0.42), inset 0 0 0 6px rgba(255, 255, 255, 0.35);
+}
+
+.gameover-aftermath__paper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(118deg, transparent 0 46%, rgba(107, 78, 143, 0.045) 46% 48%, transparent 48% 100%);
+  mix-blend-mode: multiply;
+}
+
+.gameover-aftermath__lead,
+.gameover-aftermath__story-grid { position: relative; z-index: 1; }
+.gameover-aftermath__lead { border-bottom-color: rgba(49, 39, 64, 0.22); }
+.gameover-aftermath__kicker { color: #5b4bb7; }
+.gameover-aftermath__headline { color: #17121e; text-shadow: none; }
+.gameover-aftermath__subheadline,
+.gameover-aftermath__body { color: rgba(31, 25, 42, 0.75); }
+
+.gameover-aftermath__photo-frame {
+  padding: 6px;
+  border: 1px solid rgba(25, 20, 33, 0.22);
+  border-radius: 3px;
+  background: #fff;
+  box-shadow: 0 12px 24px rgba(31, 24, 43, 0.22);
+  transform: rotate(-0.35deg);
+}
+
+.gameover-aftermath__photo {
+  height: min(47dvh, 470px);
+  min-height: 330px;
+  object-position: center top;
+  filter: saturate(0.9) contrast(1.08);
+}
+
+.gameover-aftermath__caption {
+  color: rgba(31, 25, 42, 0.58);
+  font-family: Georgia, 'Times New Roman', serif;
+  font-style: italic;
+}
+
+.gameover-aftermath__bullets li {
+  border-color: rgba(91, 75, 183, 0.2);
+  color: rgba(28, 23, 38, 0.86);
+  background: rgba(91, 75, 183, 0.08);
+}
+
+@media (max-width: 460px) {
+  .gameover-card { padding: 14px 12px 12px; border-radius: 18px 18px 8px 8px; }
+  .gameover-title { font-size: clamp(2.55rem, 15vw, 4.6rem); }
+  .gameover-aftermath__photo { height: min(46dvh, 430px); min-height: 340px; }
+}

--- a/src/screens/GameOver/GameOver.tsx
+++ b/src/screens/GameOver/GameOver.tsx
@@ -185,10 +185,6 @@ export default function GameOver() {
     <div className="gameover-shell">
       <div className="gameover-gallery-bg" aria-hidden="true" />
       <div className="gameover-gallery-flashes" aria-hidden="true" />
-      <div className="gameover-brand" aria-hidden="true">
-        <img className="gameover-brand__logo" src={LOGO_SRC} alt="" />
-      </div>
-
       <div className="gameover-card">
         <p className="gameover-eyebrow">Season {season} · Official record</p>
         <h1 className="gameover-title">Season Complete</h1>
@@ -250,6 +246,7 @@ export default function GameOver() {
                 </li>
               ))}
             </ul>
+            <img className="gameover-record-logo" src={LOGO_SRC} alt="KoleQuant" />
           </div>
 
           <div
@@ -265,6 +262,7 @@ export default function GameOver() {
                 </li>
               ))}
             </ul>
+            <img className="gameover-record-logo" src={LOGO_SRC} alt="KoleQuant" />
           </div>
         </div>
 

--- a/src/screens/GameOver/GameOver.tsx
+++ b/src/screens/GameOver/GameOver.tsx
@@ -116,7 +116,6 @@ export default function GameOver() {
   const allTimeLeaderboard = computeAllTimeLeaderboard(seasonArchives, DEFAULT_WEIGHTS).slice(0, 5);
   const aftermathStories = useMemo(() => buildAftermathStories(players, season), [players, season]);
   const activeStory = aftermathStories[storyIndex] ?? aftermathStories[0];
-  const winnerScore = seasonLeaderboard.find((entry) => entry.playerId === winner?.id)?.score ?? 0;
   const aftermathProgress = aftermathStories.length > 0
     ? ((storyIndex + 1) / aftermathStories.length) * 100
     : 0;
@@ -195,25 +194,26 @@ export default function GameOver() {
             className={`gameover-carousel__slide${carouselSlide === 0 ? ' gameover-carousel__slide--active' : ''}`}
           >
             <div className="gameover-champion-record">
-              <div className="gameover-champion-record__portrait" aria-hidden="true">
-                {winner && (
-                  <RecapImage
-                    sources={resolveAvatarCandidates(winner)}
-                    alt={winner.name}
-                    className="gameover-champion-record__image"
-                    loading="eager"
-                  />
-                )}
-              </div>
-              <div className="gameover-champion-record__copy">
+              <div className="gameover-champion-record__identity">
                 <div className="gameover-winner__label">Season champion</div>
                 <div className="gameover-winner__name">{winner?.name ?? 'TBD'}</div>
-                <p className="gameover-champion-record__verdict">The Tribunal&apos;s final decision</p>
-                <div className="gameover-champion-record__stats">
-                  <span><strong>{winnerScore}</strong> points</span>
-                  <span><strong>{week}</strong> weeks</span>
-                  <span><strong>{players.length}</strong> housemates</span>
+              </div>
+              <div className="gameover-champion-record__showpiece">
+                <div className="gameover-champion-record__portrait" aria-hidden="true">
+                  {winner && (
+                    <RecapImage
+                      sources={resolveAvatarCandidates(winner)}
+                      alt={winner.name}
+                      className="gameover-champion-record__image"
+                      loading="eager"
+                    />
+                  )}
                 </div>
+                <span className="gameover-champion-record__trophy" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M6 2h12v3h4v3a6 6 0 0 1-5.24 5.95A7 7 0 0 1 13 17.92V20h4v2H7v-2h4v-2.08a7 7 0 0 1-3.76-3.97A6 6 0 0 1 2 8V5h4V2Zm12 5v4.72A4 4 0 0 0 20 8V7h-2ZM4 7v1a4 4 0 0 0 2 3.72V7H4Z" />
+                  </svg>
+                </span>
               </div>
             </div>
 
@@ -324,57 +324,59 @@ export default function GameOver() {
                 <span style={{ width: `${aftermathProgress}%` }} />
               </div>
 
-              <div className="gameover-aftermath__meta">
-                <div>
-                  <p className="gameover-aftermath__player">{activeStory.playerName}</p>
-                  <p className="gameover-aftermath__placement">{activeStory.placementLabel}</p>
-                </div>
-                <p className="gameover-aftermath__progress">
-                  {storyIndex + 1} / {aftermathStories.length}
-                </p>
-              </div>
-
-              <div className="gameover-aftermath__paper">
-                <div className="gameover-aftermath__lead">
-                  <p className="gameover-aftermath__kicker">What happened next</p>
-                  <h2 className="gameover-aftermath__headline">{activeStory.headline}</h2>
-                  <p className="gameover-aftermath__subheadline">{activeStory.subheadline}</p>
+              <div className="gameover-aftermath__scroll">
+                <div className="gameover-aftermath__meta">
+                  <div>
+                    <p className="gameover-aftermath__player">{activeStory.playerName}</p>
+                    <p className="gameover-aftermath__placement">{activeStory.placementLabel}</p>
+                  </div>
+                  <p className="gameover-aftermath__progress">
+                    {storyIndex + 1} / {aftermathStories.length}
+                  </p>
                 </div>
 
-                <div className="gameover-aftermath__story-grid">
-                  <div className="gameover-aftermath__photo-panel">
-                    <div className="gameover-aftermath__photo-frame">
-                      <RecapImage
-                        className="gameover-aftermath__photo"
-                        sources={activeStory.imageSources}
-                        alt={activeStory.playerName}
-                      />
-                      <span className="gameover-aftermath__flash" aria-hidden="true" />
+                <div className="gameover-aftermath__paper">
+                  <div className="gameover-aftermath__lead">
+                    <p className="gameover-aftermath__kicker">What happened next</p>
+                    <h2 className="gameover-aftermath__headline">{activeStory.headline}</h2>
+                    <p className="gameover-aftermath__subheadline">{activeStory.subheadline}</p>
+                  </div>
+
+                  <div className="gameover-aftermath__story-grid">
+                    <div className="gameover-aftermath__photo-panel">
+                      <div className="gameover-aftermath__photo-frame">
+                        <RecapImage
+                          className="gameover-aftermath__photo"
+                          sources={activeStory.imageSources}
+                          alt={activeStory.playerName}
+                        />
+                        <span className="gameover-aftermath__flash" aria-hidden="true" />
+                      </div>
+                      <p className="gameover-aftermath__caption">Post-show sighting.</p>
                     </div>
-                    <p className="gameover-aftermath__caption">Post-show sighting.</p>
-                  </div>
 
-                  <div className="gameover-aftermath__copy">
-                    <ul className="gameover-aftermath__bullets">
-                      {activeStory.bulletPoints.map((bullet) => (
-                        <li key={bullet}>{bullet}</li>
-                      ))}
-                    </ul>
-                    <p className="gameover-aftermath__body">{activeStory.body}</p>
+                    <div className="gameover-aftermath__copy">
+                      <ul className="gameover-aftermath__bullets">
+                        {activeStory.bulletPoints.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                      <p className="gameover-aftermath__body">{activeStory.body}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              <div className="gameover-aftermath__contact-sheet" aria-label="Aftermath stories">
-                {aftermathStories.slice(0, 8).map((story, index) => (
-                  <span
-                    key={story.playerId}
-                    className={index === storyIndex ? 'is-active' : ''}
-                    title={story.playerName}
-                  >
-                    {String(index + 1).padStart(2, '0')}
-                  </span>
-                ))}
+                <div className="gameover-aftermath__contact-sheet" aria-label="Aftermath stories">
+                  {aftermathStories.slice(0, 8).map((story, index) => (
+                    <span
+                      key={story.playerId}
+                      className={index === storyIndex ? 'is-active' : ''}
+                      title={story.playerName}
+                    >
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                  ))}
+                </div>
               </div>
 
               <div className="gameover-aftermath__actions">

--- a/tests/gameOver.screen.test.tsx
+++ b/tests/gameOver.screen.test.tsx
@@ -75,6 +75,9 @@ describe('GameOver screen', () => {
       </Provider>,
     );
 
+    expect(document.querySelector('.gameover-champion-record__trophy')).toBeInTheDocument();
+    expect(document.querySelector('.gameover-champion-record__stats')).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole('button', { name: /^home$/i }));
 
     await waitFor(() => {
@@ -283,5 +286,14 @@ describe('GameOver screen', () => {
       expect(screen.getByText(/What happened next/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /^results$/i })).toBeInTheDocument();
     });
+
+    const aftermathScroller = document.querySelector('.gameover-aftermath__scroll');
+    const aftermathActions = document.querySelector('.gameover-aftermath__actions');
+    expect(aftermathScroller).toBeInTheDocument();
+    expect(aftermathActions).toBeInTheDocument();
+    expect(aftermathScroller?.contains(aftermathActions)).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
   });
 });

--- a/tests/unit/finale/FinalLightsOutSequence.test.tsx
+++ b/tests/unit/finale/FinalLightsOutSequence.test.tsx
@@ -106,12 +106,13 @@ describe('FinalLightsOutSequence', () => {
       height: '180px',
     });
 
-    expect(screen.getByText(/This is not a Goodbye/i)).toBeInTheDocument();
+    expect(screen.getByText(/This is not a goodbye/i)).toBeInTheDocument();
+    expect(screen.getByText(/It's see you soon/i)).toBeInTheDocument();
     expect(document.querySelector('.flo-tv-message em')).toBeNull();
-    expect(screen.getByText(/from the Big Eye\./i).tagName).toBe('SPAN');
+    expect(document.querySelectorAll('.flo-tv-message > span')).toHaveLength(2);
     const logo = document.querySelector<HTMLImageElement>('.flo-tv-logo-image');
     expect(logo?.getAttribute('src')).toContain('/assets/avatar_badges/goodbye_eye_vector.svg');
-    expect(screen.getByText(/Public's Favorite:/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Public's Favorite:/i)).toBeNull();
   });
 
   it('anchors to the main TV viewport when that element appears after mount', async () => {


### PR DESCRIPTION
## What changed

- Enlarges housemate figures in the Housemates introduction cinematic for phone screens.
- Uses face avatars for tribunal finalists and the Public Favorite voting spotlight.
- Expands the Season Complete record to an almost full-screen mobile layout and places the KoleQuant logo beneath both Top 5 ladders.
- Restyles After the Eye as a paparazzi/tabloid paper while anchoring photos at the top so faces remain visible.
- Simplifies the final TV farewell to two centered lines beneath the eye and adds a CRT power-off collapse before blackout.

## Why

These refinements follow the mobile review screenshots after PR #1184 was merged. They improve subject prominence, avoid cropped faces, keep the finale presentation consistent with the main game palette, and make the final shutdown feel intentional.

## Validation

- `npm run lint:ci -- --ignore-pattern .worktrees/**`
- `npm run typecheck`
- 5 focused test files / 22 tests passed
- QA-enabled production build passed