### PR TITLE
UI 6/8: Simplify the game navigation architecture

### DIFF
--- a/src/components/GameBottomNav/GameBottomNav.css
+++ b/src/components/GameBottomNav/GameBottomNav.css
@@ -146,3 +146,58 @@
 :root[style*="--game-bottom-controls-mode: compact"] .game-bottom-nav__glyph {
   --game-nav-glyph-size: 24px;
 }
+
+/* Refined information architecture: frequent destinations stay visible; utilities move to More. */
+.game-bottom-nav--refined-architecture .game-bottom-nav__items {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  padding-inline: 5%;
+}
+.game-bottom-nav__more-menu {
+  position: absolute;
+  right: max(10px, var(--safe-right));
+  bottom: calc(var(--nav-bar-height, 60px) + var(--safe-bottom) + 8px);
+  z-index: 5;
+  display: flex;
+  width: min(260px, calc(100vw - 28px));
+  flex-direction: column;
+  gap: 4px;
+  padding: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: rgba(12, 18, 31, 0.97);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.46), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+.game-bottom-nav__more-menu button {
+  display: flex;
+  min-height: 50px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 11px;
+  background: transparent;
+  color: rgba(244, 246, 255, 0.94);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.game-bottom-nav__more-menu button:hover,
+.game-bottom-nav__more-menu button:focus-visible { background: rgba(255, 255, 255, 0.07); }
+.game-bottom-nav__more-menu button:focus-visible { outline: 2px solid rgba(151, 139, 255, 0.88); outline-offset: -2px; }
+.game-bottom-nav__more-menu span { font-size: 0.78rem; font-weight: 800; }
+.game-bottom-nav__more-menu small { color: rgba(212, 219, 240, 0.56); font-size: 0.62rem; font-weight: 600; }
+.game-bottom-nav--refined-architecture .game-bottom-nav__item--active::after {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 18px;
+  height: 2px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: #9487ff;
+  box-shadow: 0 0 9px rgba(148, 135, 255, 0.7);
+  content: '';
+}

--- a/src/components/GameBottomNav/GameBottomNav.tsx
+++ b/src/components/GameBottomNav/GameBottomNav.tsx
@@ -1,15 +1,22 @@
+import { useEffect, useState } from 'react';
+import { useRefinedGameChrome } from '../../hooks/useRefinedGameChrome';
 import './GameBottomNav.css';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
-
 export type NavTab = 'home' | 'rules' | 'settings' | 'leaderboard' | 'profile';
 
-const NAV_ITEMS: { tab: NavTab; glyph: string; label: string }[] = [
-  { tab: 'home',        glyph: 'home_approved_final.svg',        label: 'HOME'        },
-  { tab: 'rules',       glyph: 'rules_approved_final.svg',       label: 'RULES'       },
-  { tab: 'settings',    glyph: 'settings_approved_final.svg',    label: 'SETTINGS'    },
-  { tab: 'leaderboard', glyph: 'leaderboard_approved_final.svg', label: 'BOARD'       },
-  { tab: 'profile',     glyph: 'profile_approved_final.svg',     label: 'USER'        },
+type PrimaryItem = { tab: NavTab; glyph: string; label: string; accessibleLabel: string };
+const CONTROL_ITEMS: PrimaryItem[] = [
+  { tab: 'home', glyph: 'home_approved_final.svg', label: 'HOME', accessibleLabel: 'HOME' },
+  { tab: 'rules', glyph: 'rules_approved_final.svg', label: 'RULES', accessibleLabel: 'RULES' },
+  { tab: 'settings', glyph: 'settings_approved_final.svg', label: 'SETTINGS', accessibleLabel: 'SETTINGS' },
+  { tab: 'leaderboard', glyph: 'leaderboard_approved_final.svg', label: 'BOARD', accessibleLabel: 'BOARD' },
+  { tab: 'profile', glyph: 'profile_approved_final.svg', label: 'USER', accessibleLabel: 'USER' },
+];
+const REFINED_ITEMS: PrimaryItem[] = [
+  { tab: 'home', glyph: 'home_approved_final.svg', label: 'Home', accessibleLabel: 'Home' },
+  { tab: 'leaderboard', glyph: 'leaderboard_approved_final.svg', label: 'Board', accessibleLabel: 'Leaderboard' },
+  { tab: 'profile', glyph: 'profile_approved_final.svg', label: 'Profile', accessibleLabel: 'Profile' },
 ];
 
 export interface GameBottomNavProps {
@@ -20,18 +27,9 @@ export interface GameBottomNavProps {
   onSettingsClick?: () => void;
   onLeaderboardClick?: () => void;
   onProfileClick?: () => void;
-  /** Render children (e.g. ConfirmExitModal) after the nav */
   children?: React.ReactNode;
 }
 
-
-/**
- * GameBottomNav — SVG-backed bottom navigation strip.
- *
- * Uses the final navbar shell asset pack, with icons and labels overlaid as
- * React content. Preserves full accessibility semantics and existing click
- * behavior.
- */
 export default function GameBottomNav({
   activeTab,
   disabled = false,
@@ -42,54 +40,81 @@ export default function GameBottomNav({
   onProfileClick,
   children,
 }: GameBottomNavProps) {
+  const refined = useRefinedGameChrome();
+  const [moreOpen, setMoreOpen] = useState(false);
   const navBarSrc = `${BASE}/assets/updated_nav_fab_bar/bottom_nav_shell_final.svg`;
-
   const handlers: Record<NavTab, (() => void) | undefined> = {
-    home:        onHomeClick,
-    rules:       onRulesClick,
-    settings:    onSettingsClick,
+    home: onHomeClick,
+    rules: onRulesClick,
+    settings: onSettingsClick,
     leaderboard: onLeaderboardClick,
-    profile:     onProfileClick,
+    profile: onProfileClick,
   };
+
+  useEffect(() => {
+    if (!moreOpen) return undefined;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMoreOpen(false);
+    };
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [moreOpen]);
+
+  function openDestination(tab: NavTab) {
+    setMoreOpen(false);
+    handlers[tab]?.();
+  }
+
+  const items = refined ? REFINED_ITEMS : CONTROL_ITEMS;
+  const moreIsActive = activeTab === 'rules' || activeTab === 'settings';
 
   return (
     <>
-      <nav className="game-bottom-nav nav-bar" aria-label="Main navigation">
-        {/* Background shell */}
-        <img
-          className="game-bottom-nav__shell"
-          src={navBarSrc}
-          alt=""
-          aria-hidden="true"
-          draggable={false}
-        />
-
-        {/* Nav items */}
+      <nav className={`game-bottom-nav nav-bar${refined ? ' game-bottom-nav--refined-architecture' : ''}`} aria-label="Main navigation">
+        <img className="game-bottom-nav__shell" src={navBarSrc} alt="" aria-hidden="true" draggable={false} />
+        {refined && moreOpen && (
+          <div className="game-bottom-nav__more-menu" id="game-navigation-more" role="menu" aria-label="More destinations">
+            <button type="button" role="menuitem" onClick={() => openDestination('rules')}>
+              <span>Rules</span><small>How the game works</small>
+            </button>
+            <button type="button" role="menuitem" onClick={() => openDestination('settings')}>
+              <span>Settings</span><small>Audio, display and gameplay</small>
+            </button>
+          </div>
+        )}
         <div className="game-bottom-nav__items">
-          {NAV_ITEMS.map(({ tab, glyph, label }) => {
+          {items.map(({ tab, glyph, label, accessibleLabel }) => {
             const isActive = activeTab === tab;
-            const glyphSrc = `${BASE}/assets/updated_nav_fab_bar/${glyph}`;
             return (
               <button
                 key={tab}
                 type="button"
                 className={`game-bottom-nav__item${isActive ? ' game-bottom-nav__item--active' : ''}`}
-                aria-label={label}
+                aria-label={accessibleLabel}
                 aria-current={isActive ? 'page' : undefined}
                 disabled={disabled}
                 onClick={handlers[tab]}
               >
-                <img
-                  className="game-bottom-nav__glyph"
-                  src={glyphSrc}
-                  alt=""
-                  aria-hidden="true"
-                  draggable={false}
-                />
+                <img className="game-bottom-nav__glyph" src={`${BASE}/assets/updated_nav_fab_bar/${glyph}`} alt="" aria-hidden="true" draggable={false} />
                 <span className="game-bottom-nav__label">{label}</span>
               </button>
             );
           })}
+          {refined && (
+            <button
+              type="button"
+              className={`game-bottom-nav__item game-bottom-nav__item--more${moreIsActive ? ' game-bottom-nav__item--active' : ''}`}
+              aria-label="More"
+              aria-expanded={moreOpen}
+              aria-controls="game-navigation-more"
+              aria-current={moreIsActive ? 'page' : undefined}
+              disabled={disabled}
+              onClick={() => setMoreOpen((open) => !open)}
+            >
+              <img className="game-bottom-nav__glyph" src={`${BASE}/assets/updated_nav_fab_bar/settings_approved_final.svg`} alt="" aria-hidden="true" draggable={false} />
+              <span className="game-bottom-nav__label">More</span>
+            </button>
+          )}
         </div>
       </nav>
       {children}

--- a/src/components/GameBottomNav/__tests__/GameBottomNav.test.tsx
+++ b/src/components/GameBottomNav/__tests__/GameBottomNav.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import GameBottomNav from '../GameBottomNav';
 
 describe('GameBottomNav', () => {
@@ -34,4 +35,17 @@ describe('GameBottomNav', () => {
     expect(screen.getByRole('button', { name: 'USER' })).toBeDefined();
     expect(container.querySelectorAll('.game-bottom-nav__label')).toHaveLength(5);
   });
-});
+
+  it('groups lower-frequency destinations in More for the refined architecture', async () => {
+    document.body.classList.add('experiment-game-chrome-refined');
+    render(<GameBottomNav activeTab={null} />);
+
+    expect(screen.getByRole('button', { name: 'Leaderboard' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Profile' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'RULES' })).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('menuitem', { name: /Rules/i })).toBeDefined();
+    expect(screen.getByRole('menuitem', { name: /Settings/i })).toBeDefined();
+    document.body.classList.remove('experiment-game-chrome-refined');
+  });});

--- a/src/hooks/useRefinedGameChrome.ts
+++ b/src/hooks/useRefinedGameChrome.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const REFINED_CLASS = 'experiment-game-chrome-refined';
+
+export function useRefinedGameChrome(): boolean {
+  const readVariant = () => typeof document !== 'undefined' && document.body.classList.contains(REFINED_CLASS);
+  const [isRefined, setIsRefined] = useState(readVariant);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const update = () => setIsRefined(readVariant());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isRefined;
+}


### PR DESCRIPTION
## Product summary
Refined navigation now keeps frequent destinations visible—Home, Board and Profile—and groups lower-frequency Rules and Settings under More. The original five-tab architecture remains available in control chrome.

> Stacked on UI 5/8. Merge the preceding PRs first.

### What changed
- Added a reactive refined/control presentation hook.
- Reduced the refined bar from five equal destinations to three destinations plus More.
- Added an accessible More menu with explanations for Rules and Settings.
- Added Escape-key dismissal and a stronger active-destination indicator.
- Preserved every route and the existing Save & Home protection.

### How this affects the game
The bar becomes easier to scan and gives more width to player-facing labels. Rules and Settings remain one tap behind More; no destination was removed.

### How to test
1. Open the refined game and confirm Home, Board, Profile and More are visible.
2. Open More and navigate to Rules and Settings.
3. Press Escape while More is open and confirm it closes.
4. Visit Board and Profile and confirm the correct active state.
5. Choose Home during an active season and verify Save & Home behavior is unchanged.
6. Force control chrome and confirm the original five-tab navigation returns.

### Validation
- GameBottomNav tests passed
- Full lint and TypeScript checks passed
- Production build passed