### PR TITLE
UI 5/8: Make the avatar roster feel interactive

### DIFF
--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -72,6 +72,8 @@ type Props = {
    */
   isEvicting?: boolean
   nominationCeremonyState?: 'loh' | 'danger' | 'locked'
+  /** Shared instructions announced when this tile is interactive. */
+  descriptionId?: string
 }
 
 function formatStat(value: number | null | undefined, options: { decimals?: number } = {}) {
@@ -79,7 +81,7 @@ function formatStat(value: number | null | undefined, options: { decimals?: numb
   return options.decimals != null ? value.toFixed(options.decimals) : String(value)
 }
 
-export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick, roboStats, onHoldPreviewStart, onHoldPreviewEnd, statuses, finalRank, showPermanentBadge = true, layoutId, isEvicting, nominationCeremonyState }: Props) {
+export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick, roboStats, onHoldPreviewStart, onHoldPreviewEnd, statuses, finalRank, showPermanentBadge = true, layoutId, isEvicting, nominationCeremonyState, descriptionId }: Props) {
   const profilePhotoId = getProfilePhotoAvatarId(avatarUrl)
   const attemptRef = React.useRef(0)
   const variantsRef = React.useRef<string[] | null>(null)
@@ -89,6 +91,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
   const touchStartPosRef = React.useRef<{ x: number; y: number } | null>(null)
   const isHoldActiveRef = React.useRef(false)
   const [statsOpen, setStatsOpen] = React.useState(false)
+  const [isPressing, setIsPressing] = React.useState(false)
   const [profilePhotoUrl, setProfilePhotoUrl] = React.useState<string | null>(null)
   const resolvedAvatarUrl = profilePhotoUrl ?? (profilePhotoId ? undefined : avatarUrl)
   const isSurvivorRoboTile = Boolean(roboStats) || Boolean(avatarUrl?.includes('bottts'))
@@ -162,6 +165,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
 
   function handleTouchStart(e: React.TouchEvent<HTMLDivElement>) {
     if (!onHoldPreviewStart) return
+    setIsPressing(true)
     clearLongPressTimeout()
     isHoldActiveRef.current = false
     const touch = e.touches[0]
@@ -189,12 +193,14 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
       // so the player can drag their finger away and still read the dialog.
       if (isHoldActiveRef.current) return
       clearLongPressTimeout()
+      setIsPressing(false)
       touchStartPosRef.current = null
     }
   }
 
   function handleTouchEnd() {
     clearLongPressTimeout()
+    setIsPressing(false)
     touchStartPosRef.current = null
     if (isHoldActiveRef.current) {
       isHoldActiveRef.current = false
@@ -256,8 +262,9 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
   return (
     <>
       <div
-        className={`${styles.tile} ${isEvicted ? styles.evicted : ''}`}
+        className={[styles.tile, isEvicted ? styles.evicted : '', isInteractive ? styles.interactive : '', isPressing ? styles.pressing : ''].filter(Boolean).join(' ')}
         aria-label={ariaLabel}
+        aria-describedby={isInteractive ? descriptionId : undefined}
         title={name}
         role={isInteractive ? 'button' : 'group'}
         tabIndex={isInteractive ? 0 : undefined}
@@ -299,6 +306,8 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
           <div className={styles.nameOverlay} aria-hidden="true">
             {name}
           </div>
+          {isInteractive && <span className={styles.interactionCue} aria-hidden="true">•••</span>}
+          {isPressing && <span className={styles.holdProgress} aria-hidden="true" />}
 
           {isYou && (
             <span className={styles.youBadge} aria-hidden="true">

--- a/src/components/HouseguestGrid/HouseguestGrid.module.css
+++ b/src/components/HouseguestGrid/HouseguestGrid.module.css
@@ -590,3 +590,57 @@
     animation: none !important;
   }
 }
+
+.interactionInstructions {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.interactionCue,
+.holdProgress { display: none; }
+:global(body.experiment-game-chrome-refined) .interactive { cursor: pointer; outline: none; }
+:global(body.experiment-game-chrome-refined) .interactive .avatarWrap { transition: transform 150ms ease, border-color 180ms ease, box-shadow 180ms ease; }
+:global(body.experiment-game-chrome-refined) .interactive:hover .avatarWrap,
+:global(body.experiment-game-chrome-refined) .interactive:focus-visible .avatarWrap {
+  transform: translateY(-2px);
+  border-color: rgba(151, 139, 255, 0.48);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38), 0 0 0 2px rgba(139, 125, 255, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+:global(body.experiment-game-chrome-refined) .pressing .avatarWrap { transform: scale(0.975); border-color: rgba(151, 139, 255, 0.7); }
+:global(body.experiment-game-chrome-refined) .interactionCue {
+  position: absolute;
+  bottom: 5px;
+  left: 6px;
+  z-index: 5;
+  display: inline-flex;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.54rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+:global(body.experiment-game-chrome-refined) .interactive:hover .interactionCue,
+:global(body.experiment-game-chrome-refined) .interactive:focus-visible .interactionCue,
+:global(body.experiment-game-chrome-refined) .pressing .interactionCue { opacity: 1; }
+:global(body.experiment-game-chrome-refined) .holdProgress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 6;
+  display: block;
+  width: 100%;
+  height: 3px;
+  transform-origin: left;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #786cff, #ad94ff);
+  box-shadow: 0 0 10px rgba(139, 125, 255, 0.72);
+  animation: rosterHoldProgress 450ms linear both;
+}
+@keyframes rosterHoldProgress { from { transform: scaleX(0); } to { transform: scaleX(1); } }

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -296,6 +296,10 @@ export default function HouseguestGrid({
         )}
       </div>
 
+      <p id="houseguests-interaction-instructions" className={styles.interactionInstructions}>
+        Tap a housemate to interact. Press and hold to preview their profile.
+      </p>
+
       <ul
         className={listClassName}
         role="list"
@@ -320,6 +324,7 @@ export default function HouseguestGrid({
                 layoutId={hg.layoutId}
                 isEvicting={hg.isEvicting}
                 nominationCeremonyState={hg.nominationCeremonyState}
+                descriptionId="houseguests-interaction-instructions"
               />
             </li>
           )

--- a/src/components/HouseguestGrid/__tests__/AvatarTile.test.tsx
+++ b/src/components/HouseguestGrid/__tests__/AvatarTile.test.tsx
@@ -1,8 +1,17 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import AvatarTile from '../AvatarTile'
 
 describe('AvatarTile', () => {
+  it('exposes interaction guidance and a visible affordance hook', () => {
+    const { container } = render(
+      <AvatarTile name="Taylor" onClick={vi.fn()} descriptionId="roster-help" />,
+    )
+    const tile = screen.getByRole('button', { name: 'Taylor' })
+    expect(tile).toHaveAttribute('aria-describedby', 'roster-help')
+    expect(tile.className).toContain('interactive')
+    expect(container.querySelector('[class*="interactionCue"]')).toBeTruthy()
+  })
   it('renders the nomination badge asset for nominated players', () => {
     render(
       <AvatarTile


### PR DESCRIPTION
## Product summary
Avatar tiles now acknowledge hover, keyboard focus, touch press and press-and-hold, making the roster feel like an interactive cast rather than a static image grid.

> Stacked on UI 4/8. Merge the preceding PRs first.

### What changed
- Added refined hover and focus elevation without changing the original name position or formatting.
- Added a subtle “more” affordance for interactive tiles.
- Added a 450ms touch-hold progress indicator matching the existing profile-preview threshold.
- Added shared screen-reader instructions for tap and hold behavior.
- Preserved eviction, nomination, status-badge and shared-layout animation states.

### How this affects the game
Players receive immediate feedback before an avatar action occurs and can discover profile previews more naturally. Existing avatar callbacks and gameplay effects remain unchanged.

### How to test
1. Hover and keyboard-focus several avatars in refined chrome.
2. Confirm the tile lifts and receives a clear focus treatment.
3. Press and hold on a touch device; confirm the progress line completes as the profile preview opens.
4. Move the finger away before completion and confirm the hold is cancelled.
5. Confirm a completed hold does not also fire a tap.
6. Check nominated, safe, evicted and “You” tiles for badge and label overlap.

### Validation
- AvatarTile and HouseguestGrid tests passed
- Full lint and TypeScript checks passed
- Production build passed