### PR TITLE
Refine finale typography and public vote pacing

### DIFF
--- a/src/components/HousematesBioCinematic/HousematesBioCinematic.css
+++ b/src/components/HousematesBioCinematic/HousematesBioCinematic.css
@@ -613,14 +613,14 @@
   .hbc-card__copy {
     z-index: 5;
     top: 45%;
-    right: 3vw;
-    width: 48vw;
+    right: 2.5vw;
+    width: 45vw;
     transform: translateY(-46%);
   }
 
   .hbc-card--reverse .hbc-card__copy {
     right: auto;
-    left: 3vw;
+    left: 2.5vw;
   }
 
   .hbc-card__identity {
@@ -629,13 +629,13 @@
   }
 
   .hbc-card__identity h2 {
-    font-size: clamp(2.8rem, 12.5vw, 5rem);
+    font-size: clamp(2.45rem, 10.5vw, 4.4rem);
     line-height: 0.84;
   }
 
   .hbc-card__details {
     margin-top: 8px;
-    font-size: clamp(0.55rem, 2vw, 0.72rem);
+    font-size: clamp(0.52rem, 1.8vw, 0.68rem);
   }
 
   .hbc-bubble {
@@ -643,7 +643,7 @@
     margin-top: 7px;
     padding: 9px 10px;
     border-radius: 14px 14px 14px 4px;
-    font-size: clamp(0.66rem, 2.55vw, 0.84rem);
+    font-size: clamp(0.61rem, 2.25vw, 0.78rem);
     line-height: 1.34;
   }
 
@@ -668,12 +668,12 @@
 
   .hbc-card__portrait { transform: scale(1.2); }
 
-  .hbc-card__copy { width: 47vw; }
+  .hbc-card__copy { width: 44vw; }
 
   .hbc-bubble--intro {
     display: block;
     padding: 7px 9px;
-    font-size: clamp(0.59rem, 2.3vw, 0.73rem);
+    font-size: clamp(0.56rem, 2.05vw, 0.68rem);
     line-height: 1.24;
   }
 }

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css
@@ -41,11 +41,18 @@
     calc(env(safe-area-inset-bottom, 0px) + 1rem);
 }
 
-.pf-overlay__skip {
+.pf-overlay__speed-controls {
   position: fixed;
   top: var(--floating-corner-top-offset);
   right: var(--floating-corner-right-offset);
-  z-index: 4;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.pf-overlay__skip,
+.pf-overlay__fast-forward {
   border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 999px;
   padding: 0.48rem 0.82rem;
@@ -57,6 +64,24 @@
   text-transform: uppercase;
   backdrop-filter: blur(10px);
   box-shadow: 0 16px 28px rgba(0, 0, 0, 0.3);
+}
+
+.pf-overlay__fast-forward {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.34rem;
+  border-color: rgba(165, 180, 252, 0.34);
+  background: linear-gradient(110deg, rgba(47, 53, 112, 0.9), rgba(76, 29, 149, 0.88));
+}
+
+.pf-overlay__fast-forward span {
+  font-size: 1rem;
+  line-height: 0;
+}
+
+.pf-overlay__fast-forward.is-active,
+.pf-overlay__fast-forward:disabled {
+  opacity: 0.72;
 }
 
 .pf-overlay__header,
@@ -868,8 +893,8 @@
 }
 
 .pf-overlay__spotlight {
-  min-height: 10.75rem;
-  grid-template-columns: minmax(0, 1fr) clamp(9rem, 34vw, 14rem);
+  min-height: 9.5rem;
+  grid-template-columns: minmax(0, 1fr) clamp(7.5rem, 25vw, 10rem);
   padding: 0.75rem 0.8rem;
   border-color: rgba(121, 231, 255, 0.2);
   border-radius: 1rem;
@@ -899,8 +924,10 @@
 }
 
 .pf-overlay__leader-portrait-wrap {
-  align-self: stretch;
-  overflow: hidden;
+  align-self: center;
+  width: 100%;
+  aspect-ratio: 1;
+  overflow: visible;
 }
 
 .pf-overlay__leader-avatar-wrap {
@@ -911,8 +938,9 @@
 }
 
 .pf-overlay__leader-avatar--portrait {
-  width: clamp(8.5rem, 32vw, 13rem);
-  height: clamp(8.5rem, 32vw, 13rem);
+  width: min(100%, 9.5rem);
+  height: auto;
+  aspect-ratio: 1;
   overflow: hidden;
   border: 2px solid rgba(121, 231, 255, 0.54);
   border-radius: 50%;
@@ -1038,7 +1066,17 @@
 
 @media (max-width: 420px) {
   .pf-overlay__spotlight {
-    grid-template-columns: minmax(0, 1fr) 9rem;
+    grid-template-columns: minmax(0, 1fr) 7.6rem;
+  }
+
+  .pf-overlay__speed-controls {
+    gap: 0.28rem;
+  }
+
+  .pf-overlay__skip,
+  .pf-overlay__fast-forward {
+    padding: 0.43rem 0.66rem;
+    font-size: 0.7rem;
   }
 
   .pf-overlay__header-copy {

--- a/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
+++ b/src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.tsx
@@ -72,6 +72,7 @@ const CLOCK_INTERVAL_MS = 200;
 const SURGE_SELECTION_WINDOW_MS = 6500;
 const SURGE_DURATION_MS = 7000;
 const ELIMINATION_SPOTLIGHT_MS = 1400;
+const FAST_FORWARD_ELIMINATION_INTERVAL_MS = 260;
 function formatEyeoleans(amount: number): string {
   return `${new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 0,
@@ -517,6 +518,7 @@ export default function PublicFavoriteOverlay({
   const [nextShiftAt, setNextShiftAt] = useState(() => Date.now() + eliminationIntervalMs);
   const [selectedSurgeId, setSelectedSurgeId] = useState<string | null>(candidates[0]?.id ?? null);
   const [introSkipBoostMs, setIntroSkipBoostMs] = useState(0);
+  const [fastForwarding, setFastForwarding] = useState(false);
   const [surgePending, setSurgePending] = useState(false);
   const [surgeUsed, setSurgeUsed] = useState(false);
   const [surgeActive, setSurgeActive] = useState<SurgeState | null>(null);
@@ -534,11 +536,15 @@ export default function PublicFavoriteOverlay({
     [candidates],
   );
 
+  const effectiveEliminationIntervalMs = fastForwarding
+    ? Math.min(eliminationIntervalMs, FAST_FORWARD_ELIMINATION_INTERVAL_MS)
+    : eliminationIntervalMs;
+
   const { votes, eliminated, winnerId, isComplete } = useBattleBackVoting({
     candidates: candidateIds,
     seed,
-    eliminationIntervalMs,
-    tickIntervalMs: VOTE_TICK_INTERVAL_MS,
+    eliminationIntervalMs: effectiveEliminationIntervalMs,
+    tickIntervalMs: fastForwarding ? 120 : VOTE_TICK_INTERVAL_MS,
     driftAmount: VOTE_DRIFT_AMOUNT,
     surgeTargetId: surgeActive?.playerId ?? null,
   });
@@ -565,8 +571,8 @@ export default function PublicFavoriteOverlay({
 
   useEffect(() => {
     if (isComplete) return;
-    setNextShiftAt(Date.now() + eliminationIntervalMs);
-  }, [eliminated.length, eliminationIntervalMs, isComplete]);
+    setNextShiftAt(Date.now() + effectiveEliminationIntervalMs);
+  }, [eliminated.length, effectiveEliminationIntervalMs, isComplete]);
 
   useEffect(() => {
     if (eliminated.length <= previousEliminatedCountRef.current) {
@@ -720,6 +726,17 @@ export default function PublicFavoriteOverlay({
     setNowMs(Date.now());
   }, [elapsedMs, introSkipBoostMs]);
 
+  const handleFastForward = useCallback(() => {
+    if (fastForwarding || isComplete || surgePending) return;
+    const remainingIntroMs = Math.max(0, INTRO_MS - elapsedMs);
+    if (remainingIntroMs > 0) {
+      setIntroSkipBoostMs((current) => current + remainingIntroMs);
+    }
+    setFastForwarding(true);
+    setNextShiftAt(Date.now() + Math.min(eliminationIntervalMs, FAST_FORWARD_ELIMINATION_INTERVAL_MS));
+    setNowMs(Date.now());
+  }, [elapsedMs, eliminationIntervalMs, fastForwarding, isComplete, surgePending]);
+
   const handleActivateSurge = useCallback(async () => {
     if (
       !selectedSurgeId ||
@@ -772,15 +789,29 @@ export default function PublicFavoriteOverlay({
       <div className="pf-overlay__studio" aria-hidden="true" />
       <div className="pf-overlay__scanlines" aria-hidden="true" />
       <div className="pf-overlay__stage">
-        {displayStep === 'voting' && phase === 'intro' && (
-          <button
-            type="button"
-            className="pf-overlay__skip"
-            onClick={handleSkipIntro}
-            aria-label="Skip animation"
-          >
-            Skip
-          </button>
+        {displayStep === 'voting' && (
+          <div className="pf-overlay__speed-controls" aria-label="Public vote playback controls">
+            {phase === 'intro' && (
+              <button
+                type="button"
+                className="pf-overlay__skip"
+                onClick={handleSkipIntro}
+                aria-label="Skip animation"
+              >
+                Skip
+              </button>
+            )}
+            <button
+              type="button"
+              className={`pf-overlay__fast-forward${fastForwarding ? ' is-active' : ''}`}
+              onClick={handleFastForward}
+              disabled={fastForwarding || surgePending}
+              aria-label="Fast forward public favorite vote"
+            >
+              <span aria-hidden="true">»</span>
+              {fastForwarding ? 'Forwarding' : 'Fast forward'}
+            </button>
+          </div>
         )}
 
         {phase !== 'final_reveal' && (

--- a/src/components/SeasonRecapCinematic/SeasonRecapCinematic.css
+++ b/src/components/SeasonRecapCinematic/SeasonRecapCinematic.css
@@ -1454,8 +1454,13 @@
 
   .src-category-header {
     top: 18%;
-    right: 8%;
-    max-width: 46vw;
+    right: 5%;
+    max-width: 40vw;
+  }
+
+  .src-category-title {
+    font-size: clamp(2.4rem, 8.5vw, 4.65rem);
+    line-height: 0.84;
   }
 
   .src-category-stage {
@@ -1479,6 +1484,29 @@
     right: 54px;
     bottom: 54px;
     left: 54px;
+  }
+}
+
+@media (max-width: 699px) {
+  .src-category-header {
+    right: 3.5vw;
+    max-width: 46vw;
+  }
+
+  .src-category-title {
+    font-size: clamp(2rem, 9.4vw, 3.35rem);
+    line-height: 0.86;
+    letter-spacing: -0.055em;
+  }
+
+  .src-category-subtitle {
+    max-width: 46vw;
+    font-size: clamp(0.62rem, 2.3vw, 0.78rem);
+    line-height: 1.3;
+  }
+
+  .src-category-stage {
+    right: 40%;
   }
 }
 

--- a/tests/unit/publicFavoriteOverlay.styles.test.ts
+++ b/tests/unit/publicFavoriteOverlay.styles.test.ts
@@ -7,7 +7,7 @@ function normalizeCss(css: string) {
 }
 
 describe('PublicFavoriteOverlay styles', () => {
-  it('keeps the overlay scrollable and the skip control pinned on screen', () => {
+  it('keeps the overlay scrollable and its playback controls pinned on screen', () => {
     const css = normalizeCss(
       readFileSync(
         resolve(process.cwd(), 'src/components/PublicFavoriteOverlay/PublicFavoriteOverlay.css'),
@@ -18,9 +18,11 @@ describe('PublicFavoriteOverlay styles', () => {
     expect(css).toContain('.pf-overlay {');
     expect(css).toContain('overflow-y: auto;');
     expect(css).toContain('overscroll-behavior: contain;');
-    expect(css).toContain('.pf-overlay__skip {');
+    expect(css).toContain('.pf-overlay__speed-controls {');
     expect(css).toContain('position: fixed;');
     expect(css).toContain('top: var(--floating-corner-top-offset);');
     expect(css).toContain('right: var(--floating-corner-right-offset);');
+    expect(css).toContain('.pf-overlay__fast-forward {');
+    expect(css).toContain('width: min(100%, 9.5rem);');
   });
 });

--- a/tests/unit/publicFavoriteOverlay.test.tsx
+++ b/tests/unit/publicFavoriteOverlay.test.tsx
@@ -108,6 +108,35 @@ describe('PublicFavoriteOverlay', () => {
     expect(screen.getByRole('button', { name: /watch to boost taylor/i })).toBeEnabled();
   });
 
+  it('offers a fast-forward control that accelerates the remaining vote', () => {
+    mockedUseBattleBackVoting.mockReturnValue({
+      votes: { p1: 41, p2: 34, p3: 25 },
+      eliminated: [],
+      winnerId: null,
+      isComplete: false,
+    });
+
+    render(
+      <PublicFavoriteOverlay
+        candidates={PLAYERS}
+        seed={1}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    const fastForward = screen.getByRole('button', { name: /fast forward public favorite vote/i });
+    expect(fastForward).toBeEnabled();
+
+    fireEvent.click(fastForward);
+
+    expect(screen.getByRole('button', { name: /fast forward public favorite vote/i })).toBeDisabled();
+    expect(screen.getByText('Forwarding')).toBeInTheDocument();
+    expect(mockedUseBattleBackVoting.mock.calls.at(-1)?.[0]).toMatchObject({
+      eliminationIntervalMs: 260,
+      tickIntervalMs: 120,
+    });
+  });
+
   it('requests audience surge only once and shows the active state', async () => {
     mockedUseBattleBackVoting.mockReturnValue({
       votes: { p1: 38, p2: 35, p3: 27 },


### PR DESCRIPTION
## What changed
- reduce and narrow the Housemates biography copy so it no longer competes with the full-body portrait on phones
- move the season recap honor title into a smaller dedicated text column at phone and tablet widths
- constrain the Public Favorite spotlight avatar inside its card instead of cropping it
- add a persistent Fast forward control that accelerates the remaining Public Favorite eliminations
- add regression coverage for the playback control and avatar sizing

## Why
The enlarged portraits introduced in the prior finale redesign were visually stronger, but some titles and biography copy overlapped the figures at mobile breakpoints. The Public Favorite spotlight portrait could also exceed its panel, and the full vote sequence lacked a quick playback option.

## Impact
Phone layouts keep the housemates as the visual focus while preserving readable copy. Public Favorite avatars remain fully visible, and players can reach the final reveal in a few seconds when they choose Fast forward.

## Validation
- `npm run lint:ci -- --ignore-pattern .worktrees/**`
- `npm run typecheck`
- focused Vitest suite: 12 tests passed
- QA-enabled production build
- browser verification at a 347 × 738 phone viewport
- Fast forward reached the six-player final reveal in about 1.5 seconds