### PR TITLE
Enable mobile debug launch

### DIFF
--- a/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
+++ b/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
@@ -20,7 +20,13 @@ function getAvatarUrls(): string[] {
   );
 }
 
-export default function AssetPreloaderOverlay() {
+interface AssetPreloaderOverlayProps {
+  destination?: string;
+}
+
+export default function AssetPreloaderOverlay({
+  destination = '/game',
+}: AssetPreloaderOverlayProps) {
   const navigate = useNavigate();
   const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState('Opening the competition arena.');
@@ -48,14 +54,14 @@ export default function AssetPreloaderOverlay() {
       if (cancelled || doneFiredRef.current) return;
       doneFiredRef.current = true;
       setStatus('Entering the house.');
-      navigate('/game');
+      navigate(destination);
     }
 
     void run();
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [destination, navigate]);
 
   return (
     <KolequantSplash

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
@@ -175,6 +175,12 @@ export default function DebugPanel() {
   const [selectedStatusPlayer, setSelectedStatusPlayer] = useState('');
   const [selectedF4Evictee, setSelectedF4Evictee] = useState('');
   const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction');
+
+  // AppShell stays mounted while the hash route changes. When debug is enabled
+  // by the mobile launch flow, open the drawer as soon as access becomes active.
+  useEffect(() => {
+    if (isDebug) setIsOpen(true);
+  }, [isDebug]);
 
   if (!isDebug) return null;
 

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
@@ -161,12 +161,18 @@ export default function DebugPanel() {
   const isE2E = (window as { __E2E__?: boolean }).__E2E__ === true;
   const isDebug = isE2E || isDebugAccessGranted(searchParams, window.location.hostname);
 
+  if (!isDebug) return null;
+
+  return <DebugPanelContent searchParams={searchParams} />;
+}
+
+function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const game = useAppSelector((s) => s.game);
   const incomingLogs = useAppSelector(selectIncomingInteractionLogs);
 
-  const [isOpen, setIsOpen] = useState(() => isDebug);
+  const [isOpen, setIsOpen] = useState(true);
   const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase);
   const [selectedHoH, setSelectedHoH] = useState('');
   const [nominee1, setNominee1] = useState('');
@@ -175,14 +181,6 @@ export default function DebugPanel() {
   const [selectedStatusPlayer, setSelectedStatusPlayer] = useState('');
   const [selectedF4Evictee, setSelectedF4Evictee] = useState('');
   const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction');
-
-  // AppShell stays mounted while the hash route changes. When debug is enabled
-  // by the mobile launch flow, open the drawer as soon as access becomes active.
-  useEffect(() => {
-    if (isDebug) setIsOpen(true);
-  }, [isDebug]);
-
-  if (!isDebug) return null;
 
   const alive = game.players.filter(
     (p) => p.status !== 'evicted' && p.status !== 'jury',

--- a/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
+++ b/src/components/DebugPanel/__tests__/DebugPanel.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { configureStore } from '@reduxjs/toolkit'
 import { Provider } from 'react-redux'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import DebugPanel from '../DebugPanel'
 import gameReducer from '../../../store/gameSlice'
@@ -26,6 +26,35 @@ function makeStore() {
 }
 
 describe('DebugPanel forced shock controls', () => {
+  it('opens when the mounted app navigates into debug mode', async () => {
+    const user = userEvent.setup()
+    const store = makeStore()
+
+    function DebugRouteHarness() {
+      const navigate = useNavigate()
+      return (
+        <>
+          <button type="button" onClick={() => navigate('/game?debug=1&qa=1')}>
+            Enter debug game
+          </button>
+          <DebugPanel />
+        </>
+      )
+    }
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/']}>
+          <DebugRouteHarness />
+        </MemoryRouter>
+      </Provider>,
+    )
+
+    expect(screen.queryByRole('complementary', { name: 'Debug Panel' })).toBeNull()
+    await user.click(screen.getByRole('button', { name: 'Enter debug game' }))
+    expect(screen.getByRole('complementary', { name: 'Debug Panel' })).toBeInTheDocument()
+  })
+
   it('can place a player in the Tribunal for battle-back testing', async () => {
     const user = userEvent.setup()
     const store = makeStore()

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
@@ -98,6 +99,8 @@ const HUB_BUTTONS = [
 
 type ClassicPrompt = 'resume-or-new' | 'confirm-new' | null;
 type SurvivorPrompt = 'resume-or-new' | 'ended' | 'confirm-new' | null;
+
+const DEBUG_GAME_ROUTE = '/game?debug=1&qa=1';
 
 interface HubAssetState {
   ready: boolean;
@@ -237,12 +240,15 @@ export default function HomeHub() {
   // reuse the existing Play → preloader → /game flow without setting state in
   // an effect on mount.
   const [preloading, setPreloading] = useState(autoStartGame);
+  const [debugLaunch, setDebugLaunch] = useState(false);
   const [playSelectionOpen, setPlaySelectionOpen] = useState(false);
   const [housematesBioOpen, setHousematesBioOpen] = useState(false);
   const [classicPrompt, setClassicPrompt] = useState<ClassicPrompt>(null);
   const [survivorPrompt, setSurvivorPrompt] = useState<SurvivorPrompt>(null);
   const [survivorRulesOpen, setSurvivorRulesOpen] = useState(false);
   const survivorRulesDismissed = hasSeenSurvivorRules(activeProfileId);
+  const canLaunchWithDebug = import.meta.env.DEV || Capacitor.isNativePlatform();
+  const gameRoute = debugLaunch ? DEBUG_GAME_ROUTE : '/game';
 
   const savedRuns = useMemo(
     () => (!isGuest && activeProfileId ? loadSavedRunProfile(activeProfileId) : null),
@@ -290,7 +296,7 @@ export default function HomeHub() {
     dispatch(hydrateSocial(snapshot.social));
     if (snapshot.publicOpinion) dispatch(hydratePublicOpinion(snapshot.publicOpinion));
     if (snapshot.challenge) dispatch(hydrateChallenge(snapshot.challenge));
-    navigate('/game');
+    navigate(gameRoute);
   }
 
   function startClassicRun() {
@@ -433,6 +439,15 @@ export default function HomeHub() {
         setHousematesBioOpen(true);
       },
     },
+    ...(canLaunchWithDebug
+      ? [{
+          key: 'debug-launch',
+          label: `Debug Menu: ${debugLaunch ? 'On' : 'Off'}`,
+          icon: <span aria-hidden="true">🛠️</span>,
+          variant: 'secondary_wide' as const,
+          onClick: () => setDebugLaunch((enabled) => !enabled),
+        }]
+      : []),
     {
       key: 'back',
       label: 'Back',
@@ -494,7 +509,7 @@ export default function HomeHub() {
       )}
 
       {/* Asset preloader overlay — shown when Play is pressed (fresh start or new season) */}
-      {preloading && <AssetPreloaderOverlay />}
+      {preloading && <AssetPreloaderOverlay destination={gameRoute} />}
 
       {housematesBioOpen && (
         <HousematesBioCinematic onComplete={() => setHousematesBioOpen(false)} />

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -110,7 +110,9 @@ vi.mock('../../../components/PermissionPrompts/PermissionPrompts', () => ({
 }));
 
 vi.mock('../../../components/AssetPreloaderOverlay/AssetPreloaderOverlay', () => ({
-  default: () => <div data-testid="asset-preloader-overlay" />,
+  default: ({ destination }: { destination?: string }) => (
+    <div data-destination={destination} data-testid="asset-preloader-overlay" />
+  ),
 }));
 
 vi.mock('../../../components/HousematesBioCinematic/HousematesBioCinematic', () => ({
@@ -365,6 +367,24 @@ describe('HomeHub', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('starts a fresh game with debug enabled from the Play menu', async () => {
+    renderHomeHub();
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debug Menu: Off' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Campaign' }));
+
+    expect(screen.getByTestId('asset-preloader-overlay')).toHaveAttribute(
+      'data-destination',
+      '/game?debug=1&qa=1',
+    );
   });
 
   it('shows Survival rules before starting a fresh Survival run', async () => {


### PR DESCRIPTION
## What changed

- Adds a native mobile Debug Menu toggle to the Play menu for iPhone and Android builds.
- Preserves the debug-enabled destination through asset preloading, resumed games, and fresh game starts.
- Automatically opens the debug drawer when the mounted app enters debug mode.
- Adds regression coverage for mobile debug launching and route-driven debug-panel opening.

## Why

Mobile users could only enable debug by editing the game URL after pressing Play, which is not practical inside the iOS and Android apps. The Play flow also replaced the route during preloading, so debug query parameters were not reliably preserved.

## Impact

Native mobile testers can enable **Debug Menu: On** before choosing Campaign, Survival, or a saved run. Normal production web players do not see the launcher; local development retains access.

## Validation

- `npm run typecheck`
- `npx vitest run src/components/DebugPanel/__tests__/DebugPanel.test.tsx src/screens/HomeHub/__tests__/HomeHub.test.tsx` (16 tests passed)
- `git diff --check`