### PR TITLE
Improve incoming social interactions

### DIFF
--- a/docs/INCOMING_SOCIAL_INTERACTIONS_REDESIGN.md
+++ b/docs/INCOMING_SOCIAL_INTERACTIONS_REDESIGN.md
@@ -1,0 +1,142 @@
+# Incoming Social Interactions: Research and Redesign
+
+## Design goal
+
+Incoming interactions should feel like houseguests pursuing their own goals, not a notification feed that gives the player four differently colored affinity buttons. A strong interaction must answer four questions:
+
+1. Why did this person approach me now?
+2. What do they want from me?
+3. What am I risking by answering this way?
+4. Will the game remember what I said when I act later?
+
+The optimal solution is a deterministic social simulation with authored voice, persistent memory, concrete commitments, and downstream game consequences. An LLM can eventually add surface variation, but it should never own truth, rules, or outcomes.
+
+## What successful systems do
+
+### Prom Week / Comme il Faut
+
+[Prom Week's social exchanges](https://promweek.soe.ucsc.edu/2012/02/22/prom-weeks-social-exchanges/) model an interaction as an initiator's intent plus the responder's reaction. Desires and reactions are ranked from many social considerations, and scenes are selected only after the simulation determines the result.
+
+Its broader [social physics design](https://promweek.soe.ucsc.edu/2011/11/12/gameplay-and-social-physics/) adds the crucial ingredients missing from shallow dialogue systems: characters with particular histories, remembered actions referenced in later dialogue, and repercussions that spread across multiple characters.
+
+Transferable lesson: select an intent from state first, express it through dialogue second, then create durable and sometimes indirect state changes.
+
+### The Sims 4: Neighborhood Stories
+
+[Neighborhood Stories](https://www.ea.com/games/the-sims/the-sims-4/news/introducing-neighborhood-stories) lets autonomous Sims call the player for input, delays the actual life change, and later reports what happened. Traits and relationship levels affect whether changes are considered, while dynamic outcomes account for conflicting traits and existing relationships.
+
+Transferable lesson: requests become engaging when the answer causes a later event and a follow-up, rather than resolving completely on the same card.
+
+### Middle-earth: Shadow of War
+
+The official [Shadow of War overview](https://www.shadowofwar.com/about/) describes the Nemesis System as producing unique personal stories with individual enemies and followers. Its power is not conversational breadth; it is explicit recurrence. A character returns with visible evidence that a previous encounter mattered.
+
+Transferable lesson: prioritize a small number of remembered, resurfaced relationship beats over a large volume of disposable messages.
+
+### Generative Agents research
+
+The [Generative Agents paper](https://arxiv.org/abs/2304.03442) found that observation, planning, and reflection each contributed to believable behavior. Agents stored experiences, synthesized higher-level reflections, retrieved relevant memories, and used them in future plans.
+
+Transferable lesson: raw event memory is not enough. The simulation eventually needs derived beliefs such as “the player makes promises but breaks them under pressure.”
+
+## Diagnosis of the previous module
+
+The existing implementation already had strong foundations:
+
+- phase-aware autonomous intent selection;
+- relationship, personality, urgency, and event-pressure scoring;
+- gratitude, resentment, neglect, and trust memory;
+- authored voice profiles and large scenario variant banks;
+- delivery pacing, priority, deduplication, expiration, and save safety.
+
+The artificial feeling came from the final meter of the experience:
+
+- most text described vague “people,” “things,” and “movement” rather than named social objects;
+- replies mostly mapped to positive, neutral, negative, or dismiss;
+- the player could reassure a nominee and nominate them moments later without the game connecting those actions;
+- consequences were immediate affinity deltas, so interactions rarely created anticipation;
+- useful information and flavor messages had nearly identical mechanical value;
+- hidden memory existed, but the interface did not show the player what the relationship expected next.
+
+## Implemented loop: social contracts
+
+High-stakes affirmative responses can now create one of three promises:
+
+| Conversation | Promise | Verification point |
+| --- | --- | --- |
+| Nominee or safety request to the human LOH | Keep them off the block | Nominations lock |
+| Nominee pitch to the human safety holder | Use safety on them | Safety decision locks |
+| Nominee pitch before the human eviction vote | Vote to keep them | Human vote locks |
+
+The loop is:
+
+1. An AI houseguest chooses an intent from game state.
+2. The inbox explains why the approach happened and what is at stake.
+3. The player can make a clearly labeled promise or stay noncommittal.
+4. The promise remains visible in an Active Promises section.
+5. The corresponding nomination, safety, or vote action verifies the promise.
+6. The beneficiary remembers a kept or broken promise.
+7. Affinity, trust/resentment, influence, the TV/Diary feed, and future AI decisions change.
+8. The inbox builds a visible credibility record from kept and broken promises.
+
+Current default tuning:
+
+- kept promise: +9 beneficiary affinity, +4 gratitude, +3 trust momentum, +100 influence;
+- broken promise: -16 beneficiary affinity, +5 resentment, -4 trust momentum, -150 influence;
+- skipped or twist-invalidated decision windows void the promise instead of unfairly punishing the player.
+
+## Concrete information
+
+Gossip and warnings now select and name a living third-party houseguest, using the sender's relationship graph to prefer a plausible target. Engaging with actionable gossip or warnings grants information, so these interactions are strategically distinct from compliments and check-ins.
+
+## Presentation rules
+
+- Show **Why now** and **What it means** on every card.
+- Use response descriptions to expose social meaning without revealing exact hidden calculations.
+- Mark promise-creating options before the player commits.
+- Pin unresolved promises above the inbox.
+- Show promise outcomes on the original interaction.
+- Preserve authored character voice; simulation metadata must not replace dialogue.
+
+## Recommended next layers
+
+### 1. Belief and rumor propagation
+
+Add claims with subject, source, confidence, truth state, and audience. A player who repeats a rumor should risk discovery; houseguests should accept claims based on trust in the speaker versus trust in the subject. This is the most valuable next step because it creates multi-character repercussions.
+
+### 2. Relationship dimensions
+
+Split the single affinity signal into at least:
+
+- warmth: personal liking;
+- trust: belief that the person keeps their word;
+- threat: strategic danger;
+- obligation: favors owed.
+
+A houseguest should be able to like the player, distrust them, fear them, and still vote with them. That contradiction is where reality and intrigue emerge.
+
+### 3. Recurring arcs
+
+Promote high-intensity memories into named arcs: loyal ally, uneasy deal, betrayed confidant, information broker, public rival. Give each arc escalation and payoff scenes. Limit active arcs so the cast remains memorable rather than noisy.
+
+### 4. Private versus public responses
+
+Track who witnessed or later learned about an exchange. Public reassurance should be more binding than a private vague answer; exposed lies should affect multiple relationships.
+
+### 5. Reflection summaries
+
+At week end, derive one short belief per important pair from recent events, for example: “Lia thinks you protect allies when you have power.” Use that belief in intent ranking and later dialogue. Keep it deterministic and inspectable.
+
+## Metrics for tuning
+
+Measure the system by outcomes, not message count:
+
+- percentage of interactions caused by a legible game-state trigger;
+- percentage that resurface in a later event or line;
+- promise acceptance, kept, broken, and void rates;
+- number of distinct houseguests involved in consequences per week;
+- repeated scenario and phrase rate;
+- inbox abandonment and automatic-expiry rate;
+- difference in later nomination/vote behavior after kept versus broken promises.
+
+The target is fewer disposable contacts and more remembered contacts. If players can recount “I promised Lia safety, broke it, and she turned Nova against me,” the module is working.

--- a/src/components/IncomingInteractionsInbox/IncomingInteractionsInbox.css
+++ b/src/components/IncomingInteractionsInbox/IncomingInteractionsInbox.css
@@ -48,6 +48,16 @@
   color: rgba(226, 232, 240, 0.65);
 }
 
+.inbox-header__credibility {
+  font-size: 0.68rem;
+  color: #c4b5fd;
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  background: rgba(124, 58, 237, 0.13);
+  border-radius: 999px;
+  padding: 0.22rem 0.48rem;
+  white-space: nowrap;
+}
+
 .inbox-header__close {
   border: none;
   background: rgba(148, 163, 184, 0.16);
@@ -65,7 +75,7 @@
 }
 
 .inbox-list {
-  padding: 0.75rem;
+  padding: 0.58rem;
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
@@ -75,13 +85,13 @@
 .inbox-sections {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.72rem;
 }
 
 .inbox-section {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.42rem;
 }
 
 .inbox-section__title {
@@ -99,10 +109,36 @@
   color: rgba(148, 163, 184, 0.7);
 }
 
+.inbox-section--promises {
+  padding: 0.65rem;
+  border-radius: 12px;
+  border: 1px solid rgba(245, 158, 11, 0.28);
+  background: linear-gradient(135deg, rgba(120, 53, 15, 0.18), rgba(15, 23, 42, 0.72));
+}
+
+.inbox-section__title--promises {
+  color: #fcd34d;
+}
+
+.inbox-promises {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.inbox-promise {
+  display: flex;
+  flex-direction: column;
+  gap: 0.14rem;
+  font-size: 0.76rem;
+}
+
+.inbox-promise strong { color: #fef3c7; }
+.inbox-promise span { color: rgba(226, 232, 240, 0.72); }
+
 .inbox-section__list {
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.48rem;
 }
 
 .inbox-empty {
@@ -122,11 +158,11 @@
   background: rgba(15, 23, 42, 0.75);
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 12px;
-  padding: 0.65rem 0.7rem;
+  padding: 0.52rem 0.58rem;
   border-left: 3px solid transparent;
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.34rem;
 }
 
 .inbox-item--unread {
@@ -154,13 +190,13 @@
 .inbox-item__header {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.45rem;
 }
 
 .inbox-item__title {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.12rem;
   flex: 1;
   min-width: 0;
 }
@@ -270,10 +306,28 @@
 
 .inbox-item__text {
   margin: 0;
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   line-height: 1.3;
   color: rgba(226, 232, 240, 0.95);
 }
+
+.inbox-item__promise {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.42rem 0.5rem;
+  border-radius: 9px;
+  font-size: 0.7rem;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  background: rgba(120, 53, 15, 0.18);
+  color: #fde68a;
+}
+
+.inbox-item__promise small { color: rgba(254, 243, 199, 0.68); }
+.inbox-item__promise--kept { border-color: rgba(34, 197, 94, 0.38); background: rgba(20, 83, 45, 0.2); color: #bbf7d0; }
+.inbox-item__promise--broken { border-color: rgba(239, 68, 68, 0.42); background: rgba(127, 29, 29, 0.22); color: #fecaca; }
+.inbox-item__promise--void { border-color: rgba(148, 163, 184, 0.25); background: rgba(51, 65, 85, 0.2); color: #cbd5e1; }
 
 .inbox-item--resolved .inbox-item__from,
 .inbox-item--resolved .inbox-item__text,
@@ -287,22 +341,29 @@
 }
 
 .inbox-item__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.26rem;
 }
 
 .inbox-action {
   border: none;
   border-radius: 999px;
-  padding: 0.3rem 0.7rem;
-  font-size: 0.72rem;
+  min-height: 30px;
+  padding: 0.28rem 0.22rem;
+  font-size: 0.6rem;
   font-weight: 700;
   cursor: pointer;
   color: #f8fafc;
   background: rgba(148, 163, 184, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.12;
+  text-align: center;
 }
 
+.inbox-action small { color: rgba(226, 232, 240, 0.68); font-size: 0.61rem; line-height: 1.25; font-weight: 500; }
 .inbox-action--positive {
   background: rgba(34, 197, 94, 0.22);
 }
@@ -321,4 +382,9 @@
 
 .inbox-action:hover {
   filter: brightness(1.1);
+}
+
+@media (max-width: 520px) {
+  .inbox-header__summary { display: none; }
+  .inbox-item__actions { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }

--- a/src/components/IncomingInteractionsInbox/IncomingInteractionsInbox.tsx
+++ b/src/components/IncomingInteractionsInbox/IncomingInteractionsInbox.tsx
@@ -5,6 +5,7 @@ import {
   markAllIncomingInteractionsRead,
   selectIncomingInboxOpen,
   selectIncomingInteractions,
+  selectSocialCommitments,
   selectUnreadIncomingInteractionCount,
 } from '../../social/socialSlice';
 import { getIncomingInteractionPriority } from '../../social/incomingInteractionScheduler';
@@ -18,6 +19,11 @@ import {
   getIncomingInteractionResponseOptions,
   getIncomingInteractionTone,
 } from '../../social/incomingInteractionPresentation';
+import {
+  getSocialCommitmentDueCopy,
+  getSocialCommitmentLabel,
+  getSocialCredibility,
+} from '../../social/socialCommitments';
 import type {
   IncomingInteraction,
   IncomingInteractionPriority,
@@ -25,6 +31,7 @@ import type {
   IncomingInteractionType,
   RelationshipsMap,
   SocialMemoryMap,
+  SocialCommitment,
 } from '../../social/types';
 import type { Player } from '../../types';
 import PlayerAvatar from '../PlayerAvatar/PlayerAvatar';
@@ -94,6 +101,7 @@ function InteractionItem({
   relationships,
   socialMemory,
   humanId,
+  commitment,
 }: {
   interaction: IncomingInteraction;
   priority: IncomingInteractionPriority;
@@ -105,26 +113,23 @@ function InteractionItem({
   relationships: RelationshipsMap;
   socialMemory: SocialMemoryMap;
   humanId: string;
+  commitment?: SocialCommitment;
 }) {
   const fromPlayer = playerById.get(interaction.fromId);
   const fromName = fromPlayer?.name ?? interaction.fromId;
   const typeLabel = getIncomingInteractionTypeLabel(interaction.type);
   const typeIcon = TYPE_ICONS[interaction.type] ?? '💌';
   const isUnread = !interaction.read && !interaction.resolved;
-  const resolvedLabel = interaction.resolved
+  const resolvedLabel: string | null = interaction.resolved
     ? formatResponseLabel(interaction.type, interaction.resolvedWith)
     : isUnread
       ? 'New'
-      : 'Read';
+      : null;
   const priorityLabel = PRIORITY_LABELS[priority];
   const isUrgent = isExpiringThisWeek(interaction, currentWeek);
   const expiryLabel = showExpiry ? getExpiryLabel(interaction, currentWeek, priority) : null;
   const expiryClass = expiryLabel && priority === 'high' ? ' inbox-item__expiry--urgent' : '';
   const shouldShowActions = showActions && !interaction.resolved;
-  const responseOptions = useMemo(
-    () => (shouldShowActions ? getIncomingInteractionResponseOptions(interaction.type) : []),
-    [shouldShowActions, interaction.type],
-  );
   const tone = useMemo(
     () =>
       getIncomingInteractionTone({
@@ -135,6 +140,14 @@ function InteractionItem({
         isUrgent,
       }),
     [interaction, relationships, socialMemory, humanId, isUrgent],
+  );
+  const responseOptions = useMemo(
+    () => (
+      shouldShowActions
+        ? getIncomingInteractionResponseOptions(interaction.type, interaction, tone)
+        : []
+    ),
+    [shouldShowActions, interaction, tone],
   );
 
   return (
@@ -160,9 +173,11 @@ function InteractionItem({
         <div className="inbox-item__title">
           <div className="inbox-item__from-row">
             <span className="inbox-item__from">{fromName}</span>
-            <span className={`inbox-item__priority inbox-item__priority--${priority}`}>
-              {priorityLabel}
-            </span>
+            {priority === 'high' && (
+              <span className={`inbox-item__priority inbox-item__priority--${priority}`}>
+                {priorityLabel}
+              </span>
+            )}
           </div>
           <div className="inbox-item__type-row">
             <span className="inbox-item__type-icon" aria-hidden="true">
@@ -177,12 +192,24 @@ function InteractionItem({
             {expiryLabel && <span className={`inbox-item__expiry${expiryClass}`}>{expiryLabel}</span>}
           </div>
         </div>
-        <span className={`inbox-item__status${isUnread ? ' inbox-item__status--new' : ''}`}>
-          {resolvedLabel}
-        </span>
+        {resolvedLabel && (
+          <span className={`inbox-item__status${isUnread ? ' inbox-item__status--new' : ''}`}>
+            {resolvedLabel}
+          </span>
+        )}
       </div>
 
       <p className="inbox-item__text">{interaction.text}</p>
+
+      {commitment && (
+        <div className={`inbox-item__promise inbox-item__promise--${commitment.status}`}>
+          <strong>
+            {commitment.status === 'pending' ? 'Promise active' : `Promise ${commitment.status}`}
+          </strong>
+          <span>{getSocialCommitmentLabel(commitment.kind)}</span>
+          {commitment.status === 'pending' && <small>{getSocialCommitmentDueCopy(commitment.kind)}</small>}
+        </div>
+      )}
 
       {shouldShowActions && (
         <div className="inbox-item__actions">
@@ -190,10 +217,13 @@ function InteractionItem({
             <button
               key={`${interaction.id}-${option.responseType}`}
               type="button"
+              aria-label={option.label}
+              title={option.description}
+              data-response-type={option.responseType}
               className={`inbox-action inbox-action--${option.style}`}
               onClick={() => onRespond(interaction.id, option.responseType)}
             >
-              {option.label}
+              <span>{option.label}</span>
             </button>
           ))}
         </div>
@@ -212,6 +242,7 @@ export default function IncomingInteractionsInbox() {
   const currentWeek = game.week ?? 1;
   const relationships = useAppSelector((s) => s.social?.relationships ?? {});
   const socialMemory = useAppSelector((s) => s.social?.socialMemory ?? {});
+  const commitments = useAppSelector(selectSocialCommitments);
 
   const humanPlayer = players.find((player) => player.isUser);
   const socialModuleAvailability = useMemo(() => getSocialModuleAvailability(game), [game]);
@@ -269,6 +300,11 @@ export default function IncomingInteractionsInbox() {
       ).length,
     [pendingInteractions, currentWeek],
   );
+  const pendingCommitments = useMemo(
+    () => commitments.filter((commitment) => commitment.status === 'pending'),
+    [commitments],
+  );
+  const credibility = useMemo(() => getSocialCredibility(commitments), [commitments]);
 
   const headerSummary =
     pendingInteractions.length === 0
@@ -302,6 +338,9 @@ export default function IncomingInteractionsInbox() {
           <div className="inbox-header__title">📥 Incoming Interactions</div>
           <div className="inbox-header__meta">
             <span className="inbox-header__summary">{headerSummary}</span>
+            <span className="inbox-header__credibility">
+              Credibility {credibility.score}% · {credibility.label}
+            </span>
             <button
               className="inbox-header__close"
               type="button"
@@ -318,13 +357,25 @@ export default function IncomingInteractionsInbox() {
             <div className="inbox-empty">No incoming interactions yet.</div>
           ) : (
             <div className="inbox-sections">
-              <section className="inbox-section" aria-label="Needs Response">
-                <h3 className="inbox-section__title">Needs Response</h3>
-                {needsResponseInteractions.length === 0 ? (
-                  <div className="inbox-empty inbox-empty--compact">
-                    No interactions need a response.
+              {pendingCommitments.length > 0 && (
+                <section className="inbox-section inbox-section--promises" aria-label="Active Promises">
+                  <h3 className="inbox-section__title inbox-section__title--promises">Active Promises</h3>
+                  <div className="inbox-promises">
+                    {pendingCommitments.map((commitment) => (
+                      <div className="inbox-promise" key={commitment.id}>
+                        <strong>{getSocialCommitmentLabel(commitment.kind)}</strong>
+                        <span>
+                          {playerById.get(commitment.beneficiaryId)?.name ?? commitment.beneficiaryId}
+                          {' · '}{getSocialCommitmentDueCopy(commitment.kind)}
+                        </span>
+                      </div>
+                    ))}
                   </div>
-                ) : (
+                </section>
+              )}
+              {needsResponseInteractions.length > 0 && (
+                <section className="inbox-section" aria-label="Needs Response">
+                  <h3 className="inbox-section__title">Needs Response</h3>
                   <div className="inbox-section__list" role="list">
                     {needsResponseInteractions.map(({ interaction, priority }) => (
                       <InteractionItem
@@ -341,11 +392,12 @@ export default function IncomingInteractionsInbox() {
                         relationships={relationships}
                         socialMemory={socialMemory}
                         humanId={humanPlayer.id}
+                        commitment={commitments.find((entry) => entry.interactionId === interaction.id)}
                       />
                     ))}
                   </div>
-                )}
-              </section>
+                </section>
+              )}
               {updateInteractions.length > 0 && (
                 <section className="inbox-section" aria-label="Updates">
                   <h3 className="inbox-section__title inbox-section__title--updates">Updates</h3>
@@ -365,6 +417,7 @@ export default function IncomingInteractionsInbox() {
                         relationships={relationships}
                         socialMemory={socialMemory}
                         humanId={humanPlayer.id}
+                        commitment={commitments.find((entry) => entry.interactionId === interaction.id)}
                       />
                     ))}
                   </div>
@@ -391,6 +444,7 @@ export default function IncomingInteractionsInbox() {
                         relationships={relationships}
                         socialMemory={socialMemory}
                         humanId={humanPlayer.id}
+                        commitment={commitments.find((entry) => entry.interactionId === interaction.id)}
                       />
                     ))}
                   </div>

--- a/src/components/IncomingInteractionsInbox/__tests__/IncomingInteractionsInbox.test.tsx
+++ b/src/components/IncomingInteractionsInbox/__tests__/IncomingInteractionsInbox.test.tsx
@@ -178,7 +178,7 @@ describe('IncomingInteractionsInbox', () => {
 
     renderInbox(store);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Thank' }));
+    fireEvent.click(document.querySelector('[data-response-type="positive"]')!);
 
     const entry = store.getState().social.incomingInteractions.find((i) => i.id === 'interaction-3');
     expect(entry?.resolved).toBe(true);
@@ -208,7 +208,7 @@ describe('IncomingInteractionsInbox', () => {
 
     renderInbox(store);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Join' }));
+    fireEvent.click(document.querySelector('[data-response-type="accept"]')!);
 
     const socialState = store.getState().social;
     expect(socialState.relationships[otherPlayer.id]?.[humanId]?.tags).toContain('alliance');
@@ -254,8 +254,11 @@ describe('IncomingInteractionsInbox', () => {
 
     renderInbox(store);
 
-    expect(screen.getByRole('button', { name: 'Fire back' })).toBeInTheDocument();
+    expect(document.querySelector('[data-response-type="negative"]')).toBeInTheDocument();
     expect(screen.getByText(/Bitter/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Context' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Why now')).not.toBeInTheDocument();
+    expect(screen.queryByText('What it means')).not.toBeInTheDocument();
   });
 
   it('closes and logs the reason when the phase changes to eviction results', () => {

--- a/src/social/__tests__/incomingInteractionPresentation.test.ts
+++ b/src/social/__tests__/incomingInteractionPresentation.test.ts
@@ -35,6 +35,25 @@ describe('incomingInteractionPresentation', () => {
     expect(getIncomingInteractionResponseLabel('warning', 'positive')).toBe('Thank');
   });
 
+  it('varies player-facing choices while preserving the same response intents', () => {
+    const labelSets = Array.from({ length: 8 }, (_, index) =>
+      getIncomingInteractionResponseOptions(
+        'check_in',
+        makeInteraction({ id: `check-in-${index}`, fromId: `p${index}`, type: 'check_in' }),
+        'Curious',
+      ).map((option) => option.label).join('|'),
+    );
+
+    expect(new Set(labelSets).size).toBeGreaterThan(1);
+    expect(
+      getIncomingInteractionResponseOptions(
+        'check_in',
+        makeInteraction({ type: 'check_in' }),
+        'Guarded',
+      ).map((option) => option.responseType),
+    ).toEqual(['positive', 'neutral', 'negative', 'dismiss']);
+  });
+
   it('derives a warm tone from strong gratitude and trust', () => {
     const interaction = makeInteraction({ type: 'compliment' });
     const relationships: RelationshipsMap = {

--- a/src/social/constants.ts
+++ b/src/social/constants.ts
@@ -22,6 +22,7 @@ export const SOCIAL_INITIAL_STATE: SocialState = {
     deliveredThisPhase: 0,
   },
   socialMemory: {},
+  commitments: [],
   influenceWeights: {},
   panelOpen: false,
   weekStartRelSnapshot: {},

--- a/src/social/incomingInteractionAutonomy.ts
+++ b/src/social/incomingInteractionAutonomy.ts
@@ -720,6 +720,28 @@ function buildInteractionTextContext(
   };
 }
 
+/** Pick a concrete third party for gossip/warnings instead of vague “people” talk. */
+function selectInteractionSubject(
+  actorId: string,
+  playerId: string,
+  type: IncomingInteractionType,
+  context: AutonomyContext,
+): AutonomyPlayer | undefined {
+  if (type !== 'gossip' && type !== 'warning') return undefined;
+  const candidates = context.players.filter(
+    (candidate) =>
+      candidate.id !== actorId &&
+      candidate.id !== playerId &&
+      candidate.status !== 'evicted' &&
+      candidate.status !== 'jury',
+  );
+  return candidates.sort((left, right) => {
+    const leftAffinity = normalizeAffinity(context.relationships[actorId]?.[left.id]?.affinity ?? 0);
+    const rightAffinity = normalizeAffinity(context.relationships[actorId]?.[right.id]?.affinity ?? 0);
+    return leftAffinity - rightAffinity || left.id.localeCompare(right.id);
+  })[0];
+}
+
 function renderInteractionTemplate(template: string, textContext: InteractionTextContext): string {
   return template
     .replace(/\{actor\}/g, textContext.actorName)
@@ -937,16 +959,22 @@ export function scheduleIncomingInteractionsForPhase(
       pendingInteractions,
       context.random,
     );
+    const subject = selectInteractionSubject(actor.id, playerId, plan.type, context);
+    const subjectName = subject?.name ?? subject?.id;
+    const interactionText = subjectName
+      ? `${textResult.text} ${plan.type === 'gossip' ? 'The name at the center of it is' : 'Keep an eye on'} ${subjectName}.`
+      : textResult.text;
     const interaction: IncomingInteraction = {
       id: generateInteractionId(),
       fromId: actor.id,
       type: plan.type,
-      text: textResult.text,
+      text: interactionText,
       payload: {
         scenarioKey: plan.scenarioKey,
         variantFamilyId: textResult.variantFamilyId,
         phase,
         actorStatus: actor.status,
+        subjectId: subject?.id,
       },
       createdAt: Date.now(),
       createdWeek: week,

--- a/src/social/incomingInteractionPresentation.ts
+++ b/src/social/incomingInteractionPresentation.ts
@@ -1,5 +1,10 @@
 import { normalizeAffinity } from './affinityUtils';
 import { socialConfig } from './socialConfig';
+import {
+  getCommitmentKindForInteraction,
+  getSocialCommitmentDueCopy,
+  getSocialCommitmentLabel,
+} from './socialCommitments';
 import type {
   IncomingInteraction,
   IncomingInteractionResponseType,
@@ -24,6 +29,8 @@ export interface IncomingInteractionResponseOption {
   label: string;
   responseType: IncomingInteractionResponseType;
   style: IncomingInteractionResponseStyle;
+  description: string;
+  createsCommitment?: boolean;
 }
 
 const RESPONSE_STYLE_BY_TYPE: Record<IncomingInteractionResponseType, IncomingInteractionResponseStyle> = {
@@ -95,6 +102,191 @@ const RESPONSE_OPTIONS_BY_TYPE: Record<
     { label: 'Dismiss', responseType: 'dismiss' },
   ],
 };
+
+type ResponseBlueprint = Array<{
+  label: string;
+  responseType: IncomingInteractionResponseType;
+}>;
+
+// The social engine still receives stable response intents, but the words the
+// player sees vary so different people do not feel like copies of one form.
+const RESPONSE_OPTION_VARIANTS_BY_TYPE: Partial<
+  Record<IncomingInteractionType, ResponseBlueprint[]>
+> = {
+  warning: [
+    [
+      { label: 'Take seriously', responseType: 'positive' },
+      { label: 'Ask more', responseType: 'neutral' },
+      { label: 'Doubt it', responseType: 'negative' },
+      { label: 'Ignore it', responseType: 'dismiss' },
+    ],
+  ],
+  snide_remark: [
+    [
+      { label: 'Defuse', responseType: 'positive' },
+      { label: 'Stay cool', responseType: 'neutral' },
+      { label: 'Call it out', responseType: 'negative' },
+      { label: 'Walk away', responseType: 'dismiss' },
+    ],
+  ],
+  deal_offer: [
+    [
+      { label: 'Shake on it', responseType: 'accept' },
+      { label: 'Ask time', responseType: 'neutral' },
+      { label: 'Counter', responseType: 'decline' },
+      { label: 'End pitch', responseType: 'dismiss' },
+    ],
+  ],
+  alliance_proposal: [
+    [
+      { label: 'Lock it in', responseType: 'accept' },
+      { label: 'Test waters', responseType: 'neutral' },
+      { label: 'Keep distance', responseType: 'decline' },
+      { label: 'Change subject', responseType: 'dismiss' },
+    ],
+  ],
+  nomination_plea: [
+    [
+      { label: 'Comfort', responseType: 'positive' },
+      { label: 'Hear out', responseType: 'neutral' },
+      { label: 'Hold ground', responseType: 'negative' },
+      { label: 'End talk', responseType: 'dismiss' },
+    ],
+  ],
+  compliment: [
+    [
+      { label: 'Return it', responseType: 'positive' },
+      { label: 'Play it cool', responseType: 'neutral' },
+      { label: 'Deflect it', responseType: 'negative' },
+      { label: 'Move on', responseType: 'dismiss' },
+    ],
+  ],
+  gossip: [
+    [
+      { label: 'Ask details', responseType: 'positive' },
+      { label: 'Listen', responseType: 'neutral' },
+      { label: 'Challenge', responseType: 'negative' },
+      { label: 'Stop rumor', responseType: 'dismiss' },
+    ],
+  ],
+  check_in: [
+    [
+      { label: 'Be honest', responseType: 'positive' },
+      { label: 'Ask them back', responseType: 'neutral' },
+      { label: 'Keep distance', responseType: 'negative' },
+      { label: 'Leave it', responseType: 'dismiss' },
+    ],
+    [
+      { label: 'Let them in', responseType: 'positive' },
+      { label: 'Joke it off', responseType: 'neutral' },
+      { label: 'Set boundary', responseType: 'negative' },
+      { label: 'End the chat', responseType: 'dismiss' },
+    ],
+  ],
+  other: [
+    [
+      { label: 'Engage', responseType: 'positive' },
+      { label: 'Stay neutral', responseType: 'neutral' },
+      { label: 'Push back', responseType: 'negative' },
+      { label: 'Move along', responseType: 'dismiss' },
+    ],
+  ],
+};
+
+const SCENARIO_RESPONSE_OPTIONS: Record<string, ResponseBlueprint> = {
+  generic_gossip: [
+    { label: 'Ask source', responseType: 'positive' },
+    { label: 'Listen', responseType: 'neutral' },
+    { label: 'Defend them', responseType: 'negative' },
+    { label: 'Kill rumor', responseType: 'dismiss' },
+  ],
+  betrayal_warning: [
+    { label: 'Trust warning', responseType: 'positive' },
+    { label: 'Ask for proof', responseType: 'neutral' },
+    { label: 'Question motive', responseType: 'negative' },
+    { label: 'Drop it', responseType: 'dismiss' },
+  ],
+  survivor_gratitude: [
+    { label: 'Share moment', responseType: 'positive' },
+    { label: 'Accept thanks', responseType: 'neutral' },
+    { label: 'Downplay it', responseType: 'negative' },
+    { label: 'Move on', responseType: 'dismiss' },
+  ],
+  post_veto_gratitude: [
+    { label: 'Celebrate', responseType: 'positive' },
+    { label: 'Stay modest', responseType: 'neutral' },
+    { label: 'Call in favor', responseType: 'negative' },
+    { label: 'Change subject', responseType: 'dismiss' },
+  ],
+  nomination_aftershock: [
+    { label: 'Reassure them', responseType: 'positive' },
+    { label: 'Stay vague', responseType: 'neutral' },
+    { label: 'Stand firm', responseType: 'negative' },
+    { label: 'End talk', responseType: 'dismiss' },
+  ],
+};
+
+const CHECK_IN_OPTIONS_BY_TONE: Partial<Record<IncomingInteractionTone, ResponseBlueprint>> = {
+  Warm: [
+    { label: 'Open up', responseType: 'positive' },
+    { label: 'Keep it easy', responseType: 'neutral' },
+    { label: 'Hold back', responseType: 'negative' },
+    { label: 'Wrap it up', responseType: 'dismiss' },
+  ],
+  Trusting: [
+    { label: 'Confide in them', responseType: 'positive' },
+    { label: 'Stay casual', responseType: 'neutral' },
+    { label: 'Keep your guard', responseType: 'negative' },
+    { label: 'Move on', responseType: 'dismiss' },
+  ],
+  Guarded: [
+    { label: 'Meet halfway', responseType: 'positive' },
+    { label: 'Stay measured', responseType: 'neutral' },
+    { label: 'Set boundary', responseType: 'negative' },
+    { label: 'End the chat', responseType: 'dismiss' },
+  ],
+  Bitter: [
+    { label: 'Acknowledge hurt', responseType: 'positive' },
+    { label: 'Keep your cool', responseType: 'neutral' },
+    { label: 'Push back', responseType: 'negative' },
+    { label: 'Walk away', responseType: 'dismiss' },
+  ],
+  'Feels ignored': [
+    { label: 'Give time', responseType: 'positive' },
+    { label: 'Check briefly', responseType: 'neutral' },
+    { label: 'Stay distant', responseType: 'negative' },
+    { label: 'Put it off', responseType: 'dismiss' },
+  ],
+};
+
+function getStableVariantIndex(interaction: IncomingInteraction, tone: IncomingInteractionTone | undefined, count: number): number {
+  const source = `${interaction.fromId}|${interaction.id}|${interaction.payload?.scenarioKey ?? ''}|${tone ?? ''}`;
+  let hash = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    hash = Math.imul(31, hash) + source.charCodeAt(index) | 0;
+  }
+  return Math.abs(hash) % count;
+}
+
+function getResponseBlueprints(
+  type: IncomingInteractionType,
+  interaction?: IncomingInteraction,
+  tone?: IncomingInteractionTone,
+): ResponseBlueprint {
+  if (!interaction) return RESPONSE_OPTIONS_BY_TYPE[type];
+
+  const scenarioKey = interaction.payload?.scenarioKey;
+  if (typeof scenarioKey === 'string' && SCENARIO_RESPONSE_OPTIONS[scenarioKey]) {
+    return SCENARIO_RESPONSE_OPTIONS[scenarioKey];
+  }
+
+  if (type === 'check_in' && tone && CHECK_IN_OPTIONS_BY_TONE[tone]) {
+    return CHECK_IN_OPTIONS_BY_TONE[tone];
+  }
+
+  const variants = [RESPONSE_OPTIONS_BY_TYPE[type], ...(RESPONSE_OPTION_VARIANTS_BY_TYPE[type] ?? [])];
+  return variants[getStableVariantIndex(interaction, tone, variants.length)];
+}
 
 const DEFAULT_TONES_BY_TYPE: Partial<Record<IncomingInteractionType, IncomingInteractionTone>> = {
   compliment: 'Warm',
@@ -173,12 +365,51 @@ function detectTrustingTone(trustHigh: boolean, affinity: number): boolean {
 
 export function getIncomingInteractionResponseOptions(
   type: IncomingInteractionType,
+  interaction?: IncomingInteraction,
+  tone?: IncomingInteractionTone,
 ): IncomingInteractionResponseOption[] {
-  const options = RESPONSE_OPTIONS_BY_TYPE[type];
+  const options = getResponseBlueprints(type, interaction, tone);
+  const commitmentKind = interaction ? getCommitmentKindForInteraction(interaction) : null;
   return options.map((option) => ({
     ...option,
     style: RESPONSE_STYLE_BY_TYPE[option.responseType] ?? 'neutral',
+    ...(commitmentKind ? getCommitmentResponsePresentation(commitmentKind, option.responseType) : {
+      description: getDefaultResponseDescription(option.responseType),
+    }),
   }));
+}
+
+function getDefaultResponseDescription(responseType: IncomingInteractionResponseType): string {
+  if (responseType === 'positive' || responseType === 'accept') return 'Builds trust and goodwill.';
+  if (responseType === 'neutral') return 'Avoids a commitment, with a smaller relationship gain.';
+  if (responseType === 'negative' || responseType === 'decline') return 'Sets a clear boundary and damages trust.';
+  return 'Ends the conversation without engaging.';
+}
+
+function getCommitmentResponsePresentation(
+  kind: NonNullable<ReturnType<typeof getCommitmentKindForInteraction>>,
+  responseType: IncomingInteractionResponseType,
+): { label?: string; description: string; createsCommitment?: boolean } {
+  const makesPromise = responseType === 'positive' || responseType === 'accept';
+  if (makesPromise) {
+    const label = kind === 'protect_from_nomination'
+      ? 'Promise safety'
+      : kind === 'use_safety_on_player'
+        ? 'Promise the power'
+        : 'Promise your vote';
+    return {
+      label,
+      description: `Creates a promise: ${getSocialCommitmentLabel(kind)}. ${getSocialCommitmentDueCopy(kind)}.`,
+      createsCommitment: true,
+    };
+  }
+  if (responseType === 'neutral') {
+    return { label: 'Give no guarantees', description: 'Keeps your options open without making a promise.' };
+  }
+  if (responseType === 'negative' || responseType === 'decline') {
+    return { label: 'Refuse clearly', description: 'No promise is made, but they will remember the rejection.' };
+  }
+  return { label: 'End the talk', description: 'Dismisses them and closes the conversation.' };
 }
 
 export function getIncomingInteractionResponseLabel(

--- a/src/social/incomingInteractions.ts
+++ b/src/social/incomingInteractions.ts
@@ -3,12 +3,15 @@ import type { AppDispatch, RootState } from '../store/store';
 import { socialConfig } from './socialConfig';
 import { logIncomingInteractionDecision } from './incomingInteractionLogging';
 import {
+  addSocialCommitment,
+  applyInfoDelta,
   dismissIncomingInteraction,
   resolveExpiredIncomingInteractionsForWeek,
   resolveIncomingInteraction,
   updateRelationship,
   updateSocialMemory,
 } from './socialSlice';
+import { createCommitmentFromInteraction } from './socialCommitments';
 import { isIncomingInteractionInvalidated } from './incomingInteractionValidity';
 import {
   buildSocialMemoryDeltaForResponse,
@@ -159,6 +162,14 @@ export function respondToIncomingInteraction({
       }),
     );
 
+    const commitment = createCommitmentFromInteraction({
+      interaction,
+      responseType,
+      promisorId: humanPlayer.id,
+      week: currentWeek,
+    });
+    if (commitment) dispatch(addSocialCommitment(commitment));
+
     const delta = getResponseDelta(responseType);
     const acceptedAlliance =
       interaction.type === 'alliance_proposal' && responseType === 'accept';
@@ -203,6 +214,14 @@ export function respondToIncomingInteraction({
           event: memoryEvent,
         }),
       );
+    }
+
+    // Actionable intel now pays out information, so gossip and warnings matter strategically.
+    if (
+      (interaction.type === 'gossip' || interaction.type === 'warning') &&
+      (responseType === 'positive' || responseType === 'neutral')
+    ) {
+      dispatch(applyInfoDelta({ playerId: humanPlayer.id, delta: 1 }));
     }
 
     const text = buildResponseLogText(interaction, responseType, fromName);

--- a/src/social/socialCommitments.ts
+++ b/src/social/socialCommitments.ts
@@ -1,0 +1,270 @@
+import { addTvEvent } from '../store/gameSlice';
+import { socialConfig } from './socialConfig';
+import {
+  applyInfluenceDelta,
+  resolveSocialCommitment,
+  updateRelationship,
+  updateSocialMemory,
+} from './socialSlice';
+import type {
+  IncomingInteraction,
+  IncomingInteractionResponseType,
+  RelationshipsMap,
+  SocialCommitment,
+  SocialCommitmentKind,
+} from './types';
+
+interface CommitmentPlayer {
+  id: string;
+  name?: string;
+  isUser?: boolean;
+}
+
+interface CommitmentState {
+  game: {
+    week?: number;
+    nomineeIds?: string[];
+    povSavedId?: string | null;
+    votes?: Record<string, string>;
+    players?: CommitmentPlayer[];
+  };
+  social: {
+    commitments?: SocialCommitment[];
+    relationships?: RelationshipsMap;
+    influenceBank?: Record<string, number>;
+  };
+}
+
+export interface CommitmentStore {
+  dispatch: (action: unknown) => unknown;
+  getState: () => CommitmentState;
+}
+
+const KIND_LABELS: Record<SocialCommitmentKind, string> = {
+  protect_from_nomination: 'Keep them off the block',
+  use_safety_on_player: 'Use safety on them',
+  vote_to_keep: 'Vote to keep them',
+};
+
+const KIND_DUE_COPY: Record<SocialCommitmentKind, string> = {
+  protect_from_nomination: 'Checked when nominations lock',
+  use_safety_on_player: 'Checked when the safety decision locks',
+  vote_to_keep: 'Checked when your eviction vote locks',
+};
+
+function scenarioKey(interaction: IncomingInteraction): string {
+  const value = interaction.payload?.scenarioKey;
+  return typeof value === 'string' ? value : '';
+}
+
+/** Determine whether an interaction can create an objectively testable promise. */
+export function getCommitmentKindForInteraction(
+  interaction: IncomingInteraction,
+): SocialCommitmentKind | null {
+  const scenario = scenarioKey(interaction);
+  if (interaction.type === 'nomination_plea' || scenario === 'hoh_safety_request') {
+    return 'protect_from_nomination';
+  }
+  if (interaction.type === 'deal_offer' && scenario === 'nominee_veto_pitch') {
+    return 'use_safety_on_player';
+  }
+  if (interaction.type === 'deal_offer' && scenario === 'live_vote_pitch') {
+    return 'vote_to_keep';
+  }
+  return null;
+}
+
+export function getSocialCommitmentLabel(kind: SocialCommitmentKind): string {
+  return KIND_LABELS[kind];
+}
+
+export function getSocialCommitmentDueCopy(kind: SocialCommitmentKind): string {
+  return KIND_DUE_COPY[kind];
+}
+
+export function createCommitmentFromInteraction({
+  interaction,
+  responseType,
+  promisorId,
+  week,
+}: {
+  interaction: IncomingInteraction;
+  responseType: IncomingInteractionResponseType;
+  promisorId: string;
+  week: number;
+}): SocialCommitment | null {
+  if (responseType !== 'accept' && responseType !== 'positive') return null;
+  const kind = getCommitmentKindForInteraction(interaction);
+  if (!kind) return null;
+  return {
+    id: `commitment-${interaction.id}`,
+    interactionId: interaction.id,
+    kind,
+    promisorId,
+    beneficiaryId: interaction.fromId,
+    createdWeek: week,
+    dueWeek: week,
+    status: 'pending',
+  };
+}
+
+export function getSocialCredibility(commitments: SocialCommitment[]): {
+  score: number;
+  label: 'Unproven' | 'Shaky' | 'Credible' | 'Trusted';
+  kept: number;
+  broken: number;
+} {
+  const kept = commitments.filter((entry) => entry.status === 'kept').length;
+  const broken = commitments.filter((entry) => entry.status === 'broken').length;
+  const resolved = kept + broken;
+  const score = resolved === 0 ? 50 : Math.max(0, Math.min(100, Math.round((kept / resolved) * 100)));
+  const label = resolved === 0 ? 'Unproven' : score >= 80 ? 'Trusted' : score >= 55 ? 'Credible' : 'Shaky';
+  return { score, label, kept, broken };
+}
+
+function playerName(state: CommitmentState, playerId: string): string {
+  return state.game.players?.find((player) => player.id === playerId)?.name ?? playerId;
+}
+
+function resolvePromise(
+  store: CommitmentStore,
+  commitment: SocialCommitment,
+  kept: boolean,
+  reason: string,
+): void {
+  const state = store.getState();
+  const week = state.game.week ?? commitment.dueWeek;
+  const now = Date.now();
+  const outcome = kept ? 'kept' : 'broken';
+  const tuning = socialConfig.socialCommitmentConfig;
+
+  store.dispatch(
+    resolveSocialCommitment({
+      commitmentId: commitment.id,
+      status: outcome,
+      resolvedAt: now,
+      resolvedWeek: week,
+      resolutionReason: reason,
+    }),
+  );
+  store.dispatch(
+    updateRelationship({
+      source: commitment.beneficiaryId,
+      target: commitment.promisorId,
+      delta: tuning.affinityDelta[outcome],
+      tags: kept ? undefined : ['broken_promise'],
+      actionSource: 'system',
+    }),
+  );
+  store.dispatch(
+    updateSocialMemory({
+      actorId: commitment.beneficiaryId,
+      targetId: commitment.promisorId,
+      deltas: tuning.memoryDelta[outcome],
+      event: {
+        type: `${outcome}_promise_${commitment.kind}`,
+        actorId: commitment.beneficiaryId,
+        targetId: commitment.promisorId,
+        week,
+        timestamp: now,
+      },
+    }),
+  );
+
+  const currentInfluence = state.social.influenceBank?.[commitment.promisorId] ?? 0;
+  const desiredInfluenceDelta = tuning.influenceDelta[outcome];
+  const influenceDelta = desiredInfluenceDelta < 0
+    ? Math.max(desiredInfluenceDelta, -currentInfluence)
+    : desiredInfluenceDelta;
+  if (influenceDelta !== 0) {
+    store.dispatch(applyInfluenceDelta({ playerId: commitment.promisorId, delta: influenceDelta }));
+  }
+
+  const beneficiary = playerName(state, commitment.beneficiaryId);
+  store.dispatch(
+    addTvEvent({
+      text: kept
+        ? `You kept your word to ${beneficiary}. Your credibility in the house grew.`
+        : `You broke your promise to ${beneficiary}. They will remember it.`,
+      type: 'social',
+      source: 'system',
+      channels: ['tv', 'mainLog', 'dr'],
+    }),
+  );
+}
+
+function pendingForAction(state: CommitmentState, kind: SocialCommitmentKind): SocialCommitment[] {
+  const week = state.game.week ?? 1;
+  return (state.social.commitments ?? []).filter(
+    (entry) => entry.status === 'pending' && entry.kind === kind && entry.dueWeek <= week,
+  );
+}
+
+/** Verify promises immediately after the corresponding player decision succeeds. */
+export function evaluateSocialCommitmentsForAction(
+  store: CommitmentStore,
+  actionType: string,
+  payload?: unknown,
+): void {
+  const state = store.getState();
+  if (actionType === 'game/finalizeNominations' || actionType === 'game/commitNominees') {
+    const nominees = state.game.nomineeIds ?? [];
+    for (const commitment of pendingForAction(state, 'protect_from_nomination')) {
+      const kept = !nominees.includes(commitment.beneficiaryId);
+      resolvePromise(store, commitment, kept, kept ? 'protected_at_nominations' : 'nominated_after_promise');
+    }
+    return;
+  }
+
+  if (actionType === 'game/submitPovDecision') {
+    for (const commitment of pendingForAction(state, 'use_safety_on_player')) {
+      if (payload === false) {
+        resolvePromise(store, commitment, false, 'declined_to_use_safety');
+      } else if (!(state.game.nomineeIds ?? []).includes(commitment.beneficiaryId)) {
+        resolvePromise(store, commitment, true, 'protected_by_multi_save');
+      }
+    }
+    return;
+  }
+
+  if (actionType === 'game/submitPovSaveTarget' && typeof payload === 'string') {
+    if (state.game.povSavedId !== payload) return;
+    for (const commitment of pendingForAction(state, 'use_safety_on_player')) {
+      const kept = payload === commitment.beneficiaryId;
+      resolvePromise(store, commitment, kept, kept ? 'saved_with_safety' : 'saved_someone_else');
+    }
+    return;
+  }
+
+  if (actionType === 'game/submitHumanVote' && typeof payload === 'string') {
+    for (const commitment of pendingForAction(state, 'vote_to_keep')) {
+      const kept = payload !== commitment.beneficiaryId;
+      resolvePromise(store, commitment, kept, kept ? 'voted_to_keep' : 'voted_against_promise');
+    }
+    return;
+  }
+
+  if (actionType === 'game/submitHumanDoubleVote' && Array.isArray(payload)) {
+    for (const commitment of pendingForAction(state, 'vote_to_keep')) {
+      const kept = !payload.includes(commitment.beneficiaryId);
+      resolvePromise(store, commitment, kept, kept ? 'double_vote_kept_them_safe' : 'double_vote_targeted_them');
+    }
+  }
+}
+
+/** Void promises whose decision window disappeared because of a twist or skipped phase. */
+export function voidOverdueSocialCommitments(store: CommitmentStore): void {
+  const state = store.getState();
+  const week = state.game.week ?? 1;
+  for (const commitment of state.social.commitments ?? []) {
+    if (commitment.status !== 'pending' || commitment.dueWeek >= week) continue;
+    store.dispatch(
+      resolveSocialCommitment({
+        commitmentId: commitment.id,
+        status: 'void',
+        resolvedWeek: week,
+        resolutionReason: 'decision_window_passed',
+      }),
+    );
+  }
+}

--- a/src/social/socialConfig.ts
+++ b/src/social/socialConfig.ts
@@ -292,4 +292,14 @@ export const socialConfig = {
       ignore: { neglect: 3, trustMomentum: -2 },
     },
   },
+
+  // ── Social commitments ───────────────────────────────────────────────────
+  socialCommitmentConfig: {
+    affinityDelta: { kept: 9, broken: -16 },
+    influenceDelta: { kept: 100, broken: -150 },
+    memoryDelta: {
+      kept: { gratitude: 4, trustMomentum: 3 },
+      broken: { resentment: 5, trustMomentum: -4 },
+    },
+  },
 };

--- a/src/social/socialMiddleware.ts
+++ b/src/social/socialMiddleware.ts
@@ -43,6 +43,11 @@ import { collectInvalidIncomingInteractionIds } from './incomingInteractionValid
 import type { IncomingInteraction, ScheduledIncomingInteraction } from './types';
 import { seedWeekRelationships } from './weekSocialSeed';
 import { DEFAULT_ENERGY } from './constants';
+import {
+  evaluateSocialCommitmentsForAction,
+  voidOverdueSocialCommitments,
+  type CommitmentStore,
+} from './socialCommitments';
 
 const SOCIAL_PHASES = new Set<string>(['social_1', 'social_2']);
 
@@ -83,6 +88,7 @@ function handleWeekStart(api: MiddlewareAPI): void {
   const week = state.game?.week ?? 1;
   api.dispatch(decaySocialMemory());
   api.dispatch(autoResolveExpiredIncomingInteractionsForWeek(week));
+  voidOverdueSocialCommitments(api as unknown as CommitmentStore);
   seedWeekRelationships(api);
   api.dispatch(snapshotWeekRelationships());
   scheduleIncomingInteractionsForPhase('week_start', api as unknown as AutonomyStore, {
@@ -313,6 +319,12 @@ export const socialMiddleware: Middleware = (api) => (next) => (action) => {
       grantEnergy(api as unknown as MiddlewareAPI, saveId, 2);
     }
 
+    evaluateSocialCommitmentsForAction(
+      api as unknown as CommitmentStore,
+      type,
+      saveId,
+    );
+
     syncInvalidIncomingInteractions(api as unknown as MiddlewareAPI);
 
     return result;
@@ -320,7 +332,22 @@ export const socialMiddleware: Middleware = (api) => (next) => (action) => {
 
   if (type === 'game/submitPovDecision') {
     const result = next(action);
+    evaluateSocialCommitmentsForAction(
+      api as unknown as CommitmentStore,
+      type,
+      (action as unknown as { payload: boolean }).payload,
+    );
     syncInvalidIncomingInteractions(api as unknown as MiddlewareAPI);
+    return result;
+  }
+
+  if (type === 'game/submitHumanVote' || type === 'game/submitHumanDoubleVote') {
+    const result = next(action);
+    evaluateSocialCommitmentsForAction(
+      api as unknown as CommitmentStore,
+      type,
+      (action as unknown as { payload: unknown }).payload,
+    );
     return result;
   }
 
@@ -438,6 +465,9 @@ export const socialMiddleware: Middleware = (api) => (next) => (action) => {
     type === 'social/hydrateSocial'
   ) {
     const result = next(action);
+    if (type === 'game/finalizeNominations' || type === 'game/commitNominees') {
+      evaluateSocialCommitmentsForAction(api as unknown as CommitmentStore, type);
+    }
     syncInvalidIncomingInteractions(api as unknown as MiddlewareAPI);
     return result;
   }

--- a/src/social/socialSlice.ts
+++ b/src/social/socialSlice.ts
@@ -6,6 +6,7 @@ import type {
   IncomingInteractionResponseType,
   ScheduledIncomingInteraction,
   SocialActionLogEntry,
+  SocialCommitment,
   SocialMemoryEvent,
   SocialPhaseReport,
   SocialState,
@@ -337,6 +338,32 @@ const socialSlice = createSlice({
         });
       });
     },
+    /** Record a promise created by a high-stakes incoming response. */
+    addSocialCommitment(state, action: PayloadAction<SocialCommitment>) {
+      if (!state.commitments) state.commitments = [];
+      if (state.commitments.some((entry) => entry.interactionId === action.payload.interactionId)) return;
+      state.commitments.unshift(action.payload);
+    },
+    /** Mark a pending promise as kept, broken, or void. */
+    resolveSocialCommitment(
+      state,
+      action: PayloadAction<{
+        commitmentId: string;
+        status: Exclude<SocialCommitment['status'], 'pending'>;
+        resolvedAt?: number;
+        resolvedWeek?: number;
+        resolutionReason?: string;
+      }>,
+    ) {
+      const entry = (state.commitments ?? []).find(
+        (commitment) => commitment.id === action.payload.commitmentId,
+      );
+      if (!entry || entry.status !== 'pending') return;
+      entry.status = action.payload.status;
+      entry.resolvedAt = action.payload.resolvedAt ?? Date.now();
+      entry.resolvedWeek = action.payload.resolvedWeek;
+      entry.resolutionReason = action.payload.resolutionReason;
+    },
     /** Manually open the social panel (e.g. via the FAB 💬 button). */
     openSocialPanel(state) {
       state.panelOpen = true;
@@ -378,7 +405,7 @@ const socialSlice = createSlice({
      * Replaces the entire social slice with the snapshot.
      */
     hydrateSocial(_state, action: PayloadAction<SocialState>) {
-      return action.payload;
+      return { ...action.payload, commitments: action.payload.commitments ?? [] };
     },
   },
 });
@@ -410,6 +437,8 @@ export const {
   updateRelationship,
   updateSocialMemory,
   decaySocialMemory,
+  addSocialCommitment,
+  resolveSocialCommitment,
   openSocialPanel,
   closeSocialPanel,
   openIncomingInbox,
@@ -436,6 +465,10 @@ export const selectSocialPanelOpen = (state: { social: SocialState }) =>
   state.social?.panelOpen ?? false;
 export const selectSocialMemory = (state: { social: SocialState }) =>
   state.social?.socialMemory ?? {};
+export const selectSocialCommitments = (state: { social: SocialState }) =>
+  state.social?.commitments ?? [];
+export const selectPendingSocialCommitments = (state: { social: SocialState }) =>
+  selectSocialCommitments(state).filter((commitment) => commitment.status === 'pending');
 export const selectWeekStartRelSnapshot = (state: { social: SocialState }) =>
   state.social?.weekStartRelSnapshot ?? {};
 export const selectIncomingInboxOpen = (state: { social: SocialState }) =>

--- a/src/social/types.ts
+++ b/src/social/types.ts
@@ -103,6 +103,29 @@ export type IncomingInteractionResponseType =
 
 export type IncomingInteractionPriority = 'high' | 'medium' | 'low';
 
+/** A concrete future action the player promised during an incoming interaction. */
+export type SocialCommitmentKind =
+  | 'protect_from_nomination'
+  | 'use_safety_on_player'
+  | 'vote_to_keep';
+
+export type SocialCommitmentStatus = 'pending' | 'kept' | 'broken' | 'void';
+
+/** A dialogue promise that later game actions can objectively verify. */
+export interface SocialCommitment {
+  id: string;
+  interactionId: string;
+  kind: SocialCommitmentKind;
+  promisorId: string;
+  beneficiaryId: string;
+  createdWeek: number;
+  dueWeek: number;
+  status: SocialCommitmentStatus;
+  resolvedAt?: number;
+  resolvedWeek?: number;
+  resolutionReason?: string;
+}
+
 export type IncomingInteractionDecisionStage =
   | 'generation'
   | 'scheduling'
@@ -182,6 +205,8 @@ export interface SocialState {
   incomingInteractionDelivery: IncomingInteractionDeliveryState;
   /** Directed social memory entries keyed by actor → target. */
   socialMemory: SocialMemoryMap;
+  /** Promises made through incoming interactions and their eventual outcomes. */
+  commitments: SocialCommitment[];
   /**
    * Influence weights per actor and decision type: actorId → decisionType → (targetId → weight).
    * Populated by SocialInfluence.update dispatching social/influenceUpdated.

--- a/tests/social/socialCommitments.unit.test.ts
+++ b/tests/social/socialCommitments.unit.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import socialReducer, {
+  addSocialCommitment,
+  setInfluenceBankEntry,
+} from '../../src/social/socialSlice';
+import {
+  createCommitmentFromInteraction,
+  evaluateSocialCommitmentsForAction,
+  getSocialCredibility,
+  type CommitmentStore,
+} from '../../src/social/socialCommitments';
+import type { IncomingInteraction, SocialState } from '../../src/social/types';
+
+function interaction(overrides: Partial<IncomingInteraction> = {}): IncomingInteraction {
+  return {
+    id: 'promise-talk',
+    fromId: 'lia',
+    type: 'nomination_plea',
+    text: 'Please keep me safe.',
+    payload: { scenarioKey: 'nominee_hoh_plea' },
+    createdAt: 10,
+    createdWeek: 2,
+    expiresAtWeek: 3,
+    read: false,
+    requiresResponse: true,
+    resolved: false,
+    ...overrides,
+  };
+}
+
+function makeStore(nomineeIds: string[] = []): {
+  store: CommitmentStore;
+  social: () => SocialState;
+} {
+  let social = socialReducer(undefined, { type: 'init' }) as SocialState;
+  social = socialReducer(social, setInfluenceBankEntry({ playerId: 'user', value: 200 })) as SocialState;
+  const game = {
+    week: 2,
+    nomineeIds,
+    povSavedId: null,
+    votes: {},
+    players: [
+      { id: 'user', name: 'You', isUser: true },
+      { id: 'lia', name: 'Lia' },
+      { id: 'nova', name: 'Nova' },
+    ],
+  };
+  const store: CommitmentStore = {
+    getState: () => ({ game, social }),
+    dispatch: (action) => {
+      if (typeof action === 'object' && action && 'type' in action && String(action.type).startsWith('social/')) {
+        social = socialReducer(social, action as never) as SocialState;
+      }
+      return action;
+    },
+  };
+  return { store, social: () => social };
+}
+
+describe('social commitments', () => {
+  it('creates only concrete promises from affirmative high-stakes replies', () => {
+    const accepted = createCommitmentFromInteraction({
+      interaction: interaction(),
+      responseType: 'positive',
+      promisorId: 'user',
+      week: 2,
+    });
+    const vague = createCommitmentFromInteraction({
+      interaction: interaction(),
+      responseType: 'neutral',
+      promisorId: 'user',
+      week: 2,
+    });
+
+    expect(accepted).toMatchObject({
+      kind: 'protect_from_nomination',
+      beneficiaryId: 'lia',
+      promisorId: 'user',
+      status: 'pending',
+    });
+    expect(vague).toBeNull();
+  });
+
+  it('breaks a safety promise when the beneficiary is nominated and applies lasting consequences', () => {
+    const { store, social } = makeStore(['lia', 'nova']);
+    const commitment = createCommitmentFromInteraction({
+      interaction: interaction(),
+      responseType: 'positive',
+      promisorId: 'user',
+      week: 2,
+    })!;
+    store.dispatch(addSocialCommitment(commitment));
+
+    evaluateSocialCommitmentsForAction(store, 'game/commitNominees');
+
+    expect(social().commitments[0]).toMatchObject({ status: 'broken', resolutionReason: 'nominated_after_promise' });
+    expect(social().relationships.lia?.user?.affinity).toBe(-16);
+    expect(social().socialMemory.lia?.user?.resentment).toBe(5);
+    expect(social().influenceBank.user).toBe(50);
+    expect(getSocialCredibility(social().commitments)).toMatchObject({ score: 0, label: 'Shaky', broken: 1 });
+  });
+
+  it('rewards a vote promise that the player actually keeps', () => {
+    const { store, social } = makeStore(['lia', 'nova']);
+    const voteInteraction = interaction({
+      type: 'deal_offer',
+      payload: { scenarioKey: 'live_vote_pitch' },
+    });
+    const commitment = createCommitmentFromInteraction({
+      interaction: voteInteraction,
+      responseType: 'accept',
+      promisorId: 'user',
+      week: 2,
+    })!;
+    store.dispatch(addSocialCommitment(commitment));
+
+    evaluateSocialCommitmentsForAction(store, 'game/submitHumanVote', 'nova');
+
+    expect(social().commitments[0]?.status).toBe('kept');
+    expect(social().relationships.lia?.user?.affinity).toBe(9);
+    expect(social().socialMemory.lia?.user?.gratitude).toBe(4);
+    expect(social().influenceBank.user).toBe(300);
+    expect(getSocialCredibility(social().commitments)).toMatchObject({ score: 100, label: 'Trusted', kept: 1 });
+  });
+});


### PR DESCRIPTION
## What changed

- Reworked incoming interaction cards into a more compact, readable presentation.
- Replaced repetitive universal responses with interaction-specific choices and concise consequence cues.
- Added concrete third-party subjects to gossip and warnings so messages feel grounded in the current cast.
- Added persistent social commitments for nomination protection, safety use, and eviction votes.
- Made kept and broken promises affect credibility, relationships, memory, influence, and later game feedback.
- Added design documentation and focused tests for presentation and commitment behavior.

## Why

Incoming interactions felt artificial because different characters repeatedly offered the same generic choices and explanatory text. Player responses also lacked durable consequences, which weakened realism and strategic weight.

This redesign keeps the inbox compact while making messages more personal, situational, and consequential.

## Validation

- 14 focused incoming-interaction tests passed.
- Project TypeScript check passed.
- Remote diff audited against current `main`: 1 commit and only the 15 intended incoming-interaction files.