### PR TITLE
UI 1/8: Give the faux TV a clearer broadcast hierarchy

### DIFF
--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -692,3 +692,55 @@
     animation: none;
   }
 }
+
+/* Refined broadcast hierarchy: category → headline → game context. */
+.tv-zone__story { display: contents; }
+.tv-zone__story-eyebrow,
+.tv-zone__story-context { display: none; }
+
+body.experiment-game-chrome-refined .tv-zone__story {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: min(100%, 660px);
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 20px clamp(16px, 5vw, 34px);
+  text-align: center;
+}
+body.experiment-game-chrome-refined .tv-zone__story-eyebrow,
+body.experiment-game-chrome-refined .tv-zone__story-context {
+  display: inline-flex;
+  align-items: center;
+  color: rgba(223, 230, 255, 0.68);
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+body.experiment-game-chrome-refined .tv-zone__story-eyebrow::before {
+  width: 6px;
+  height: 6px;
+  margin-right: 7px;
+  border-radius: 999px;
+  background: #8b7dff;
+  box-shadow: 0 0 12px rgba(139, 125, 255, 0.72);
+  content: '';
+}
+body.experiment-game-chrome-refined .tv-zone__story-context {
+  padding-top: 2px;
+  color: rgba(203, 211, 236, 0.52);
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+}
+body.experiment-game-chrome-refined .tv-zone__story .tv-zone__now {
+  max-width: 58ch;
+  padding: 0;
+  background: none;
+  font-size: clamp(0.94rem, 2.8vw, 1.08rem);
+  font-weight: 750;
+  line-height: 1.48;
+  text-wrap: balance;
+}

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -33,6 +33,14 @@ import './ShockDangerMode.css';
 
 const NOOP = () => {};
 
+const EVENT_LABELS: Record<TvEvent['type'], string> = {
+  game: 'House update',
+  social: 'Social update',
+  vote: 'Vote update',
+  twist: 'Shock alert',
+  diary: 'Diary Room',
+};
+
 // Compact phase labels — edit these strings to change what appears in the HUD pill.
 const PHASE_LABELS: Record<string, string> = {
   week_start:               'DAY START',
@@ -303,6 +311,7 @@ export default function TvZone(props: TvZoneProps) {
   const occupancyChip = props.occupancyChip ?? null;
 
   const latestEvent = tvVisibleFeed[0];
+  const viewportEyebrow = latestEvent ? EVENT_LABELS[latestEvent.type] : 'House update';
   const announcementPrerollEvent = useMemo(() => {
     const prerollId = latestEvent?.meta?.announcementPrerollEventId;
     if (typeof prerollId !== 'string') return null;
@@ -749,6 +758,7 @@ export default function TvZone(props: TvZoneProps) {
   }, []);
 
   const phaseLabel = PHASE_LABELS[gameState.phase] ?? gameState.phase;
+  const viewportContext = `Day ${gameState.week} · ${phaseLabel}`;
   const isAtGameStart = gameState.week === 1 && gameState.phase === 'week_start';
   const canSave = !isGuest && Boolean(activeProfileId) && !isAtGameStart && !hasPendingChallenge;
   const saveChipAriaLabel = isGuest
@@ -929,18 +939,21 @@ export default function TvZone(props: TvZoneProps) {
           )}
 
           <div className="tv-zone__viewport" role="region" aria-label="Live game events display" aria-live="polite" aria-atomic="true">
-            <p
-              key={viewportMessageKey}
-              aria-hidden={hideViewportMessage}
-              className={[
-                'tv-zone__now',
-                detoxMessageActive ? 'tv-zone__now--detox-stream' : '',
-                hideViewportMessage ? 'tv-zone__now--hidden' : '',
-              ].filter(Boolean).join(' ')}
-              style={hideViewportMessage ? { opacity: 0 } : undefined}
-            >
-              {viewportDisplayText}
-            </p>
+            <div className="tv-zone__story" aria-hidden={hideViewportMessage}>
+              <span className="tv-zone__story-eyebrow">{viewportEyebrow}</span>
+              <p
+                key={viewportMessageKey}
+                className={[
+                  'tv-zone__now',
+                  detoxMessageActive ? 'tv-zone__now--detox-stream' : '',
+                  hideViewportMessage ? 'tv-zone__now--hidden' : '',
+                ].filter(Boolean).join(' ')}
+                style={hideViewportMessage ? { opacity: 0 } : undefined}
+              >
+                {viewportDisplayText}
+              </p>
+              <span className="tv-zone__story-context">{viewportContext}</span>
+            </div>
 
             {/* Twist badge — broadcast-style corner ribbon anchored to the viewport */}
             {gameState.twistActive && (

--- a/src/components/ui/__tests__/TvZone.screenStyle.test.tsx
+++ b/src/components/ui/__tests__/TvZone.screenStyle.test.tsx
@@ -43,6 +43,12 @@ describe('TvZone screen styling', () => {
     expect(viewport?.querySelector('.tv-zone__vignette')).toBeNull();
   });
 
+it('renders a broadcast hierarchy around the current TV message', () => {
+    const { container } = renderTvZone();
+    expect(container.querySelector('.tv-zone__story')).toBeTruthy();
+    expect(container.querySelector('.tv-zone__story-eyebrow')?.textContent).toBe('House update');
+    expect(container.querySelector('.tv-zone__story-context')?.textContent).toMatch(/Day 1/i);
+  });
   it('builds stable fallback keys for repeated text and different keys for different text', () => {
     const baseEvent: TvEvent = {
       id: '',


### PR DESCRIPTION
## Product summary
The faux TV now presents each update as a broadcast story: category, headline, then the current day and phase. The original control layout remains unchanged; the hierarchy appears in refined chrome.

### What changed
- Added player-facing categories such as House update, Social update, Vote update, Shock alert and Diary Room.
- Added a compact context line beneath the main message.
- Rebalanced refined typography so the important event remains the visual focus.

### How this affects the game
Players can understand what happened and where they are in the game without decoding the surrounding HUD. No phase logic, saves or event routing changed.

### How to test
1. Run the app with `?uiVariant=refined` and start Campaign.
2. Confirm the TV shows category → main message → day/phase.
3. Advance through social, voting and shock events and confirm the category follows the event.
4. Repeat with `?uiVariant=control` and confirm the original TV message presentation remains.
5. Check that announcements, vote reveals and public-save overlays still cover the TV correctly.

### Validation
- TvZone hierarchy tests passed
- Full lint and TypeScript checks passed
- Production build passed