### PR TITLE
P1: Make the game load in focused stages

### DIFF
--- a/src/components/RouteLoadingScreen/RouteLoadingScreen.css
+++ b/src/components/RouteLoadingScreen/RouteLoadingScreen.css
@@ -1,0 +1,17 @@
+.route-loading-screen {
+  min-height: 60dvh;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 0.8rem;
+  color: rgb(255 255 255 / 62%);
+  background: radial-gradient(circle at 50% 40%, rgb(112 72 255 / 12%), transparent 40%);
+}
+.route-loading-screen p { margin: 0; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.04em; }
+.route-loading-screen__signal { display: flex; align-items: end; gap: 0.24rem; height: 1.5rem; }
+.route-loading-screen__signal span { width: 0.28rem; border-radius: 999px; background: var(--color-accent, #7657ff); animation: route-signal 0.8s ease-in-out infinite alternate; }
+.route-loading-screen__signal span:nth-child(1) { height: 35%; }
+.route-loading-screen__signal span:nth-child(2) { height: 65%; animation-delay: 0.12s; }
+.route-loading-screen__signal span:nth-child(3) { height: 100%; animation-delay: 0.24s; }
+@keyframes route-signal { to { opacity: 0.32; transform: scaleY(0.65); } }
+@media (prefers-reduced-motion: reduce) { .route-loading-screen__signal span { animation: none; } }

--- a/src/components/RouteLoadingScreen/RouteLoadingScreen.tsx
+++ b/src/components/RouteLoadingScreen/RouteLoadingScreen.tsx
@@ -1,0 +1,10 @@
+import './RouteLoadingScreen.css';
+
+export default function RouteLoadingScreen() {
+  return (
+    <div className="route-loading-screen" role="status" aria-label="Loading screen">
+      <div className="route-loading-screen__signal" aria-hidden="true"><span /><span /><span /></div>
+      <p>Preparing the house…</p>
+    </div>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,9 +1,6 @@
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import NavBar from './NavBar';
-import DebugPanel from '../DebugPanel/DebugPanel';
-import FinalFaceoff from '../FinalFaceoff/FinalFaceoff';
-import SeasonFinaleOverlay from '../SeasonFinale/SeasonFinaleOverlay';
 import { useAppSelector } from '../../store/hooks';
 import { selectFinale } from '../../store/finaleSlice';
 import { selectSettings } from '../../store/settingsSlice';
@@ -15,6 +12,9 @@ import SaveRecoveryNotice from '../SaveRecoveryNotice/SaveRecoveryNotice';
 import './AppShell.css';
 
 const THEME_PRESETS = ['midnight', 'neon', 'sunset', 'ocean'];
+const DebugPanel = lazy(() => import('../DebugPanel/DebugPanel'));
+const FinalFaceoff = lazy(() => import('../FinalFaceoff/FinalFaceoff'));
+const SeasonFinaleOverlay = lazy(() => import('../SeasonFinale/SeasonFinaleOverlay'));
 
 /**
  * AppShell — persistent wrapper around every screen.
@@ -104,14 +104,16 @@ export default function AppShell() {
         <Outlet />
       </main>
       <NavBar />
-      <DebugPanel />
+      <Suspense fallback={null}><DebugPanel /></Suspense>
       {/* Mount FinalFaceoff when entering jury so it can initialise the finale.
           Also remount it for the rare recovery case where jury voting already
           completed but the season finale overlay has not started yet. */}
       {phase === 'jury' &&
         seasonFinale == null &&
-        (finale.isActive || !finale.hasStarted || finale.isComplete) && <FinalFaceoff />}
-      {seasonFinale && <SeasonFinaleOverlay />}
+        (finale.isActive || !finale.hasStarted || finale.isComplete) && (
+          <Suspense fallback={null}><FinalFaceoff /></Suspense>
+        )}
+      {seasonFinale && <Suspense fallback={null}><SeasonFinaleOverlay /></Suspense>}
       <PortraitOrientationGuard />
       <SaveRecoveryNotice />
     </div>

--- a/src/data/avatarAssetManifest.ts
+++ b/src/data/avatarAssetManifest.ts
@@ -1,0 +1,36 @@
+/**
+ * Public avatar/cutout manifest. Keeping filenames as data prevents Vite from
+ * eagerly importing every large portrait into the application JavaScript.
+ * Update this list whenever a new cast asset is added.
+ */
+export const AVATAR_ASSET_FILES = [
+  'Ali_avatar.webp', 'Ali_lia_avatar.webp', 'Aria_avatar.webp', 'Ash_avatar.webp',
+  'Bea_avatar.webp', 'Blue_avatar.webp', 'Dex_avatar.webp', 'Echo_avatar.webp',
+  'Finn_avatar.webp', 'Ivy_avatar.webp', 'Jax_avatar.webp', 'Kai_avatar.webp',
+  'Kian_avatar.webp', 'Lia_avatar.webp', 'Lia_flip_avatar.webp', 'Lux_avatar.webp',
+  'mimi_avatar.webp', 'Nico_avatar.webp', 'Noa_avatar.webp', 'Nova_avatar.webp',
+  'Pax_avatar.svg', 'Quinn_avatar.webp', 'Rae_avatar.webp', 'Remy_avatar.webp',
+  'Rey_avatar.webp', 'Rune_avatar.webp', 'Sol_avatar.webp', 'Vee_avatar.webp',
+  'Zed_avatar.webp', 'You.png',
+] as const;
+
+export const FORMAL_CUTOUT_FILES = [
+  'Aria_formal.wp2', 'Ash_formal.wp2', 'Blue_formal.wp2', 'Dex_formal.wp2',
+  'Echo_formal.wp2', 'Finn_formal.wp2', 'Aria_formal.png', 'Ash_formal.png',
+  'Bea_formal.png', 'Blue_formal.png', 'Dex_formal.png', 'Echo_formal.png',
+  'Finn_formal.png', 'Ivy_formal.png', 'Jax_formal.png', 'Kai_formal.png',
+  'Kian_formal.png', 'Lia_formal.png', 'Lux_formal.png', 'Mimi_formal.png',
+  'Nico_formal.png', 'Noa_formal.png', 'Nova_formal.png', 'Pax_formal.png',
+  'Quinn_formal.png', 'Rae_formal.png', 'Remy_formal.png', 'Rey_formal.png',
+  'Rune_formal.png', 'Sol_formal.png', 'Vee_formal.png', 'Zed_formal.png',
+] as const;
+
+export const INFORMAL_CUTOUT_FILES = [
+  'Dex_informal.webp', 'Aria_informal.png', 'Ash_informal.png', 'Bea_informal.png',
+  'Blue_informal.png', 'Echo_informal.png', 'Finn_informal.png', 'Ivy_informal.png',
+  'Jax_informal.png', 'Kai_informal.png', 'Kian_informal2.png', 'Lia_informal.png',
+  'Lux_informal.png', 'Mimi_informal.png', 'Nico_informal.png', 'Noa_informal.png',
+  'Nova_informal.png', 'Pax_informal.png', 'Quinn_informal.png', 'Rae_informal.png',
+  'Remy_informal.png', 'Rey_informal.png', 'Rune_informal.png', 'Sol_informal.png',
+  'Vee_informal.png', 'Zed_informal.png',
+] as const;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -11,25 +11,31 @@ import { createHashRouter } from 'react-router-dom';
 
 import AppShell             from './components/layout/AppShell';
 import RouteErrorBoundary   from './components/RouteErrorBoundary/RouteErrorBoundary';
+import RouteLoadingScreen   from './components/RouteLoadingScreen/RouteLoadingScreen';
 import HomeHub              from './screens/HomeHub/HomeHub';
-import GameRoute            from './routes/GameRoute';
-import DiaryRoom            from './screens/DiaryRoom/DiaryRoom';
-import Houseguests          from './screens/Houseguests/Houseguests';
-import Profile              from './screens/Profile/Profile';
-import EditProfile          from './screens/Profile/EditProfile';
-import ProfilePicker        from './screens/ProfilePicker/ProfilePicker';
-import Leaderboard          from './screens/Leaderboard/Leaderboard';
-import Credits              from './screens/Credits/Credits';
-import Week                 from './screens/Week/Week';
-import CreatePlayer         from './screens/CreatePlayer/CreatePlayer';
-import GameOver             from './screens/GameOver/GameOver';
-import SelfEvicted          from './screens/SelfEvicted/SelfEvicted';
-import Rules                from './screens/Rules/Rules';
-import PublicMeter          from './screens/PublicMeter/PublicMeter';
-import Settings             from './screens/Settings/Settings';
 import NotFound             from './screens/NotFound/NotFound';
 import { canAccessSpecialSettings } from './utils/debugMode';
-import { lazy, Suspense }   from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
+
+const GameRoute = lazy(() => import('./routes/GameRoute'));
+const DiaryRoom = lazy(() => import('./screens/DiaryRoom/DiaryRoom'));
+const Houseguests = lazy(() => import('./screens/Houseguests/Houseguests'));
+const Profile = lazy(() => import('./screens/Profile/Profile'));
+const EditProfile = lazy(() => import('./screens/Profile/EditProfile'));
+const ProfilePicker = lazy(() => import('./screens/ProfilePicker/ProfilePicker'));
+const Leaderboard = lazy(() => import('./screens/Leaderboard/Leaderboard'));
+const Credits = lazy(() => import('./screens/Credits/Credits'));
+const Week = lazy(() => import('./screens/Week/Week'));
+const CreatePlayer = lazy(() => import('./screens/CreatePlayer/CreatePlayer'));
+const GameOver = lazy(() => import('./screens/GameOver/GameOver'));
+const SelfEvicted = lazy(() => import('./screens/SelfEvicted/SelfEvicted'));
+const Rules = lazy(() => import('./screens/Rules/Rules'));
+const PublicMeter = lazy(() => import('./screens/PublicMeter/PublicMeter'));
+const Settings = lazy(() => import('./screens/Settings/Settings'));
+
+const load = (element: ReactNode) => (
+  <Suspense fallback={<RouteLoadingScreen />}>{element}</Suspense>
+);
 
 // Admin/debug screens stay hidden unless the current session has QA debug access.
 const SettingsAdmin = import.meta.env.DEV || canAccessSpecialSettings()
@@ -98,21 +104,21 @@ export const router = createHashRouter([
     errorElement: <RouteErrorBoundary />,
     children: [
       { index: true,              element: <HomeHub />      },
-      { path: 'game',             element: <GameRoute />    },
-      { path: 'diary-room',       element: <DiaryRoom />    },
-      { path: 'houseguests',      element: <Houseguests />  },
-      { path: 'profile',          element: <Profile />      },
-      { path: 'profile-edit',     element: <EditProfile />  },
-      { path: 'profile-picker',   element: <ProfilePicker /> },
-      { path: 'leaderboard',      element: <Leaderboard />  },
-      { path: 'credits',          element: <Credits />      },
-      { path: 'week',             element: <Week />         },
-      { path: 'create-player',    element: <CreatePlayer /> },
-      { path: 'game-over',        element: <GameOver />     },
-      { path: 'self-evicted',     element: <SelfEvicted />  },
-      { path: 'rules',            element: <Rules />        },
-      { path: 'public-meter',     element: <PublicMeter />  },
-      { path: 'settings',         element: <Settings />     },
+      { path: 'game',             element: load(<GameRoute />)    },
+      { path: 'diary-room',       element: load(<DiaryRoom />)    },
+      { path: 'houseguests',      element: load(<Houseguests />)  },
+      { path: 'profile',          element: load(<Profile />)      },
+      { path: 'profile-edit',     element: load(<EditProfile />)  },
+      { path: 'profile-picker',   element: load(<ProfilePicker />) },
+      { path: 'leaderboard',      element: load(<Leaderboard />)  },
+      { path: 'credits',          element: load(<Credits />)      },
+      { path: 'week',             element: load(<Week />)         },
+      { path: 'create-player',    element: load(<CreatePlayer />) },
+      { path: 'game-over',        element: load(<GameOver />)     },
+      { path: 'self-evicted',     element: load(<SelfEvicted />)  },
+      { path: 'rules',            element: load(<Rules />)        },
+      { path: 'public-meter',     element: load(<PublicMeter />)  },
+      { path: 'settings',         element: load(<Settings />)     },
       ...(SettingsAdmin != null
         ? [{ path: 'settingsatiste', element: <Suspense fallback={null}><SettingsAdmin /></Suspense> }]
         : []),

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -4,6 +4,11 @@
 import type { Player } from '../types';
 import { getById, findByName } from '../data/houseguests';
 import type { RemotePlayerOverride } from '../remoteConfig/remoteConfigTypes';
+import {
+  AVATAR_ASSET_FILES,
+  FORMAL_CUTOUT_FILES,
+  INFORMAL_CUTOUT_FILES,
+} from '../data/avatarAssetManifest';
 
 const PROFILE_PHOTO_AVATAR_PREFIX = 'profile-photo:';
 
@@ -250,35 +255,6 @@ export function resolveAvatar(player: Pick<Player, 'id' | 'name' | 'avatar'> & P
 }
 
 /**
- * Formal cutouts are stored in `public/assets/formal_attires/`.
- * Some players have a non-.png source file in that folder, so we search the
- * folder contents first before falling back to the historical stem map.
- */
-const FORMAL_CUTOUT_MODULES = import.meta.glob(
-  '../../public/assets/formal_attires/*.{png,webp,svg,jpg,jpeg,wp2}',
-  {
-    eager: true,
-    import: 'default',
-  },
-) as Record<string, string>;
-
-const INFORMAL_CUTOUT_MODULES = import.meta.glob(
-  '../../public/assets/Informal_attires/*.{png,webp,svg,jpg,jpeg,wp2}',
-  {
-    eager: true,
-    import: 'default',
-  },
-) as Record<string, string>;
-
-const AVATAR_ASSET_MODULES = import.meta.glob(
-  '../../public/assets/skins/*.{png,webp,svg,jpg,jpeg,wp2}',
-  {
-    eager: true,
-    import: 'default',
-  },
-) as Record<string, string>;
-
-/**
  * Maps canonical houseguest ids to their historical formal-cutout stems.
  * These are used as a fallback if the folder scan does not find a direct match.
  */
@@ -331,26 +307,23 @@ function collectTwinShockFullSizeLookupTokens(player: Pick<Player, 'id' | 'name'
 }
 
 function listFormalCutoutCandidates(): Array<{ basename: string; filename: string }> {
-  return Object.keys(FORMAL_CUTOUT_MODULES).map((path) => {
-    const filename = path.split('/').pop() ?? path;
+  return FORMAL_CUTOUT_FILES.map((filename) => {
     const basename = filename.replace(/\.[^.]+$/, '');
     return { basename, filename };
   });
 }
 
 function listInformalCutoutCandidates(): Array<{ basename: string; filename: string }> {
-  return Object.keys(INFORMAL_CUTOUT_MODULES).map((path) => {
-    const filename = path.split('/').pop() ?? path;
+  return INFORMAL_CUTOUT_FILES.map((filename) => {
     const basename = filename.replace(/\.[^.]+$/, '');
     return { basename, filename };
   });
 }
 
 function listAvatarAssetCandidates(): Array<{ basename: string; source: string }> {
-  return Object.entries(AVATAR_ASSET_MODULES).map(([path, source]) => {
-    const filename = path.split('/').pop() ?? path;
+  return AVATAR_ASSET_FILES.map((filename) => {
     const basename = filename.replace(/\.[^.]+$/, '');
-    return { basename, source };
+    return { basename, source: joinPublicAssetPath(`assets/skins/${filename}`) };
   });
 }
 

--- a/tests/unit/avatarAssetManifest.test.ts
+++ b/tests/unit/avatarAssetManifest.test.ts
@@ -1,0 +1,19 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  AVATAR_ASSET_FILES,
+  FORMAL_CUTOUT_FILES,
+  INFORMAL_CUTOUT_FILES,
+} from '../../src/data/avatarAssetManifest';
+
+describe('avatar asset manifest', () => {
+  it.each([
+    ['skins', AVATAR_ASSET_FILES],
+    ['formal_attires', FORMAL_CUTOUT_FILES],
+    ['Informal_attires', INFORMAL_CUTOUT_FILES],
+  ] as const)('only references files that ship in public/assets/%s', (folder, files) => {
+    const missing = files.filter((file) => !existsSync(resolve('public', 'assets', folder, file)));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Product summary
This P1 makes the app feel lighter and more intentional by loading each major destination when the player asks for it, instead of making the Home hub carry the full game upfront.

> This is a stacked PR. Review and merge **P0 / #1198** first; this PR then contains only the P1 performance layer.

### What changed
- The main game, diary room, roster, profiles, leaderboard, settings, rules and end-game screens now load as separate destinations.
- A branded “Preparing the house…” state replaces blank pauses while a destination arrives.
- Jury and season-finale presentation code is deferred until those phases actually occur.
- Avatar, formal-attire and informal-attire discovery now uses a checked public asset manifest rather than eagerly importing entire portrait folders into startup JavaScript.

### How this affects the game
The Home hub becomes interactive with much less code and styling to parse. In the production build, initial JavaScript falls from about **2.52 MB to 936 KB** (721 KB to 276 KB gzip), and initial CSS falls from about **898 KB to 45 KB** (170 KB to 10 KB gzip). The heavier game screen downloads on entry, where the new loading treatment makes the transition understandable. Game rules and saved-run formats are unchanged.

### How to test
1. Open a fresh/private browser session with network throttled to Fast 3G and confirm Home appears before game code finishes downloading.
2. Start or resume a season; confirm “Preparing the house…” appears briefly and the game opens normally.
3. Visit Roster, Diary Room, Profile, Leaderboard, Rules and Settings from navigation; confirm each opens and back navigation is unchanged.
4. Advance to jury/finale in a QA save and confirm both overlays load and play normally.
5. Check several roster tiles plus formal/informal ceremony portraits, including Lia/Ali and Dex, to verify the manifest resolves the expected assets.
6. Reload directly on `#/game` with an active saved run and confirm route recovery still works.

### Checks run
- Avatar resolution and asset-manifest suite: 7 tests passed
- Production TypeScript + Vite build passed
- Existing avatar-hold integration fixture also fails on P0 because its mock store lacks the profiles slice; P1 does not introduce that failure