### PR TITLE
P2: Roll out the refined game screen safely

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import AudioStateSync from './services/sound/AudioStateSync';
 import AudioGate from './components/AudioGate/AudioGate';
 import { loadRemoteConfig } from './remoteConfig/remoteConfigSlice';
 import { installGameDiagnostics } from './services/diagnostics/gameDiagnostics';
+import LiveOpsController from './components/LiveOpsController/LiveOpsController';
 
 if (import.meta.env.DEV) {
   console.log('[router] bundle:', import.meta.url, '| pathname:', window.location.pathname, '| hash:', window.location.hash);
@@ -47,6 +48,7 @@ export default function App() {
 
   return (
     <Provider store={store}>
+      <LiveOpsController />
       <AudioStateSync />
       {/* AudioGate is suppressed on the Intro/Home route because HomeHub
           unlocks audio via the Play gesture (see HomeHub.handlePlay). */}

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -145,6 +145,21 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+:global(body.experiment-game-chrome-refined) .avatarWrap {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  box-shadow:
+    0 10px 24px rgba(0, 0, 0, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+:global(body.experiment-game-chrome-refined) .nameOverlay {
+  bottom: 6px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-align: left;
+}
+
 .nomination_loh {
   border-color: rgba(255, 215, 96, 0.72);
   box-shadow:

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -153,13 +153,6 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-:global(body.experiment-game-chrome-refined) .nameOverlay {
-  bottom: 6px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  text-align: left;
-}
-
 .nomination_loh {
   border-color: rgba(255, 215, 96, 0.72);
   box-shadow:

--- a/src/components/LiveOpsController/LiveOpsController.tsx
+++ b/src/components/LiveOpsController/LiveOpsController.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useMemo } from 'react';
+import { selectRemoteConfig } from '../../remoteConfig/remoteConfigSlice';
+import { useAppSelector } from '../../store/hooks';
+import { configureProductTelemetry, trackProductEvent } from '../../services/liveOps/productTelemetry';
+import { isRefinedGameChromeEnabled } from '../../services/liveOps/rollouts';
+import './LiveOpsPresentation.css';
+
+export default function LiveOpsController() {
+  const config = useAppSelector(selectRemoteConfig);
+  const phase = useAppSelector((state) => state.game.phase);
+  const week = useAppSelector((state) => state.game.week);
+  const status = useAppSelector((state) => state.game.status);
+  const refinedChrome = useMemo(() => {
+    // Local QA can force either presentation without changing release config.
+    const qaVariant = import.meta.env.DEV
+      ? new URLSearchParams(window.location.search).get('uiVariant')
+      : null;
+    if (qaVariant === 'refined') return true;
+    if (qaVariant === 'control') return false;
+    return isRefinedGameChromeEnabled(config);
+  }, [config]);
+
+  useEffect(() => {
+    configureProductTelemetry(config?.operations?.telemetry);
+    document.body.classList.toggle('experiment-game-chrome-refined', refinedChrome);
+    document.body.dataset.gameChromeVariant = refinedChrome ? 'refined' : 'control';
+    const rollout = config?.operations?.rollouts?.refinedGameChrome;
+    if (rollout?.enabled) {
+      trackProductEvent('experiment_exposure', {
+        experiment: 'refined-game-chrome',
+        variant: refinedChrome ? 'refined' : 'control',
+      });
+    }
+    return () => {
+      document.body.classList.remove('experiment-game-chrome-refined');
+      delete document.body.dataset.gameChromeVariant;
+    };
+  }, [config, refinedChrome]);
+
+  useEffect(() => {
+    const trackRoute = () => trackProductEvent('screen_view', {
+      route: window.location.hash.split('?')[0] || '#/',
+    });
+    trackRoute();
+    window.addEventListener('hashchange', trackRoute);
+    return () => window.removeEventListener('hashchange', trackRoute);
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'active') return;
+    trackProductEvent('game_phase_view', { phase, week });
+  }, [phase, status, week]);
+
+  return null;
+}

--- a/src/components/LiveOpsController/LiveOpsPresentation.css
+++ b/src/components/LiveOpsController/LiveOpsPresentation.css
@@ -1,0 +1,60 @@
+/* Rollout-only presentation layer. Removing the body class is an instant rollback. */
+body.experiment-game-chrome-refined .game-screen {
+  gap: 8px;
+  padding-top: 8px;
+}
+
+body.experiment-game-chrome-refined .tv-zone {
+  border-color: rgb(255 255 255 / 10%);
+  border-radius: 22px;
+  background: linear-gradient(160deg, rgb(24 31 49 / 96%), rgb(10 15 27 / 98%));
+  box-shadow: 0 18px 50px rgb(0 0 0 / 32%), inset 0 1px rgb(255 255 255 / 7%);
+}
+
+body.experiment-game-chrome-refined .tv-zone__head {
+  min-height: 42px;
+  padding: 8px 10px;
+  background: rgb(4 8 16 / 36%);
+}
+
+body.experiment-game-chrome-refined .tv-zone__viewport {
+  --tv-screen-texture-opacity: 0.018;
+  background:
+    radial-gradient(circle at 50% -10%, rgb(119 91 255 / 20%), transparent 46%),
+    linear-gradient(180deg, #10192a, #050912);
+}
+
+body.experiment-game-chrome-refined .tv-zone__feed {
+  scrollbar-color: rgb(255 255 255 / 18%) transparent;
+}
+
+body.experiment-game-chrome-refined .game-bottom-nav {
+  margin: 0 8px 6px;
+  border-radius: 20px;
+  clip-path: inset(0 round 20px);
+}
+
+body.experiment-game-chrome-refined .game-bottom-nav__item {
+  border-color: transparent;
+  border-radius: 12px;
+  background: transparent;
+  box-shadow: none;
+}
+
+body.experiment-game-chrome-refined .game-bottom-nav__item--active {
+  border-color: rgb(255 255 255 / 8%);
+  background: rgb(255 255 255 / 8%);
+}
+
+body.experiment-game-chrome-refined .game-control-dock {
+  filter: drop-shadow(0 14px 24px rgb(0 0 0 / 34%));
+}
+
+body.experiment-game-chrome-refined .game-control-dock__icon,
+body.experiment-game-chrome-refined .game-control-dock__play {
+  filter: saturate(0.9) contrast(1.04);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.experiment-game-chrome-refined .tv-zone__viewport::before { animation: none; }
+}

--- a/src/remoteConfig/remoteConfigService.ts
+++ b/src/remoteConfig/remoteConfigService.ts
@@ -14,7 +14,7 @@
  * executed as code.  URL fields are validated to only allow http/https.
  */
 
-import type { RemoteConfig, RemotePlayerOverride } from './remoteConfigTypes';
+import type { RemoteConfig, RemoteOperations, RemotePlayerOverride, RemoteRollout } from './remoteConfigTypes';
 import type { CompSelectionMode } from '../components/compSelectionUtils';
 import { apiUrl } from '../utils/apiBase';
 
@@ -73,6 +73,11 @@ function safeStr(value: unknown): string | undefined {
 function safeOpacity(value: unknown): number | undefined {
   if (typeof value !== 'number' || !isFinite(value)) return undefined;
   return Math.max(0, Math.min(1, value));
+}
+
+function safePercentage(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !isFinite(value)) return undefined;
+  return Math.max(0, Math.min(100, value));
 }
 
 /** Returns true when the URL is an absolute http(s) URL. */
@@ -205,6 +210,46 @@ export function sanitiseRemoteConfig(raw: unknown): RemoteConfig | null {
       .map(sanitisePlayerOverride)
       .filter((o): o is RemotePlayerOverride => o !== null);
     if (overrides.length > 0) config.players = overrides;
+  }
+
+  // operations: gradual UI rollout, kill switches and privacy-safe telemetry.
+  if (r.operations && typeof r.operations === 'object' && !Array.isArray(r.operations)) {
+    const ops = r.operations as Record<string, unknown>;
+    config.operations = {};
+
+    if (ops.killSwitches && typeof ops.killSwitches === 'object' && !Array.isArray(ops.killSwitches)) {
+      const kills = ops.killSwitches as Record<string, unknown>;
+      if (typeof kills.refinedGameChrome === 'boolean') {
+        config.operations.killSwitches = { refinedGameChrome: kills.refinedGameChrome };
+      }
+    }
+
+    if (ops.rollouts && typeof ops.rollouts === 'object' && !Array.isArray(ops.rollouts)) {
+      const rollouts = ops.rollouts as Record<string, unknown>;
+      const chrome = rollouts.refinedGameChrome;
+      if (chrome && typeof chrome === 'object' && !Array.isArray(chrome)) {
+        const value = chrome as Record<string, unknown>;
+        const rollout: RemoteRollout = {};
+        if (typeof value.enabled === 'boolean') rollout.enabled = value.enabled;
+        const percentage = safePercentage(value.percentage);
+        if (percentage !== undefined) rollout.percentage = percentage;
+        const salt = safeStr(value.salt);
+        if (salt) rollout.salt = salt;
+        if (Object.keys(rollout).length > 0) config.operations.rollouts = { refinedGameChrome: rollout };
+      }
+    }
+
+    if (ops.telemetry && typeof ops.telemetry === 'object' && !Array.isArray(ops.telemetry)) {
+      const value = ops.telemetry as Record<string, unknown>;
+      const telemetry: NonNullable<RemoteOperations['telemetry']> = {};
+      if (typeof value.enabled === 'boolean') telemetry.enabled = value.enabled;
+      const samplePercentage = safePercentage(value.samplePercentage);
+      if (samplePercentage !== undefined) telemetry.samplePercentage = samplePercentage;
+      if (isSafeUrl(value.endpointUrl)) telemetry.endpointUrl = value.endpointUrl as string;
+      if (Object.keys(telemetry).length > 0) config.operations.telemetry = telemetry;
+    }
+
+    if (Object.keys(config.operations).length === 0) delete config.operations;
   }
 
   return config;

--- a/src/remoteConfig/remoteConfigTypes.ts
+++ b/src/remoteConfig/remoteConfigTypes.ts
@@ -111,6 +111,31 @@ export interface RemotePlayerOverride {
   bio?: string;
 }
 
+export interface RemoteRollout {
+  /** Master switch for this presentation experiment. Defaults to false. */
+  enabled?: boolean;
+  /** Stable percentage of installs assigned to the treatment, from 0 to 100. */
+  percentage?: number;
+  /** Change the salt to create a fresh assignment without identifying players. */
+  salt?: string;
+}
+
+export interface RemoteOperations {
+  /** Emergency switches always win over rollout configuration. */
+  killSwitches?: {
+    refinedGameChrome?: boolean;
+  };
+  rollouts?: {
+    refinedGameChrome?: RemoteRollout;
+  };
+  telemetry?: {
+    enabled?: boolean;
+    samplePercentage?: number;
+    /** Optional HTTPS collector for privacy-safe product events. */
+    endpointUrl?: string;
+  };
+}
+
 // ─── Root config ─────────────────────────────────────────────────────────────
 
 export interface RemoteConfig {
@@ -126,4 +151,6 @@ export interface RemoteConfig {
    * Only entries matching a known houseguest id are applied.
    */
   players?: RemotePlayerOverride[];
+  /** Release controls for gradual UI rollout, rollback and product measurement. */
+  operations?: RemoteOperations;
 }

--- a/src/services/liveOps/productTelemetry.ts
+++ b/src/services/liveOps/productTelemetry.ts
@@ -1,0 +1,45 @@
+import type { RemoteOperations } from '../../remoteConfig/remoteConfigTypes';
+
+const EVENT_BUFFER_KEY = 'bbmobilenew:product-events';
+type EventProperties = Record<string, string | number | boolean | null | undefined>;
+type ProductEvent = { name: string; occurredAt: string; sessionId: string; properties: EventProperties };
+
+let telemetry: NonNullable<RemoteOperations['telemetry']> | undefined;
+let sampled = false;
+const sessionId = Math.random().toString(36).slice(2, 12);
+const sessionSampleBucket = Array.from(sessionId).reduce((total, char) => total + char.charCodeAt(0), 0) % 100;
+
+export function configureProductTelemetry(next: RemoteOperations['telemetry']): void {
+  telemetry = next;
+  sampled = Boolean(next?.enabled) && sessionSampleBucket < (next?.samplePercentage ?? 0);
+}
+
+function bufferEvent(event: ProductEvent): void {
+  try {
+    const current = JSON.parse(sessionStorage.getItem(EVENT_BUFFER_KEY) ?? '[]') as ProductEvent[];
+    sessionStorage.setItem(EVENT_BUFFER_KEY, JSON.stringify([...current.slice(-99), event]));
+  } catch {
+    // Measurement must never block gameplay.
+  }
+}
+
+export function trackProductEvent(name: string, properties: EventProperties = {}): void {
+  if (!sampled) return;
+  const event: ProductEvent = { name, occurredAt: new Date().toISOString(), sessionId, properties };
+  bufferEvent(event);
+  if (!telemetry?.endpointUrl) return;
+
+  const body = JSON.stringify(event);
+  if (typeof navigator.sendBeacon === 'function' && navigator.sendBeacon(telemetry.endpointUrl, body)) return;
+  void fetch(telemetry.endpointUrl, {
+    method: 'POST',
+    body,
+    keepalive: true,
+    headers: { 'content-type': 'application/json' },
+  }).catch(() => undefined);
+}
+
+export function readBufferedProductEvents(): ProductEvent[] {
+  try { return JSON.parse(sessionStorage.getItem(EVENT_BUFFER_KEY) ?? '[]') as ProductEvent[]; }
+  catch { return []; }
+}

--- a/src/services/liveOps/rollouts.ts
+++ b/src/services/liveOps/rollouts.ts
@@ -1,0 +1,35 @@
+import type { RemoteConfig } from '../../remoteConfig/remoteConfigTypes';
+
+const INSTALL_SEED_KEY = 'bbmobilenew:liveops:install-seed';
+
+function getInstallSeed(): string {
+  try {
+    const existing = localStorage.getItem(INSTALL_SEED_KEY);
+    if (existing) return existing;
+    const values = new Uint32Array(4);
+    crypto.getRandomValues(values);
+    const created = Array.from(values, (value) => value.toString(16).padStart(8, '0')).join('');
+    localStorage.setItem(INSTALL_SEED_KEY, created);
+    return created;
+  } catch {
+    return 'ephemeral-install';
+  }
+}
+
+/** Stable FNV-1a assignment. The seed remains on-device and is never transmitted. */
+export function getRolloutBucket(seed: string, key: string, salt = ''): number {
+  let hash = 0x811c9dc5;
+  for (const char of `${key}:${salt}:${seed}`) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % 100;
+}
+
+export function isRefinedGameChromeEnabled(config: RemoteConfig | null, seed = getInstallSeed()): boolean {
+  if (config?.operations?.killSwitches?.refinedGameChrome) return false;
+  const rollout = config?.operations?.rollouts?.refinedGameChrome;
+  if (!rollout?.enabled) return false;
+  const percentage = Math.max(0, Math.min(100, rollout.percentage ?? 0));
+  return getRolloutBucket(seed, 'refined-game-chrome', rollout.salt) < percentage;
+}

--- a/tests/unit/liveOpsRollouts.test.ts
+++ b/tests/unit/liveOpsRollouts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getRolloutBucket, isRefinedGameChromeEnabled } from '../../src/services/liveOps/rollouts';
+
+describe('live operations rollouts', () => {
+  it('assigns the same install to the same bucket', () => {
+    expect(getRolloutBucket('install-a', 'chrome', 'v1')).toBe(getRolloutBucket('install-a', 'chrome', 'v1'));
+  });
+
+  it('supports complete rollout and complete rollback', () => {
+    expect(isRefinedGameChromeEnabled({
+      operations: { rollouts: { refinedGameChrome: { enabled: true, percentage: 100 } } },
+    }, 'install-a')).toBe(true);
+    expect(isRefinedGameChromeEnabled({
+      operations: { rollouts: { refinedGameChrome: { enabled: true, percentage: 0 } } },
+    }, 'install-a')).toBe(false);
+  });
+
+  it('gives the emergency kill switch priority', () => {
+    expect(isRefinedGameChromeEnabled({
+      operations: {
+        killSwitches: { refinedGameChrome: true },
+        rollouts: { refinedGameChrome: { enabled: true, percentage: 100 } },
+      },
+    }, 'install-a')).toBe(false);
+  });
+});

--- a/tests/unit/productTelemetry.test.ts
+++ b/tests/unit/productTelemetry.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  configureProductTelemetry,
+  readBufferedProductEvents,
+  trackProductEvent,
+} from '../../src/services/liveOps/productTelemetry';
+
+describe('product telemetry', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('buffers sampled privacy-safe product events without requiring a collector', () => {
+    configureProductTelemetry({ enabled: true, samplePercentage: 100 });
+    trackProductEvent('game_phase_view', { phase: 'social_1', week: 2 });
+
+    expect(readBufferedProductEvents()).toEqual([
+      expect.objectContaining({
+        name: 'game_phase_view',
+        properties: { phase: 'social_1', week: 2 },
+      }),
+    ]);
+  });
+
+  it('does not collect events when operations telemetry is disabled', () => {
+    configureProductTelemetry({ enabled: false, samplePercentage: 100 });
+    trackProductEvent('screen_view', { route: '#/game' });
+    expect(readBufferedProductEvents()).toEqual([]);
+  });
+});

--- a/tests/unit/remoteConfig.test.ts
+++ b/tests/unit/remoteConfig.test.ts
@@ -174,6 +174,29 @@ describe('sanitiseRemoteConfig', () => {
     // Only non-empty strings are kept
     expect(result?.challenge?.weeklyGameKeys).toEqual(['quickTapRace', 'colorMatch']);
   });
+
+  it('sanitises rollout controls and telemetry endpoints', () => {
+    const result = sanitiseRemoteConfig({
+      operations: {
+        killSwitches: { refinedGameChrome: true, unknown: true },
+        rollouts: { refinedGameChrome: { enabled: true, percentage: 140, salt: 'july' } },
+        telemetry: { enabled: true, samplePercentage: -5, endpointUrl: 'https://events.example.com/v1' },
+      },
+    });
+
+    expect(result?.operations).toEqual({
+      killSwitches: { refinedGameChrome: true },
+      rollouts: { refinedGameChrome: { enabled: true, percentage: 100, salt: 'july' } },
+      telemetry: { enabled: true, samplePercentage: 0, endpointUrl: 'https://events.example.com/v1' },
+    });
+  });
+
+  it('drops unsafe telemetry collector URLs', () => {
+    const result = sanitiseRemoteConfig({
+      operations: { telemetry: { enabled: true, endpointUrl: 'javascript:alert(1)' } },
+    });
+    expect(result?.operations?.telemetry?.endpointUrl).toBeUndefined();
+  });
 });
 
 // ─── remote config endpoint policy ────────────────────────────────────────────


### PR DESCRIPTION
## Product summary
This P2 turns the visual modernization into a controlled release instead of an all-or-nothing redesign. The refined game chrome can be shown to a stable percentage of installs, measured with privacy-safe events, and switched off immediately.

> This is a stacked PR. Review and merge **P0 / #1198**, then **P1 / #1199**, before this P2 layer.

### What changed
- Added a refined presentation for the faux TV, avatar roster, action dock and bottom navigation: calmer surfaces, softer depth, clearer grouping and fewer “button inside button” visual boxes.
- Added deterministic percentage rollout. The same install stays in the same variant; the on-device assignment seed is never transmitted.
- Added an emergency kill switch that always overrides rollout settings.
- Added opt-in, sampled product events for screen views, game-phase views and experiment exposure. Events contain route, phase, week and variant—not player names, roster data or profile details. An HTTPS collector is optional; telemetry is off by default.
- Added a development-only `?uiVariant=refined` / `?uiVariant=control` override and a `data-game-chrome-variant` body marker for fast QA.

### How this affects the game
Players in the treatment group receive a more modern, less visually noisy broadcast interface while gameplay logic remains identical. Product owners can begin at 5–10%, compare phase progression and navigation health against control, expand gradually, or rollback instantly through live config. With no operations config, every player stays on today’s control design and no telemetry is collected.

### How to test
1. Run the app locally with `?uiVariant=control`, start Campaign, and confirm the existing TV, roster and navigation design remains unchanged.
2. Repeat with `?uiVariant=refined`; confirm the TV has a softer 22px frame, roster cards use the refined 14px treatment, the action dock is clearer, and bottom navigation floats with a simpler active state.
3. Inspect the body and confirm `data-game-chrome-variant` matches `control` or `refined`.
4. Supply live config with `operations.rollouts.refinedGameChrome = { enabled: true, percentage: 100, salt: qa }`; confirm refined is selected without the URL override.
5. Add `operations.killSwitches.refinedGameChrome = true`; reload and confirm control wins even at 100% rollout.
6. Enable telemetry at 100% without an endpoint and inspect the session event buffer `bbmobilenew:product-events`; move between screens and phases and confirm only route/phase/week/variant metadata appears.
7. Set rollout and telemetry percentages to 0 and confirm no treatment and no events.

### Suggested release sequence
- Internal QA: forced URL variant
- 5%: watch errors, save failures and phase progression
- 25%: compare navigation and early-week completion
- 50%: inspect device/browser segments
- 100%: keep the kill switch available for at least one release cycle

### Checks run
- Remote-config, rollout and telemetry suite: 36 tests passed
- Production TypeScript + Vite build passed
- In-app browser visual QA passed for control and refined variants