### PR TITLE
Fix the mobile debug minigame picker

### DIFF
--- a/src/components/DebugPanel/DebugPanel.css
+++ b/src/components/DebugPanel/DebugPanel.css
@@ -239,6 +239,76 @@
   background: rgba(180 20 20 / 0.4);
 }
 
+/* In-panel minigame picker. Native select popups are unreliable in some
+   Android WebViews/emulators, so keep the complete interaction in the drawer. */
+.dbg-minigame-picker {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+}
+.dbg-minigame-picker__label {
+  color: #ccc;
+  font-size: 0.8rem;
+}
+.dbg-minigame-picker__trigger {
+  min-width: 0;
+  min-height: 2.25rem;
+  padding: 0.4rem 0.55rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: 1px solid #777;
+  border-radius: 5px;
+  background: #222;
+  color: #eee;
+  font: inherit;
+  text-align: left;
+  touch-action: manipulation;
+}
+.dbg-minigame-picker__trigger span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dbg-minigame-picker__options {
+  grid-column: 1 / -1;
+  max-height: min(18rem, 45dvh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem;
+  border: 1px solid rgba(255 255 255 / 0.18);
+  border-radius: 6px;
+  background: #151522;
+}
+.dbg-minigame-picker__option {
+  flex: 0 0 auto;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.65rem;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #e0e0f0;
+  font: inherit;
+  text-align: left;
+  touch-action: manipulation;
+}
+.dbg-minigame-picker__option + .dbg-minigame-picker__option {
+  border-top: 1px solid rgba(255 255 255 / 0.06);
+}
+.dbg-minigame-picker__option[aria-selected='true'] {
+  background: #16213e;
+  color: #fff;
+}
+.dbg-minigame-picker__option:active {
+  background: #0f3460;
+}
+
 /* Hide on very small screens (phones in portrait) by tucking behind toggle */
 @media (max-width: 360px) {
   .dbg-panel {

--- a/src/components/DebugPanel/MinigameDebugControls.tsx
+++ b/src/components/DebugPanel/MinigameDebugControls.tsx
@@ -18,6 +18,9 @@ export default function MinigameDebugControls() {
   const [localSeed, setLocalSeed] = useState(String(debug.forceSeed ?? ''));
   const [skipRules, setSkipRules] = useState(debug.skipRules ?? false);
   const [fastFwd, setFastFwd] = useState(debug.fastForwardCountdown ?? false);
+  const [gamePickerOpen, setGamePickerOpen] = useState(false);
+
+  const selectedGameTitle = ALL_GAMES.find((game) => game.key === localKey)?.title ?? '(random)';
 
   const handleApply = () => {
     dispatch(
@@ -35,6 +38,7 @@ export default function MinigameDebugControls() {
     setLocalSeed('');
     setSkipRules(false);
     setFastFwd(false);
+    setGamePickerOpen(false);
     dispatch(clearDebugOverrides());
   };
 
@@ -46,21 +50,51 @@ export default function MinigameDebugControls() {
 
       <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 6 }}>
         {/* Force game key */}
-        <label style={{ fontSize: '0.8rem', color: '#ccc' }}>
-          Force Game
-          <select
-            value={localKey}
-            onChange={(e) => setLocalKey(e.target.value)}
-            style={{ marginLeft: 8, background: '#222', color: '#eee', border: '1px solid #555', borderRadius: 4, padding: '2px 4px' }}
+        <div className="dbg-minigame-picker">
+          <span className="dbg-minigame-picker__label">Force Game</span>
+          <button
+            type="button"
+            className="dbg-minigame-picker__trigger"
+            aria-label="Force Game"
+            aria-haspopup="listbox"
+            aria-expanded={gamePickerOpen}
+            onClick={() => setGamePickerOpen((open) => !open)}
           >
-            <option value="">(random)</option>
-            {ALL_GAMES.map((g) => (
-              <option key={g.key} value={g.key}>
-                {g.title}
-              </option>
-            ))}
-          </select>
-        </label>
+            <span>{selectedGameTitle}</span>
+            <span aria-hidden="true">{gamePickerOpen ? '▴' : '▾'}</span>
+          </button>
+          {gamePickerOpen && (
+            <div className="dbg-minigame-picker__options" role="listbox" aria-label="Minigame options">
+              <button
+                type="button"
+                role="option"
+                aria-selected={localKey === ''}
+                className="dbg-minigame-picker__option"
+                onClick={() => {
+                  setLocalKey('');
+                  setGamePickerOpen(false);
+                }}
+              >
+                (random)
+              </button>
+              {ALL_GAMES.map((game) => (
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={localKey === game.key}
+                  className="dbg-minigame-picker__option"
+                  key={game.key}
+                  onClick={() => {
+                    setLocalKey(game.key);
+                    setGamePickerOpen(false);
+                  }}
+                >
+                  {game.title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
 
         {/* Force seed */}
         <label style={{ fontSize: '0.8rem', color: '#ccc' }}>

--- a/src/components/DebugPanel/__tests__/MinigameDebugControls.test.tsx
+++ b/src/components/DebugPanel/__tests__/MinigameDebugControls.test.tsx
@@ -1,0 +1,37 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+import challengeReducer from '../../../store/challengeSlice';
+import { getAllGames } from '../../../minigames/registry';
+import MinigameDebugControls from '../MinigameDebugControls';
+
+describe('MinigameDebugControls', () => {
+  it('opens the in-panel game picker and applies a selected game', async () => {
+    const user = userEvent.setup();
+    const store = configureStore({ reducer: { challenge: challengeReducer } });
+    const game = getAllGames().find((entry) => !entry.retired);
+
+    expect(game).toBeDefined();
+
+    render(
+      <Provider store={store}>
+        <MinigameDebugControls />
+      </Provider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Force Game' });
+    expect(screen.queryByRole('listbox', { name: 'Minigame options' })).toBeNull();
+
+    await user.click(trigger);
+    expect(screen.getByRole('listbox', { name: 'Minigame options' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: game!.title }));
+    expect(trigger).toHaveTextContent(game!.title);
+    expect(screen.queryByRole('listbox', { name: 'Minigame options' })).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(store.getState().challenge.debug.forceGameKey).toBe(game!.key);
+  });
+});


### PR DESCRIPTION
## What changed

- Replaces the Minigame Debug native `<select>` with a touch-friendly picker rendered inside the debug drawer.
- Shows large tappable minigame rows and keeps long option lists independently scrollable.
- Closes the picker after selection and preserves the existing Apply/Clear debug override behavior.
- Adds regression coverage for opening the picker, choosing a real game, closing it, and applying the override.

## Why

The Android emulator/WebView displayed the native selector but did not open its platform dropdown, leaving mobile testers unable to force a minigame. Keeping the option UI inside the drawer avoids reliance on the native popup.

## Impact

Mobile and emulator users can tap **Force Game**, select any registered minigame from the in-panel list, and apply it normally. Debug drawer scrolling is unchanged.

## Validation

- Targeted ESLint passed.
- 6 focused DebugPanel and MinigameDebugControls tests passed.
- Git whitespace checks passed.
- Full local typecheck was blocked by an unrelated unstaged Hangman edit (`isComposing` on `Event`); those Hangman files are not included in this PR.