### PR TITLE
Add one-time Tribunal phase announcement

### DIFF
--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -89,6 +89,7 @@ const MAJOR_KEYS = new Set([
   'coup_detat',
   'spotlight_veto',
   'democracia',
+  'tribunal_phase',
   'twist',
   'loh_comp_announcement',
   'pos_comp_announcement',
@@ -110,6 +111,7 @@ const ANNOUNCEMENT_META: Record<string, { title: string; subtitle: string; isLiv
   coup_detat:           { title: 'Detox!',                     subtitle: 'Both nominees cleared. Holder names two backup nominees. ⚡',    isLive: true,  autoDismissMs: null },
   spotlight_veto:       { title: 'Force Majeure!',             subtitle: 'The holder is forced to use the power this ceremony. ✨',        isLive: true,  autoDismissMs: null },
   democracia:           { title: 'DEMOCRACIA!',                subtitle: 'The house will elect the new Leader of the House by secret vote.', isLive: true,  autoDismissMs: null },
+  tribunal_phase:       { title: `Congrats all, you've just made it to tribunal.`, subtitle: 'Your voices will crown the winner.', isLive: true, autoDismissMs: null },
   twist:                { title: 'Shock Alert!',               subtitle: 'The Big Eye has a surprise.',                                  isLive: true,  autoDismissMs: null },
   loh_comp_announcement: { title: 'LOH Competition',           subtitle: 'Power is up for grabs — who will become Leader of the House?', isLive: true,  autoDismissMs: null },
   pos_comp_announcement: { title: 'Power of Safety',           subtitle: 'It\'s time for the Power of Safety competition!',              isLive: true,  autoDismissMs: null },
@@ -201,6 +203,7 @@ const SHOCK_ANNOUNCEMENT_KEYS = new Set([
   'battle_back_rules',
   'battle_back_challenge',
   'democracia',
+  'tribunal_phase',
 ]);
 
 type TvZonePublicSaveReveal = {
@@ -300,6 +303,11 @@ export default function TvZone(props: TvZoneProps) {
   const occupancyChip = props.occupancyChip ?? null;
 
   const latestEvent = tvVisibleFeed[0];
+  const announcementPrerollEvent = useMemo(() => {
+    const prerollId = latestEvent?.meta?.announcementPrerollEventId;
+    if (typeof prerollId !== 'string') return null;
+    return tvVisibleFeed.find((event) => event.id === prerollId) ?? null;
+  }, [latestEvent, tvVisibleFeed]);
   const publicSaveRevealActive = Boolean(props.publicSaveReveal);
   const voteResultsRevealActive = Boolean(props.voteResultsReveal);
   const democraciaResultsRevealActive = Boolean(props.democraciaResultsReveal);
@@ -448,11 +456,13 @@ export default function TvZone(props: TvZoneProps) {
 
   // Event-based announcement: only explicit meta.major / ev.major (no text heuristics).
   const eventAnnouncement = useMemo<Announcement | null>(() => {
-    if (!latestEvent) return null;
-    if (latestEvent.id === dismissedEventId) return null;
-    const majorKey = extractMajorKey(latestEvent);
-    return majorKey ? buildAnnouncement(majorKey, latestEvent) : null;
-  }, [latestEvent, dismissedEventId]);
+    const announcementEvent = announcementPrerollEvent ?? latestEvent;
+    if (!announcementEvent) return null;
+    if (announcementEvent.id === dismissedEventId) return null;
+    const majorKey = extractMajorKey(announcementEvent);
+    return majorKey ? buildAnnouncement(majorKey, announcementEvent) : null;
+  }, [announcementPrerollEvent, latestEvent, dismissedEventId]);
+  const eventAnnouncementSource = announcementPrerollEvent ?? latestEvent;
 
   // Active announcement precedence: priorityAnnouncement, then externalAnnouncement,
   // then phaseAnnouncement, then eventAnnouncement.
@@ -552,15 +562,15 @@ export default function TvZone(props: TvZoneProps) {
       if (phaseAnnouncement) {
         setDismissedPhase(gameState.phase);
         setPhaseAnnouncement(null);
-      } else if (latestEvent) {
-        setDismissedEventId(latestEvent.id);
+      } else if (eventAnnouncementSource) {
+        setDismissedEventId(eventAnnouncementSource.id);
       }
       onExternalAnnouncementDismiss?.();
     } else if (phaseAnnouncement) {
       setDismissedPhase(gameState.phase);
       setPhaseAnnouncement(null);
-    } else if (latestEvent) {
-      setDismissedEventId(latestEvent.id);
+    } else if (eventAnnouncementSource) {
+      setDismissedEventId(eventAnnouncementSource.id);
     }
     if (skipPostDismissFade) {
       setPostDismissBlocked(false);
@@ -576,7 +586,7 @@ export default function TvZone(props: TvZoneProps) {
   }, [
     priorityAnnouncement,
     externalAnnouncement,
-    latestEvent,
+    eventAnnouncementSource,
     phaseAnnouncement,
     eventAnnouncement,
     gameState.phase,

--- a/src/components/ui/__tests__/TvZone.announcement.test.tsx
+++ b/src/components/ui/__tests__/TvZone.announcement.test.tsx
@@ -601,6 +601,45 @@ describe('TvZone — announcement overlay', () => {
     vi.useRealTimers();
   });
 
+  it('plays the Tribunal phase shock before revealing the queued day-start message', () => {
+    vi.useFakeTimers();
+    const store = makeStore();
+    renderTvZone(store);
+
+    act(() => {
+      store.dispatch(addTvEvent(makeEvent({
+        id: 'tribunal-phase-preroll',
+        text: `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`,
+        meta: { major: 'tribunal_phase' },
+      })));
+    });
+    const tribunalPrerollId = store.getState().game.tvFeed[0].id;
+    act(() => {
+      store.dispatch(addTvEvent(makeEvent({
+        id: 'tribunal-day-start',
+        text: `Day 5 begins! 🏠 It's time for the LOH competition.`,
+        meta: { announcementPrerollEventId: tribunalPrerollId },
+      })));
+    });
+
+    expect(document.body.querySelector('[data-testid="shock-intro-overlay"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(SHOCK_INTRO_SETTLE_MS);
+    });
+
+    expect(screen.getByRole('dialog', { name: /Congrats all, you've just made it to tribunal/i })).toBeDefined();
+
+    act(() => {
+      window.dispatchEvent(new Event('tv:announcement-dismiss'));
+      vi.advanceTimersByTime(POST_DISMISS_SETTLE_MS);
+    });
+
+    expect(screen.queryByRole('dialog', { name: /made it to tribunal/i })).toBeNull();
+    expect(document.querySelector('.tv-zone__now')).toHaveTextContent('Day 5 begins!');
+    vi.useRealTimers();
+  });
+
   it('applies the Back 2 the Game styling when the major key is battle_back', () => {
     vi.useFakeTimers();
     const store = makeStore();

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -432,6 +432,7 @@ export function createInitialGameState(options?: { twinShockConsumed?: boolean }
     pendingForcedShock: null,
     dayStartShock: null,
     dayStartShockUsedThisSeason: false,
+    tribunalPhaseAnnounced: false,
     twinShock: createInitialTwinShockState(),
     twinShockConsumed,
     twinShockActivatedSeason: null,
@@ -480,7 +481,7 @@ function pushEvent(
   text: string,
   type: TvEvent['type'],
   meta?: TvEvent['meta'],
-) {
+): TvEvent {
   const ts = Date.now();
   const event: TvEvent = {
     id: `${state.phase}-w${state.week}-${ts}-${++_pushEventCounter}`,
@@ -490,6 +491,7 @@ function pushEvent(
     meta: buildTvMeta(state, meta),
   };
   state.tvFeed = [event, ...state.tvFeed].slice(0, 50);
+  return event;
 }
 
 function pushDetoxEvent(state: GameState, text: string) {
@@ -4442,7 +4444,26 @@ const gameSlice = createSlice({
           state.awaitingCoLohNomination = false;
           state.coLohNomineeByCoLohId = null;
           state.awaitingPosTieBreak = false;
-          pushEvent(state, `Day ${state.week} begins! 🏠 It's time for the LOH competition.`, 'game');
+          const tribunalPhaseBegins =
+            state.tribunalPhaseAnnounced !== true &&
+            state.players.some((player) => player.status === 'jury');
+          const tribunalAnnouncement = tribunalPhaseBegins
+            ? pushEvent(
+                state,
+                `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`,
+                'game',
+                { major: 'tribunal_phase' },
+              )
+            : null;
+          if (tribunalPhaseBegins) {
+            state.tribunalPhaseAnnounced = true;
+          }
+          pushEvent(
+            state,
+            `Day ${state.week} begins! 🏠 It's time for the LOH competition.`,
+            'game',
+            tribunalAnnouncement ? { announcementPrerollEventId: tribunalAnnouncement.id } : undefined,
+          );
           break;
         }
         case 'loh_comp_announcement': {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -815,6 +815,8 @@ export interface GameState {
   dayStartShock?: DayStartShockState | null;
   /** True after Morning Shock activates, preventing another activation this season. */
   dayStartShockUsedThisSeason?: boolean;
+  /** True after the one-time Tribunal phase announcement has played. */
+  tribunalPhaseAnnounced?: boolean;
   /**
    * When set, the VoteResultsPopup is shown with the vote tally before
    * advancing. Maps nominee ID → number of votes received.

--- a/tests/tribunalPhaseAnnouncement.test.ts
+++ b/tests/tribunalPhaseAnnouncement.test.ts
@@ -1,0 +1,71 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { describe, expect, it } from 'vitest';
+import gameReducer, { advance, setPhase } from '../src/store/gameSlice';
+import type { GameState, Player } from '../src/types';
+
+const TRIBUNAL_MESSAGE = `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`;
+
+function makePlayers(): Player[] {
+  return [
+    { id: 'p0', name: 'Player 0', avatar: '🧑', status: 'active', isUser: true },
+    { id: 'p1', name: 'Player 1', avatar: '🧑', status: 'active' },
+    { id: 'p2', name: 'Player 2', avatar: '🧑', status: 'active' },
+    { id: 'j0', name: 'Juror 0', avatar: '🧑', status: 'jury' },
+  ];
+}
+
+function makeStore(overrides: Partial<GameState> = {}) {
+  const game: GameState = {
+    season: 1,
+    week: 4,
+    phase: 'week_end',
+    seed: 42,
+    lohId: 'p0',
+    nomineeIds: [],
+    posWinnerId: null,
+    replacementNeeded: false,
+    awaitingNominations: false,
+    pendingNominee1Id: null,
+    awaitingPovDecision: false,
+    players: makePlayers(),
+    tvFeed: [],
+    isLive: false,
+    ...overrides,
+  };
+  return configureStore({ reducer: { game: gameReducer }, preloadedState: { game } });
+}
+
+describe('Tribunal phase announcement', () => {
+  it('queues the one-time shock message immediately before the next day message', () => {
+    const store = makeStore();
+
+    store.dispatch(advance());
+
+    const state = store.getState().game;
+    expect(state.phase).toBe('week_start');
+    expect(state.tribunalPhaseAnnounced).toBe(true);
+    expect(state.tvFeed[0].text).toContain('Day 5 begins!');
+    expect(state.tvFeed[1]).toMatchObject({
+      text: TRIBUNAL_MESSAGE,
+      meta: { major: 'tribunal_phase' },
+    });
+    expect(state.tvFeed[0].meta?.announcementPrerollEventId).toBe(state.tvFeed[1].id);
+
+    store.dispatch(setPhase('week_end'));
+    store.dispatch(advance());
+
+    expect(store.getState().game.tvFeed.filter((event) => event.text === TRIBUNAL_MESSAGE)).toHaveLength(1);
+  });
+
+  it('does not announce before the first Tribunal member exists', () => {
+    const players = makePlayers().map((player) => (
+      player.status === 'jury' ? { ...player, status: 'evicted' as const } : player
+    ));
+    const store = makeStore({ players });
+
+    store.dispatch(advance());
+
+    expect(store.getState().game.tribunalPhaseAnnounced).not.toBe(true);
+    expect(store.getState().game.tvFeed.some((event) => event.text === TRIBUNAL_MESSAGE)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- Adds the one-time Tribunal announcement when the first Tribunal member exists.
- Reuses the shock presentation and queues it immediately before the next “Day X begins” TV message.
- Persists the announcement guard so it does not repeat across later days or saves.

## Validation
- Focused Tribunal and TvZone tests pass (72 tests).
- TypeScript typecheck passes.
- ESLint passes for the changed files.