### PR TITLE
Ship the refined game interface by default

### DIFF
--- a/src/components/LiveOpsController/LiveOpsController.tsx
+++ b/src/components/LiveOpsController/LiveOpsController.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { selectRemoteConfig } from '../../remoteConfig/remoteConfigSlice';
 import { useAppSelector } from '../../store/hooks';
 import { configureProductTelemetry, trackProductEvent } from '../../services/liveOps/productTelemetry';
-import { isRefinedGameChromeEnabled } from '../../services/liveOps/rollouts';
+import { resolveRefinedGameChrome } from '../../services/liveOps/rollouts';
 import './LiveOpsPresentation.css';
 
 export default function LiveOpsController() {
@@ -11,16 +11,9 @@ export default function LiveOpsController() {
   const week = useAppSelector((state) => state.game.week);
   const status = useAppSelector((state) => state.game.status);
   const refinedChrome = useMemo(() => {
-    // Local QA can force either presentation without changing release config.
-    // Keep the override available in a production-style local preview, where
-    // Vite's live-reload client is intentionally absent for stability.
-    const isLocalPreview = ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
-    const qaVariant = import.meta.env.DEV || isLocalPreview
-      ? new URLSearchParams(window.location.search).get('uiVariant')
-      : null;
-    if (qaVariant === 'refined') return true;
-    if (qaVariant === 'control') return false;
-    return isRefinedGameChromeEnabled(config);
+    // Refined is the shipped experience. Keep explicit URL overrides available
+    // in every environment so the legacy control can still be compared later.
+    return resolveRefinedGameChrome(config, window.location.search);
   }, [config]);
 
   useEffect(() => {

--- a/src/services/liveOps/rollouts.ts
+++ b/src/services/liveOps/rollouts.ts
@@ -29,7 +29,22 @@ export function getRolloutBucket(seed: string, key: string, salt = ''): number {
 export function isRefinedGameChromeEnabled(config: RemoteConfig | null, seed = getInstallSeed()): boolean {
   if (config?.operations?.killSwitches?.refinedGameChrome) return false;
   const rollout = config?.operations?.rollouts?.refinedGameChrome;
-  if (!rollout?.enabled) return false;
+  // The refined chrome is now the shipped experience. A rollout remains
+  // available for deliberate experiments, but missing/disabled configuration
+  // must not silently restore the legacy interface in production.
+  if (!rollout?.enabled) return true;
   const percentage = Math.max(0, Math.min(100, rollout.percentage ?? 0));
   return getRolloutBucket(seed, 'refined-game-chrome', rollout.salt) < percentage;
+}
+
+/** Resolve the shipped variant, with an explicit URL override for comparison. */
+export function resolveRefinedGameChrome(
+  config: RemoteConfig | null,
+  search: string,
+  seed?: string,
+): boolean {
+  const requestedVariant = new URLSearchParams(search).get('uiVariant');
+  if (requestedVariant === 'refined') return true;
+  if (requestedVariant === 'control') return false;
+  return isRefinedGameChromeEnabled(config, seed);
 }


### PR DESCRIPTION
## Product summary

This fixes the live-versus-local mismatch after the game-screen modernization was merged.

The refined game interface is now the normal experience on GitHub Pages and other production builds. The legacy control interface remains available through an explicit comparison URL.

## What was wrong

The redesigned interface was still treated as an experiment. Local testing used `?uiVariant=refined`, but production deliberately ignored that parameter and had no rollout configuration enabling the redesign. This caused a mixed live experience:

- the new House Feed setting was visible;
- the old navigation still rendered;
- inline history stayed visible regardless of the setting;
- the refined Log button was missing.

## What changed

- Refined game chrome now defaults to enabled when no rollout is configured.
- URL comparison overrides now work in every environment, including GitHub Pages.
- `?uiVariant=control` shows the legacy interface for future comparison.
- `?uiVariant=refined` explicitly shows the new interface.
- An emergency kill switch and deliberate percentage rollout still take priority when configured.

## Player impact

Normal game links will now consistently show the redesigned navbar, adaptive House Feed behavior, Log launcher, compact controls, and updated layout. Players will no longer receive the half-upgraded control presentation.

## How to test

1. Open the ordinary live game URL without a `uiVariant` parameter and confirm the refined navbar and Log behavior appear.
2. In Classic, turn House Feed off and confirm inline rows disappear while the Log button remains.
3. Turn House Feed on and confirm 1–3 adaptive rows appear.
4. Open the same live URL with `?uiVariant=control` before the hash to compare the legacy interface.
5. Open it with `?uiVariant=refined` to explicitly return to the redesigned interface.

## Validation

- ESLint passed
- TypeScript checks passed
- Rollout unit tests passed
- Production build passed
