### PR TITLE
Expose debug launcher during QA

### DIFF
--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Capacitor } from '@capacitor/core';
 import { useLocation, useNavigate, type NavigateFunction } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame, hydrateGame } from '../../store/gameSlice';
@@ -101,6 +100,9 @@ type ClassicPrompt = 'resume-or-new' | 'confirm-new' | null;
 type SurvivorPrompt = 'resume-or-new' | 'ended' | 'confirm-new' | null;
 
 const DEBUG_GAME_ROUTE = '/game?debug=1&qa=1';
+// Temporary QA switch: keep the launcher available in web, emulator, and native
+// builds. Set to false before producing the public store release.
+const ENABLE_PUBLIC_DEBUG_LAUNCHER = true;
 
 interface HubAssetState {
   ready: boolean;
@@ -247,7 +249,6 @@ export default function HomeHub() {
   const [survivorPrompt, setSurvivorPrompt] = useState<SurvivorPrompt>(null);
   const [survivorRulesOpen, setSurvivorRulesOpen] = useState(false);
   const survivorRulesDismissed = hasSeenSurvivorRules(activeProfileId);
-  const canLaunchWithDebug = import.meta.env.DEV || Capacitor.isNativePlatform();
   const gameRoute = debugLaunch ? DEBUG_GAME_ROUTE : '/game';
 
   const savedRuns = useMemo(
@@ -439,7 +440,7 @@ export default function HomeHub() {
         setHousematesBioOpen(true);
       },
     },
-    ...(canLaunchWithDebug
+    ...(ENABLE_PUBLIC_DEBUG_LAUNCHER
       ? [{
           key: 'debug-launch',
           label: `Debug Menu: ${debugLaunch ? 'On' : 'Off'}`,


### PR DESCRIPTION
## What changed

- Shows the **Debug Menu** launcher in web, emulator, and native builds during QA.
- Removes the Capacitor-only visibility restriction.
- Adds a single `ENABLE_PUBLIC_DEBUG_LAUNCHER` switch that can be set to `false` before the public store release.
- Keeps direct `#/game?debug=1&qa=1` links working.

## Why

The previous launcher was restricted to environments detected as native Capacitor. Android Studio emulator sessions and phone-accessed web builds can run without that detection, so the Debug Menu option was missing even though debug access was still needed for testing.

## Impact

Testers can enable the debug drawer from the Play menu on desktop, phone browsers, Android Studio emulators, and installed native apps. This visibility is intentionally temporary for QA and clearly marked for removal before release.

## Validation

- Targeted ESLint passed.
- TypeScript typecheck passed.
- 16 focused HomeHub and DebugPanel tests passed.
- Git whitespace checks passed.