### PR TITLE
Add Twin Shock audio and Day 5 hint

### DIFF
--- a/src/components/TwinShockIntroCinematic/TwinShockIntroCinematic.tsx
+++ b/src/components/TwinShockIntroCinematic/TwinShockIntroCinematic.tsx
@@ -71,7 +71,7 @@ export default function TwinShockIntroCinematic({
     skipRef.current?.focus();
 
     SoundManager.panicStopAllMusic();
-    const audio = createCinematicAudio(asset('/assets/sounds/tv_winner_reveal.mp3'), 0.62);
+    const audio = createCinematicAudio(asset('/assets/sounds/Twin_shock_presentation.mp4'), 0.62);
     audioRef.current = audio;
     if ((window as IntroHubAudioWindow)._introhubMusicOn !== false) audio.play();
 

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -24,6 +24,7 @@ import type { GameRegistryEntry, GameCategory } from '../minigames/registry';
 import { computeScores } from '../minigames/scoring';
 import type { RawResult } from '../minigames/scoring';
 import type { CwgoPrizeType } from '../features/cwgo/cwgoCompetitionSlice';
+import { TWIN_SHOCK_LIA_ID } from '../bb/twinShock';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,14 @@ function hashStringU32(s: string): number {
   return h;
 }
 
+function shouldForceTwinShockHintGame(state: RootState, prizeType?: CwgoPrizeType | string): boolean {
+  const game = state.game;
+  const isLohChallenge = prizeType === 'LOH' || (prizeType == null && game.phase === 'loh_comp');
+  return isLohChallenge
+    && game.week === 5
+    && game.twinShockConsumed !== true
+    && game.players.some((player) => player.id === TWIN_SHOCK_LIA_ID && player.status === 'active');
+}
 // ─── State ────────────────────────────────────────────────────────────────────
 
 export interface ChallengeRun {
@@ -426,6 +435,10 @@ export const startChallenge =
       }
     }
 
+    if (shouldForceTwinShockHintGame(state, opts.prizeType)) {
+      const twinHintGame = getGame('castleRescue');
+      if (twinHintGame) gameEntry = twinHintGame;
+    }
     // Derive a per-challenge seed from the base seed + game key hash.
     const challengeSeed = deriveSeed(gameSeed, gameEntry.key);
 


### PR DESCRIPTION
## What changed

- Uses Twin_shock_presentation.mp4 as the soundtrack for the existing Twin Shock intro cinematic.
- Keeps the cinematic's existing fade-out and background-music restoration behavior.
- Forces Find your twin for the Day 5 LOH competition while Lia is active and the Twin Shock remains unresolved.

## Why

The Twin Shock presentation needs its dedicated music, and the Day 5 competition provides a subtle gameplay clue before the twist resolves.

## Validation

- npm run typecheck
- 15 relevant Twin Shock tests passed