### PR TITLE
P0: Protect active game sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { SoundManager } from './services/sound/SoundManager';
 import AudioStateSync from './services/sound/AudioStateSync';
 import AudioGate from './components/AudioGate/AudioGate';
 import { loadRemoteConfig } from './remoteConfig/remoteConfigSlice';
+import { installGameDiagnostics } from './services/diagnostics/gameDiagnostics';
 
 if (import.meta.env.DEV) {
   console.log('[router] bundle:', import.meta.url, '| pathname:', window.location.pathname, '| hash:', window.location.hash);
@@ -38,6 +39,7 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    installGameDiagnostics();
     void SoundManager.init();
     // Fetch the remote live-config on startup; falls back to cache or defaults.
     void store.dispatch(loadRemoteConfig());

--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { avatarVariants } from '../../utils/avatarCase'
-import { getProfilePhotoAvatarId } from '../../utils/avatar'
+import { getLocalAvatarFallback, getProfilePhotoAvatarId } from '../../utils/avatar'
 import { imageIdToDataUrl } from '../../utils/imageDb'
 import { getBadgesForPlayer } from '../../utils/statusBadges'
 import styles from './HouseguestGrid.module.css'
@@ -138,7 +138,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
     }
 
     exhaustedRef.current = true
-    img.src = '/avatars/placeholder.png'
+    img.src = getLocalAvatarFallback(name, isYou)
   }
 
   // Resolve badges: normalise statuses prop to a joined string then derive BadgeInfo[]

--- a/src/components/RouteErrorBoundary/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary/RouteErrorBoundary.tsx
@@ -1,9 +1,17 @@
+import { useEffect, useState } from 'react';
 import { isRouteErrorResponse, useNavigate, useRouteError } from 'react-router-dom';
+import { captureGameDiagnostic, type GameDiagnostic } from '../../services/diagnostics/gameDiagnostics';
 import './RouteErrorBoundary.css';
 
 export default function RouteErrorBoundary() {
   const error = useRouteError();
   const navigate = useNavigate();
+  const [diagnostic, setDiagnostic] = useState<GameDiagnostic | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setDiagnostic(captureGameDiagnostic('route-error', error));
+  }, [error]);
 
   let status: number | undefined;
   let message = 'An unexpected error occurred.';
@@ -14,34 +22,32 @@ export default function RouteErrorBoundary() {
     message = error.statusText || message;
   } else if (error instanceof Error) {
     message = error.message;
-    if (import.meta.env.DEV) {
-      stack = error.stack;
-    }
+    if (import.meta.env.DEV) stack = error.stack;
   }
 
   return (
     <div className="route-error">
-      <div className="route-error__code" aria-hidden="true">
-        {status ?? '⚠️'}
-      </div>
+      <div className="route-error__code" aria-hidden="true">{status ?? '!'}</div>
       <h1 className="route-error__title">Something went wrong</h1>
       <p className="route-error__message">{message}</p>
-      {stack && (
-        <pre className="route-error__stack">{stack}</pre>
-      )}
+      {stack && <pre className="route-error__stack">{stack}</pre>}
       <div className="route-error__actions">
-        <button
-          className="route-error__btn route-error__btn--primary"
-          onClick={() => navigate('/')}
-        >
-          🏠 Go Home
+        <button className="route-error__btn route-error__btn--primary" onClick={() => navigate('/')}>
+          Go Home
         </button>
-        <button
-          className="route-error__btn"
-          onClick={() => window.location.reload()}
-        >
-          ↺ Reload
+        <button className="route-error__btn" onClick={() => window.location.reload()}>
+          Reload
         </button>
+        {diagnostic && (
+          <button
+            className="route-error__btn"
+            onClick={() => {
+              void navigator.clipboard?.writeText(JSON.stringify(diagnostic, null, 2)).then(() => setCopied(true));
+            }}
+          >
+            {copied ? 'Diagnostic copied' : 'Copy diagnostic'}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/SaveRecoveryNotice/SaveRecoveryNotice.css
+++ b/src/components/SaveRecoveryNotice/SaveRecoveryNotice.css
@@ -1,0 +1,36 @@
+.save-recovery-notice {
+  position: fixed;
+  z-index: 8500;
+  top: max(0.75rem, env(safe-area-inset-top));
+  left: max(0.75rem, env(safe-area-inset-left));
+  right: max(0.75rem, env(safe-area-inset-right));
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  max-width: 28rem;
+  margin: 0 auto;
+  padding: 0.85rem 0.9rem 0.85rem 1rem;
+  color: #fff;
+  border: 1px solid rgb(255 255 255 / 16%);
+  border-radius: 1rem;
+  background: rgb(17 24 39 / 96%);
+  box-shadow: 0 1rem 3rem rgb(0 0 0 / 42%);
+  backdrop-filter: blur(16px);
+}
+
+.save-recovery-notice div { display: grid; gap: 0.2rem; }
+.save-recovery-notice strong { font-size: 0.88rem; }
+.save-recovery-notice span { color: rgb(255 255 255 / 70%); font-size: 0.75rem; line-height: 1.35; }
+.save-recovery-notice button {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  color: inherit;
+  border: 0;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 9%);
+  font: inherit;
+  font-size: 1.25rem;
+}

--- a/src/components/SaveRecoveryNotice/SaveRecoveryNotice.tsx
+++ b/src/components/SaveRecoveryNotice/SaveRecoveryNotice.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import {
+  clearLastSavePersistenceIssue,
+  getLastSavePersistenceIssue,
+  SAVE_PERSISTENCE_ISSUE_EVENT,
+  type SavePersistenceIssue,
+} from '../../store/saveStatePersistence';
+import './SaveRecoveryNotice.css';
+
+export default function SaveRecoveryNotice() {
+  const [issue, setIssue] = useState<SavePersistenceIssue | null>(() => getLastSavePersistenceIssue());
+
+  useEffect(() => {
+    const onIssue = (event: Event) => {
+      setIssue((event as CustomEvent<SavePersistenceIssue>).detail);
+    };
+    window.addEventListener(SAVE_PERSISTENCE_ISSUE_EVENT, onIssue);
+    return () => window.removeEventListener(SAVE_PERSISTENCE_ISSUE_EVENT, onIssue);
+  }, []);
+
+  if (!issue) return null;
+  const copy = issue.kind === 'write_failed'
+    ? {
+        title: 'Progress could not be saved',
+        body: 'Your season is still open. Free some browser storage, then use Save & Home again.',
+      }
+    : {
+        title: 'Save recovered safely',
+        body: 'A damaged save was set aside. The game opened the last valid version it could find.',
+      };
+
+  return (
+    <aside className="save-recovery-notice" role="alert">
+      <div><strong>{copy.title}</strong><span>{copy.body}</span></div>
+      <button type="button" onClick={() => { clearLastSavePersistenceIssue(); setIssue(null); }} aria-label="Dismiss save notice">×</button>
+    </aside>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -10,6 +10,8 @@ import { selectSettings } from '../../store/settingsSlice';
 import { selectRemoteConfig } from '../../remoteConfig/remoteConfigSlice';
 import useGameMode from '../../hooks/useGameMode';
 import { buildViewportMetaContent } from './viewportMeta';
+import PortraitOrientationGuard from './PortraitOrientationGuard';
+import SaveRecoveryNotice from '../SaveRecoveryNotice/SaveRecoveryNotice';
 import './AppShell.css';
 
 const THEME_PRESETS = ['midnight', 'neon', 'sunset', 'ocean'];
@@ -110,6 +112,8 @@ export default function AppShell() {
         seasonFinale == null &&
         (finale.isActive || !finale.hasStarted || finale.isComplete) && <FinalFaceoff />}
       {seasonFinale && <SeasonFinaleOverlay />}
+      <PortraitOrientationGuard />
+      <SaveRecoveryNotice />
     </div>
   );
 }

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -41,6 +41,7 @@ export default function NavBar() {
   const canPersistActiveRun = !isGuest && Boolean(activeProfileId);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [saveError, setSaveError] = useState(false);
   const humanInPendingChallenge =
     Boolean(pendingChallenge && humanPlayer && pendingChallenge.participants.includes(humanPlayer.id));
   const humanInPendingMinigame =
@@ -65,6 +66,7 @@ export default function NavBar() {
       navigate('/');
       return;
     }
+    setSaveError(false);
     setConfirmOpen(true);
   }
 
@@ -92,8 +94,11 @@ export default function NavBar() {
   }
 
   function saveThenReturnHome() {
-    saveActiveRun();
-    returnHome();
+    if (saveActiveRun()) {
+      returnHome();
+      return;
+    }
+    setSaveError(true);
   }
 
   function quitWithoutSaving() {
@@ -111,11 +116,14 @@ export default function NavBar() {
     return null;
   }
 
-  const hasSavedRun = canPersistActiveRun;
-  const modalTitle = hasSavedRun ? 'Return to Home hub?' : 'Unsaved progress';
-  const modalDescription = hasSavedRun
-    ? 'Your saved progress will be available when you come back.'
-    : 'Save before returning home, or quit without saving.';
+  const modalTitle = saveError
+    ? 'Progress was not saved'
+    : canPersistActiveRun ? 'Save and return home?' : 'Leave this season?';
+  const modalDescription = saveError
+    ? 'Your season is still open. Free some browser storage and try again.'
+    : canPersistActiveRun
+      ? 'We will save your current week before returning to the Home hub.'
+      : 'Guest seasons cannot be saved. Leaving will discard this run.';
 
   return (
     <GameBottomNav
@@ -131,11 +139,11 @@ export default function NavBar() {
         open={confirmOpen}
         title={modalTitle}
         description={modalDescription}
-        confirmLabel={hasSavedRun ? 'Return Home' : 'Save first'}
-        secondaryLabel={hasSavedRun ? undefined : 'Quit without saving'}
+        confirmLabel={canPersistActiveRun ? (saveError ? 'Try saving again' : 'Save & Home') : 'Quit without saving'}
+        secondaryLabel={canPersistActiveRun ? 'Quit without saving' : undefined}
         cancelLabel="Cancel"
-        onConfirm={hasSavedRun ? returnHome : saveThenReturnHome}
-        onSecondary={hasSavedRun ? undefined : quitWithoutSaving}
+        onConfirm={canPersistActiveRun ? saveThenReturnHome : quitWithoutSaving}
+        onSecondary={canPersistActiveRun ? quitWithoutSaving : undefined}
         onCancel={() => setConfirmOpen(false)}
       />
     </GameBottomNav>

--- a/src/components/layout/PortraitOrientationGuard.css
+++ b/src/components/layout/PortraitOrientationGuard.css
@@ -1,0 +1,73 @@
+.portrait-orientation-guard {
+  display: none;
+}
+
+@media (orientation: landscape) and (max-height: 520px) and (pointer: coarse) {
+  .portrait-orientation-guard {
+    position: fixed;
+    inset: 0;
+    z-index: 12000;
+    display: grid;
+    grid-template-columns: auto minmax(0, 24rem);
+    place-content: center;
+    align-items: center;
+    gap: clamp(1.5rem, 5vw, 4rem);
+    padding: max(1.5rem, env(safe-area-inset-top)) max(2rem, env(safe-area-inset-right))
+      max(1.5rem, env(safe-area-inset-bottom)) max(2rem, env(safe-area-inset-left));
+    color: #f7f8ff;
+    text-align: left;
+    background:
+      radial-gradient(circle at 20% 20%, rgb(101 72 255 / 28%), transparent 34%),
+      radial-gradient(circle at 80% 75%, rgb(255 53 143 / 18%), transparent 32%),
+      #090d18;
+  }
+
+  .portrait-orientation-guard__phone {
+    width: 4.75rem;
+    aspect-ratio: 9 / 17;
+    padding: 0.3rem;
+    border: 0.18rem solid rgb(255 255 255 / 85%);
+    border-radius: 1rem;
+    box-shadow: 0 1rem 3rem rgb(0 0 0 / 35%);
+    transform: rotate(-90deg);
+    animation: portrait-guard-rotate 1.5s ease-in-out 0.25s both;
+  }
+
+  .portrait-orientation-guard__phone span {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 0.65rem;
+    background: linear-gradient(145deg, #7048ff, #ff358f);
+  }
+
+  .portrait-orientation-guard__eyebrow {
+    margin: 0 0 0.35rem;
+    color: #b9a9ff;
+    font-size: 0.7rem;
+    font-weight: 800;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .portrait-orientation-guard h1 {
+    margin: 0;
+    font-size: clamp(1.5rem, 5vw, 2.5rem);
+    line-height: 1;
+  }
+
+  .portrait-orientation-guard p:last-child {
+    margin: 0.65rem 0 0;
+    color: rgb(247 248 255 / 72%);
+    font-size: clamp(0.8rem, 2vw, 1rem);
+    line-height: 1.45;
+  }
+}
+
+@keyframes portrait-guard-rotate {
+  to { transform: rotate(0deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .portrait-orientation-guard__phone { animation: none; transform: none; }
+}

--- a/src/components/layout/PortraitOrientationGuard.tsx
+++ b/src/components/layout/PortraitOrientationGuard.tsx
@@ -1,0 +1,17 @@
+import './PortraitOrientationGuard.css';
+
+/** Friendly browser fallback when orientation locking is unavailable. */
+export default function PortraitOrientationGuard() {
+  return (
+    <aside className="portrait-orientation-guard" role="status" aria-live="polite">
+      <div className="portrait-orientation-guard__phone" aria-hidden="true">
+        <span />
+      </div>
+      <div>
+        <p className="portrait-orientation-guard__eyebrow">Best played upright</p>
+        <h1>Rotate your device</h1>
+        <p>Big Brother Mobile is designed as a portrait game. Your season will be waiting.</p>
+      </div>
+    </aside>
+  );
+}

--- a/src/services/diagnostics/gameDiagnostics.test.ts
+++ b/src/services/diagnostics/gameDiagnostics.test.ts
@@ -1,0 +1,15 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { captureGameDiagnostic, getLastGameDiagnostic } from './gameDiagnostics';
+
+describe('game diagnostics', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('stores a privacy-safe support report for the current route', () => {
+    const report = captureGameDiagnostic('route-error', new Error('render failed'));
+
+    expect(report.reason).toBe('route-error');
+    expect(report.message).toBe('render failed');
+    expect(getLastGameDiagnostic()).toEqual(report);
+    expect(JSON.stringify(report)).not.toContain('players');
+  });
+});

--- a/src/services/diagnostics/gameDiagnostics.ts
+++ b/src/services/diagnostics/gameDiagnostics.ts
@@ -1,0 +1,72 @@
+import type { Middleware } from '@reduxjs/toolkit';
+
+const DIAGNOSTIC_KEY = 'bbmobilenew:lastGameDiagnostic';
+
+export type GameDiagnostic = {
+  capturedAt: string;
+  reason: string;
+  route: string;
+  phase?: string;
+  week?: number;
+  gameId?: string | null;
+  runId?: string | null;
+  saveVersion?: number;
+  lastAction?: string;
+  activeSurface?: string;
+  message?: string;
+};
+
+let latestContext: Partial<GameDiagnostic> = {};
+let installed = false;
+
+function activeSurface(state: any): string {
+  if (state?.game?.seasonFinale) return 'season-finale';
+  if (state?.finale?.isActive) return 'jury-finale';
+  if (state?.challenge?.pendingChallenge) return 'challenge';
+  if (state?.game?.pendingMinigame) return 'minigame';
+  if (state?.game?.evictionOverlayPlayerId) return 'eviction-overlay';
+  return 'main-game';
+}
+
+export const gameDiagnosticsMiddleware: Middleware = (api) => (next) => (action) => {
+  const result = next(action);
+  const state = api.getState() as any;
+  latestContext = {
+    phase: state?.game?.phase,
+    week: state?.game?.week,
+    gameId: state?.game?.gameId ?? null,
+    runId: state?.game?.runId ?? null,
+    saveVersion: state?.game?.saveVersion,
+    lastAction: typeof action === 'object' && action && 'type' in action ? String(action.type) : 'unknown',
+    activeSurface: activeSurface(state),
+  };
+  return result;
+};
+
+export function captureGameDiagnostic(reason: string, error?: unknown): GameDiagnostic {
+  const report: GameDiagnostic = {
+    capturedAt: new Date().toISOString(),
+    reason,
+    route: typeof window === 'undefined' ? '' : `${window.location.pathname}${window.location.hash}`,
+    ...latestContext,
+    message: error instanceof Error ? error.message : typeof error === 'string' ? error : undefined,
+  };
+  try { sessionStorage.setItem(DIAGNOSTIC_KEY, JSON.stringify(report)); } catch { /* best effort */ }
+  return report;
+}
+
+export function getLastGameDiagnostic(): GameDiagnostic | null {
+  try {
+    const raw = sessionStorage.getItem(DIAGNOSTIC_KEY);
+    return raw ? JSON.parse(raw) as GameDiagnostic : null;
+  } catch {
+    return null;
+  }
+}
+
+export function installGameDiagnostics(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+  window.addEventListener('error', (event) => captureGameDiagnostic('window-error', event.error ?? event.message));
+  window.addEventListener('unhandledrejection', (event) => captureGameDiagnostic('unhandled-rejection', event.reason));
+}

--- a/src/services/diagnostics/gameDiagnostics.ts
+++ b/src/services/diagnostics/gameDiagnostics.ts
@@ -19,7 +19,21 @@ export type GameDiagnostic = {
 let latestContext: Partial<GameDiagnostic> = {};
 let installed = false;
 
-function activeSurface(state: any): string {
+type DiagnosticState = {
+  game?: {
+    seasonFinale?: unknown;
+    pendingMinigame?: unknown;
+    evictionOverlayPlayerId?: unknown;
+    phase?: string;
+    week?: number;
+    gameId?: string | null;
+    runId?: string | null;
+    saveVersion?: number;
+  };
+  finale?: { isActive?: boolean };
+  challenge?: { pendingChallenge?: unknown };
+};
+function activeSurface(state: DiagnosticState): string {
   if (state?.game?.seasonFinale) return 'season-finale';
   if (state?.finale?.isActive) return 'jury-finale';
   if (state?.challenge?.pendingChallenge) return 'challenge';
@@ -30,7 +44,7 @@ function activeSurface(state: any): string {
 
 export const gameDiagnosticsMiddleware: Middleware = (api) => (next) => (action) => {
   const result = next(action);
-  const state = api.getState() as any;
+  const state = api.getState() as DiagnosticState;
   latestContext = {
     phase: state?.game?.phase,
     week: state?.game?.week,

--- a/src/services/sound/SoundManager.ts
+++ b/src/services/sound/SoundManager.ts
@@ -42,6 +42,10 @@
  */
 
 import { SOUND_REGISTRY } from './sounds';
+
+// Only the tiny, frequently-used interface sounds are worth warming during
+// the first gesture. Everything else is created on demand when it is needed.
+const MOBILE_SFX_PRIME_KEYS = ['ui:navigate', 'ui:confirm', 'ui:error'] as const;
 import type { SoundCategory, SoundEntry } from './sounds';
 import {
   MUSIC_TRACK_SOUND_KEYS,
@@ -1093,16 +1097,17 @@ class _SoundManager {
   }
 
   /**
-   * Pre-create and prime one pool element per registered SFX key during a
-   * user gesture. The element is paused immediately so stale startup sounds
-   * cannot become audible later.
+   * Pre-create the small set of common interface sounds during a user gesture.
+   * The element is paused immediately so stale startup sounds cannot become
+   * audible later. Ceremony and minigame audio remains lazy/on-demand.
    */
   private _primeSfxForMobile(): void {
     if (typeof document === 'undefined' || this._sfxPrimed) return;
     this._sfxPrimed = true;
 
-    for (const [key, entry] of Object.entries(SOUND_REGISTRY)) {
-      if (entry.category === 'music') continue; // music handled separately
+    for (const key of MOBILE_SFX_PRIME_KEYS) {
+      const entry = SOUND_REGISTRY[key];
+      if (!entry) continue;
       let pool = this._sfxPools.get(key);
       if (!pool) {
         pool = [];

--- a/src/store/saveStatePersistence.test.ts
+++ b/src/store/saveStatePersistence.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  clearLastSavePersistenceIssue,
+  CORRUPT_SAVE_RECOVERY_KEY,
+  getLastSavePersistenceIssue,
   loadSavedRunProfile,
   markSurvivorAchievementCelebrationSeen,
   saveRunSnapshot,
@@ -10,10 +13,26 @@ import {
 describe('saveStatePersistence survivor progression', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
+    clearLastSavePersistenceIssue();
   });
 
   afterEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
+    clearLastSavePersistenceIssue();
+  });
+
+  it('quarantines a damaged run and reports a visible recovery event', () => {
+    const key = savedRunsKeyForProfile('profile-1');
+    localStorage.setItem(key, '{damaged-json');
+
+    const profile = loadSavedRunProfile('profile-1');
+
+    expect(profile.runs).toEqual({});
+    expect(localStorage.getItem(key)).toBeNull();
+    expect(sessionStorage.getItem(CORRUPT_SAVE_RECOVERY_KEY)).toBe('{damaged-json');
+    expect(getLastSavePersistenceIssue()?.kind).toBe('corrupt_recovered');
   });
 
   it('normalizes missing survivor achievement unlock maps to an empty object', () => {

--- a/src/store/saveStatePersistence.ts
+++ b/src/store/saveStatePersistence.ts
@@ -27,6 +27,33 @@ import type { SurvivorAchievementUnlockMap } from '../modes/survivorAchievements
 /** Prefix for per-profile saved-season localStorage keys. */
 export const SAVED_STATE_KEY_PREFIX = 'bbmobilenew:savedSeason:';
 export const SAVED_RUNS_KEY_PREFIX = 'bbmobilenew:savedRuns:';
+export const SAVE_PERSISTENCE_ISSUE_EVENT = 'bb:save-persistence-issue';
+export const CORRUPT_SAVE_RECOVERY_KEY = 'bbmobilenew:recovery:lastCorruptSave';
+
+export type SavePersistenceIssue = {
+  kind: 'write_failed' | 'corrupt_recovered';
+  occurredAt: string;
+};
+
+let lastSavePersistenceIssue: SavePersistenceIssue | null = null;
+
+function reportSavePersistenceIssue(kind: SavePersistenceIssue['kind']): void {
+  if (lastSavePersistenceIssue?.kind === kind) return;
+  lastSavePersistenceIssue = { kind, occurredAt: new Date().toISOString() };
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent<SavePersistenceIssue>(SAVE_PERSISTENCE_ISSUE_EVENT, {
+      detail: lastSavePersistenceIssue,
+    }));
+  }
+}
+
+export function getLastSavePersistenceIssue(): SavePersistenceIssue | null {
+  return lastSavePersistenceIssue;
+}
+
+export function clearLastSavePersistenceIssue(): void {
+  lastSavePersistenceIssue = null;
+}
 
 /** Shape of what we persist for a manual season save. */
 export interface SavedSeasonSnapshot {
@@ -160,6 +187,7 @@ export function saveSeasonSnapshot(key: string, snapshot: SavedSeasonSnapshot): 
     return true;
   } catch {
     // Storage unavailable or quota exceeded.
+    reportSavePersistenceIssue('write_failed');
     return false;
   }
 }
@@ -187,15 +215,31 @@ export function loadSeasonSnapshot(key: string): SavedSeasonSnapshot | null {
 
 export function loadSavedRunProfile(profileId: string): SavedRunProfile {
   const key = savedRunsKeyForProfile(profileId);
+  let malformedRaw: string | null = null;
   try {
     const raw = localStorage.getItem(key);
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<SavedRunProfile>;
       const normalized = normalizeRunProfile(profileId, parsed);
       if (normalized) return normalized;
+      malformedRaw = raw;
     }
   } catch {
-    // Fall through to legacy migration.
+    try {
+      malformedRaw = localStorage.getItem(key);
+    } catch {
+      malformedRaw = null;
+    }
+  }
+
+  if (malformedRaw) {
+    try {
+      sessionStorage.setItem(CORRUPT_SAVE_RECOVERY_KEY, malformedRaw);
+      localStorage.removeItem(key);
+    } catch {
+      // Recovery can continue even if the damaged payload cannot be quarantined.
+    }
+    reportSavePersistenceIssue('corrupt_recovered');
   }
 
   const legacy = loadSeasonSnapshot(savedStateKeyForProfile(profileId));
@@ -217,6 +261,7 @@ export function saveRunProfile(profile: SavedRunProfile): boolean {
     localStorage.setItem(savedRunsKeyForProfile(profile.profileId), JSON.stringify(profile));
     return true;
   } catch {
+    reportSavePersistenceIssue('write_failed');
     return false;
   }
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -42,6 +42,7 @@ import adsReducer, { loadAdsState, saveAdsState } from './adsSlice';
 import { adsMiddleware } from './adsMiddleware';
 import remoteConfigReducer from '../remoteConfig/remoteConfigSlice';
 import { secretMissionMiddleware } from './secretMissionMiddleware';
+import { gameDiagnosticsMiddleware } from '../services/diagnostics/gameDiagnostics';
 
 export const store = configureStore({
   reducer: {
@@ -85,6 +86,7 @@ export const store = configureStore({
       publicOpinionMiddleware,
       adsMiddleware,
       secretMissionMiddleware,
+      gameDiagnosticsMiddleware,
     ),
 });
 

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -65,6 +65,19 @@ export function getDicebear(seed: string): string {
   return `https://api.dicebear.com/7.x/pixel-art/svg?seed=${encoded}`;
 }
 
+/** Guaranteed, base-aware fallback that never depends on a third-party service. */
+export function getLocalAvatarFallback(name: string, isUser = false): string {
+  if (isUser) return joinPublicAssetPath('assets/skins/You.png');
+  const initials = (name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join('') || '?').replace(/[&<>"']/g, '');
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" rx="24" fill="#172033"/><circle cx="64" cy="64" r="48" fill="#263653"/><text x="64" y="76" text-anchor="middle" font-family="system-ui,sans-serif" font-size="38" font-weight="700" fill="#f5f7ff">${initials}</text></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
 /**
  * Returns the base path prefix for avatar URLs.
  * Priority: window.AVATAR_BASE_PATH > process.env.PUBLIC_URL > import.meta.env.BASE_URL
@@ -205,7 +218,7 @@ export function resolveAvatarCandidates(player: Pick<Player, 'id' | 'name' | 'av
     );
   }
 
-  candidates.push(getDicebear(player.name));
+  candidates.push(getDicebear(player.name), getLocalAvatarFallback(player.name, isUserPlayer));
 
   return candidates;
 }
@@ -228,7 +241,7 @@ export const getAvatarCandidatesFor = resolveAvatarCandidates;
  *  - First onError: swap src to getDicebear(player.name)
  *  - Second onError (Dicebear unreachable): show emoji / initials fallback
  */
-export function resolveAvatar(player: Pick<Player, 'id' | 'name' | 'avatar'>): string {
+export function resolveAvatar(player: Pick<Player, 'id' | 'name' | 'avatar'> & Partial<Pick<Player, 'isUser'>>): string {
   const candidates = resolveAvatarCandidates(player);
   if (typeof window !== 'undefined' && (window as Window & { __AVATAR_DEBUG?: boolean }).__AVATAR_DEBUG) {
     console.debug('[avatar] resolveAvatar candidates for', player.name, candidates);

--- a/tests/unit/avatarCandidates.test.ts
+++ b/tests/unit/avatarCandidates.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { resolveAvatarCandidates } from '../../src/utils/avatar';
+import { getLocalAvatarFallback, resolveAvatar, resolveAvatarCandidates } from '../../src/utils/avatar';
 
 describe('resolveAvatarCandidates', () => {
+  it('preserves the user identity and ends with a bundled fallback', () => {
+    const player = { id: 'guest-1', name: 'You', avatar: '', isUser: true } as const;
+    const candidates = resolveAvatarCandidates(player);
+
+    expect(candidates.at(-1)).toContain('assets/skins/You.png');
+    expect(resolveAvatar(player)).toBe(candidates[0]);
+  });
+
+  it('provides an offline-safe initials fallback for houseguests', () => {
+    expect(getLocalAvatarFallback('Nova Ray')).toMatch(/^data:image\/svg\+xml,/);
+  });
+
   it('prefers an explicit Lia avatar path before any scanned avatar asset', () => {
     const candidates = resolveAvatarCandidates({
       id: 'lia',


### PR DESCRIPTION
## Product summary
This P0 makes an active season safer and more dependable before we reshape the screen itself.

### What changed
- Avatar tiles now have a bundled, base-path-aware fallback, including a guaranteed player portrait when remote images are unavailable.
- Audio startup primes only the three common interface sounds instead of attempting to start the full sound library on the first tap.
- Small phones get a polished rotate-device message when the browser cannot enforce portrait mode.
- Save & Home now actually saves before leaving. A failed write keeps the season open and offers a retry; damaged saves are set aside and explained to the player.
- Crash diagnostics record game phase, week, run ID, last action, and active surface without storing player names or roster data. The error screen can copy this support report.

### How this affects the game
Players should see fewer broken portraits, fewer startup audio warnings and less work on the first interaction. Most importantly, the game will no longer leave an active run after a failed save. Support reports also become useful enough to reproduce phase-specific crashes without collecting personal content.

### How to test
1. Start a signed-in season, advance beyond week start, choose Home, then select **Save & Home**. Resume the run from Home.
2. In browser devtools, make localStorage writes throw or fill the site quota. Choose **Save & Home** and confirm the modal stays open with a retry message.
3. Put malformed JSON in `bbmobilenew:savedRuns:<profile id>`, reload, and confirm the recovery notice appears and the app remains usable.
4. Disable the network, reload a game with a missing avatar, and confirm every tile still shows a local portrait or initials.
5. On a phone, rotate to landscape and confirm the rotate-device screen covers the game without overlapping controls.
6. Trigger a route error in a development build and confirm **Copy diagnostic** produces phase/week/action context without roster data.

### Checks run
- 50 focused tests passed (avatar, save recovery, diagnostics, navigation and audio queue)
- Production TypeScript + Vite build passed