### PR TITLE
UI 3/8: Standardize chips and status language

### DIFF
--- a/src/components/GameTopChip/GameTopChip.css
+++ b/src/components/GameTopChip/GameTopChip.css
@@ -91,3 +91,26 @@ button.game-top-chip:focus-visible {
   color: var(--color-text, #fff);
   line-height: 1;
 }
+
+/* Semantic tones keep context chips quieter than actionable or urgent state. */
+.game-top-chip--neutral {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+.game-top-chip--danger {
+  border-color: rgba(255, 194, 194, 0.36);
+  background: linear-gradient(135deg, #c73b4f, #8e2438);
+  box-shadow: 0 0 14px rgba(199, 59, 79, 0.26);
+}
+.game-top-chip--success {
+  border-color: rgba(202, 255, 230, 0.3);
+  background: linear-gradient(135deg, #16845f, #11654b);
+  box-shadow: 0 0 14px rgba(31, 200, 132, 0.2);
+}
+body.experiment-game-chrome-refined .game-top-chip {
+  min-width: 0;
+  border-radius: 9px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+body.experiment-game-chrome-refined .game-top-chip::after { display: none; }

--- a/src/components/GameTopChip/GameTopChip.tsx
+++ b/src/components/GameTopChip/GameTopChip.tsx
@@ -13,6 +13,8 @@ export interface GameTopChipProps {
   disabled?: boolean;
   ariaLabel?: string;
   title?: string;
+  /** Semantic visual tone. */
+  tone?: 'accent' | 'neutral' | 'danger' | 'success';
   /** Additional class names */
   className?: string;
 }
@@ -30,6 +32,7 @@ export default function GameTopChip({
   disabled = false,
   ariaLabel,
   title,
+  tone = 'accent',
   className = '',
 }: GameTopChipProps) {
   const Tag = onClick ? 'button' : 'span';
@@ -43,7 +46,7 @@ export default function GameTopChip({
 
   return (
     <Tag
-      className={`game-top-chip ${className}`.trim()}
+      className={`game-top-chip game-top-chip--${tone} ${className}`.trim()}
       aria-label={ariaLabel ?? normalizedLabel}
       title={title}
       style={chipStyle}

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -24,6 +24,7 @@ import type { TvEvent } from '../../types';
 import TopUtilityButton from '../TopUtilityButton/TopUtilityButton';
 import { getViewportMessageKey } from './tvZoneKeys';
 import { LIVE_VOTE_PITCHES_EVENT_KEY } from '../../constants/tvEvents';
+import { formatCycleAriaLabel, formatCycleLabel, formatPhaseLabel } from '../../utils/gameStatusLanguage';
 import ShockIntroOverlay from './ShockIntroOverlay/ShockIntroOverlay';
 import ConfessionalSpotlightOverlay from '../FloatingActionBar/ConfessionalSpotlightOverlay';
 import DemocraciaResultsReveal from './DemocraciaResultsReveal/DemocraciaResultsReveal';
@@ -39,39 +40,6 @@ const EVENT_LABELS: Record<TvEvent['type'], string> = {
   vote: 'Vote update',
   twist: 'Shock alert',
   diary: 'Diary Room',
-};
-
-// Compact phase labels — edit these strings to change what appears in the HUD pill.
-const PHASE_LABELS: Record<string, string> = {
-  week_start:               'DAY START',
-  loh_comp_announcement:    'LOH COMP',
-  loh_comp:                 'LOH COMP',
-  loh_results:              'LOH RESULTS',
-  social_1:             'SOCIAL',
-  nominations:          'NOMS',
-  nomination_results:       'NOMS RESULTS',
-  pre_veto_public_save:     'PUBLIC SAFETY',
-  pos_comp_announcement:    'POS COMP',
-  pos_comp:                 'POS COMP',
-  pos_results:          'POS RESULTS',
-  pos_ceremony:         'SAFETY',
-  pos_ceremony_results: 'SAFETY RESULTS',
-  social_2:             'SOCIAL',
-  live_vote:            'VOTE',
-  eviction_results:     'ELIM',
-  week_end:             'DAY END',
-  final4_eviction:      'F4 ELIM',
-  final3:               'THE FINALE',
-  final3_comp1:         'F3 P1',
-  final3_comp1_minigame: 'F3 P1',
-  final3_comp2:         'F3 P2',
-  final3_comp2_minigame: 'F3 P2',
-  final3_comp3:         'F3 P3',
-  final3_comp3_minigame: 'F3 P3',
-  final3_decision:      'FINAL LOH',
-  jury_announcement:    'TRIBUNAL',
-  jury_cinematic:       'TRIBUNAL',
-  jury:                 'TRIBUNAL',
 };
 
 // ─── Announcement configuration ──────────────────────────────────────────────
@@ -757,7 +725,7 @@ export default function TvZone(props: TvZoneProps) {
     };
   }, []);
 
-  const phaseLabel = PHASE_LABELS[gameState.phase] ?? gameState.phase;
+  const phaseLabel = formatPhaseLabel(gameState.phase);
   const viewportContext = `Day ${gameState.week} · ${phaseLabel}`;
   const isAtGameStart = gameState.week === 1 && gameState.phase === 'week_start';
   const canSave = !isGuest && Boolean(activeProfileId) && !isAtGameStart && !hasPendingChallenge;
@@ -892,12 +860,12 @@ export default function TvZone(props: TvZoneProps) {
       <div className="tv-zone__head">
         {/* Left: pinned phase chip */}
         <div className="tv-zone__head-phase">
-          <GameTopChip label={phaseLabel} className="tv-zone__head-chip" />
+          <GameTopChip label={phaseLabel} tone="accent" className="tv-zone__head-chip" />
         </div>
 
         {/* Center: scrollable single-row status chips */}
         <ul className="tv-zone__head-pills" aria-label="Game status chips">
-          <li><GameTopChip label={`S${gameState.season}D${gameState.week}`} className="tv-zone__head-chip" /></li>
+          <li><GameTopChip label={formatCycleLabel(gameState.week)} ariaLabel={formatCycleAriaLabel(gameState.season, gameState.week)} tone="neutral" className="tv-zone__head-chip" /></li>
         </ul>
 
         <div className="tv-zone__head-actions">

--- a/src/utils/gameStatusLanguage.test.ts
+++ b/src/utils/gameStatusLanguage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { formatCycleAriaLabel, formatCycleLabel, formatPhaseLabel } from './gameStatusLanguage';
+
+describe('game status language', () => {
+  it('uses player-facing phase names instead of implementation keys', () => {
+    expect(formatPhaseLabel('nominations')).toBe('Nominations');
+    expect(formatPhaseLabel('pos_ceremony')).toBe('Safety ceremony');
+    expect(formatPhaseLabel('eviction_results')).toBe('Elimination');
+  });
+
+  it('separates compact visible cycle text from its full accessible label', () => {
+    expect(formatCycleLabel(4)).toBe('Day 4');
+    expect(formatCycleAriaLabel(2, 4)).toBe('Season 2, day 4');
+  });
+});

--- a/src/utils/gameStatusLanguage.ts
+++ b/src/utils/gameStatusLanguage.ts
@@ -1,0 +1,45 @@
+import type { Phase } from '../types';
+
+const PHASE_LABELS: Partial<Record<Phase, string>> = {
+  week_start: 'Day start',
+  loh_comp_announcement: 'LOH competition',
+  loh_comp: 'LOH competition',
+  loh_results: 'LOH results',
+  social_1: 'Social phase',
+  nominations: 'Nominations',
+  nomination_results: 'Nomination results',
+  pre_veto_public_save: 'Public safety',
+  pos_comp_announcement: 'POS competition',
+  pos_comp: 'POS competition',
+  pos_results: 'POS results',
+  pos_ceremony: 'Safety ceremony',
+  pos_ceremony_results: 'Safety results',
+  social_2: 'Social phase',
+  live_vote: 'Live vote',
+  eviction_results: 'Elimination',
+  week_end: 'Day complete',
+  final4_eviction: 'Final 4 elimination',
+  final3: 'The finale',
+  final3_comp1: 'Final LOH · Part 1',
+  final3_comp1_minigame: 'Final LOH · Part 1',
+  final3_comp2: 'Final LOH · Part 2',
+  final3_comp2_minigame: 'Final LOH · Part 2',
+  final3_comp3: 'Final LOH · Part 3',
+  final3_comp3_minigame: 'Final LOH · Part 3',
+  final3_decision: 'Final LOH decision',
+  jury_announcement: 'Tribunal',
+  jury_cinematic: 'Tribunal',
+  jury: 'Tribunal',
+};
+
+export function formatPhaseLabel(phase: Phase): string {
+  return PHASE_LABELS[phase] ?? phase.replace(/_/g, ' ');
+}
+
+export function formatCycleLabel(week: number): string {
+  return `Day ${week}`;
+}
+
+export function formatCycleAriaLabel(season: number, week: number): string {
+  return `Season ${season}, day ${week}`;
+}


### PR DESCRIPTION
## Product summary
Game status chips now use one vocabulary and semantic tone system. Implementation-style abbreviations have been replaced with clearer phase names where space allows.

> Stacked on UI 2/8. Merge the preceding PRs first.

### What changed
- Centralized player-facing phase and day labels.
- Changed compressed strings such as NOMS RESULTS and S1D1 into clearer labels such as Nomination results and Day 1.
- Added accent, neutral, danger and success tones to the shared top-chip component.
- Kept full season/day meaning in the accessible label.

### How this affects the game
Players should spend less time interpreting HUD shorthand, and future phases can reuse the same status language instead of inventing new chips.

### How to test
1. Advance a Campaign through LOH, nominations, POS, voting and elimination.
2. Confirm the phase chip uses consistent, readable wording.
3. Confirm the cycle chip reads Day N and a screen reader receives Season N, day N.
4. Check long finale labels on a narrow phone and confirm they scroll without covering utility controls.
5. Confirm status tones remain distinguishable without changing gameplay state.

### Validation
- Status-language and GameTopChip tests passed
- Full lint and TypeScript checks passed
- Production build passed