### PR TITLE
Extend Housemates profile beats

### DIFF
--- a/src/components/HousematesBioCinematic/HousematesBioCinematic.tsx
+++ b/src/components/HousematesBioCinematic/HousematesBioCinematic.tsx
@@ -139,18 +139,10 @@ function HousemateScene({ card, index }: { card: HousematesBioCard; index: numbe
         </motion.div>
 
         <motion.div
-          className="hbc-bubble hbc-bubble--intro"
-          initial={{ opacity: 0, y: 20, scale: 0.96 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          transition={{ delay: 0.46, duration: 0.48, ease: [0.22, 1, 0.36, 1] }}
-        >
-          {card.introduction}
-        </motion.div>
-        <motion.div
           className="hbc-bubble hbc-bubble--dream"
           initial={{ opacity: 0, y: 20, scale: 0.96 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
-          transition={{ delay: 1.48, duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          transition={{ delay: 0.58, duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
         >
           <span className="hbc-bubble__label">Why I’m here</span>
           {card.prizePlan}

--- a/src/components/HousematesBioCinematic/__tests__/housematesBioData.test.ts
+++ b/src/components/HousematesBioCinematic/__tests__/housematesBioData.test.ts
@@ -25,9 +25,9 @@ describe('Housemates biography cinematic', () => {
     }
   });
 
-  it('keeps the complete cinematic below two minutes', () => {
-    expect(HOUSEMATES_BIO_DURATION_MS).toBeLessThanOrEqual(120_000);
-    expect(HOUSEMATES_BIO_DURATION_MS).toBeGreaterThan(100_000);
+  it('holds every housemate on screen for 5.1 seconds', () => {
+    expect(HOUSEMATE_CARD_MS).toBe(5_100);
+    expect(HOUSEMATES_BIO_DURATION_MS).toBe(131_400);
   });
 
   it('keeps the five mystery housemates in a separate unlockable wildcard collection', () => {

--- a/src/components/HousematesBioCinematic/housematesBioTimeline.ts
+++ b/src/components/HousematesBioCinematic/housematesBioTimeline.ts
@@ -1,7 +1,7 @@
 import { HOUSEMATES_BIO_CARDS, type HousematesBioCard } from './housematesBioData';
 
 export const HOUSEMATES_INTRO_MS = 3_800;
-export const HOUSEMATE_CARD_MS = 4_100;
+export const HOUSEMATE_CARD_MS = 5_100;
 export const HOUSEMATES_OUTRO_MS = 6_400;
 export const HOUSEMATES_CREDIT_MS = 4_700;
 export const HOUSEMATES_LOGO_MS = 4_300;


### PR DESCRIPTION
## What changed
- increase every Housemates biography card from 4.1 seconds to 5.1 seconds
- remove the redundant introductory speech balloon that repeated the displayed name, location, and profession
- bring the remaining unique “Why I’m here” balloon in earlier
- update the cinematic timing regression test

## Why
The profile cards moved too quickly, while the first callout repeated information already shown directly above it. This gives each person more screen presence and keeps only the meaningful, biography-specific motivation.

## Impact
All 22 profiles receive one additional second. The complete cinematic now runs approximately 2 minutes 11 seconds.

## Validation
- targeted ESLint passed
- `npm run typecheck`
- Housemates cinematic test suite: 4 tests passed
- QA-enabled production build passed