### PR TITLE
UI 2/8: Make the action dock explain itself

### DIFF
--- a/src/components/GameControlDock/GameControlDock.css
+++ b/src/components/GameControlDock/GameControlDock.css
@@ -398,3 +398,47 @@
     display: none;
   }
 }
+
+/* Refined dock hierarchy: one primary Continue action, four quieter utilities. */
+body.experiment-game-chrome-refined .game-control-dock {
+  width: min(calc(88% * var(--game-action-dock-scale, 1)), calc(360px * var(--game-action-dock-scale, 1)));
+}
+body.experiment-game-chrome-refined .dock-hit-area::after {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 50%;
+  min-width: max-content;
+  transform: translateX(-50%);
+  color: rgba(224, 230, 250, 0.58);
+  content: attr(data-label);
+  font-size: clamp(0.42rem, 1.65vw, 0.54rem);
+  font-weight: 750;
+  letter-spacing: 0.055em;
+  line-height: 1;
+  text-transform: uppercase;
+  text-shadow: 0 1px 5px rgba(0, 0, 0, 0.9);
+  pointer-events: none;
+}
+body.experiment-game-chrome-refined .dock-hit-area--play::before {
+  position: absolute;
+  inset: -10% -8% 16%;
+  z-index: -1;
+  border: 1px solid rgba(143, 132, 255, 0.16);
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(116, 103, 255, 0.14), transparent 68%);
+  box-shadow: 0 8px 22px rgba(41, 33, 112, 0.2);
+  content: '';
+}
+body.experiment-game-chrome-refined .dock-hit-area--play::after {
+  top: calc(100% + 4px);
+  color: rgba(245, 246, 255, 0.94);
+  font-size: clamp(0.48rem, 1.85vw, 0.61rem);
+  font-weight: 850;
+  letter-spacing: 0.09em;
+}
+body.experiment-game-chrome-refined .dock-hit-area--unavailable::after,
+body.experiment-game-chrome-refined .dock-hit-area:disabled::after { opacity: 0.48; }
+body.experiment-game-chrome-refined .dock-hit-area:focus-visible {
+  outline-color: rgba(151, 139, 255, 0.92);
+  outline-offset: 3px;
+}

--- a/src/components/GameControlDock/GameControlDock.tsx
+++ b/src/components/GameControlDock/GameControlDock.tsx
@@ -125,6 +125,8 @@ export default function GameControlDock({
         className={`dock-hit-area hit-social dock-hit-area--social${chatFlash ? ' dock-hit-area--flash dock-node--flash' : ''}${socialUnavailableClass}`}
         type="button"
         aria-label={`Social${chatBadgeCount ? ` (${chatBadgeCount})` : ''}`}
+        data-label="Social"
+        title="Social actions"
         aria-disabled={socialDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onChatClick}
@@ -139,6 +141,8 @@ export default function GameControlDock({
         className={`dock-hit-area hit-requests dock-hit-area--requests${requestsUnavailableClass}`}
         type="button"
         aria-label={`Incoming requests${incomingRequestsBadgeCount ? ` (${incomingRequestsBadgeCount})` : ''}`}
+        data-label="Requests"
+        title="Incoming requests"
         aria-disabled={incomingRequestsDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onIncomingRequestsClick}
@@ -153,6 +157,8 @@ export default function GameControlDock({
         className={`dock-hit-area hit-play dock-hit-area--play${primaryPulse ? ' dock-hit-area--pulse dock-node--pulse' : ''}`}
         type="button"
         aria-label="Advance to next phase"
+        data-label="Continue"
+        title="Continue to the next game phase"
         disabled={primaryDisabled}
         onClick={primaryDisabled ? undefined : onPrimaryActionClick}
       />
@@ -160,6 +166,8 @@ export default function GameControlDock({
         className={`dock-hit-area hit-stats dock-hit-area--stats${publicUnavailableClass}`}
         type="button"
         aria-label={`Public meter${publicMeterBadgeCount ? ` (${publicMeterBadgeCount})` : ''}`}
+        data-label="Public"
+        title="Public meter"
         aria-disabled={publicMeterDisabled || disabled}
         disabled={disabled}
         onClick={disabled ? undefined : onPublicMeterClick}
@@ -174,6 +182,8 @@ export default function GameControlDock({
         className={`dock-hit-area hit-confessional dock-hit-area--confessional${confessionalFlash ? ` dock-hit-area--confessional-flash dock-hit-area--confessional-flash-${confessionalFlashTick % 2}` : ''}${confessionalPersistentFlash ? ' dock-hit-area--confessional-persistent' : ''}`}
         type="button"
         aria-label={`Confessional${confessionalBadgeCount ? ` (${confessionalBadgeCount})` : ''}`}
+        data-label="Diary"
+        title="Diary Room"
         disabled={disabled}
         onClick={disabled ? undefined : onToolClick}
       >

--- a/src/components/GameControlDock/__tests__/GameControlDock.test.tsx
+++ b/src/components/GameControlDock/__tests__/GameControlDock.test.tsx
@@ -4,6 +4,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import GameControlDock from '../GameControlDock';
 
 describe('GameControlDock', () => {
+  it('exposes concise visible labels for the refined action hierarchy', () => {
+    render(<GameControlDock />);
+    expect(screen.getByRole('button', { name: 'Advance to next phase' })).toHaveAttribute('data-label', 'Continue');
+    expect(screen.getByRole('button', { name: 'Social' })).toHaveAttribute('data-label', 'Social');
+    expect(screen.getByRole('button', { name: 'Incoming requests' })).toHaveAttribute('data-label', 'Requests');
+    expect(screen.getByRole('button', { name: 'Public meter' })).toHaveAttribute('data-label', 'Public');
+    expect(screen.getByRole('button', { name: 'Confessional' })).toHaveAttribute('data-label', 'Diary');
+  });
   it('uses the clean glassy dock shell, play, and icon assets', () => {
     const { container } = render(<GameControlDock />);
 


### PR DESCRIPTION
## Product summary
The action dock now communicates one primary action—Continue—and four quieter supporting actions instead of relying on icon recognition alone.

> Stacked on UI 1/8. Merge the preceding PR first.

### What changed
- Added concise visible labels for Social, Requests, Continue, Public and Diary in refined chrome.
- Gave Continue stronger visual emphasis and reduced competition from secondary actions.
- Added useful native titles while retaining existing accessible names, badges and disabled states.

### How this affects the game
New players should understand the dock without trial-and-error. The actions, phase progression and availability rules are unchanged.

### How to test
1. Open a refined Campaign and confirm all five actions have readable labels.
2. Confirm Continue is visually primary.
3. Trigger energy, request, public-meter and Diary badges and confirm they remain legible.
4. Disable or block an action and confirm both icon and label communicate the unavailable state.
5. Test every action and verify it opens the same destination or progresses the same phase as before.

### Validation
- GameControlDock tests passed
- Full lint and TypeScript checks passed
- Production build passed