### PR TITLE
UI 4/8: Turn the game log into a useful activity center

### DIFF
--- a/src/components/TVLog/TVLog.css
+++ b/src/components/TVLog/TVLog.css
@@ -53,7 +53,7 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.03);
   font-size: 0.78rem;
   color: var(--color-text-muted, #9ca3af);
-  cursor: pointer;
+  cursor: default;
   transition: background 0.15s ease;
 }
 
@@ -160,4 +160,119 @@
   .tv-log[data-mobile-two-line='true'] .tv-log__text {
     -webkit-line-clamp: 1;
   }
+}
+
+/* Activity-center presentation is enabled only for the refined game chrome. */
+.tv-log-shell { display: contents; }
+.tv-log__toolbar,
+.tv-log__type,
+.tv-log__time { display: none; }
+.tv-log__event {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.tv-log__copy { display: contents; }
+
+body.experiment-game-chrome-refined .tv-log-shell {
+  display: flex;
+  flex: 0 0 auto;
+  min-height: 0;
+  flex-direction: column;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(4, 8, 16, 0.24);
+}
+body.experiment-game-chrome-refined .tv-log__toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px 6px;
+}
+body.experiment-game-chrome-refined .tv-log__heading-group {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+body.experiment-game-chrome-refined .tv-log__heading {
+  color: rgba(238, 241, 255, 0.76);
+  font-size: 0.61rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+body.experiment-game-chrome-refined .tv-log__count {
+  display: inline-grid;
+  min-width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(238, 241, 255, 0.62);
+  font-size: 0.58rem;
+  font-weight: 800;
+}
+body.experiment-game-chrome-refined .tv-log__filters {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  gap: 4px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+body.experiment-game-chrome-refined .tv-log__filter {
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(213, 220, 242, 0.55);
+  font-size: 0.58rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+body.experiment-game-chrome-refined .tv-log__filter--active {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(139, 125, 255, 0.13);
+  color: rgba(244, 245, 255, 0.94);
+}
+body.experiment-game-chrome-refined .tv-log { border-top-color: rgba(255, 255, 255, 0.035); }
+body.experiment-game-chrome-refined .tv-log__item { padding: 0; }
+body.experiment-game-chrome-refined .tv-log__event { min-height: var(--tv-log-item-h); padding: 5px 10px; }
+body.experiment-game-chrome-refined .tv-log__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+body.experiment-game-chrome-refined .tv-log__type,
+body.experiment-game-chrome-refined .tv-log__time { display: inline; }
+body.experiment-game-chrome-refined .tv-log__type {
+  color: rgba(187, 196, 225, 0.48);
+  font-size: 0.52rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+body.experiment-game-chrome-refined .tv-log__time {
+  flex: 0 0 auto;
+  color: rgba(187, 196, 225, 0.4);
+  font-size: 0.55rem;
+  font-weight: 700;
+}
+body.experiment-game-chrome-refined .tv-log__event:focus-visible {
+  border-radius: 8px;
+  outline: 2px solid rgba(151, 139, 255, 0.86);
+  outline-offset: -2px;
 }

--- a/src/components/TVLog/TVLog.tsx
+++ b/src/components/TVLog/TVLog.tsx
@@ -4,47 +4,38 @@ import { tease } from '../../utils/tvLogTemplates';
 import './TVLog.css';
 
 const MAX_ADAPTIVE_VISIBLE_ROWS = 3;
+type ActivityFilter = 'all' | TvEvent['type'];
 
 const TYPE_ICONS: Record<TvEvent['type'], string> = {
-  game: '🎮',
-  social: '💬',
-  vote: '🗳️',
-  twist: '🌀',
-  diary: '📖',
+  game: '🎮', social: '💬', vote: '🗳️', twist: '🌀', diary: '📖',
 };
+const TYPE_LABELS: Record<TvEvent['type'], string> = {
+  game: 'Game', social: 'Social', vote: 'Vote', twist: 'Shock', diary: 'Diary',
+};
+const FILTERS: Array<{ value: ActivityFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'game', label: 'Game' },
+  { value: 'social', label: 'Social' },
+  { value: 'vote', label: 'Votes' },
+  { value: 'twist', label: 'Shocks' },
+  { value: 'diary', label: 'Diary' },
+];
 
 export interface TVLogProps {
-  /** Full list of TV events, newest first. */
   entries: TvEvent[];
-  /**
-   * Text currently displayed in the main TV viewport.
-   * When the first entry's text matches this value it is suppressed from the
-   * log to avoid showing a duplicate row when older rows remain available.
-   */
   mainTVMessage?: string;
-  /**
-   * Maximum number of rows visible before the list scrolls.
-   * The log always keeps at least one visible row so older entries remain
-   * reachable without letting the feed crowd the roster.
-   * @default 3
-   */
   maxVisible?: number;
-  /**
-   * When enabled, small screens clamp each collapsed feed entry to two text
-   * lines while older messages remain reachable via scroll.
-   */
   mobileTwoLineMode?: boolean;
 }
 
-/**
- * TVLog — a compact, scrollable event-log strip.
- *
- * Features:
- *   - Duplicate suppression: hides the first entry when it matches the main TV message and older entries remain.
- *   - Reserves at least one visible row; grows up to three rows when the viewport has room.
- *   - Teaser truncation: long lines are clipped to 60 chars; tap/click to expand.
- *   - Optional mobile two-line mode that clamps row copy without hiding the log.
- */
+function formatEventAge(timestamp: number): string {
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60_000));
+  if (minutes < 1) return 'Now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return hours < 24 ? `${hours}h` : `${Math.floor(hours / 24)}d`;
+}
+
 export default function TVLog({
   entries,
   mainTVMessage,
@@ -52,73 +43,84 @@ export default function TVLog({
   mobileTwoLineMode = false,
 }: TVLogProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>('all');
   const effectiveMaxVisible = Math.max(1, maxVisible);
 
-  // Suppress the first entry only when older rows remain, so the log never
-  // collapses to an empty strip just because the main TV repeats the newest row.
   const visible = useMemo(() => {
-    if (!mainTVMessage || entries.length <= 1) return entries;
-
-    const [latestEntry, ...olderEntries] = entries;
-    return latestEntry.text === mainTVMessage ? olderEntries : entries;
-  }, [entries, mainTVMessage]);
+    const deduplicated = !mainTVMessage || entries.length <= 1
+      ? entries
+      : entries[0].text === mainTVMessage ? entries.slice(1) : entries;
+    return activityFilter === 'all'
+      ? deduplicated
+      : deduplicated.filter((entry) => entry.type === activityFilter);
+  }, [activityFilter, entries, mainTVMessage]);
 
   function toggleExpand(id: string) {
-    setExpandedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+    setExpandedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   }
 
   return (
-    <ul
-      className="tv-log"
-      data-testid="tv-feed"
-      data-mobile-two-line={mobileTwoLineMode ? 'true' : undefined}
-      style={{ '--tv-log-max-vis': effectiveMaxVisible } as CSSProperties}
-      aria-label="Game event log"
-    >
-      {visible.length === 0 && (
-        <li className="tv-log__item tv-log__item--empty" aria-hidden="true">
-          <span className="tv-log__icon" aria-hidden="true">•</span>
-          <span className="tv-log__text">Game log</span>
-        </li>
-      )}
-      {visible.map((ev) => {
-        const isExpanded = expandedIds.has(ev.id);
-        const displayText = isExpanded ? ev.text : tease(ev.text);
-        return (
-          <li
-            key={ev.id}
-            className={[
-              'tv-log__item',
-              `tv-log__item--${ev.type}`,
-              isExpanded ? 'tv-log__item--expanded' : '',
-            ].filter(Boolean).join(' ')}
-            onClick={() => toggleExpand(ev.id)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                toggleExpand(ev.id);
-              }
-            }}
-            aria-expanded={isExpanded}
-            aria-label={isExpanded ? ev.text : displayText}
-          >
-            <span className="tv-log__icon" aria-hidden="true">
-              {TYPE_ICONS[ev.type]}
-            </span>
-            <span className="tv-log__text">{displayText}</span>
+    <section className="tv-log-shell" aria-labelledby="tv-log-heading">
+      <div className="tv-log__toolbar">
+        <div className="tv-log__heading-group">
+          <span className="tv-log__heading" id="tv-log-heading">Recent events</span>
+          <span className="tv-log__count" aria-label={`${visible.length} visible events`}>{visible.length}</span>
+        </div>
+        <div className="tv-log__filters" role="group" aria-label="Filter game events">
+          {FILTERS.map((filter) => (
+            <button
+              key={filter.value}
+              type="button"
+              className={`tv-log__filter${activityFilter === filter.value ? ' tv-log__filter--active' : ''}`}
+              aria-pressed={activityFilter === filter.value}
+              onClick={() => setActivityFilter(filter.value)}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <ul
+        className="tv-log"
+        data-testid="tv-feed"
+        data-mobile-two-line={mobileTwoLineMode ? 'true' : undefined}
+        style={{ '--tv-log-max-vis': effectiveMaxVisible } as CSSProperties}
+        aria-label="Game event log"
+      >
+        {visible.length === 0 && (
+          <li className="tv-log__item tv-log__item--empty" aria-live="polite">
+            <span className="tv-log__icon" aria-hidden="true">•</span>
+            <span className="tv-log__text">No matching events yet</span>
           </li>
-        );
-      })}
-    </ul>
+        )}
+        {visible.map((event) => {
+          const isExpanded = expandedIds.has(event.id);
+          const displayText = isExpanded ? event.text : tease(event.text);
+          return (
+            <li key={event.id} className={`tv-log__item tv-log__item--${event.type}${isExpanded ? ' tv-log__item--expanded' : ''}`}>
+              <button
+                type="button"
+                className="tv-log__event"
+                onClick={() => toggleExpand(event.id)}
+                aria-expanded={isExpanded}
+                aria-label={`${TYPE_LABELS[event.type]} event: ${event.text}`}
+              >
+                <span className="tv-log__icon" aria-hidden="true">{TYPE_ICONS[event.type]}</span>
+                <span className="tv-log__copy">
+                  <span className="tv-log__type">{TYPE_LABELS[event.type]}</span>
+                  <span className="tv-log__text">{displayText}</span>
+                </span>
+                <time className="tv-log__time" dateTime={new Date(event.timestamp).toISOString()}>{formatEventAge(event.timestamp)}</time>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
   );
 }

--- a/src/components/TVLog/__tests__/TVLog.test.tsx
+++ b/src/components/TVLog/__tests__/TVLog.test.tsx
@@ -144,3 +144,25 @@ describe('TVLog — mobile compact mode', () => {
     );
   });
 });
+
+describe('TVLog — activity filters', () => {
+  it('filters the feed without changing the underlying event list', async () => {
+    const entries: TvEvent[] = [
+      makeEvent({ id: 'game', text: 'Competition announced', type: 'game' }),
+      makeEvent({ id: 'social', text: 'A new alliance formed', type: 'social' }),
+    ];
+    render(<TVLog entries={entries} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Social' }));
+    expect(screen.getByText('A new alliance formed')).toBeDefined();
+    expect(screen.queryByText('Competition announced')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Social' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('labels each event by type and exposes its timestamp', () => {
+    const entries: TvEvent[] = [makeEvent({ id: 'vote', text: 'The vote is locked', type: 'vote' })];
+    const { container } = render(<TVLog entries={entries} />);
+    expect(screen.getByText('Vote')).toBeDefined();
+    expect(container.querySelector('time[datetime]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Product summary
The plain event strip becomes a compact activity center in refined chrome, with event types, timestamps and filters while preserving the tight game-screen footprint.

> Stacked on UI 3/8. Merge the preceding PRs first.

### What changed
- Added Recent events heading and visible event count.
- Added All, Game, Social, Votes, Shocks and Diary filters.
- Added type labels and relative event age.
- Replaced button-like list rows with real semantic buttons while preserving tap-to-expand.
- Kept duplicate suppression and the responsive one-to-three-row height budget.

### How this affects the game
Players can find an important vote or social event without scanning unrelated messages. Filtering is presentation-only and never deletes domain events.

### How to test
1. Generate several types of events in a refined Campaign.
2. Select every filter and confirm only matching events appear.
3. Return to All and confirm the full feed returns.
4. Tap a long event to expand and collapse it.
5. Test keyboard focus and activation on filters and event rows.
6. Test a small screen and confirm filters scroll horizontally while the roster remains reachable.

### Validation
- 14 TVLog tests passed
- Full lint and TypeScript checks passed
- Production build passed