### PR TITLE
Fix Day 5 Twin Shock challenge

### DIFF
--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -42,7 +42,7 @@ function shouldForceTwinShockHintGame(state: RootState, prizeType?: CwgoPrizeTyp
   const isLohChallenge = prizeType === 'LOH' || (prizeType == null && game.phase === 'loh_comp');
   return isLohChallenge
     && game.week === 5
-    && game.twinShockConsumed !== true
+    && game.twinShockResolution == null
     && game.players.some((player) => player.id === TWIN_SHOCK_LIA_ID && player.status === 'active');
 }
 // ─── State ────────────────────────────────────────────────────────────────────

--- a/tests/integration/challenge.flow.dispatch.test.tsx
+++ b/tests/integration/challenge.flow.dispatch.test.tsx
@@ -231,6 +231,20 @@ describe('challenge flow – startChallenge thunk', () => {
     expect(state.challenge.pending?.phase).toBe('rules');
   });
 
+  it('forces Find your twin for an activated but unresolved Day 5 Twin Shock', () => {
+    const initialGame = gameReducer(undefined, { type: '@@INIT' });
+    const store = makeStoreWithGame({
+      week: 5,
+      phase: 'loh_comp',
+      twinShockConsumed: true,
+      twinShockResolution: null,
+    });
+    const participants = initialGame.players.map((player) => player.id);
+
+    dispatchThunk(store, startChallenge(55, participants, { prizeType: 'LOH' }));
+
+    expect(store.getState().challenge.pending?.game.key).toBe('castleRescue');
+  });
   it('leaves challenge.history empty until completeChallenge is called', () => {
     const store = makeStore();
 


### PR DESCRIPTION
## What changed

- Forces Find your twin for the Day 5 LOH competition when Lia is active and the Twin Shock has not actually resolved.
- Adds a regression test for the activated-but-unresolved state.

## Root cause

The previous condition checked twinShockConsumed. That flag becomes true when the twist activates, so it incorrectly prevented the Day 5 hint. The rule now checks twinShockResolution instead.

## Validation

- npm run typecheck
- Targeted Day 5 challenge regression passed
- Twin Shock unit tests passed; the broader integration file still has an unrelated existing spectator-animation timeout