### PR TITLE
Fix cinematic credits transitions and sunset

### DIFF
--- a/src/cinematic/camera/cameraPath.ts
+++ b/src/cinematic/camera/cameraPath.ts
@@ -44,8 +44,8 @@ export const sampleCamera = (progress: number, frame: number): CameraSample => {
 
   // Briefly inspect the KoleQuant yacht, then release back to the coast-wide
   // path so the sunset can complete over the landscape.
-  const focusIn = easedRange(frame, 1430, 1472);
-  const focusOut = 1 - easedRange(frame, 1502, 1550);
+  const focusIn = easedRange(frame, 1590, 1636);
+  const focusOut = 1 - easedRange(frame, 1668, 1718);
   const yachtFocus = focusIn * focusOut;
   const focusPosition = new Vector3(38, 19, -504);
   const focusTarget = new Vector3(42, 5, -558);

--- a/src/cinematic/camera/cameraPath.ts
+++ b/src/cinematic/camera/cameraPath.ts
@@ -44,8 +44,8 @@ export const sampleCamera = (progress: number, frame: number): CameraSample => {
 
   // Briefly inspect the KoleQuant yacht, then release back to the coast-wide
   // path so the sunset can complete over the landscape.
-  const focusIn = easedRange(frame, 1590, 1636);
-  const focusOut = 1 - easedRange(frame, 1668, 1718);
+  const focusIn = easedRange(frame, 1586, 1620);
+  const focusOut = 1 - easedRange(frame, 1640, 1678);
   const yachtFocus = focusIn * focusOut;
   const focusPosition = new Vector3(38, 19, -504);
   const focusTarget = new Vector3(42, 5, -558);

--- a/src/cinematic/celestial/celestialGeometry.ts
+++ b/src/cinematic/celestial/celestialGeometry.ts
@@ -1,0 +1,17 @@
+import type { TimelineState } from '../timeline/timeline';
+import { lerp } from '../utils/math';
+
+export const CELESTIAL_DISC_RADIUS = 12;
+export const CELESTIAL_EYE_SCALE = 0.92;
+export const CELESTIAL_PUPIL_RADIUS = CELESTIAL_DISC_RADIUS / CELESTIAL_EYE_SCALE;
+
+export const getCelestialBreath = (frame: number): number =>
+  1 + Math.sin(frame * 0.026) * 0.008;
+
+export const getCelestialEyePosition = (state: TimelineState): readonly [number, number] => {
+  const moonY = lerp(-42, 138, state.moonProgress);
+  return [
+    lerp(moonY, 15, state.sunPositionProgress),
+    lerp(-540, -760, state.sunPositionProgress),
+  ];
+};

--- a/src/cinematic/city/City.tsx
+++ b/src/cinematic/city/City.tsx
@@ -330,10 +330,10 @@ const Roads = ({ state }: { state: TimelineState }) => {
 };
 
 export const City = ({ frame, state }: CityProps) => {
-  // Once the camera has emerged over the coast, remove the last nearby tower
-  // silhouettes so the held finale remains an unobstructed beach horizon.
-  if (state.coastProgress >= 0.995) return null;
-  const exitDrop = Math.pow(state.coastProgress, 3) * 190;
+  // Complete the city exit before the opaque coastal plate appears. This
+  // prevents buildings, sea, and beach geometry from double-exposing.
+  if (state.cityExitProgress >= 0.995) return null;
+  const exitDrop = Math.pow(state.cityExitProgress, 2.2) * 250;
 
   return (
   <group position={[0, -exitDrop, 0]}>

--- a/src/cinematic/city/City.tsx
+++ b/src/cinematic/city/City.tsx
@@ -330,10 +330,11 @@ const Roads = ({ state }: { state: TimelineState }) => {
 };
 
 export const City = ({ frame, state }: CityProps) => {
-  // Complete the city exit before the opaque coastal plate appears. This
-  // prevents buildings, sea, and beach geometry from double-exposing.
+  // The coast reveals from the distant horizon forward while the city eases
+  // below the camera. Opaque, depth-tested coast pixels replace the city
+  // spatially instead of cross-fading two complete scenes.
   if (state.cityExitProgress >= 0.995) return null;
-  const exitDrop = Math.pow(state.cityExitProgress, 2.2) * 250;
+  const exitDrop = Math.pow(state.cityExitProgress, 2.45) * 205;
 
   return (
   <group position={[0, -exitDrop, 0]}>

--- a/src/cinematic/components/CinematicComposition.tsx
+++ b/src/cinematic/components/CinematicComposition.tsx
@@ -55,7 +55,7 @@ const THUNDER_STRIKES = [
 ] as const;
 
 const CinematicThunder = () => {
-  const { fps } = useVideoConfig();
+  const { fps, durationInFrames } = useVideoConfig();
   const { isPlayer } = getRemotionEnvironment();
   const relativeSource = 'assets/sounds/cinematic-thunder.wav';
   const source = isPlayer && typeof document !== 'undefined'
@@ -67,7 +67,7 @@ const CinematicThunder = () => {
       {THUNDER_STRIKES.map((strike) => (
         <Sequence
           key={strike.frame}
-          from={strike.frame}
+          from={Math.round((strike.frame / 1799) * (durationInFrames - 1))}
           durationInFrames={Math.round(4.2 * fps)}
         >
           <Audio src={source} volume={strike.volume} />
@@ -189,13 +189,13 @@ export const CinematicComposition = ({
         }}
       >
         <fog attach="fog" args={[state.fogColor, state.fogNear, state.fogFar]} />
-        <Atmosphere frame={frame} state={state} />
+        <Atmosphere frame={state.frame} state={state} />
         <CinematicLighting state={state} />
-        <City frame={frame} state={state} />
-        <FinalCoast frame={frame} state={state} />
-        <CinematicCamera frame={frame} progress={state.progress} />
+        <City frame={state.frame} state={state} />
+        <FinalCoast frame={state.frame} state={state} />
+        <CinematicCamera frame={state.frame} progress={state.progress} />
       </ThreeCanvas>
-      <LightningOverlay frame={frame} opacity={state.lightningBolt} />
+      <LightningOverlay frame={state.frame} opacity={state.lightningBolt} />
       <OptionalAssetLayer state={state} />
       <div
         className="big-eye-cinematic__grain"

--- a/src/cinematic/effects/Atmosphere.tsx
+++ b/src/cinematic/effects/Atmosphere.tsx
@@ -11,7 +11,13 @@ import {
 } from 'three';
 import { CINEMATIC_CONFIG } from '../config/cinematicConfig';
 import type { TimelineState } from '../timeline/timeline';
-import { easedRange, lerp } from '../utils/math';
+import {
+  CELESTIAL_EYE_SCALE,
+  CELESTIAL_PUPIL_RADIUS,
+  getCelestialBreath,
+  getCelestialEyePosition,
+} from '../celestial/celestialGeometry';
+import { easedRange } from '../utils/math';
 import { createSeededRandom, randomBetween } from '../utils/seededRandom';
 
 type AtmosphereProps = {
@@ -306,19 +312,21 @@ const CelestialEye = ({ opacity, frame, state }: {
   const outline = useMemo(() => createEyeOutline(), []);
   if (opacity <= 0.001) return null;
 
-  const moonY = lerp(-42, 138, state.moonProgress);
-  const y = lerp(moonY, 15, state.sunPositionProgress);
-  const z = lerp(-543, -763, state.sunPositionProgress);
+  const [y, z] = getCelestialEyePosition(state);
   const revealOpen = Math.min(1, opacity * 1.25);
   const narrativeEyeOpen = 1 - easedRange(frame, 1545, 1588);
   const open = revealOpen * narrativeEyeOpen;
-  const breathe = 1 + Math.sin((frame - 1080) * 0.018) * 0.012;
+  const breathe = getCelestialBreath(state.frame);
   const rotation = (frame - 990) * 0.0014;
 
   return (
     <group
       position={[0, y, z]}
-      scale={[0.92 * breathe, 0.92 * breathe * (0.035 + open * 0.965), 0.92]}
+      scale={[
+        CELESTIAL_EYE_SCALE * breathe,
+        CELESTIAL_EYE_SCALE * breathe * (0.035 + open * 0.965),
+        CELESTIAL_EYE_SCALE,
+      ]}
     >
       <Line
         points={outline}
@@ -347,7 +355,7 @@ const CelestialEye = ({ opacity, frame, state }: {
         />
       </group>
       <mesh position={[0, 0, -0.8]} rotation={[0, 0, rotation]}>
-        <ringGeometry args={[12.65, 13.15, 96]} />
+        <ringGeometry args={[CELESTIAL_PUPIL_RADIUS - 0.27, CELESTIAL_PUPIL_RADIUS + 0.27, 96]} />
         <meshBasicMaterial
           color="#9cd6e2"
           transparent

--- a/src/cinematic/environment/FinalCoast.tsx
+++ b/src/cinematic/environment/FinalCoast.tsx
@@ -1,18 +1,18 @@
 import { Line } from '@react-three/drei';
-import { useLoader } from '@react-three/fiber';
 import { useMemo } from 'react';
-import { getRemotionEnvironment, staticFile } from 'remotion';
 import {
   BufferGeometry,
+  CanvasTexture,
   Color,
   DoubleSide,
   Float32BufferAttribute,
+  LinearFilter,
   SRGBColorSpace,
   Texture,
-  TextureLoader,
   Vector3,
 } from 'three';
 import type { TimelineState } from '../timeline/timeline';
+import { clamp01 } from '../utils/math';
 
 const SEA_VERTEX = `
   varying vec2 vUv;
@@ -25,6 +25,7 @@ const SEA_VERTEX = `
 const SEA_FRAGMENT = `
   uniform float uTime;
   uniform float uOpacity;
+  uniform float uGoldenHour;
   uniform float uSunset;
   varying vec2 vUv;
 
@@ -33,9 +34,17 @@ const SEA_FRAGMENT = `
     float waveB = sin(vUv.y * 91.0 - uTime * 0.037 + vUv.x * 47.0) * 0.5 + 0.5;
     float glint = smoothstep(0.945, 1.0, waveA * 0.66 + waveB * 0.34);
     float horizon = smoothstep(0.0, 1.0, vUv.y);
-    vec3 deep = vec3(0.035, 0.16, 0.22);
-    vec3 horizonBlue = vec3(0.28, 0.52, 0.61);
-    vec3 color = mix(deep, horizonBlue, horizon * 0.78);
+    vec3 dayDeep = vec3(0.035, 0.16, 0.22);
+    vec3 dayHorizon = vec3(0.28, 0.52, 0.61);
+    vec3 afternoonDeep = vec3(0.075, 0.18, 0.22);
+    vec3 afternoonHorizon = vec3(0.54, 0.43, 0.35);
+    vec3 eveningDeep = vec3(0.025, 0.055, 0.105);
+    vec3 eveningHorizon = vec3(0.22, 0.13, 0.19);
+    vec3 dayColor = mix(dayDeep, dayHorizon, horizon * 0.78);
+    vec3 afternoonColor = mix(afternoonDeep, afternoonHorizon, horizon * 0.84);
+    vec3 eveningColor = mix(eveningDeep, eveningHorizon, horizon * 0.76);
+    vec3 color = mix(dayColor, afternoonColor, uGoldenHour * 0.78);
+    color = mix(color, eveningColor, uSunset * 0.94);
     color += glint * vec3(0.2, 0.4, 0.44) * (0.12 + horizon * 0.24);
 
     float reflectionCentre = 0.528
@@ -44,11 +53,13 @@ const SEA_FRAGMENT = `
     float reflectionTightness = mix(18.0, 72.0, horizon);
     float sunPath = exp(-abs(vUv.x - reflectionCentre) * reflectionTightness);
     float brokenLight = smoothstep(0.48, 0.92, waveA * 0.55 + waveB * 0.45);
-    float reflectionFade = 1.0 - smoothstep(0.22, 0.94, uSunset);
+    float reflectionFade = 1.0 - smoothstep(0.7, 1.0, uSunset);
     float spill = sunPath * (0.16 + brokenLight * 1.18)
       * (0.32 + horizon * 0.9) * reflectionFade;
-    color += vec3(1.0, 0.58, 0.19) * spill;
-    color += vec3(1.0, 0.88, 0.54) * sunPath * glint * horizon * reflectionFade * 0.72;
+    vec3 reflectionWarm = mix(vec3(1.0, 0.68, 0.26), vec3(1.0, 0.19, 0.045), uSunset * 0.86);
+    color += reflectionWarm * spill;
+    color += mix(vec3(1.0, 0.88, 0.54), vec3(1.0, 0.38, 0.11), uSunset)
+      * sunPath * glint * horizon * reflectionFade * 0.72;
     gl_FragColor = vec4(color, uOpacity);
   }
 `;
@@ -160,7 +171,11 @@ const createShoreGeometry = (edge: readonly ShorePoint[], side: -1 | 1): BufferG
   return geometry;
 };
 
-const CloudBank = ({ frame, opacity }: { frame: number; opacity: number }) => {
+const CloudBank = ({ frame, opacity, state }: {
+  frame: number;
+  opacity: number;
+  state: TimelineState;
+}) => {
   const clouds = useMemo(() => [
     { x: -122, y: 96, z: -650, width: 145, height: 44, drift: 0.004 },
     { x: 106, y: 76, z: -620, width: 126, height: 37, drift: -0.003 },
@@ -172,25 +187,30 @@ const CloudBank = ({ frame, opacity }: { frame: number; opacity: number }) => {
 
   return (
     <group>
-      {clouds.map((cloud, index) => (
-        <mesh
-          key={`${cloud.x}-${cloud.z}`}
-          position={[cloud.x + frame * cloud.drift, cloud.y, cloud.z]}
-          scale={[cloud.width, cloud.height, 1]}
-        >
-          <planeGeometry args={[1, 1]} />
-          <shaderMaterial
-            vertexShader={CLOUD_VERTEX}
-            fragmentShader={CLOUD_FRAGMENT}
-            uniforms={{
-              uColor: { value: new Color(index % 2 === 0 ? '#f2e6dc' : '#d7e5e7') },
-              uOpacity: { value: opacity * (index === 2 ? 0.34 : 0.48) },
-            }}
-            transparent
-            depthWrite={false}
-          />
-        </mesh>
-      ))}
+      {clouds.map((cloud, index) => {
+        const cloudColor = new Color(index % 2 === 0 ? '#f2e6dc' : '#d7e5e7')
+          .lerp(new Color('#efb092'), state.goldenHourProgress * 0.62)
+          .lerp(new Color('#553446'), state.sunsetProgress * 0.86);
+        return (
+          <mesh
+            key={`${cloud.x}-${cloud.z}`}
+            position={[cloud.x + frame * cloud.drift, cloud.y, cloud.z]}
+            scale={[cloud.width, cloud.height, 1]}
+          >
+            <planeGeometry args={[1, 1]} />
+            <shaderMaterial
+              vertexShader={CLOUD_VERTEX}
+              fragmentShader={CLOUD_FRAGMENT}
+              uniforms={{
+                uColor: { value: cloudColor },
+                uOpacity: { value: opacity * (index === 2 ? 0.34 : 0.48) },
+              }}
+              transparent
+              depthWrite={false}
+            />
+          </mesh>
+        );
+      })}
     </group>
   );
 };
@@ -213,11 +233,13 @@ const createSailGeometry = (side: -1 | 1): BufferGeometry => {
 
 const createSailLogoGeometry = (): BufferGeometry => {
   const geometry = new BufferGeometry();
+  // A narrow band running parallel to the starboard sail's hypotenuse. The
+  // texture reads from the mast-side top toward the lower outer corner.
   geometry.setAttribute('position', new Float32BufferAttribute([
-    0.05, 2.65, 0,
-    0.05, 4.25, 0,
-    3.22, 2.65, 0,
-    2.35, 4.25, 0,
+    0.12, 6.0, 0,
+    0.84, 6.44, 0,
+    3.2, 1.03, 0,
+    3.92, 1.47, 0,
   ], 3));
   geometry.setAttribute('uv', new Float32BufferAttribute([
     0, 0,
@@ -228,6 +250,56 @@ const createSailLogoGeometry = (): BufferGeometry => {
   geometry.setIndex([0, 2, 1, 1, 2, 3]);
   geometry.computeVertexNormals();
   return geometry;
+};
+
+const createKoleQuantLogoTexture = (): Texture => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1024;
+  canvas.height = 256;
+  const context = canvas.getContext('2d');
+  if (context == null) {
+    throw new Error('Unable to create the KoleQuant sail mark.');
+  }
+
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+  context.strokeStyle = '#30465a';
+  context.lineWidth = 10;
+  for (const phase of [0, Math.PI]) {
+    context.beginPath();
+    for (let index = 0; index <= 48; index += 1) {
+      const t = index / 48;
+      const x = 72 + Math.sin(t * Math.PI * 3 + phase) * 30;
+      const y = 31 + t * 194;
+      if (index === 0) context.moveTo(x, y);
+      else context.lineTo(x, y);
+    }
+    context.stroke();
+  }
+  context.strokeStyle = 'rgba(48, 70, 90, 0.72)';
+  context.lineWidth = 5;
+  for (let index = 0; index <= 9; index += 1) {
+    const t = index / 9;
+    const y = 37 + t * 182;
+    const phase = t * Math.PI * 3;
+    context.beginPath();
+    context.moveTo(72 + Math.sin(phase) * 30, y);
+    context.lineTo(72 + Math.sin(phase + Math.PI) * 30, y);
+    context.stroke();
+  }
+
+  context.fillStyle = '#243b4d';
+  context.font = '700 118px Montserrat, Arial, sans-serif';
+  context.textBaseline = 'middle';
+  context.fillText('KoleQuant', 142, 132);
+
+  const texture = new CanvasTexture(canvas);
+  texture.colorSpace = SRGBColorSpace;
+  texture.minFilter = LinearFilter;
+  texture.magFilter = LinearFilter;
+  texture.needsUpdate = true;
+  return texture;
 };
 
 const createYachtHullGeometry = (): BufferGeometry => {
@@ -274,6 +346,7 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
   const hullGeometry = useMemo(() => createYachtHullGeometry(), []);
   const bob = Math.sin(frame * 0.035 + position[0] * 0.08) * 0.12;
   const roll = Math.sin(frame * 0.022 + position[2] * 0.03) * 0.012;
+  const translucent = opacity < 0.999;
 
   return (
     <group
@@ -287,13 +360,21 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
           roughness={0.2}
           metalness={0.12}
           clearcoat={0.9}
-          transparent
+          transparent={translucent}
           opacity={opacity}
+          depthWrite={!translucent}
         />
       </mesh>
       <mesh position={[0, 1.32, -0.2]} scale={[2.48, 0.13, 3.85]}>
         <sphereGeometry args={[1, 22, 10]} />
-        <meshStandardMaterial color="#18303b" roughness={0.42} metalness={0.36} transparent opacity={opacity} />
+        <meshStandardMaterial
+          color="#18303b"
+          roughness={0.42}
+          metalness={0.36}
+          transparent={translucent}
+          opacity={opacity}
+          depthWrite={!translucent}
+        />
       </mesh>
       <mesh position={[0, 1.43, 0.56]} scale={[1.72, 0.32, 1.6]}>
         <sphereGeometry args={[1, 24, 12]} />
@@ -302,8 +383,9 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
           roughness={0.14}
           metalness={0.5}
           clearcoat={0.88}
-          transparent
-          opacity={opacity * 0.96}
+          transparent={translucent}
+          opacity={opacity}
+          depthWrite={!translucent}
         />
       </mesh>
       <mesh position={[0, 1.62, 1.25]} rotation={[-0.09, 0, 0]}>
@@ -313,8 +395,9 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
           roughness={0.08}
           metalness={0.58}
           clearcoat={1}
-          transparent
-          opacity={opacity * 0.74}
+          transparent={translucent}
+          opacity={opacity}
+          depthWrite={!translucent}
         />
       </mesh>
       {[-1, 1].map((side) => (
@@ -334,30 +417,31 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
       ))}
       <mesh position={[0, 5.15, 0]}>
         <cylinderGeometry args={[0.075, 0.1, 9.2, 10]} />
-        <meshStandardMaterial color="#c6d1ce" metalness={0.82} roughness={0.24} transparent opacity={opacity} />
+        <meshStandardMaterial color="#c6d1ce" metalness={0.82} roughness={0.24} transparent={translucent} opacity={opacity} />
       </mesh>
       <mesh position={[1.65, 3.22, 0.08]} rotation={[0, 0, Math.PI / 2]}>
         <cylinderGeometry args={[0.05, 0.075, 3.3, 10]} />
-        <meshStandardMaterial color="#bac8c7" metalness={0.78} roughness={0.2} transparent opacity={opacity} />
+        <meshStandardMaterial color="#bac8c7" metalness={0.78} roughness={0.2} transparent={translucent} opacity={opacity} />
       </mesh>
       <mesh geometry={rightSail} position={[0, 1.35, 0.04]}>
-        <meshBasicMaterial color="#f5f0e8" side={DoubleSide} transparent opacity={opacity * 0.94} />
+        <meshBasicMaterial color="#f5f0e8" side={DoubleSide} transparent={translucent} opacity={opacity} />
       </mesh>
       {brand === 'kolequant' && logoTexture && (
         <mesh geometry={sailLogoGeometry} position={[0, 1.35, 0.065]} renderOrder={9}>
           <meshBasicMaterial
             map={logoTexture}
-            color="#334953"
+            color="#ffffff"
             transparent
             opacity={opacity}
             side={DoubleSide}
+            alphaTest={0.025}
             depthWrite={false}
             toneMapped={false}
           />
         </mesh>
       )}
       <mesh geometry={leftSail} position={[0, 1.35, 0.02]} scale={[0.72, 0.78, 1]}>
-        <meshBasicMaterial color="#cfdfe0" side={DoubleSide} transparent opacity={opacity * 0.86} />
+        <meshBasicMaterial color="#cfdfe0" side={DoubleSide} transparent={translucent} opacity={opacity} />
       </mesh>
       <Line
         points={[new Vector3(0, 9.68, 0.08), new Vector3(4.72, 1.42, 0.08)]}
@@ -418,20 +502,9 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
 };
 
 const Yachts = ({ frame, opacity }: { frame: number; opacity: number }) => {
-  const { isPlayer } = getRemotionEnvironment();
-  const logoSource = useMemo(
-    () => isPlayer && typeof document !== 'undefined'
-      ? new URL('assets/kolequant.png', document.baseURI).toString()
-      : staticFile('assets/kolequant.png'),
-    [isPlayer],
-  );
-  const loadedLogoTexture = useLoader(TextureLoader, logoSource);
-  const logoTexture = useMemo(() => {
-    const texture = loadedLogoTexture.clone();
-    texture.colorSpace = SRGBColorSpace;
-    texture.needsUpdate = true;
-    return texture;
-  }, [loadedLogoTexture]);
+  // CanvasTexture is created synchronously, so the coast never suspends the
+  // entire WebGL canvas while a late image asset is fetched on mobile.
+  const logoTexture = useMemo(() => createKoleQuantLogoTexture(), []);
 
   return (
     <group>
@@ -441,7 +514,7 @@ const Yachts = ({ frame, opacity }: { frame: number; opacity: number }) => {
           brand="kolequant"
           frame={frame}
           logoTexture={logoTexture}
-          opacity={opacity * 0.92}
+          opacity={opacity}
           position={[0, 0, 0]}
           rotation={0}
         />
@@ -501,8 +574,20 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
     [],
   );
   const opacity = state.coastProgress;
+  const detailOpacity = clamp01((opacity - 0.16) / 0.84);
+  const sandColor = new Color('#c69a72')
+    .lerp(new Color('#b66d50'), state.goldenHourProgress * 0.62)
+    .lerp(new Color('#55303a'), state.sunsetProgress * 0.9);
+  const leftShoreColor = new Color('#172722')
+    .lerp(new Color('#2f2b26'), state.goldenHourProgress * 0.5)
+    .lerp(new Color('#11151d'), state.sunsetProgress * 0.88);
+  const rightShoreColor = new Color('#1d2b25')
+    .lerp(new Color('#3a3028'), state.goldenHourProgress * 0.5)
+    .lerp(new Color('#141721'), state.sunsetProgress * 0.88);
 
-  if (opacity <= 0.001) return null;
+  // Mount only after the city has completed its exit. The landscape plate is
+  // intentionally opaque so no building geometry can show through the sea.
+  if (opacity <= 0.12) return null;
 
   return (
     <group>
@@ -513,23 +598,22 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
           fragmentShader={SEA_FRAGMENT}
           uniforms={{
             uTime: { value: frame },
-            uOpacity: { value: opacity * 0.96 },
+            uOpacity: { value: 1 },
+            uGoldenHour: { value: state.goldenHourProgress },
             uSunset: { value: state.sunsetProgress },
           }}
-          transparent
-          depthWrite={false}
+          depthWrite
         />
       </mesh>
 
       <mesh geometry={beachGeometry} renderOrder={4}>
-        <meshBasicMaterial
-          color="#a97858"
-          transparent
-          opacity={opacity * 0.96}
+        <meshStandardMaterial
+          color={sandColor}
+          roughness={0.82}
+          metalness={0.03}
           side={DoubleSide}
-          depthTest={false}
-          depthWrite={false}
-          fog={false}
+          depthTest
+          depthWrite
         />
       </mesh>
       <Line
@@ -537,25 +621,24 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
         color="#f1e2cf"
         lineWidth={2.3}
         transparent
-        opacity={opacity * 0.62}
+        opacity={detailOpacity * 0.62}
         depthWrite={false}
       />
       {[leftGeometry, rightGeometry].map((geometry, index) => (
         <mesh key={index} geometry={geometry}>
-          <meshBasicMaterial
-            color={index === 0 ? '#172722' : '#1d2b25'}
-            transparent
-            opacity={opacity * 0.98}
-            fog={false}
+          <meshStandardMaterial
+            color={index === 0 ? leftShoreColor : rightShoreColor}
+            roughness={0.84}
+            metalness={0.04}
           />
         </mesh>
       ))}
 
-      <Line points={leftSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={opacity * 0.54} depthWrite={false} />
-      <Line points={rightSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={opacity * 0.54} depthWrite={false} />
-      <CloudBank frame={frame} opacity={opacity} />
-      <Yachts frame={frame} opacity={opacity} />
-      <BirdFlock frame={frame} opacity={opacity} />
+      <Line points={leftSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={detailOpacity * 0.54} depthWrite={false} />
+      <Line points={rightSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={detailOpacity * 0.54} depthWrite={false} />
+      <CloudBank frame={frame} opacity={detailOpacity} state={state} />
+      <Yachts frame={frame} opacity={detailOpacity} />
+      <BirdFlock frame={frame} opacity={detailOpacity} />
     </group>
   );
 };

--- a/src/cinematic/environment/FinalCoast.tsx
+++ b/src/cinematic/environment/FinalCoast.tsx
@@ -25,6 +25,7 @@ const SEA_VERTEX = `
 const SEA_FRAGMENT = `
   uniform float uTime;
   uniform float uOpacity;
+  uniform float uReveal;
   uniform float uGoldenHour;
   uniform float uSunset;
   varying vec2 vUv;
@@ -32,6 +33,11 @@ const SEA_FRAGMENT = `
   void main() {
     float waveA = sin(vUv.y * 155.0 + uTime * 0.052 + sin(vUv.x * 31.0)) * 0.5 + 0.5;
     float waveB = sin(vUv.y * 91.0 - uTime * 0.037 + vUv.x * 47.0) * 0.5 + 0.5;
+    float revealNoise = (waveA - 0.5) * 0.024 + (waveB - 0.5) * 0.016;
+    float revealFront = 1.0 - clamp(uReveal, 0.0, 1.0);
+    if (vUv.y + revealNoise < revealFront) discard;
+    float revealEdge = 1.0 - smoothstep(0.0, 0.045, abs(vUv.y + revealNoise - revealFront));
+
     float glint = smoothstep(0.945, 1.0, waveA * 0.66 + waveB * 0.34);
     float horizon = smoothstep(0.0, 1.0, vUv.y);
     vec3 dayDeep = vec3(0.035, 0.16, 0.22);
@@ -45,6 +51,7 @@ const SEA_FRAGMENT = `
     vec3 eveningColor = mix(eveningDeep, eveningHorizon, horizon * 0.76);
     vec3 color = mix(dayColor, afternoonColor, uGoldenHour * 0.78);
     color = mix(color, eveningColor, uSunset * 0.94);
+    color += mix(vec3(0.1, 0.2, 0.23), vec3(0.48, 0.28, 0.16), uGoldenHour) * revealEdge * 0.035;
     color += glint * vec3(0.2, 0.4, 0.44) * (0.12 + horizon * 0.24);
 
     float reflectionCentre = 0.528
@@ -61,6 +68,50 @@ const SEA_FRAGMENT = `
     color += mix(vec3(1.0, 0.88, 0.54), vec3(1.0, 0.38, 0.11), uSunset)
       * sunPath * glint * horizon * reflectionFade * 0.72;
     gl_FragColor = vec4(color, uOpacity);
+  }
+`;
+const COAST_SURFACE_VERTEX = `
+  varying vec3 vLocalPosition;
+  void main() {
+    vLocalPosition = position;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const COAST_SURFACE_FRAGMENT = `
+  uniform vec3 uBaseColor;
+  uniform float uReveal;
+  uniform float uNearDepth;
+  uniform float uFarDepth;
+  uniform float uRockiness;
+  uniform float uSunset;
+  varying vec3 vLocalPosition;
+
+  float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+  }
+
+  void main() {
+    vec2 p = vLocalPosition.xz;
+    float depth = clamp((-vLocalPosition.z - uNearDepth) / (uFarDepth - uNearDepth), 0.0, 1.0);
+    float grain = hash(floor(p * 2.7));
+    float broad = hash(floor(p * 0.16));
+    float windRipple = sin(p.x * 0.19 + sin(p.y * 0.075) * 2.1) * 0.5 + 0.5;
+    float revealNoise = (broad - 0.5) * 0.055 + (windRipple - 0.5) * 0.028;
+    float revealFront = 1.0 - clamp(uReveal, 0.0, 1.0);
+    if (depth + revealNoise < revealFront) discard;
+
+    float fine = hash(floor(p * 7.5));
+    float sandTexture = windRipple * 0.09 + (grain - 0.5) * 0.16 + (fine - 0.5) * 0.08;
+    float rockVein = sin(p.x * 0.075 + sin(p.y * 0.045) * 2.7) * 0.11 + (broad - 0.5) * 0.24;
+    float surfaceTexture = mix(sandTexture, rockVein, uRockiness);
+    vec3 color = uBaseColor * (0.9 + surfaceTexture);
+    color += vec3(0.24, 0.17, 0.105) * smoothstep(0.86, 1.0, grain) * (1.0 - uRockiness) * 0.48;
+    color *= 1.0 - uSunset * 0.16;
+
+    float edge = 1.0 - smoothstep(0.0, 0.055, abs(depth + revealNoise - revealFront));
+    color += mix(vec3(0.15, 0.22, 0.24), vec3(0.42, 0.29, 0.2), uSunset) * edge * 0.04;
+    gl_FragColor = vec4(color, 1.0);
   }
 `;
 
@@ -574,7 +625,7 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
     [],
   );
   const opacity = state.coastProgress;
-  const detailOpacity = clamp01((opacity - 0.16) / 0.84);
+  const detailOpacity = clamp01((opacity - 0.38) / 0.62);
   const sandColor = new Color('#c69a72')
     .lerp(new Color('#b66d50'), state.goldenHourProgress * 0.62)
     .lerp(new Color('#55303a'), state.sunsetProgress * 0.9);
@@ -585,9 +636,10 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
     .lerp(new Color('#3a3028'), state.goldenHourProgress * 0.5)
     .lerp(new Color('#141721'), state.sunsetProgress * 0.88);
 
-  // Mount only after the city has completed its exit. The landscape plate is
-  // intentionally opaque so no building geometry can show through the sea.
-  if (opacity <= 0.12) return null;
+  // Reveal opaque coast pixels from the distant horizon toward the camera.
+  // This keeps the city spatially continuous during the transition without
+  // double-exposing two transparent worlds.
+  if (opacity <= 0.001) return null;
 
   return (
     <group>
@@ -599,6 +651,7 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
           uniforms={{
             uTime: { value: frame },
             uOpacity: { value: 1 },
+            uReveal: { value: opacity },
             uGoldenHour: { value: state.goldenHourProgress },
             uSunset: { value: state.sunsetProgress },
           }}
@@ -607,12 +660,18 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
       </mesh>
 
       <mesh geometry={beachGeometry} renderOrder={4}>
-        <meshStandardMaterial
-          color={sandColor}
-          roughness={0.82}
-          metalness={0.03}
+        <shaderMaterial
+          vertexShader={COAST_SURFACE_VERTEX}
+          fragmentShader={COAST_SURFACE_FRAGMENT}
+          uniforms={{
+            uBaseColor: { value: sandColor },
+            uReveal: { value: clamp01((opacity - 0.68) / 0.32) },
+            uNearDepth: { value: 324 },
+            uFarDepth: { value: 535 },
+            uRockiness: { value: 0 },
+            uSunset: { value: state.sunsetProgress },
+          }}
           side={DoubleSide}
-          depthTest
           depthWrite
         />
       </mesh>
@@ -626,10 +685,19 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
       />
       {[leftGeometry, rightGeometry].map((geometry, index) => (
         <mesh key={index} geometry={geometry}>
-          <meshStandardMaterial
-            color={index === 0 ? leftShoreColor : rightShoreColor}
-            roughness={0.84}
-            metalness={0.04}
+          <shaderMaterial
+            vertexShader={COAST_SURFACE_VERTEX}
+            fragmentShader={COAST_SURFACE_FRAGMENT}
+            uniforms={{
+              uBaseColor: { value: index === 0 ? leftShoreColor : rightShoreColor },
+              uReveal: { value: clamp01((opacity - 0.48) / 0.52) },
+              uNearDepth: { value: 425 },
+              uFarDepth: { value: 895 },
+              uRockiness: { value: 1 },
+              uSunset: { value: state.sunsetProgress },
+            }}
+            side={DoubleSide}
+            depthWrite
           />
         </mesh>
       ))}

--- a/src/cinematic/lighting/CinematicLighting.tsx
+++ b/src/cinematic/lighting/CinematicLighting.tsx
@@ -1,4 +1,9 @@
 import { AdditiveBlending, Color } from 'three';
+import {
+  CELESTIAL_DISC_RADIUS,
+  getCelestialBreath,
+  getCelestialEyePosition,
+} from '../celestial/celestialGeometry';
 import type { TimelineState } from '../timeline/timeline';
 import { clamp01, lerp, smootherstep } from '../utils/math';
 
@@ -116,7 +121,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
   return (
     <group position={[0, 0, 2.25]}>
       <mesh>
-        <planeGeometry args={[27.2, 27.2]} />
+        <planeGeometry args={[CELESTIAL_DISC_RADIUS * 2.02, CELESTIAL_DISC_RADIUS * 2.02]} />
         <shaderMaterial
           vertexShader={HALO_VERTEX}
           fragmentShader={APERTURE_FRAGMENT}
@@ -130,7 +135,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
         />
       </mesh>
       <mesh position={[0, 0, 0.08]}>
-        <ringGeometry args={[12.75, 13.18, 96]} />
+        <ringGeometry args={[CELESTIAL_DISC_RADIUS - 0.28, CELESTIAL_DISC_RADIUS + 0.28, 96]} />
         <meshBasicMaterial
           color="#d8fff7"
           transparent
@@ -143,17 +148,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
     </group>
   );
 };
-const CelestialBody = ({
-  state,
-  sunX,
-  sunY,
-  moonY,
-}: {
-  state: TimelineState;
-  sunX: number;
-  sunY: number;
-  moonY: number;
-}) => {
+const CelestialBody = ({ state, sunX }: { state: TimelineState; sunX: number }) => {
   const sunsetOcclusion = 1 - smootherstep(clamp01((state.sunsetProgress - 0.72) / 0.28));
   const sunMorph = state.sunMorph;
   const lunarStrength = 1 - sunMorph;
@@ -161,13 +156,13 @@ const CelestialBody = ({
   const sunVisibility = state.sunIntensity * state.sunRevealProgress;
   const celestialVisibility = Math.min(1, moonVisibility + sunVisibility) * sunsetOcclusion;
   const x = lerp(0, sunX, state.sunHorizonProgress);
-  const settledY = lerp(moonY, sunY, state.sunPositionProgress);
-  const y = settledY + state.sunHorizonProgress * 18 - state.sunsetProgress * 58;
-  const breathe = 1 + Math.sin(state.frame * 0.026) * 0.008;
-  const z = lerp(-540, -760, state.sunPositionProgress);
+  const [eyeY, eyeZ] = getCelestialEyePosition(state);
+  const y = lerp(eyeY, 7.5, state.sunHorizonProgress) - state.sunsetProgress * 34;
+  const breathe = getCelestialBreath(state.frame);
+  const z = lerp(eyeZ, -1135, state.sunHorizonProgress);
   const bodyScale = breathe;
-  const sunVisualScale = lerp(1, 1.65, state.sunHorizonProgress);
-  const haloScale = lerp(1, 1.4, state.sunHorizonProgress);
+  const sunVisualScale = lerp(1, 3.15, state.sunHorizonProgress);
+  const haloScale = lerp(1, 2.25, state.sunHorizonProgress);
   const glowColor = mixColor(
     mixColor('#afc9e3', '#ffc25f', sunMorph),
     '#ff5b24',
@@ -197,7 +192,7 @@ const CelestialBody = ({
         />
       </mesh>
       <mesh scale={[sunVisualScale, sunVisualScale, sunVisualScale]}>
-        <sphereGeometry args={[12, 64, 48]} />
+        <sphereGeometry args={[CELESTIAL_DISC_RADIUS, 64, 48]} />
         <shaderMaterial
           vertexShader={CELESTIAL_VERTEX}
           fragmentShader={CELESTIAL_FRAGMENT}
@@ -245,7 +240,7 @@ export const CinematicLighting = ({ state }: { state: TimelineState }) => {
         intensity={state.moonIntensity * 0.36}
         position={[-120, moonY, -310]}
       />
-      <CelestialBody state={state} sunX={sunX} sunY={sunY} moonY={moonY} />
+      <CelestialBody state={state} sunX={sunX} />
     </>
   );
 };

--- a/src/cinematic/lighting/CinematicLighting.tsx
+++ b/src/cinematic/lighting/CinematicLighting.tsx
@@ -1,6 +1,6 @@
 import { AdditiveBlending, Color } from 'three';
 import type { TimelineState } from '../timeline/timeline';
-import { lerp } from '../utils/math';
+import { clamp01, lerp, smootherstep } from '../utils/math';
 
 const mixColor = (from: string, to: string, amount: number): string =>
   `#${new Color(from).lerp(new Color(to), amount).getHexString()}`;
@@ -62,6 +62,7 @@ const APERTURE_FRAGMENT = `
 `;
 const CELESTIAL_FRAGMENT = `
   uniform float uSunMorph;
+  uniform float uSunset;
   uniform float uTime;
   uniform float uOpacity;
   varying vec2 vUv;
@@ -100,8 +101,8 @@ const CELESTIAL_FRAGMENT = `
       * sin((vUv.x - vUv.y) * 63.0 + uTime * 0.008);
     float solarLimb = clamp(max(0.0, vNormal.z), 0.0, 1.0);
     float coreHeat = pow(solarLimb, 0.46);
-    vec3 sunEdge = vec3(1.0, 0.30, 0.055);
-    vec3 sunCore = vec3(1.0, 0.88, 0.47);
+    vec3 sunEdge = mix(vec3(1.0, 0.30, 0.055), vec3(0.82, 0.055, 0.018), uSunset);
+    vec3 sunCore = mix(vec3(1.0, 0.88, 0.47), vec3(1.0, 0.43, 0.12), uSunset * 0.82);
     vec3 sun = mix(sunEdge, sunCore, coreHeat);
     sun *= 1.0 + solarCellA * 0.045 + solarCellB * 0.022;
     sun += vec3(1.0, 0.72, 0.28) * pow(solarLimb, 2.2) * 0.12;
@@ -115,7 +116,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
   return (
     <group position={[0, 0, 2.25]}>
       <mesh>
-        <planeGeometry args={[35.5, 35.5]} />
+        <planeGeometry args={[27.2, 27.2]} />
         <shaderMaterial
           vertexShader={HALO_VERTEX}
           fragmentShader={APERTURE_FRAGMENT}
@@ -129,7 +130,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
         />
       </mesh>
       <mesh position={[0, 0, 0.08]}>
-        <ringGeometry args={[16.65, 17.15, 96]} />
+        <ringGeometry args={[12.75, 13.18, 96]} />
         <meshBasicMaterial
           color="#d8fff7"
           transparent
@@ -153,10 +154,12 @@ const CelestialBody = ({
   sunY: number;
   moonY: number;
 }) => {
-  const sunsetOcclusion = 1 - Math.min(1, state.sunsetProgress * 1.5);
-  const celestialVisibility = Math.min(1, state.moonIntensity + state.sunIntensity) * sunsetOcclusion;
+  const sunsetOcclusion = 1 - smootherstep(clamp01((state.sunsetProgress - 0.72) / 0.28));
   const sunMorph = state.sunMorph;
   const lunarStrength = 1 - sunMorph;
+  const moonVisibility = state.moonIntensity * lunarStrength;
+  const sunVisibility = state.sunIntensity * state.sunRevealProgress;
+  const celestialVisibility = Math.min(1, moonVisibility + sunVisibility) * sunsetOcclusion;
   const x = lerp(0, sunX, state.sunHorizonProgress);
   const settledY = lerp(moonY, sunY, state.sunPositionProgress);
   const y = settledY + state.sunHorizonProgress * 18 - state.sunsetProgress * 58;
@@ -165,7 +168,11 @@ const CelestialBody = ({
   const bodyScale = breathe;
   const sunVisualScale = lerp(1, 1.65, state.sunHorizonProgress);
   const haloScale = lerp(1, 1.4, state.sunHorizonProgress);
-  const glowColor = mixColor('#afc9e3', '#ffc25f', sunMorph);
+  const glowColor = mixColor(
+    mixColor('#afc9e3', '#ffc25f', sunMorph),
+    '#ff5b24',
+    state.sunsetProgress * 0.82,
+  );
   const coronaPulse = 0.92 + Math.sin(state.frame * 0.048) * 0.045;
 
   return (
@@ -179,7 +186,7 @@ const CelestialBody = ({
             uColor: { value: new Color(glowColor) },
             uOpacity: {
               value: celestialVisibility
-                * (lunarStrength * 0.18 + sunMorph * 0.44)
+                * (lunarStrength * 0.18 + sunMorph * state.sunRevealProgress * 0.44)
                 * coronaPulse,
             },
           }}
@@ -196,6 +203,7 @@ const CelestialBody = ({
           fragmentShader={CELESTIAL_FRAGMENT}
           uniforms={{
             uSunMorph: { value: sunMorph },
+            uSunset: { value: state.sunsetProgress },
             uTime: { value: state.frame },
             uOpacity: { value: celestialVisibility },
           }}
@@ -206,7 +214,7 @@ const CelestialBody = ({
       </mesh>
       <pointLight
         color={glowColor}
-        intensity={(state.moonIntensity * 0.62 + state.sunIntensity * 1.3) * sunsetOcclusion}
+        intensity={(moonVisibility * 0.62 + sunVisibility * 1.3) * sunsetOcclusion}
         distance={390}
       />
       <CelestialAperture closure={state.apertureClosure} />
@@ -218,12 +226,15 @@ export const CinematicLighting = ({ state }: { state: TimelineState }) => {
   const sunX = 22;
   const sunY = 15;
   const moonY = lerp(-42, 138, state.moonProgress);
-  const sunColor = state.sunWarmth > 0.3 ? '#ffc49a' : '#d8efff';
+  const sunColor = mixColor('#d8efff', '#ff8a48', state.sunWarmth);
+  const ambientColor = mixColor('#8ea3d4', '#9b6670', state.sunsetProgress * 0.72);
+  const hemisphereSky = mixColor('#8ba6e4', '#513b55', state.sunsetProgress * 0.78);
+  const hemisphereGround = mixColor('#080b15', '#1b0d14', state.sunsetProgress * 0.75);
 
   return (
     <>
-      <ambientLight color="#8ea3d4" intensity={state.ambientIntensity} />
-      <hemisphereLight args={['#8ba6e4', '#080b15', 0.26 + state.lightning * 0.35]} />
+      <ambientLight color={ambientColor} intensity={state.ambientIntensity} />
+      <hemisphereLight args={[hemisphereSky, hemisphereGround, 0.26 + state.lightning * 0.35]} />
       <directionalLight
         color={sunColor}
         intensity={state.sunIntensity * 1.45}

--- a/src/cinematic/timeline/timeline.test.ts
+++ b/src/cinematic/timeline/timeline.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { CINEMATIC_CONFIG } from '../config/cinematicConfig';
+import { getTimelineState } from './timeline';
+
+const authoredToOutputFrame = (authoredFrame: number): number =>
+  (authoredFrame / 1799) * (CINEMATIC_CONFIG.durationInFrames - 1);
+
+describe('cinematic timeline handoffs', () => {
+  it('keeps sunlight hidden while the aperture is closed', () => {
+    const hiddenSun = getTimelineState(authoredToOutputFrame(1400));
+
+    expect(hiddenSun.apertureClosure).toBeGreaterThan(0.99);
+    expect(hiddenSun.sunMorph).toBeGreaterThan(0.99);
+    expect(hiddenSun.sunRevealProgress).toBe(0);
+    expect(hiddenSun.sunIntensity).toBe(0);
+  });
+
+  it('never leaves a gap between the city and the opaque coast', () => {
+    for (let authoredFrame = 1540; authoredFrame <= 1600; authoredFrame += 2) {
+      const state = getTimelineState(authoredToOutputFrame(authoredFrame));
+      const cityStillCoversFrame = state.cityExitProgress < 0.995;
+      const coastCoversFrame = state.coastProgress > 0.12;
+
+      expect(cityStillCoversFrame || coastCoversFrame).toBe(true);
+    }
+  });
+
+  it('holds a multi-second graded sunset before final darkness', () => {
+    const sunsetStart = getTimelineState(authoredToOutputFrame(1672));
+    const sunsetMiddle = getTimelineState(authoredToOutputFrame(1730));
+    const sunsetEnd = getTimelineState(authoredToOutputFrame(1786));
+
+    expect(sunsetStart.sunsetProgress).toBe(0);
+    expect(sunsetMiddle.sunsetProgress).toBeGreaterThan(0.35);
+    expect(sunsetMiddle.sunsetProgress).toBeLessThan(0.7);
+    expect(sunsetMiddle.fadeToDark).toBe(0);
+    expect(sunsetEnd.sunsetProgress).toBe(1);
+    expect(sunsetEnd.fadeToDark).toBeGreaterThan(0.6);
+  });
+});

--- a/src/cinematic/timeline/timeline.ts
+++ b/src/cinematic/timeline/timeline.ts
@@ -73,7 +73,7 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   // visibly opening; the sunrise illumination then follows the reveal.
   const sunRevealProgress = easedRange(frame, 1480, 1542);
   const sunPositionProgress = easedRange(frame, 1438, 1545);
-  const sunHorizonProgress = easedRange(frame, 1622, 1668);
+  const sunHorizonProgress = easedRange(frame, 1606, 1662);
   // Establish a restrained pre-dawn before the shutter opens, then let full
   // daylight arrive with the revealed sun and coastline.
   const preDawn = easedRange(frame, 1328, 1438);
@@ -81,13 +81,13 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   const dawnProgress = clamp01(preDawn * 0.42 + fullDaylight * 0.58);
   // Drop the city below camera before the opaque coast settles in. Keeping
   // these beats adjacent avoids the transparent city/sea double exposure.
-  const cityExitProgress = easedRange(frame, 1510, 1580);
-  const coastProgress = easedRange(frame, 1550, 1625);
-  const goldenHourProgress = easedRange(frame, 1550, 1688);
+  const coastProgress = easedRange(frame, 1498, 1640);
+  const cityExitProgress = easedRange(frame, 1518, 1638);
+  const goldenHourProgress = easedRange(frame, 1535, 1688);
   // Give the wide landscape a few seconds to move through afternoon, sunset,
   // and evening before the final blackout.
-  const sunsetProgress = easedRange(frame, 1672, 1786);
-  const finalDarkness = easedRange(frame, 1762, 1799);
+  const sunsetProgress = easedRange(frame, 1684, 1786);
+  const finalDarkness = easedRange(frame, 1766, 1799);
   const stormProgress = rangeProgress(frame, 300, 930);
   const eveningProgress = rangeProgress(frame, 810, 1320);
   const cloudBuild = easedRange(frame, 300, 465);

--- a/src/cinematic/timeline/timeline.ts
+++ b/src/cinematic/timeline/timeline.ts
@@ -6,10 +6,13 @@ export type TimelineState = {
   progress: number;
   dawnProgress: number;
   sunMorph: number;
+  sunRevealProgress: number;
   sunPositionProgress: number;
   sunHorizonProgress: number;
+  goldenHourProgress: number;
   sunsetProgress: number;
   apertureClosure: number;
+  cityExitProgress: number;
   coastProgress: number;
   stormProgress: number;
   eveningProgress: number;
@@ -66,6 +69,9 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   const apertureClosure = Math.min(apertureClose, 1 - apertureOpen);
   // The celestial texture changes only while the aperture is fully closed.
   const sunMorph = easedRange(frame, 1344, 1374);
+  // Keep both the sun and its building reflections dark until the shutter is
+  // visibly opening; the sunrise illumination then follows the reveal.
+  const sunRevealProgress = easedRange(frame, 1480, 1542);
   const sunPositionProgress = easedRange(frame, 1438, 1545);
   const sunHorizonProgress = easedRange(frame, 1622, 1668);
   // Establish a restrained pre-dawn before the shutter opens, then let full
@@ -73,9 +79,15 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   const preDawn = easedRange(frame, 1328, 1438);
   const fullDaylight = easedRange(frame, 1438, 1650);
   const dawnProgress = clamp01(preDawn * 0.42 + fullDaylight * 0.58);
-  const coastProgress = easedRange(frame, 1530, 1650);
-  const sunsetProgress = easedRange(frame, 1722, 1782);
-  const finalDarkness = easedRange(frame, 1768, 1799);
+  // Drop the city below camera before the opaque coast settles in. Keeping
+  // these beats adjacent avoids the transparent city/sea double exposure.
+  const cityExitProgress = easedRange(frame, 1510, 1580);
+  const coastProgress = easedRange(frame, 1550, 1625);
+  const goldenHourProgress = easedRange(frame, 1550, 1688);
+  // Give the wide landscape a few seconds to move through afternoon, sunset,
+  // and evening before the final blackout.
+  const sunsetProgress = easedRange(frame, 1672, 1786);
+  const finalDarkness = easedRange(frame, 1762, 1799);
   const stormProgress = rangeProgress(frame, 300, 930);
   const eveningProgress = rangeProgress(frame, 810, 1320);
   const cloudBuild = easedRange(frame, 300, 465);
@@ -92,8 +104,10 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   let skyHorizon = mixColor('#091936', '#293441', stormShade * 0.82);
   skyTop = mixColor(skyTop, '#7ba9c5', dawnProgress);
   skyHorizon = mixColor(skyHorizon, '#e9c0a3', dawnProgress);
-  skyTop = mixColor(skyTop, '#050611', sunsetProgress * 0.92);
-  skyHorizon = mixColor(skyHorizon, '#210d12', sunsetProgress * 0.86);
+  skyTop = mixColor(skyTop, '#647d9a', goldenHourProgress * 0.48);
+  skyHorizon = mixColor(skyHorizon, '#ef9b67', goldenHourProgress * 0.72);
+  skyTop = mixColor(skyTop, '#0b1024', sunsetProgress * 0.96);
+  skyHorizon = mixColor(skyHorizon, '#5a2635', sunsetProgress * 0.9);
 
   const strikeOne = pulse(frame, 435, 8);
   const strikeTwo = pulse(frame, 570, 10);
@@ -111,16 +125,23 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
     progress,
     dawnProgress,
     sunMorph,
+    sunRevealProgress,
     sunPositionProgress,
     sunHorizonProgress,
+    goldenHourProgress,
     sunsetProgress,
     apertureClosure,
+    cityExitProgress,
     coastProgress,
     stormProgress,
     eveningProgress,
     skyTop,
     skyHorizon,
-    fogColor: mixColor(mixColor('#17263d', '#465567', stormShade), '#9fb6be', dawnProgress),
+    fogColor: mixColor(
+      mixColor(mixColor('#17263d', '#465567', stormShade), '#9fb6be', dawnProgress),
+      '#73505a',
+      sunsetProgress * 0.72,
+    ),
     fogNear: lerp(155, 125, stormShade),
     fogFar: lerp(720, 590, stormShade) + dawnProgress * 74,
     starsOpacity: 0.96 * (1 - stormShade * 0.96) * (1 - easedRange(frame, 1318, 1470)),
@@ -129,9 +150,12 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
     rainIntensity,
     wetness,
     ambientIntensity: (0.34 - stormShade * 0.08 + lightning * 0.72 + dawnProgress * 0.7)
-      * (1 - sunsetProgress * 0.58),
-    sunIntensity: sunMorph * (0.42 + dawnProgress * 0.95) * (1 - sunsetProgress * 0.28),
-    sunWarmth: 1 - dawnProgress * 0.38,
+      * (1 - sunsetProgress * 0.66),
+    sunIntensity: sunMorph
+      * sunRevealProgress
+      * (0.42 + dawnProgress * 0.95)
+      * (1 - sunsetProgress * 0.38),
+    sunWarmth: clamp01(0.48 + (1 - dawnProgress) * 0.44 + sunsetProgress * 0.46),
     moonIntensity: moonReveal * (1 - sunMorph) * 1.28,
     moonProgress: easedRange(frame, 810, 960),
     windowIntensity: nightLightFade * (2.12 + stormShade * 0.66),


### PR DESCRIPTION
## What changed

- Resize and synchronize the iris/photo-blend with the Eye and keep all solar glow/reflections hidden until the reveal.
- Replace the transparent city-to-coast overlap with a clean opaque handoff.
- Rework the KoleQuant yacht sail mark so it follows the sail diagonal and remains readable during the close-up.
- Extend the final sunset into a gradual golden-hour-to-evening transition, including coordinated sky, sea, reflection, sand, clouds, and final darkness.
- Fix authored-frame timing for scene, camera, lightning, and thunder.
- Remove the late-loading logo texture that could suspend the WebGL canvas on mobile and produce a one-second blank blue frame.
- Add timeline regression tests for the sun reveal, scene handoff, and sunset duration.

## Root cause

The blank-frame issue came from a texture loader first mounting late in the coast scene. On slower mobile decoding/fetch paths it suspended the full Three.js canvas while the DOM credits remained visible. The yacht mark is now generated synchronously, so the canvas stays rendered throughout the sequence.

Several visual overlaps also came from mixed output-frame and authored-frame timing plus translucent scene layers sharing the transition window.

## Validation

- TypeScript typecheck
- Targeted ESLint
- Vitest: 8 tests passed
- Production build
- Visual frame checks across the iris reveal, coast handoff, yacht close-up, sunset, and final darkness
- Local browser playback smoke test