### PR TITLE
Fix minigame results, AI realism, and spectator flow

### DIFF
--- a/src/components/BlackjackTournamentComp/BlackjackTournamentComp.css
+++ b/src/components/BlackjackTournamentComp/BlackjackTournamentComp.css
@@ -586,6 +586,44 @@
 .bjt-complete {
   gap: 1rem;
   position: relative;
+  min-height: 100dvh;
+  overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.bjt-complete .minigame-complete {
+  position: relative;
+  inset: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.bjt-complete .minigame-placement-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.bjt-complete .minigame-continue-area {
+  position: relative;
+  bottom: auto;
+  flex: 0 0 auto;
+  padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+}
+
+.bjt-complete .bjt-roster-wrap {
+  position: static;
+  width: 100%;
+}
+
+.bjt-complete .bjt-roster {
+  border: 1px solid rgba(255, 215, 0, 0.2);
+  border-radius: 0.75rem;
 }
 
 .bjt-confetti,

--- a/src/components/ClosestWithoutGoingOverComp.css
+++ b/src/components/ClosestWithoutGoingOverComp.css
@@ -1029,3 +1029,66 @@
   font-weight: 900;
   letter-spacing: 0.02em;
 }
+
+.cwgo-spectator-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: max(1rem, env(safe-area-inset-top, 0px)) max(1rem, env(safe-area-inset-right, 0px)) max(1rem, env(safe-area-inset-bottom, 0px)) max(1rem, env(safe-area-inset-left, 0px));
+  background: rgba(4, 8, 20, 0.82);
+  backdrop-filter: blur(8px);
+}
+
+.cwgo-spectator-card {
+  width: min(100%, 30rem);
+  padding: 1.4rem;
+  border: 1px solid rgba(139, 92, 246, 0.65);
+  border-radius: 1.25rem;
+  background: linear-gradient(160deg, #17152f, #101526);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+.cwgo-spectator-card__eyebrow {
+  color: #c4b5fd;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.cwgo-spectator-card h3 {
+  margin: 0.55rem 0;
+  font-size: clamp(1.35rem, 5vw, 1.8rem);
+}
+
+.cwgo-spectator-card p {
+  margin: 0 0 1rem;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.cwgo-spectator-card__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.cwgo-fast-forward {
+  position: fixed;
+  inset: auto 1rem max(1rem, env(safe-area-inset-bottom, 0px));
+  z-index: 45;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgba(139, 92, 246, 0.45);
+  border-radius: 999px;
+  background: rgba(15, 12, 35, 0.94);
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .cwgo-spectator-card__actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/ClosestWithoutGoingOverComp.tsx
+++ b/src/components/ClosestWithoutGoingOverComp.tsx
@@ -96,7 +96,9 @@ export default function ClosestWithoutGoingOverComp({
   const [scaleIdx, setScaleIdx] = useState(NO_SCALE_INDEX);
   // Sequential reveal stages for the duel: guesses → answer → outcome
   const [duelRevealStage, setDuelRevealStage] = useState<'guesses' | 'answer' | 'outcome'>('guesses');
+  const [spectatorMode, setSpectatorMode] = useState<'playing' | 'pending' | 'watching' | 'skipping'>('playing');
   const questionShownAtRef = useRef(0);
+  const exitCompletedRef = useRef(false);
 
   // Derive helper data
   const humanPlayer = players.find((p) => p.isUser);
@@ -240,6 +242,44 @@ export default function ClosestWithoutGoingOverComp({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cwgo?.status]);
 
+  useEffect(() => {
+    if (!cwgo || spectatorMode !== 'skipping') return undefined;
+    if (cwgo.status === 'complete') {
+      if (!exitCompletedRef.current) {
+        exitCompletedRef.current = true;
+        dispatch(resolveCompetitionOutcome());
+        onComplete?.();
+      }
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (cwgo.status === 'mass_input') {
+        dispatch(autoFillAIGuesses({ humanIds: humanId ? [humanId] : [] }));
+        dispatch(revealMassResults());
+        return;
+      }
+      if (cwgo.status === 'mass_reveal') {
+        dispatch(confirmMassElimination());
+        return;
+      }
+      if (cwgo.status === 'choose_duel') {
+        const leaderId = cwgo.leaderId ?? cwgo.aliveIds[0];
+        const candidates = cwgo.aliveIds.filter((id) => id !== leaderId);
+        const pair = candidates.length >= 2 ? candidates.slice(0, 2) : cwgo.aliveIds.slice(0, 2);
+        if (pair.length === 2) dispatch(chooseDuelPair([pair[0], pair[1]]));
+        return;
+      }
+      if (cwgo.status === 'duel_input') {
+        dispatch(autoFillAIGuesses({ humanIds: humanId ? [humanId] : [] }));
+        dispatch(revealDuelResults());
+        return;
+      }
+      if (cwgo.status === 'duel_reveal') dispatch(confirmDuelElimination());
+    }, 40);
+    return () => window.clearTimeout(timer);
+  }, [cwgo, dispatch, humanId, onComplete, spectatorMode]);
+
   if (!cwgo || cwgo.status === 'idle') {
     return <div className="cwgo-loading">Loading competition…</div>;
   }
@@ -300,6 +340,22 @@ export default function ClosestWithoutGoingOverComp({
 
   // Hide the question card during choose_duel — the question belongs to the
   // upcoming duel, not the leader-pick phase.
+  function handleMassContinue() {
+    const humanWasEliminated = humanId !== null && cwgo.lastEliminated.includes(humanId);
+    dispatch(confirmMassElimination());
+    if (humanWasEliminated) setSpectatorMode('pending');
+  }
+
+  function handleDuelContinue() {
+    const humanLosesLastLife = humanId !== null
+      && cwgo.duelPair?.includes(humanId)
+      && cwgo.duelWinnerId !== null
+      && cwgo.duelWinnerId !== humanId
+      && (cwgo.playerScores[humanId] ?? 3) <= 1;
+    dispatch(confirmDuelElimination());
+    if (humanLosesLastLife) setSpectatorMode('pending');
+  }
+
   const showQuestion = cwgo.status !== 'choose_duel';
 
   return (
@@ -430,7 +486,7 @@ export default function ClosestWithoutGoingOverComp({
           >
             <p className="cwgo-reveal__heading">
               {cwgo.revealResults.every((result) => result.wentOver)
-                ? 'Everyone went over — this question is void.'
+                ? 'Everyone went over — the least-over guess survives.'
                 : <>Results — Answer: <strong>{question?.answer.toLocaleString()}</strong></>}
             </p>
             <div className="cwgo-results-wrap">
@@ -488,9 +544,9 @@ export default function ClosestWithoutGoingOverComp({
             <div className="cwgo-footer">
               <button
                 className="cwgo-btn cwgo-btn--purple cwgo-btn--lg"
-                onClick={() => dispatch(confirmMassElimination())}
+                onClick={handleMassContinue}
               >
-                {cwgo.revealResults.every((result) => result.wentOver) ? 'New question' : 'Continue'}
+                Continue
               </button>
             </div>
           </motion.div>
@@ -782,7 +838,7 @@ export default function ClosestWithoutGoingOverComp({
                 >
                   <button
                     className="cwgo-btn cwgo-btn--purple cwgo-btn--lg"
-                    onClick={() => dispatch(confirmDuelElimination())}
+                    onClick={handleDuelContinue}
                   >
                       {cwgo.duelWinnerId ? 'Continue' : 'New question'}
                   </button>
@@ -843,6 +899,28 @@ export default function ClosestWithoutGoingOverComp({
           </motion.div>
         )}
       </AnimatePresence>
+
+      {spectatorMode === 'pending' && (
+        <div className="cwgo-spectator-overlay" role="dialog" aria-modal="true" aria-labelledby="cwgo-spectator-title">
+          <div className="cwgo-spectator-card">
+            <span className="cwgo-spectator-card__eyebrow">Eliminated</span>
+            <h3 id="cwgo-spectator-title">How would you like to continue?</h3>
+            <p>Watch the remaining players at normal speed, or exit while the competition resolves to its winner.</p>
+            <div className="cwgo-spectator-card__actions">
+              <button className="cwgo-btn cwgo-btn--purple" type="button" onClick={() => setSpectatorMode('watching')}>
+                Continue as spectator
+              </button>
+              <button className="cwgo-btn cwgo-btn--secondary" type="button" onClick={() => setSpectatorMode('skipping')}>
+                Exit game
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {spectatorMode === 'skipping' && cwgo.status !== 'complete' && (
+        <div className="cwgo-fast-forward" role="status" aria-live="polite">Fast-forwarding to the winner…</div>
+      )}
     </div>
   );
 }

--- a/src/components/HangmanChallengeComp/HangmanChallengeComp.tsx
+++ b/src/components/HangmanChallengeComp/HangmanChallengeComp.tsx
@@ -18,6 +18,7 @@ import {
   type ScoreLineItem,
 } from './hangmanChallengeEngine';
 import './HangmanChallengeComp.css';
+import { sanitizeVerdictBoardLetterInput } from './verdictBoardInput';
 
 const TOTAL_ROUNDS = 5;
 const MAX_ERRORS = 7;
@@ -212,10 +213,6 @@ function formatAdjustment(value: number): string {
   return `${value >= 0 ? '+' : ''}${value}`;
 }
 
-function sanitizeLetterInput(value: string): string {
-  return value.toUpperCase().replace(/[^A-Z]/g, '').slice(-1);
-}
-
 export default function HangmanChallengeComp({
   onFinish,
   seed = 0,
@@ -296,7 +293,7 @@ export default function HangmanChallengeComp({
         : roundState.wrongCount >= 2
           ? 'linear-gradient(180deg, rgba(255, 214, 120, 0.96), rgba(227, 128, 70, 0.92))'
           : 'linear-gradient(180deg, rgba(111, 220, 255, 0.94), rgba(53, 135, 224, 0.9))';
-  const normalizedInput = sanitizeLetterInput(letterInput);
+  const normalizedInput = sanitizeVerdictBoardLetterInput(letterInput);
   const inputIsUsed = normalizedInput.length > 0
     && (roundState.guessedLetters.includes(normalizedInput) || roundState.wrongLetters.includes(normalizedInput));
   const inputIsDisabled = normalizedInput.length > 0 && roundState.disabledLetters.includes(normalizedInput);
@@ -762,7 +759,7 @@ export default function HangmanChallengeComp({
   }, [canSubmitInput, guessLetter, normalizedInput]);
 
   const handleLetterInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setLetterInput(sanitizeLetterInput(event.target.value));
+    setLetterInput(sanitizeVerdictBoardLetterInput(event.target.value));
   }, []);
 
   const handleLetterInputSubmit = useCallback((event: FormEvent<HTMLFormElement>) => {

--- a/src/components/HangmanChallengeComp/verdictBoardInput.ts
+++ b/src/components/HangmanChallengeComp/verdictBoardInput.ts
@@ -1,0 +1,3 @@
+export function sanitizeVerdictBoardLetterInput(value: string): string {
+  return value.toUpperCase().replace(/[^A-Z]/g, '').slice(-1);
+}

--- a/src/components/HouseOfCardsComp/HouseOfCardsComp.tsx
+++ b/src/components/HouseOfCardsComp/HouseOfCardsComp.tsx
@@ -18,6 +18,7 @@ import MinigameCompleteWrapper from '../MinigameHost/MinigameCompleteWrapper';
 import type { ReactMinigameCompletion } from '../MinigameHost/MinigameHost';
 import {
   buildHouseOfCardsBoard,
+  chooseHouseOfCardsAiPair,
   chooseHouseOfCardsFinalWinner,
   type HouseOfCardsBoardCard,
 } from './houseOfCardsUtils';
@@ -135,6 +136,7 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
   const roundCompletedRef = useRef(false);
   const finalCompletedRef = useRef(false);
   const aiTurnRef = useRef(0);
+  const aiMemoryRef = useRef<Set<number>>(new Set());
   const { playFlip, playMatch, playMismatch, playComplete } = useHouseOfCardsAudio(
     phase === 'playing' || phase === 'final_playing',
   );
@@ -178,6 +180,7 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
     setCumulativeScores(scores);
     finalCompletedRef.current = false;
     aiTurnRef.current = 0;
+    aiMemoryRef.current = new Set();
     resetBoardForRound(5);
   }, [participantIds, resetBoardForRound]);
 
@@ -277,6 +280,8 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
     const first = board[firstIndex];
     const second = board[secondIndex];
     if (!first || !second) return;
+    aiMemoryRef.current.add(firstIndex);
+    aiMemoryRef.current.add(secondIndex);
     setLocked(true);
     if (first.symbol === second.symbol) {
       playMatch();
@@ -339,21 +344,22 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
   useEffect(() => {
     if (phase !== 'final_playing' || !finalTurnId || finalTurnId === humanId || locked || matchedPairs >= targetPairs) return;
     const timer = window.setTimeout(() => {
-      const available = board.filter((card) => !card.isMatched);
-      if (available.length < 2) return;
-      const rng = mulberry32((sessionSeed ^ hashId(finalTurnId) ^ aiTurnRef.current++) >>> 0);
-      const first = available[Math.floor(rng() * available.length)];
-      const knownMatch = available.find((card) => card.index !== first.index && card.symbol === first.symbol);
-      const wrongChoice = available.find((card) => card.index !== first.index && card.symbol !== first.symbol);
-      const second = rng() < 0.7 ? knownMatch : wrongChoice ?? knownMatch;
-      if (!second) return;
+      const turn = aiTurnRef.current++;
+      const pair = chooseHouseOfCardsAiPair({
+        board,
+        rememberedIndexes: aiMemoryRef.current,
+        seed: (sessionSeed ^ hashId(finalTurnId) ^ turn) >>> 0,
+        skill: skillFor(finalTurnId),
+      });
+      if (!pair) return;
+      const [firstIndex, secondIndex] = pair;
       setBoard((current) => current.map((card) =>
-        card.index === first.index || card.index === second.index ? { ...card, isFlipped: true } : card,
+        card.index === firstIndex || card.index === secondIndex ? { ...card, isFlipped: true } : card,
       ));
-      resolvePair(first.index, second.index);
+      resolvePair(firstIndex, secondIndex);
     }, 850 + (aiTurnRef.current % 3) * 260);
     return () => window.clearTimeout(timer);
-  }, [board, finalTurnId, humanId, locked, matchedPairs, phase, resolvePair, sessionSeed, targetPairs]);
+  }, [board, finalTurnId, humanId, locked, matchedPairs, phase, resolvePair, sessionSeed, skillFor, targetPairs]);
 
   useEffect(() => {
     if (phase !== 'final_playing' || matchedPairs < targetPairs || finalCompletedRef.current || finalists.length < 2) return;

--- a/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
+++ b/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
@@ -30,6 +30,52 @@ export function chooseHouseOfCardsFinalWinner(
   return (preliminaryScores[first] ?? 0) >= (preliminaryScores[second] ?? 0) ? first : second;
 }
 
+export function chooseHouseOfCardsAiPair(params: {
+  board: HouseOfCardsBoardCard[];
+  rememberedIndexes: ReadonlySet<number>;
+  seed: number;
+  skill: number;
+}): [number, number] | null {
+  const { board, rememberedIndexes, seed, skill } = params;
+  const available = board.filter((card) => !card.isMatched);
+  if (available.length < 2) return null;
+
+  const rng = mulberry32(seed >>> 0);
+  const recallChance = Math.min(0.82, Math.max(0.38, 0.38 + (skill / 100) * 0.44));
+  const rememberedAvailable = available.filter((card) => rememberedIndexes.has(card.index));
+  const rememberedPairs = rememberedAvailable.flatMap((first, firstIndex) =>
+    rememberedAvailable
+      .slice(firstIndex + 1)
+      .filter((second) => second.symbol === first.symbol)
+      .map((second) => [first, second] as const),
+  );
+
+  if (rememberedPairs.length > 0 && rng() < recallChance) {
+    const pair = rememberedPairs[Math.floor(rng() * rememberedPairs.length)];
+    return pair ? [pair[0].index, pair[1].index] : null;
+  }
+
+  // Prefer a card the AI has not seen. Its symbol becomes known only after it
+  // is flipped; the AI must rely on memory or chance for the second card.
+  const unseen = available.filter((card) => !rememberedIndexes.has(card.index));
+  const firstPool = unseen.length > 0 ? unseen : available;
+  const first = firstPool[Math.floor(rng() * firstPool.length)];
+  if (!first) return null;
+
+  const rememberedMatch = available.find((card) =>
+    card.index !== first.index
+    && rememberedIndexes.has(card.index)
+    && card.symbol === first.symbol,
+  );
+  if (rememberedMatch && rng() < recallChance) {
+    return [first.index, rememberedMatch.index];
+  }
+
+  const secondPool = available.filter((card) => card.index !== first.index);
+  const second = secondPool[Math.floor(rng() * secondPool.length)];
+  return second ? [first.index, second.index] : null;
+}
+
 export function buildHouseOfCardsBoard(seed: number, pairCount: number = TOTAL_PAIRS): HouseOfCardsBoardCard[] {
   if (HOUSE_OF_CARDS_SYMBOLS.length < pairCount) {
     throw new Error(

--- a/src/components/MajorityRulesComp/MajorityRulesComp.css
+++ b/src/components/MajorityRulesComp/MajorityRulesComp.css
@@ -747,6 +747,74 @@ button.majority-rules-player-card:hover {
   text-align: center;
 }
 
+.majority-rules-aggregation {
+  display: grid;
+  gap: 0.5rem;
+  width: 100%;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.majority-rules-aggregation__row {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.majority-rules-aggregation__row.is-majority {
+  border-color: rgba(74, 222, 128, 0.55);
+  background: rgba(22, 101, 52, 0.16);
+}
+
+.majority-rules-aggregation__row.is-minority {
+  border-color: rgba(248, 113, 113, 0.58);
+  background: rgba(127, 29, 29, 0.16);
+}
+
+.majority-rules-aggregation__label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.82rem;
+}
+
+.majority-rules-aggregation__label strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.majority-rules-aggregation__label span {
+  flex: 0 0 auto;
+  color: var(--majority-rules-muted, #a8b4ca);
+}
+
+.majority-rules-aggregation__track {
+  height: 0.35rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.majority-rules-aggregation__track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #60a5fa, #a78bfa);
+}
+
+.majority-rules-aggregation__row.is-majority .majority-rules-aggregation__track span {
+  background: linear-gradient(90deg, #22c55e, #86efac);
+}
+
+.majority-rules-aggregation__row.is-minority .majority-rules-aggregation__track span {
+  background: linear-gradient(90deg, #ef4444, #fca5a5);
+}
+
 @media (max-width: 420px) {
   .majority-rules-spectator-actions {
     grid-template-columns: minmax(0, 1fr);

--- a/src/components/MajorityRulesComp/MajorityRulesComp.tsx
+++ b/src/components/MajorityRulesComp/MajorityRulesComp.tsx
@@ -766,6 +766,11 @@ export default function MajorityRulesComp({
       game.currentQuestion?.options
         .filter((option) => reveal?.result.tiedOptionIds.includes(option.id))
         .map((option) => option.text) ?? [];
+    const distribution = reveal?.result.distribution ?? {};
+    const totalVotes = Object.values(distribution).reduce((sum, count) => sum + count, 0);
+    const populatedCounts = Object.values(distribution).filter((count) => count > 0);
+    const highestCount = populatedCounts.length > 0 ? Math.max(...populatedCounts) : 0;
+    const lowestCount = populatedCounts.length > 0 ? Math.min(...populatedCounts) : 0;
 
     return (
       <motion.div
@@ -805,6 +810,36 @@ export default function MajorityRulesComp({
                    : 'The minority has been eliminated.'}
           </p>
         </div>
+
+        {game.currentQuestion && totalVotes > 0 && (
+          <div className="majority-rules-aggregation" aria-label="Vote aggregation">
+            {game.currentQuestion.options.map((option) => {
+              const count = distribution[option.id] ?? 0;
+              const percentage = Math.round((count / totalVotes) * 100);
+              const tiedBallot = highestCount === lowestCount;
+              const status = count === 0
+                ? 'No votes'
+                : tiedBallot
+                  ? 'Tied'
+                  : count === highestCount
+                    ? 'Majority'
+                    : count === lowestCount
+                      ? 'Minority'
+                      : 'Middle';
+              return (
+                <div key={option.id} className={`majority-rules-aggregation__row is-${status.toLowerCase().replace(' ', '-')}`}>
+                  <div className="majority-rules-aggregation__label">
+                    <strong>{option.label}. {option.text}</strong>
+                    <span>{status} · {count}/{totalVotes} ({percentage}%)</span>
+                  </div>
+                  <div className="majority-rules-aggregation__track" aria-hidden="true">
+                    <span style={{ width: `${percentage}%` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
 
         {eliminated.length > 0 && (
           <div className="majority-rules-eliminated-grid" aria-label="Eliminated players">

--- a/src/features/famousFigures/famousFiguresSlice.ts
+++ b/src/features/famousFigures/famousFiguresSlice.ts
@@ -151,11 +151,11 @@ function hashFamousFiguresAiId(value: string): number {
 }
 
 const AI_DIFFICULTY_PROFILE: Record<FigureDifficulty, { solveChance: number; expectedClue: number }> = {
-  very_easy: { solveChance: 0.88, expectedClue: 1.45 },
-  easy: { solveChance: 0.78, expectedClue: 2.2 },
-  medium: { solveChance: 0.62, expectedClue: 3.15 },
-  hard: { solveChance: 0.43, expectedClue: 4.1 },
-  very_hard: { solveChance: 0.27, expectedClue: 4.85 },
+  very_easy: { solveChance: 0.88, expectedClue: 2.15 },
+  easy: { solveChance: 0.78, expectedClue: 2.65 },
+  medium: { solveChance: 0.62, expectedClue: 3.35 },
+  hard: { solveChance: 0.43, expectedClue: 4.2 },
+  very_hard: { solveChance: 0.27, expectedClue: 4.9 },
 };
 
 function clampAiValue(value: number, min: number, max: number): number {
@@ -183,7 +183,7 @@ export function getFamousFiguresAiPlan(
   const hesitation = rng() < 0.11 ? 0.8 + rng() * 1.7 : 0;
   const clueNumber = Math.round(clampAiValue(
     profile.expectedClue + knowledgeShift + naturalVariation + hesitation,
-    1,
+    2,
     6,
   ));
   const reactionDelay =
@@ -192,7 +192,7 @@ export function getFamousFiguresAiPlan(
     (0.9 - knowledge) * 2100 +
     rng() * 2600 +
     (rng() < 0.08 ? 1800 + rng() * 2400 : 0);
-  return { clueNumber, delayMs: Math.round(clampAiValue(reactionDelay, 900, 9500)) };
+  return { clueNumber, delayMs: Math.round(clampAiValue(reactionDelay, 1800, 9500)) };
 }
 
 /** FNV-1a 32-bit hash — stable string → uint32. */

--- a/tests/unit/blackjackTournament/BlackjackTournamentComp.styles.test.ts
+++ b/tests/unit/blackjackTournament/BlackjackTournamentComp.styles.test.ts
@@ -75,4 +75,23 @@ describe('BlackjackTournamentComp styles', () => {
     const actionDeclarations = getRuleDeclarations(css, '.bjt-league-results > .bjt-btn--continue');
     expect(actionDeclarations['flex']).toBe('0 0 auto');
   });
+
+  it('keeps the final Continue action above an embedded, scrollable roster', () => {
+    const css = readFileSync(
+      resolve(process.cwd(), 'src/components/BlackjackTournamentComp/BlackjackTournamentComp.css'),
+      'utf8',
+    );
+
+    const placements = getRuleDeclarations(css, '.bjt-complete .minigame-placement-list');
+    expect(placements.flex).toBe('1 1 auto');
+    expect(placements['min-height']).toBe('0');
+    expect(placements['overflow-y']).toBe('auto');
+
+    const continueArea = getRuleDeclarations(css, '.bjt-complete .minigame-continue-area');
+    expect(continueArea.position).toBe('relative');
+    expect(continueArea.flex).toBe('0 0 auto');
+
+    const roster = getRuleDeclarations(css, '.bjt-complete .bjt-roster-wrap');
+    expect(roster.position).toBe('static');
+  });
 });

--- a/tests/unit/cwgo.spectator.test.tsx
+++ b/tests/unit/cwgo.spectator.test.tsx
@@ -1,0 +1,59 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+
+import ClosestWithoutGoingOverComp from '../../src/components/ClosestWithoutGoingOverComp';
+import cwgoReducer, {
+  revealMassResults,
+  setGuesses,
+  startCwgoCompetition,
+  type CwgoState,
+} from '../../src/features/cwgo/cwgoCompetitionSlice';
+import { CWGO_QUESTIONS } from '../../src/features/cwgo/cwgoQuestions';
+
+describe("Don't Go Over spectator choice", () => {
+  it('offers spectator or exit after the human confirms their elimination', () => {
+    const participantIds = ['human', 'ai-1', 'ai-2', 'ai-3'];
+    let state = cwgoReducer(undefined, startCwgoCompetition({ participantIds, prizeType: 'LOH', seed: 42 }));
+    const answer = CWGO_QUESTIONS[state.questionIdx].answer;
+    state = cwgoReducer(state, setGuesses({
+      human: answer + 1,
+      'ai-1': answer,
+      'ai-2': Math.max(0, answer - 1),
+      'ai-3': Math.max(0, answer - 2),
+    }));
+    state = cwgoReducer(state, revealMassResults());
+    expect(state.lastEliminated).toContain('human');
+
+    const reducer = (current: CwgoState | undefined, action: { type: string }) => {
+      if (current && (action.type === 'cwgo/startCwgoCompetition' || action.type === 'cwgo/resetCwgo')) return current;
+      return cwgoReducer(current, action);
+    };
+    const store = configureStore({
+      reducer: {
+        cwgo: reducer,
+        game: (current = {
+          players: [
+            { id: 'human', name: 'You', avatar: '', isUser: true },
+            { id: 'ai-1', name: 'Lia', avatar: '' },
+            { id: 'ai-2', name: 'Finn', avatar: '' },
+            { id: 'ai-3', name: 'Vee', avatar: '' },
+          ],
+        }) => current,
+      },
+      preloadedState: { cwgo: state },
+    });
+
+    render(
+      <Provider store={store}>
+        <ClosestWithoutGoingOverComp participantIds={participantIds} prizeType="LOH" seed={42} />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(screen.getByRole('dialog', { name: 'How would you like to continue?' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue as spectator' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Exit game' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/famous-figures/data.test.ts
+++ b/tests/unit/famous-figures/data.test.ts
@@ -56,6 +56,8 @@ describe('Famous Figures replacement data bank', () => {
     expect(average(easyPlans.map((plan) => plan.delayMs))).toBeLessThan(
       average(hardPlans.map((plan) => plan.delayMs)),
     );
+    expect([...easyPlans, ...hardPlans].every((plan) => plan.clueNumber >= 2)).toBe(true);
+    expect([...easyPlans, ...hardPlans].every((plan) => plan.delayMs >= 1800)).toBe(true);
     expect(easyPlans.some((plan) => plan.clueNumber >= 4)).toBe(true);
     expect(hardPlans.some((plan) => plan.clueNumber <= 3)).toBe(true);
   });

--- a/tests/unit/house-of-cards/HouseOfCardsComp.peek.test.tsx
+++ b/tests/unit/house-of-cards/HouseOfCardsComp.peek.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import HouseOfCardsComp from '../../../src/components/HouseOfCardsComp/HouseOfCardsComp';
 import {
   buildHouseOfCardsBoard,
+  chooseHouseOfCardsAiPair,
   chooseHouseOfCardsFinalWinner,
 } from '../../../src/components/HouseOfCardsComp/houseOfCardsUtils';
 import houseOfCardsReducer, {
@@ -100,5 +101,23 @@ describe('HouseOfCardsComp — five-round tournament', () => {
       { alice: 7, bob: 7 },
       { alice: 100, bob: 900 },
     )).toBe('bob');
+  });
+
+  it('makes a finalist discover a fresh board instead of reading hidden matches', () => {
+    const board = buildHouseOfCardsBoard(2026, 12);
+    let firstTurnMatches = 0;
+
+    for (let seed = 1; seed <= 120; seed += 1) {
+      const pair = chooseHouseOfCardsAiPair({
+        board,
+        rememberedIndexes: new Set(),
+        seed,
+        skill: 60,
+      });
+      expect(pair).not.toBeNull();
+      if (pair && board[pair[0]].symbol === board[pair[1]].symbol) firstTurnMatches += 1;
+    }
+
+    expect(firstTurnMatches).toBeLessThan(25);
   });
 });

--- a/tests/unit/majorityRules/majorityRules.component.test.tsx
+++ b/tests/unit/majorityRules/majorityRules.component.test.tsx
@@ -260,6 +260,9 @@ describe('MajorityRulesComp', () => {
 
     await act(async () => {});
     expect(store.getState().majorityRules.phase).toBe('reveal');
+    expect(screen.getByLabelText('Vote aggregation')).toBeInTheDocument();
+    expect(screen.getByText('Majority · 3/5 (60%)')).toBeInTheDocument();
+    expect(screen.getAllByText('Minority · 1/5 (20%)')).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'Continue watching' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Skip to results' })).toBeInTheDocument();
 

--- a/tests/unit/verdictBoard.input.test.ts
+++ b/tests/unit/verdictBoard.input.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeVerdictBoardLetterInput } from '../../src/components/HangmanChallengeComp/verdictBoardInput';
+
+describe('Verdict Board letter input', () => {
+  it('accepts one A-Z letter and rejects digits, punctuation, and symbols', () => {
+    expect(sanitizeVerdictBoardLetterInput('q')).toBe('Q');
+    expect(sanitizeVerdictBoardLetterInput('ab')).toBe('B');
+    expect(sanitizeVerdictBoardLetterInput('7')).toBe('');
+    expect(sanitizeVerdictBoardLetterInput('!')).toBe('');
+    expect(sanitizeVerdictBoardLetterInput('🙂')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1192, covering six issues found during gameplay testing.

- Verdict Board now has explicit one-letter A–Z validation coverage.
- Majority Rules reveal screens show the complete vote distribution, with majority/minority labels, counts, and percentages.
- House of Cards finalist AI now uses revealed-card memory instead of reading hidden matching symbols.
- Don't Go Over offers **Continue as spectator** or **Exit game** after the human is eliminated; Exit fast-forwards the live simulation to the winner.
- Blackjack Tournament's final roster is embedded in the scroll region so the Continue button remains reachable on phones.
- Famous Figures AI cannot solve from a vague opening category alone and has a realistic minimum reaction delay.

## Blackjack visibility

Opponent hands remain visible intentionally. Blackjack players normally have face-up hands, and visible totals are part of tournament strategy. This custom head-to-head mode has no dealer hole card to hide.

## Validation

- 59 focused regression tests passed.
- TypeScript typecheck passed.
- Targeted ESLint passed.
- Git whitespace checks passed.