### PR TITLE
Fix Twin Shock audio fade and duration

### DIFF
--- a/src/components/TwinShockIntroCinematic/TwinShockIntroCinematic.tsx
+++ b/src/components/TwinShockIntroCinematic/TwinShockIntroCinematic.tsx
@@ -9,8 +9,10 @@ import {
 import './TwinShockIntroCinematic.css';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
-export const TWIN_SHOCK_INTRO_DURATION_MS = 13_800;
-const REDUCED_DURATION_MS = 3_800;
+export const TWIN_SHOCK_INTRO_DURATION_MS = 16_200;
+const REDUCED_DURATION_MS = 6_200;
+const CINEMATIC_FADE_OUT_MS = 1_200;
+const SKIP_FADE_OUT_MS = 420;
 
 type CinematicStage = 'signal' | 'childhood' | 'grown' | 'reveal' | 'verdict';
 
@@ -51,6 +53,8 @@ export default function TwinShockIntroCinematic({
   const [elapsedMs, setElapsedMs] = useState(0);
   const onCompleteRef = useRef(onComplete);
   const completedRef = useRef(false);
+  const fadeStartedRef = useRef(false);
+  const completionTimerRef = useRef<number | null>(null);
   const audioRef = useRef<CinematicAudioController | null>(null);
   const skipRef = useRef<HTMLButtonElement | null>(null);
 
@@ -58,12 +62,18 @@ export default function TwinShockIntroCinematic({
     onCompleteRef.current = onComplete;
   }, [onComplete]);
 
-  const finish = useCallback(() => {
+  const complete = useCallback(() => {
     if (completedRef.current) return;
     completedRef.current = true;
-    audioRef.current?.fadeOutAndStop(420);
     onCompleteRef.current();
   }, []);
+
+  const skip = useCallback(() => {
+    if (completedRef.current || completionTimerRef.current != null) return;
+    fadeStartedRef.current = true;
+    audioRef.current?.fadeOutAndStop(SKIP_FADE_OUT_MS);
+    completionTimerRef.current = window.setTimeout(complete, SKIP_FADE_OUT_MS);
+  }, [complete]);
 
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
@@ -79,26 +89,31 @@ export default function TwinShockIntroCinematic({
     const intervalId = window.setInterval(() => {
       const nextElapsed = performance.now() - startedAt;
       setElapsedMs(Math.min(durationMs, nextElapsed));
+      if (!fadeStartedRef.current && nextElapsed >= durationMs - CINEMATIC_FADE_OUT_MS) {
+        fadeStartedRef.current = true;
+        audio.fadeOutAndStop(CINEMATIC_FADE_OUT_MS);
+      }
       if (nextElapsed >= durationMs) {
         window.clearInterval(intervalId);
-        finish();
+        complete();
       }
     }, 60);
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') finish();
+      if (event.key === 'Escape') skip();
     };
     window.addEventListener('keydown', handleKeyDown);
 
     return () => {
       window.clearInterval(intervalId);
+      if (completionTimerRef.current != null) window.clearTimeout(completionTimerRef.current);
       window.removeEventListener('keydown', handleKeyDown);
       document.body.style.overflow = previousOverflow;
       audio.dispose();
       audioRef.current = null;
       void SoundManager.syncMusic();
     };
-  }, [durationMs, finish]);
+  }, [complete, durationMs, skip]);
 
   const stage = useMemo(
     () => stageAt(elapsedMs, prefersReducedMotion),
@@ -121,7 +136,7 @@ export default function TwinShockIntroCinematic({
       <div className="twin-intro__scan" aria-hidden="true" />
       <div className="twin-intro__grain" aria-hidden="true" />
 
-      <button ref={skipRef} className="twin-intro__skip" type="button" onClick={finish}>
+      <button ref={skipRef} className="twin-intro__skip" type="button" onClick={skip}>
         Skip <span aria-hidden="true">×</span>
       </button>
 

--- a/src/components/TwinShockIntroCinematic/__tests__/TwinShockIntroCinematic.test.tsx
+++ b/src/components/TwinShockIntroCinematic/__tests__/TwinShockIntroCinematic.test.tsx
@@ -45,7 +45,7 @@ describe('TwinShockIntroCinematic', () => {
     expect(container.querySelector('.twin-intro')).toHaveAttribute('data-stage', 'reveal');
     act(() => vi.advanceTimersByTime(3_700));
     expect(container.querySelector('.twin-intro')).toHaveAttribute('data-stage', 'verdict');
-    act(() => vi.advanceTimersByTime(3_000));
+    act(() => vi.advanceTimersByTime(5_400));
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
@@ -53,6 +53,7 @@ describe('TwinShockIntroCinematic', () => {
     const onComplete = vi.fn();
     render(<TwinShockIntroCinematic reveal={reveal} onComplete={onComplete} />);
     fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+    act(() => vi.advanceTimersByTime(420));
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What changed

- Extends the Twin Shock cinematic by 2.4 seconds, from 13.8 to 16.2 seconds.
- Starts a 1.2-second soundtrack fade before the cinematic unmounts, making the fade audible.
- Gives the Skip action a 420ms fade before the avatar reveal begins.
- Updates cinematic timing tests.

## Root cause

The previous fade began at the same moment the cinematic unmounted, and cleanup disposed the audio immediately.

## Validation

- npm run typecheck
- 15 relevant Twin Shock tests passed