### PR TITLE
Ship hardened WebGL credits V2

### DIFF
--- a/docs/BIG_EYE_CINEMATIC.md
+++ b/docs/BIG_EYE_CINEMATIC.md
@@ -107,3 +107,16 @@ Suggested eye prompt:
 - `src/cinematic/credits/`: configurable final credit overlay
 - `src/cinematic/components/`: shared composition and optional-asset handling
 - `src/remotion/`: Remotion registration and composition metadata
+## Version archive
+
+The approved first WebGL credits cut is preserved by the annotated Git tag
+**credits-webgl-v1**, which points to commit **8091bacc**. This keeps the complete
+V1 implementation available without duplicating its source and assets inside
+the V2 bundle.
+
+To inspect or restore it safely on a new branch:
+
+    git switch -c restore/credits-webgl-v1 credits-webgl-v1
+
+V2 continues on the normal credits feature branch. Editable credit copy and
+timing remain in src/cinematic/config/cinematicConfig.ts.

--- a/src/cinematic/camera/cameraPath.ts
+++ b/src/cinematic/camera/cameraPath.ts
@@ -47,8 +47,8 @@ export const sampleCamera = (progress: number, frame: number): CameraSample => {
   const focusIn = easedRange(frame, 1586, 1620);
   const focusOut = 1 - easedRange(frame, 1640, 1678);
   const yachtFocus = focusIn * focusOut;
-  const focusPosition = new Vector3(38, 19, -504);
-  const focusTarget = new Vector3(42, 5, -558);
+  const focusPosition = new Vector3(44, 20, -565);
+  const focusTarget = new Vector3(48, 5, -622);
   position.lerp(focusPosition, yachtFocus);
   target.lerp(focusTarget, yachtFocus);
 

--- a/src/cinematic/city/City.tsx
+++ b/src/cinematic/city/City.tsx
@@ -2,17 +2,27 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 import {
   AdditiveBlending,
   Color,
-  DynamicDrawUsage,
   InstancedMesh,
   Object3D,
+  StaticDrawUsage,
 } from 'three';
 import { CINEMATIC_CONFIG } from '../config/cinematicConfig';
+import type { CinematicQuality } from '../config/cinematicQuality';
 import type { TimelineState } from '../timeline/timeline';
 import { CITY_LAYOUT, type BoxInstance } from './cityLayout';
+import { Storefronts, UmbrellaPedestrians } from './StreetLife';
 
+const RETAIL_PODIUMS: readonly BoxInstance[] = CITY_LAYOUT.buildings
+  .filter((building) => Math.abs(building.position[0]) < 35)
+  .map((building, index) => ({
+    position: [building.position[0], 4.15, building.position[2]],
+    scale: [building.scale[0] + 0.34, 8.3, building.scale[2] + 0.34],
+    color: index % 2 === 0 ? '#3a464b' : '#323e44',
+  }));
 type CityProps = {
   frame: number;
   state: TimelineState;
+  quality: CinematicQuality;
 };
 
 type InstancedBoxesProps = {
@@ -36,14 +46,14 @@ const InstancedBoxes = ({ instances, material, opacity = 1, emissiveIntensity = 
       mesh.setMatrixAt(index, helper.matrix);
       mesh.setColorAt(index, new Color(instance.color));
     });
-    mesh.instanceMatrix.setUsage(DynamicDrawUsage);
+    mesh.instanceMatrix.setUsage(StaticDrawUsage);
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
   }, [helper, instances]);
 
   const transparent = opacity < 1;
   return (
-    <instancedMesh ref={meshRef} args={[undefined, undefined, instances.length]} frustumCulled={false}>
+    <instancedMesh ref={meshRef} args={[undefined, undefined, instances.length]}>
       <boxGeometry args={[1, 1, 1]} />
       {material === 'building' && (
         <meshPhysicalMaterial vertexColors color="#ffffff" roughness={0.36} metalness={0.62} clearcoat={0.22} />
@@ -75,11 +85,16 @@ const InstancedBoxes = ({ instances, material, opacity = 1, emissiveIntensity = 
   );
 };
 
-const BuildingWindows = ({ frame, intensity }: { frame: number; intensity: number }) => {
+const BuildingWindows = ({ frame, intensity, quality }: { frame: number; intensity: number; quality: CinematicQuality }) => {
   const meshRef = useRef<InstancedMesh>(null);
   const helper = useMemo(() => new Object3D(), []);
   const colorHelper = useMemo(() => new Color(), []);
   const highlightColor = useMemo(() => new Color('#fffef5'), []);
+  const apartmentWindows = useMemo(
+    () => CITY_LAYOUT.windows.filter((window) => !(Math.abs(window.position[0]) < 35 && window.position[1] < 9.2)),
+    [],
+  );
+  const sampledFrame = quality === 'balanced' ? Math.floor(frame / 2) * 2 : frame;
   const warmPalette = useMemo(() => [
     new Color('#fffdf1'),
     new Color('#fff4c7'),
@@ -91,10 +106,10 @@ const BuildingWindows = ({ frame, intensity }: { frame: number; intensity: numbe
     const mesh = meshRef.current;
     if (!mesh) return;
 
-    CITY_LAYOUT.windows.forEach((window, index) => {
-      const slowWave = 0.5 + Math.sin(frame * (0.009 + (index % 7) * 0.0011) + index * 1.71) * 0.5;
+    apartmentWindows.forEach((window, index) => {
+      const slowWave = 0.5 + Math.sin(sampledFrame * (0.009 + (index % 7) * 0.0011) + index * 1.71) * 0.5;
       const flickerPeriod = 10 + ((index * 7) % 31);
-      const flickerStep = Math.floor((frame + (index % flickerPeriod)) / flickerPeriod);
+      const flickerStep = Math.floor((sampledFrame + (index % flickerPeriod)) / flickerPeriod);
       const randomSample = Math.sin((flickerStep + 1) * (index + 11) * 12.9898) * 43758.5453;
       const flickerValue = randomSample - Math.floor(randomSample);
       const isReactiveWindow = index % 4 === 0;
@@ -125,10 +140,10 @@ const BuildingWindows = ({ frame, intensity }: { frame: number; intensity: numbe
 
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
-  }, [colorHelper, frame, helper, highlightColor, intensity, warmPalette]);
+  }, [apartmentWindows, colorHelper, helper, highlightColor, intensity, sampledFrame, warmPalette]);
 
   return (
-    <instancedMesh ref={meshRef} args={[undefined, undefined, CITY_LAYOUT.windows.length]} frustumCulled={false}>
+    <instancedMesh ref={meshRef} args={[undefined, undefined, apartmentWindows.length]} frustumCulled={false}>
       <boxGeometry args={[1, 1, 1]} />
       <meshBasicMaterial
         color={new Color('#ffd47f')
@@ -149,25 +164,69 @@ const StreetFurniture = ({ state }: { state: TimelineState }) => {
   const poleInstances = useMemo<BoxInstance[]>(
     () => CITY_LAYOUT.streetLights.map(([x, , z]) => ({
       position: [x, 2.8, z],
-      scale: [0.18, 5.6, 0.18],
-      color: '#26324b',
+      scale: [0.22, 5.6, 0.22],
+      color: '#1d2428',
     })),
     [],
   );
+  const baseInstances = useMemo<BoxInstance[]>(
+    () => CITY_LAYOUT.streetLights.map(([x, , z]) => ({
+      position: [x, 0.42, z],
+      scale: [0.58, 0.84, 0.58],
+      color: '#20282c',
+    })),
+    [],
+  );
+  const armInstances = useMemo<BoxInstance[]>(
+    () => CITY_LAYOUT.streetLights.map(([x, y, z]) => {
+      const side = Math.sign(x) || 1;
+      return {
+        position: [x - side * 0.5, y + 0.02, z],
+        scale: [1.08, 0.13, 0.18],
+        color: '#1d2428',
+      };
+    }),
+    [],
+  );
+  const capInstances = useMemo<BoxInstance[]>(
+    () => CITY_LAYOUT.streetLights.map(([x, y, z]) => {
+      const side = Math.sign(x) || 1;
+      return {
+        position: [x - side * 0.95, y + 0.32, z],
+        scale: [0.78, 0.16, 0.78],
+        color: '#252e32',
+      };
+    }),
+    [],
+  );
+
   return (
     <>
       <InstancedBoxes instances={poleInstances} material="roof" />
-      {CITY_LAYOUT.streetLights.map(([x, y, z], index) => (
-        <mesh key={`${x}-${z}`} position={[x, y, z]}>
-          <sphereGeometry args={[0.23, 8, 8]} />
-          <meshStandardMaterial
-            color={index % 3 === 0 ? '#b9efff' : '#e8f8ff'}
-            emissive={index % 3 === 0 ? '#5de7ff' : '#d8f4ff'}
-            emissiveIntensity={state.streetLightIntensity}
-            toneMapped={false}
-          />
-        </mesh>
-      ))}
+      <InstancedBoxes instances={baseInstances} material="roof" />
+      <InstancedBoxes instances={armInstances} material="roof" />
+      <InstancedBoxes instances={capInstances} material="roof" />
+      {CITY_LAYOUT.streetLights.map(([x, y, z]) => {
+        const side = Math.sign(x) || 1;
+        const lampX = x - side * 0.95;
+        return (
+          <group key={x + ':' + z} position={[lampX, y - 0.24, z]}>
+            <mesh>
+              <boxGeometry args={[0.68, 0.92, 0.68]} />
+              <meshStandardMaterial color="#252e32" metalness={0.72} roughness={0.38} />
+            </mesh>
+            <mesh position={[0, -0.03, 0]}>
+              <boxGeometry args={[0.42, 0.6, 0.42]} />
+              <meshStandardMaterial
+                color="#ffe0aa"
+                emissive="#ffc36f"
+                emissiveIntensity={state.streetLightIntensity * 0.78}
+                toneMapped={false}
+              />
+            </mesh>
+          </group>
+        );
+      })}
       {CITY_LAYOUT.intersections.map((z, index) => (
         <group key={z} position={[index % 2 === 0 ? -10.2 : 10.2, 0, z]}>
           <mesh position={[0, 2.8, 0]}>
@@ -314,7 +373,7 @@ const Roads = ({ state }: { state: TimelineState }) => {
       {[-1, 1].map((side) => (
         <mesh key={side} position={[side * 11, 0.22, roadMidpoint]}>
           <boxGeometry args={[CINEMATIC_CONFIG.city.sidewalkWidth, 0.42, roadLength]} />
-          <meshStandardMaterial color="#161e2c" roughness={0.7} metalness={0.24} />
+          <meshPhysicalMaterial color="#161e2c" roughness={0.7 - state.wetness * 0.36} metalness={0.24 + state.wetness * 0.32} clearcoat={state.wetness * 0.7} />
         </mesh>
       ))}
       {CITY_LAYOUT.intersections.map((z) => (
@@ -329,12 +388,12 @@ const Roads = ({ state }: { state: TimelineState }) => {
   );
 };
 
-export const City = ({ frame, state }: CityProps) => {
+export const City = ({ frame, state, quality }: CityProps) => {
   // The coast reveals from the distant horizon forward while the city eases
   // below the camera. Opaque, depth-tested coast pixels replace the city
   // spatially instead of cross-fading two complete scenes.
-  if (state.cityExitProgress >= 0.995) return null;
-  const exitDrop = Math.pow(state.cityExitProgress, 2.45) * 205;
+  if (state.cityExitProgress >= 0.82) return null;
+  const exitDrop = Math.pow(state.cityExitProgress, 2.35) * 320;
 
   return (
   <group position={[0, -exitDrop, 0]}>
@@ -345,9 +404,12 @@ export const City = ({ frame, state }: CityProps) => {
     <Roads state={state} />
     <InstancedBoxes instances={CITY_LAYOUT.distantBuildings} material="distant" />
     <InstancedBoxes instances={CITY_LAYOUT.buildings} material="building" />
+    <InstancedBoxes instances={RETAIL_PODIUMS} material="building" />
     <InstancedBoxes instances={CITY_LAYOUT.roofDetails} material="roof" />
-    <BuildingWindows frame={frame} intensity={state.windowIntensity} />
+    <BuildingWindows frame={frame} intensity={state.windowIntensity} quality={quality} />
+    <Storefronts frame={frame} state={state} />
     <StreetFurniture state={state} />
+    <UmbrellaPedestrians frame={frame} state={state} quality={quality} />
     <VehicleTraffic frame={frame} state={state} />
   </group>
   );

--- a/src/cinematic/city/StreetLife.tsx
+++ b/src/cinematic/city/StreetLife.tsx
@@ -1,0 +1,404 @@
+import { useMemo } from 'react'
+import { CanvasTexture, DoubleSide, LinearFilter, SRGBColorSpace } from 'three'
+import type { CinematicQuality } from '../config/cinematicQuality'
+import type { TimelineState } from '../timeline/timeline'
+import { clamp01, lerp } from '../utils/math'
+import { CITY_LAYOUT } from './cityLayout'
+
+type ShopKind = 'produce' | 'coffee' | 'market' | 'arcade' | 'garage'
+
+type ShopStyle = {
+  kind: ShopKind
+  label: string
+  accent: string
+  glow: string
+  interior: string
+}
+
+const SHOP_STYLES: readonly ShopStyle[] = [
+  {
+    kind: 'produce',
+    label: 'FRESH MARKET',
+    accent: '#7ead72',
+    glow: '#dff1a4',
+    interior: '#4b5a32',
+  },
+  {
+    kind: 'coffee',
+    label: 'NIGHT OWL COFFEE',
+    accent: '#b77955',
+    glow: '#ffd5a1',
+    interior: '#5a3022',
+  },
+  { kind: 'market', label: 'MINI MARKET', accent: '#4b98a5', glow: '#a5f1e9', interior: '#23495a' },
+  {
+    kind: 'arcade',
+    label: 'PIXEL ARCADE',
+    accent: '#7657a8',
+    glow: '#dbb6ff',
+    interior: '#241f50',
+  },
+  { kind: 'garage', label: 'CITY GARAGE', accent: '#647181', glow: '#d3e5ee', interior: '#31383f' },
+] as const
+
+type StoreSpec = {
+  side: -1 | 1
+  facadeX: number
+  z: number
+  width: number
+  style: ShopStyle
+}
+
+const STORE_SPECS: StoreSpec[] = []
+;([-1, 1] as const).forEach((side, sideIndex) => {
+  CITY_LAYOUT.buildings
+    .filter(
+      (building) =>
+        Math.sign(building.position[0]) === side &&
+        Math.abs(building.position[0]) < 35 &&
+        building.position[2] > -455 &&
+        building.position[2] < 118
+    )
+    .filter((_, index) => index % 2 === 0)
+    .slice(0, 8)
+    .forEach((building, index) => {
+      STORE_SPECS.push({
+        side,
+        facadeX: building.position[0] - side * (building.scale[0] / 2 + 0.24),
+        z: building.position[2],
+        width: Math.min(9.6, building.scale[2] * 0.68),
+        style: SHOP_STYLES[(index + sideIndex * 2) % SHOP_STYLES.length] ?? SHOP_STYLES[0],
+      })
+    })
+})
+
+const createSignTexture = (style: ShopStyle): CanvasTexture => {
+  const canvas = document.createElement('canvas')
+  canvas.width = 1024
+  canvas.height = 256
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error('Unable to create storefront signage.')
+
+  const gradient = context.createLinearGradient(0, 0, canvas.width, 0)
+  gradient.addColorStop(0, '#0b1118')
+  gradient.addColorStop(0.48, style.interior)
+  gradient.addColorStop(1, '#0b1118')
+  context.fillStyle = gradient
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  context.strokeStyle = style.accent
+  context.lineWidth = 10
+  context.strokeRect(12, 12, canvas.width - 24, canvas.height - 24)
+  context.fillStyle = style.glow
+  context.shadowColor = style.glow
+  context.shadowBlur = 22
+  context.font = '700 82px Montserrat, Arial, sans-serif'
+  context.textAlign = 'center'
+  context.textBaseline = 'middle'
+  context.fillText(style.label, canvas.width / 2, canvas.height / 2 + 4)
+
+  const texture = new CanvasTexture(canvas)
+  texture.colorSpace = SRGBColorSpace
+  texture.minFilter = LinearFilter
+  texture.magFilter = LinearFilter
+  texture.needsUpdate = true
+  return texture
+}
+
+type PedestrianSpec = {
+  side: -1 | 1
+  targetZ: number
+  facadeX: number
+  approach: -1 | 1
+  delay: number
+  storeKey: string
+  coat: string
+  umbrella: string
+}
+
+const PEDESTRIAN_STORES = [...STORE_SPECS]
+  .filter((store) => store.style.kind !== 'garage')
+  .sort((first, second) => second.z - first.z)
+  .slice(0, 10)
+
+const PEDESTRIANS: readonly PedestrianSpec[] = PEDESTRIAN_STORES.map((store, index) => ({
+  side: store.side,
+  targetZ: store.z,
+  facadeX: store.facadeX,
+  approach: index % 2 === 0 ? -1 : 1,
+  delay: index * 18,
+  storeKey: store.side + ':' + store.z,
+  coat: ['#8296a8', '#9b6870', '#658b84', '#82758e'][index % 4] ?? '#8296a8',
+  umbrella: ['#a76572', '#b49a60', '#4d8e92', '#75809b', '#856d99'][index % 5] ?? '#6d7285',
+}))
+
+const getPedestrianJourney = (frame: number, person: PedestrianSpec, index: number): number =>
+  clamp01((frame - 382 - person.delay) / (250 + (index % 3) * 18))
+
+export const Storefronts = ({ frame, state }: { frame: number; state: TimelineState }) => {
+  const signTextures = useMemo(
+    () =>
+      Object.fromEntries(
+        SHOP_STYLES.map((style) => [style.kind, createSignTexture(style)])
+      ) as Record<ShopKind, CanvasTexture>,
+    []
+  )
+  const nightStrength = clamp01(0.36 + state.windowIntensity * 0.27)
+  const reflectedStrength = clamp01(state.wetness * 0.22 + state.rainIntensity * 0.08)
+
+  return (
+    <group>
+      {STORE_SPECS.map((store, index) => {
+        const roadOffset = -store.side * 0.28
+        const isGarage = store.style.kind === 'garage'
+        const hasAwning = store.style.kind === 'produce' || store.style.kind === 'coffee'
+        const storeKey = store.side + ':' + store.z
+        const visitorIndex = PEDESTRIANS.findIndex((person) => person.storeKey === storeKey)
+        const visitor = visitorIndex >= 0 ? PEDESTRIANS[visitorIndex] : undefined
+        const journey = visitor ? getPedestrianJourney(frame, visitor, visitorIndex) : 0
+        const doorOpen = visitor
+          ? clamp01((journey - 0.56) / 0.13) * (1 - clamp01((journey - 0.96) / 0.04))
+          : 0
+        const panelWidth = Math.max(1.8, (store.width - 2.5) / 2)
+        const panelOffset = 1.25 + panelWidth / 2
+
+        return (
+          <group key={storeKey} position={[store.facadeX, 0, store.z]}>
+            <mesh position={[roadOffset, 3.95, 0]}>
+              <boxGeometry args={[0.64, 7.9, store.width + 0.9]} />
+              <meshStandardMaterial color="#2b373c" roughness={0.5} metalness={0.54} />
+            </mesh>
+            <mesh position={[roadOffset, 8.22, 0]}>
+              <boxGeometry args={[0.8, 0.54, store.width + 1.15]} />
+              <meshStandardMaterial color="#303a3e" roughness={0.38} metalness={0.7} />
+            </mesh>
+
+            {isGarage ? (
+              <mesh position={[roadOffset - store.side * 0.37, 3.02, 0]}>
+                <boxGeometry args={[0.18, 5.55, store.width - 0.7]} />
+                <meshStandardMaterial
+                  color="#4a565f"
+                  roughness={0.42}
+                  metalness={0.76}
+                  emissive={store.style.interior}
+                  emissiveIntensity={nightStrength * 0.18}
+                />
+              </mesh>
+            ) : (
+              <>
+                {([-1, 1] as const).map((panel) => (
+                  <mesh
+                    key={panel}
+                    position={[roadOffset - store.side * 0.38, 3.05, panel * panelOffset]}
+                  >
+                    <boxGeometry args={[0.18, 5.05, panelWidth]} />
+                    <meshPhysicalMaterial
+                      color="#183039"
+                      roughness={0.1 + state.wetness * 0.12}
+                      metalness={0.42}
+                      clearcoat={1}
+                      emissive={store.style.interior}
+                      emissiveIntensity={nightStrength * 0.4}
+                    />
+                  </mesh>
+                ))}
+                <mesh position={[roadOffset - store.side * 0.4, 2.62, 0]}>
+                  <boxGeometry args={[0.22, 4.85, 2.18]} />
+                  <meshStandardMaterial color="#080d11" roughness={0.78} metalness={0.16} />
+                </mesh>
+                {([-1, 1] as const).map((panel) => (
+                  <mesh
+                    key={'door-' + panel}
+                    position={[
+                      roadOffset - store.side * 0.54,
+                      2.64,
+                      panel * (0.52 + doorOpen * 0.58),
+                    ]}
+                  >
+                    <boxGeometry args={[0.12, 4.55, 0.98]} />
+                    <meshPhysicalMaterial
+                      color="#294550"
+                      roughness={0.08}
+                      metalness={0.46}
+                      clearcoat={1}
+                      transparent
+                      opacity={0.78}
+                    />
+                  </mesh>
+                ))}
+              </>
+            )}
+
+            <mesh position={[roadOffset - store.side * 0.38, 6.7, 0]}>
+              <boxGeometry args={[0.42, 1.22, store.width + 0.72]} />
+              <meshStandardMaterial
+                color={store.style.accent}
+                roughness={0.28}
+                metalness={0.58}
+                emissive={store.style.glow}
+                emissiveIntensity={nightStrength * 0.3}
+              />
+            </mesh>
+            <mesh
+              position={[roadOffset - store.side * 0.62, 6.7, 0]}
+              rotation={[0, store.side > 0 ? -Math.PI / 2 : Math.PI / 2, 0]}
+            >
+              <planeGeometry args={[store.width, 0.98]} />
+              <meshBasicMaterial
+                map={signTextures[store.style.kind]}
+                color="#ffffff"
+                side={DoubleSide}
+                toneMapped={false}
+              />
+            </mesh>
+
+            {hasAwning && (
+              <mesh
+                position={[roadOffset - store.side * 1.18, 5.7, 0]}
+                rotation={[0, 0, store.side * 0.08]}
+              >
+                <boxGeometry args={[2, 0.13, store.width + 0.5]} />
+                <meshStandardMaterial
+                  color={index % 2 === 0 ? store.style.accent : '#d2c7b5'}
+                  roughness={0.5}
+                  metalness={0.18}
+                />
+              </mesh>
+            )}
+
+            <mesh position={[-store.side * 1.6, 0.265, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+              <planeGeometry args={[3, store.width * 0.92]} />
+              <meshBasicMaterial
+                color={store.style.glow}
+                transparent
+                opacity={reflectedStrength}
+                depthWrite={false}
+                toneMapped={false}
+              />
+            </mesh>
+          </group>
+        )
+      })}
+    </group>
+  )
+}
+
+export const UmbrellaPedestrians = ({
+  frame,
+  state,
+  quality,
+}: {
+  frame: number
+  state: TimelineState
+  quality: CinematicQuality
+}) => {
+  if (state.rainIntensity <= 0.002) return null
+
+  const opacity = Math.min(1, state.rainIntensity * 1.7)
+  const sampledFrame = quality === 'balanced' ? Math.floor(frame / 2) * 2 : frame
+  const visiblePedestrians = PEDESTRIANS.map((person, index) => ({ person, index })).filter(
+    ({ index }) => quality === 'high' || index % 5 !== 4
+  )
+
+  return (
+    <group>
+      {visiblePedestrians.map(({ person, index }) => {
+        const journey = getPedestrianJourney(sampledFrame, person, index)
+        const startFrame = 382 + person.delay
+        const arrival = clamp01(journey / 0.82)
+        const easedArrival = arrival * arrival * (3 - 2 * arrival)
+        const entering = clamp01((journey - 0.82) / 0.18)
+        const appear = clamp01((sampledFrame - startFrame) / 14)
+        const concealed = clamp01((journey - 0.985) / 0.015)
+        const visibleScale = Math.min(1, state.rainIntensity * 1.8) * appear * (1 - concealed)
+        if (visibleScale <= 0.01) return null
+
+        const doorX = person.facadeX - person.side * 0.82
+        const x = lerp(person.side * 10.35, doorX, easedArrival) + person.side * entering * 3.1
+        const z = lerp(person.targetZ + person.approach * 10.8, person.targetZ, easedArrival)
+        const walkStrength = 1 - entering
+        const bob = Math.abs(Math.sin(sampledFrame * 0.18 + index * 1.7)) * 0.11 * walkStrength
+        const step = Math.sin(sampledFrame * 0.18 + index * 1.7) * 0.34 * walkStrength
+
+        return (
+          <group key={person.storeKey} position={[x, 0, z]}>
+            {([-1, 1] as const).map((leg) => (
+              <mesh
+                key={leg}
+                position={[0, 0.72 + bob, leg * 0.19]}
+                rotation={[leg * step, 0, 0]}
+                scale={[0.12 * visibleScale, 0.72 * visibleScale, 0.12 * visibleScale]}
+              >
+                <cylinderGeometry args={[1, 1, 1, 7]} />
+                <meshStandardMaterial
+                  color={person.coat}
+                  emissive={person.coat}
+                  emissiveIntensity={0.28}
+                  roughness={0.72}
+                  transparent
+                  opacity={opacity}
+                />
+              </mesh>
+            ))}
+            <mesh
+              position={[0, 1.62 + bob, 0]}
+              rotation={[person.side * -0.07, 0, person.approach * 0.05]}
+              scale={[visibleScale, visibleScale, visibleScale]}
+            >
+              <capsuleGeometry args={[0.42, 1.28, 4, 8]} />
+              <meshStandardMaterial
+                color={person.coat}
+                emissive={person.coat}
+                emissiveIntensity={0.42}
+                roughness={0.66}
+                transparent
+                opacity={opacity}
+              />
+            </mesh>
+            <mesh
+              position={[0, 2.92 + bob, 0]}
+              scale={[0.4 * visibleScale, 0.4 * visibleScale, 0.4 * visibleScale]}
+            >
+              <sphereGeometry args={[1, 8, 6]} />
+              <meshStandardMaterial
+                color="#c69b80"
+                emissive="#6f4838"
+                emissiveIntensity={0.24}
+                roughness={0.72}
+                transparent
+                opacity={opacity}
+              />
+            </mesh>
+            <mesh
+              position={[-person.side * 0.24, 3.02 + bob, 0]}
+              rotation={[0, 0, person.side * -0.1]}
+              scale={[0.045 * visibleScale, 0.7 * visibleScale, 0.045 * visibleScale]}
+            >
+              <cylinderGeometry args={[1, 1, 1, 6]} />
+              <meshStandardMaterial
+                color="#aeb8b8"
+                roughness={0.34}
+                metalness={0.72}
+                transparent
+                opacity={opacity}
+              />
+            </mesh>
+            <mesh
+              position={[-person.side * 0.24, 3.7 + bob, 0]}
+              rotation={[0, 0, person.side * -0.1]}
+              scale={[1.3 * visibleScale, 0.44 * visibleScale, 1.3 * visibleScale]}
+            >
+              <sphereGeometry args={[1, 12, 6, 0, Math.PI * 2, 0, Math.PI / 2]} />
+              <meshBasicMaterial
+                color={person.umbrella}
+                side={DoubleSide}
+                transparent
+                opacity={opacity * 0.9}
+                toneMapped={false}
+              />
+            </mesh>
+          </group>
+        )
+      })}
+    </group>
+  )
+}

--- a/src/cinematic/components/CinematicComposition.tsx
+++ b/src/cinematic/components/CinematicComposition.tsx
@@ -1,4 +1,5 @@
 import { ThreeCanvas } from '@remotion/three';
+import { useMemo } from 'react';
 import {
   AbsoluteFill,
   Audio,
@@ -12,6 +13,7 @@ import { ACESFilmicToneMapping, SRGBColorSpace } from 'three';
 import { CinematicCamera } from '../camera/CinematicCamera';
 import { City } from '../city/City';
 import { CINEMATIC_AUDIO, CINEMATIC_CONFIG } from '../config/cinematicConfig';
+import { getCinematicQuality } from '../config/cinematicQuality';
 import { CreditsOverlay } from '../credits/CreditsOverlay';
 import { Atmosphere } from '../effects/Atmosphere';
 import { FinalCoast } from '../environment/FinalCoast';
@@ -160,7 +162,9 @@ export const CinematicComposition = ({
 }: CinematicCompositionProps) => {
   const frame = useCurrentFrame();
   const { width, height } = useVideoConfig();
+  const { isPlayer } = getRemotionEnvironment();
   const state = getTimelineState(frame);
+  const quality = useMemo(() => getCinematicQuality(isPlayer), [isPlayer]);
 
   return (
     <AbsoluteFill className="big-eye-cinematic">
@@ -178,9 +182,9 @@ export const CinematicComposition = ({
         }}
         gl={{
           alpha: false,
-          antialias: true,
+          antialias: quality === 'high',
           powerPreference: 'high-performance',
-          preserveDrawingBuffer: true,
+          preserveDrawingBuffer: !isPlayer,
         }}
         onCreated={({ gl }) => {
           gl.toneMapping = ACESFilmicToneMapping;
@@ -189,9 +193,9 @@ export const CinematicComposition = ({
         }}
       >
         <fog attach="fog" args={[state.fogColor, state.fogNear, state.fogFar]} />
-        <Atmosphere frame={state.frame} state={state} />
-        <CinematicLighting state={state} />
-        <City frame={state.frame} state={state} />
+        <Atmosphere frame={state.frame} state={state} quality={quality} />
+        <CinematicLighting state={state} quality={quality} />
+        <City frame={state.frame} state={state} quality={quality} />
         <FinalCoast frame={state.frame} state={state} />
         <CinematicCamera frame={state.frame} progress={state.progress} />
       </ThreeCanvas>

--- a/src/cinematic/config/cinematicQuality.ts
+++ b/src/cinematic/config/cinematicQuality.ts
@@ -1,0 +1,19 @@
+export type CinematicQuality = 'high' | 'balanced';
+
+type NavigatorWithMemory = Navigator & { deviceMemory?: number };
+
+export const getCinematicQuality = (isPlayer: boolean): CinematicQuality => {
+  if (!isPlayer || typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return 'high';
+  }
+
+  const device = navigator as NavigatorWithMemory;
+  const cores = device.hardwareConcurrency ?? 8;
+  const memory = device.deviceMemory ?? 8;
+  const coarsePointer = window.matchMedia?.('(pointer: coarse)').matches ?? false;
+  const compactViewport = Math.min(window.innerWidth, window.innerHeight) <= 900;
+
+  return coarsePointer || compactViewport || cores <= 4 || memory <= 4
+    ? 'balanced'
+    : 'high';
+};

--- a/src/cinematic/effects/Atmosphere.tsx
+++ b/src/cinematic/effects/Atmosphere.tsx
@@ -10,6 +10,7 @@ import {
   Vector3,
 } from 'three';
 import { CINEMATIC_CONFIG } from '../config/cinematicConfig';
+import type { CinematicQuality } from '../config/cinematicQuality';
 import type { TimelineState } from '../timeline/timeline';
 import {
   CELESTIAL_EYE_SCALE,
@@ -23,6 +24,7 @@ import { createSeededRandom, randomBetween } from '../utils/seededRandom';
 type AtmosphereProps = {
   frame: number;
   state: TimelineState;
+  quality: CinematicQuality;
 };
 
 const SKY_VERTEX = `
@@ -78,7 +80,7 @@ const CLOUD_FRAGMENT = `
   }
 `;
 
-const SkyDome = ({ state }: { state: TimelineState }) => {
+const SkyDome = ({ state, quality }: { state: TimelineState; quality: CinematicQuality }) => {
   const uniforms = useMemo(() => ({
     uTop: { value: new Color(state.skyTop) },
     uHorizon: { value: new Color(state.skyHorizon) },
@@ -87,7 +89,7 @@ const SkyDome = ({ state }: { state: TimelineState }) => {
 
   return (
     <mesh position={[0, 70, -150]} scale={[1, 0.72, 1]}>
-      <sphereGeometry args={[720, 32, 20]} />
+      <sphereGeometry args={[720, quality === 'high' ? 32 : 24, quality === 'high' ? 20 : 14]} />
       <shaderMaterial
         side={BackSide}
         uniforms={uniforms}
@@ -99,10 +101,10 @@ const SkyDome = ({ state }: { state: TimelineState }) => {
   );
 };
 
-const Stars = ({ opacity, frame }: { opacity: number; frame: number }) => {
+const Stars = ({ opacity, frame, quality }: { opacity: number; frame: number; quality: CinematicQuality }) => {
   const { positions, colors } = useMemo(() => {
     const random = createSeededRandom(CINEMATIC_CONFIG.seed + 11);
-    const count = 2300;
+    const count = quality === 'high' ? 2300 : 1350;
     const positionValues = new Float32Array(count * 3);
     const colorValues = new Float32Array(count * 3);
     const cool = new Color('#dff8ff');
@@ -119,7 +121,7 @@ const Stars = ({ opacity, frame }: { opacity: number; frame: number }) => {
     }
 
     return { positions: positionValues, colors: colorValues };
-  }, []);
+  }, [quality]);
 
   if (opacity <= 0.001) return null;
   const twinkle = 0.9 + Math.sin(frame * 0.018) * 0.08;
@@ -143,12 +145,13 @@ const Stars = ({ opacity, frame }: { opacity: number; frame: number }) => {
   );
 };
 
-const CloudLayer = ({ frame, state, height, offset, scale }: {
+const CloudLayer = ({ frame, state, height, offset, scale, quality }: {
   frame: number;
   state: TimelineState;
   height: number;
   offset: number;
   scale: number;
+  quality: CinematicQuality;
 }) => {
   const uniforms = useMemo(() => ({
     uOpacity: { value: state.cloudOpacity },
@@ -158,7 +161,7 @@ const CloudLayer = ({ frame, state, height, offset, scale }: {
 
   return (
     <mesh position={[0, height, -150]} scale={[scale, scale * 0.72, scale]}>
-      <sphereGeometry args={[690, 32, 20]} />
+      <sphereGeometry args={[690, quality === 'high' ? 32 : 24, quality === 'high' ? 20 : 14]} />
       <shaderMaterial
         uniforms={uniforms}
         vertexShader={CLOUD_VERTEX}
@@ -180,12 +183,13 @@ type RainDrop = {
   thickness: number;
 };
 
-const Rain = ({ frame, intensity }: { frame: number; intensity: number }) => {
+const Rain = ({ frame, intensity, quality }: { frame: number; intensity: number; quality: CinematicQuality }) => {
   const meshRef = useRef<InstancedMesh>(null);
   const helper = useMemo(() => new Object3D(), []);
+  const sampledFrame = quality === 'balanced' ? Math.floor(frame / 2) * 2 : frame;
   const drops = useMemo<RainDrop[]>(() => {
     const random = createSeededRandom(CINEMATIC_CONFIG.seed + 91);
-    return Array.from({ length: 820 }, () => ({
+    return Array.from({ length: quality === 'high' ? 720 : 430 }, () => ({
       x: randomBetween(random, -78, 78),
       yOffset: randomBetween(random, 0, 118),
       z: randomBetween(random, CINEMATIC_CONFIG.city.farZ, CINEMATIC_CONFIG.city.nearZ),
@@ -193,14 +197,14 @@ const Rain = ({ frame, intensity }: { frame: number; intensity: number }) => {
       length: randomBetween(random, 2.2, 6.4),
       thickness: randomBetween(random, 0.018, 0.048),
     }));
-  }, []);
+  }, [quality]);
 
   useLayoutEffect(() => {
     const mesh = meshRef.current;
     if (!mesh) return;
 
     drops.forEach((drop, index) => {
-      const travel = (frame * drop.speed + drop.yOffset) % 118;
+      const travel = (sampledFrame * drop.speed + drop.yOffset) % 118;
       helper.position.set(drop.x + travel * 0.08, 112 - travel, drop.z);
       helper.rotation.set(0, 0, -0.13);
       helper.scale.set(drop.thickness, drop.length, drop.thickness);
@@ -209,7 +213,7 @@ const Rain = ({ frame, intensity }: { frame: number; intensity: number }) => {
     });
     mesh.instanceMatrix.setUsage(DynamicDrawUsage);
     mesh.instanceMatrix.needsUpdate = true;
-  }, [drops, frame, helper]);
+  }, [drops, helper, sampledFrame]);
 
   if (intensity <= 0.001) return null;
 
@@ -385,13 +389,13 @@ const CelestialEye = ({ opacity, frame, state }: {
   );
 };
 
-export const Atmosphere = ({ frame, state }: AtmosphereProps) => (
+export const Atmosphere = ({ frame, state, quality }: AtmosphereProps) => (
   <>
-    <SkyDome state={state} />
-    <Stars opacity={state.starsOpacity} frame={frame} />
-    <CloudLayer frame={frame} state={state} height={82} offset={0.4} scale={1.04} />
-    <CloudLayer frame={frame} state={state} height={103} offset={8.7} scale={1.22} />
-    <Rain frame={frame} intensity={state.rainIntensity} />
+    <SkyDome state={state} quality={quality} />
+    <Stars opacity={state.starsOpacity} frame={frame} quality={quality} />
+    <CloudLayer frame={frame} state={state} height={82} offset={0.4} scale={1.04} quality={quality} />
+    <CloudLayer frame={frame} state={state} height={103} offset={8.7} scale={1.22} quality={quality} />
+    <Rain frame={frame} intensity={state.rainIntensity} quality={quality} />
     <LightningBolt frame={frame} intensity={state.lightningBolt} />
     <CelestialEye opacity={state.eyeOpacity} frame={frame} state={state} />
   </>

--- a/src/cinematic/environment/FinalCoast.tsx
+++ b/src/cinematic/environment/FinalCoast.tsx
@@ -33,12 +33,14 @@ const SEA_FRAGMENT = `
   void main() {
     float waveA = sin(vUv.y * 155.0 + uTime * 0.052 + sin(vUv.x * 31.0)) * 0.5 + 0.5;
     float waveB = sin(vUv.y * 91.0 - uTime * 0.037 + vUv.x * 47.0) * 0.5 + 0.5;
+    float waveC = sin(vUv.y * 226.0 + uTime * 0.073 + sin(vUv.x * 18.0) * 1.8) * 0.5 + 0.5;
     float revealNoise = (waveA - 0.5) * 0.024 + (waveB - 0.5) * 0.016;
     float revealFront = 1.0 - clamp(uReveal, 0.0, 1.0);
     if (vUv.y + revealNoise < revealFront) discard;
     float revealEdge = 1.0 - smoothstep(0.0, 0.045, abs(vUv.y + revealNoise - revealFront));
 
-    float glint = smoothstep(0.945, 1.0, waveA * 0.66 + waveB * 0.34);
+    float glint = smoothstep(0.91, 1.0, waveA * 0.46 + waveB * 0.3 + waveC * 0.24);
+    float softCrest = smoothstep(0.76, 0.96, waveC * 0.62 + waveA * 0.38);
     float horizon = smoothstep(0.0, 1.0, vUv.y);
     vec3 dayDeep = vec3(0.035, 0.16, 0.22);
     vec3 dayHorizon = vec3(0.28, 0.52, 0.61);
@@ -51,22 +53,25 @@ const SEA_FRAGMENT = `
     vec3 eveningColor = mix(eveningDeep, eveningHorizon, horizon * 0.76);
     vec3 color = mix(dayColor, afternoonColor, uGoldenHour * 0.78);
     color = mix(color, eveningColor, uSunset * 0.94);
+    color *= 0.97 + (waveB - 0.5) * 0.045;
     color += mix(vec3(0.1, 0.2, 0.23), vec3(0.48, 0.28, 0.16), uGoldenHour) * revealEdge * 0.035;
-    color += glint * vec3(0.2, 0.4, 0.44) * (0.12 + horizon * 0.24);
+    color += glint * vec3(0.24, 0.46, 0.49) * (0.14 + horizon * 0.29);
+    color += softCrest * vec3(0.16, 0.31, 0.34) * (0.025 + horizon * 0.055);
 
     float reflectionCentre = 0.528
-      + sin(vUv.y * 31.0 + uTime * 0.018) * 0.009
-      + sin(vUv.y * 73.0 - uTime * 0.011) * 0.004;
-    float reflectionTightness = mix(18.0, 72.0, horizon);
+      + sin(vUv.y * 31.0 + uTime * 0.018) * 0.011
+      + sin(vUv.y * 73.0 - uTime * 0.011) * 0.005;
+    float reflectionTightness = mix(12.0, 58.0, horizon);
     float sunPath = exp(-abs(vUv.x - reflectionCentre) * reflectionTightness);
-    float brokenLight = smoothstep(0.48, 0.92, waveA * 0.55 + waveB * 0.45);
-    float reflectionFade = 1.0 - smoothstep(0.7, 1.0, uSunset);
-    float spill = sunPath * (0.16 + brokenLight * 1.18)
-      * (0.32 + horizon * 0.9) * reflectionFade;
-    vec3 reflectionWarm = mix(vec3(1.0, 0.68, 0.26), vec3(1.0, 0.19, 0.045), uSunset * 0.86);
-    color += reflectionWarm * spill;
-    color += mix(vec3(1.0, 0.88, 0.54), vec3(1.0, 0.38, 0.11), uSunset)
-      * sunPath * glint * horizon * reflectionFade * 0.72;
+    float reflectionScatter = exp(-abs(vUv.x - reflectionCentre) * mix(7.0, 22.0, horizon));
+    float brokenLight = smoothstep(0.39, 0.88, waveA * 0.42 + waveB * 0.28 + waveC * 0.3);
+    float reflectionFade = 1.0 - smoothstep(0.82, 1.0, uSunset);
+    float spill = (sunPath * (0.34 + brokenLight * 1.58) + reflectionScatter * glint * 0.36)
+      * (0.4 + horizon * 1.12) * reflectionFade * (0.88 + uGoldenHour * 0.42);
+    vec3 reflectionWarm = mix(vec3(1.0, 0.75, 0.32), vec3(1.0, 0.18, 0.035), uSunset * 0.86);
+    color += reflectionWarm * spill * 1.08;
+    color += mix(vec3(1.0, 0.93, 0.66), vec3(1.0, 0.34, 0.08), uSunset)
+      * sunPath * glint * horizon * reflectionFade * 1.05;
     gl_FragColor = vec4(color, uOpacity);
   }
 `;
@@ -97,7 +102,7 @@ const COAST_SURFACE_FRAGMENT = `
     float grain = hash(floor(p * 2.7));
     float broad = hash(floor(p * 0.16));
     float windRipple = sin(p.x * 0.19 + sin(p.y * 0.075) * 2.1) * 0.5 + 0.5;
-    float revealNoise = (broad - 0.5) * 0.055 + (windRipple - 0.5) * 0.028;
+    float revealNoise = 0.0;
     float revealFront = 1.0 - clamp(uReveal, 0.0, 1.0);
     if (depth + revealNoise < revealFront) discard;
 
@@ -148,28 +153,6 @@ const CLOUD_FRAGMENT = `
 
 type ShorePoint = readonly [number, number];
 
-const LEFT_EDGE: readonly ShorePoint[] = [
-  [-48, -425],
-  [-57, -472],
-  [-74, -525],
-  [-68, -580],
-  [-96, -644],
-  [-124, -710],
-  [-158, -790],
-  [-202, -895],
-] as const;
-
-const RIGHT_EDGE: readonly ShorePoint[] = [
-  [50, -425],
-  [64, -476],
-  [60, -532],
-  [88, -590],
-  [104, -650],
-  [132, -724],
-  [162, -806],
-  [212, -895],
-] as const;
-
 const BEACH_EDGE: readonly ShorePoint[] = [
   [-360, -522],
   [-220, -516],
@@ -200,28 +183,6 @@ const createBeachGeometry = (): BufferGeometry => {
   geometry.computeVertexNormals();
   return geometry;
 };
-const createShoreGeometry = (edge: readonly ShorePoint[], side: -1 | 1): BufferGeometry => {
-  const positions: number[] = [];
-  const outerX = side * 370;
-  for (let index = 0; index < edge.length - 1; index += 1) {
-    const current = edge[index];
-    const next = edge[index + 1];
-    if (!current || !next) continue;
-    positions.push(
-      outerX, 0, current[1],
-      current[0], 0.12, current[1],
-      outerX, 0, next[1],
-      current[0], 0.12, current[1],
-      next[0], 0.12, next[1],
-      outerX, 0, next[1],
-    );
-  }
-  const geometry = new BufferGeometry();
-  geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
-  geometry.computeVertexNormals();
-  return geometry;
-};
-
 const CloudBank = ({ frame, opacity, state }: {
   frame: number;
   opacity: number;
@@ -385,12 +346,13 @@ type YachtProps = {
   frame: number;
   logoTexture?: Texture;
   opacity: number;
+  sunset: number;
   position: readonly [number, number, number];
   rotation: number;
   scale?: number;
 };
 
-const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale = 1 }: YachtProps) => {
+const Yacht = ({ brand, frame, logoTexture, opacity, sunset, position, rotation, scale = 1 }: YachtProps) => {
   const rightSail = useMemo(() => createSailGeometry(1), []);
   const leftSail = useMemo(() => createSailGeometry(-1), []);
   const sailLogoGeometry = useMemo(() => createSailLogoGeometry(), []);
@@ -398,6 +360,7 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
   const bob = Math.sin(frame * 0.035 + position[0] * 0.08) * 0.12;
   const roll = Math.sin(frame * 0.022 + position[2] * 0.03) * 0.012;
   const translucent = opacity < 0.999;
+  const navigationLight = opacity * clamp01((sunset - 0.28) / 0.42) * (1 - clamp01((sunset - 0.95) / 0.05));
 
   return (
     <group
@@ -532,6 +495,18 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
           </mesh>
         </group>
       )}
+      <mesh position={[-2.48, 1.48, -1.72]}>
+        <sphereGeometry args={[0.14, 8, 6]} />
+        <meshBasicMaterial color="#ff5d68" transparent opacity={navigationLight} toneMapped={false} />
+      </mesh>
+      <mesh position={[2.48, 1.48, -1.72]}>
+        <sphereGeometry args={[0.14, 8, 6]} />
+        <meshBasicMaterial color="#71f1b1" transparent opacity={navigationLight} toneMapped={false} />
+      </mesh>
+      <mesh position={[0, 1.72, 0.82]}>
+        <boxGeometry args={[1.55, 0.22, 0.54]} />
+        <meshBasicMaterial color="#ffd49a" transparent opacity={navigationLight * 0.78} toneMapped={false} />
+      </mesh>
       <Line
         points={[new Vector3(-2.15, 0.18, -4.2), new Vector3(-3.3, 0.12, -14.5)]}
         color="#d6f7f3"
@@ -552,20 +527,21 @@ const Yacht = ({ brand, frame, logoTexture, opacity, position, rotation, scale =
   );
 };
 
-const Yachts = ({ frame, opacity }: { frame: number; opacity: number }) => {
+const Yachts = ({ frame, opacity, sunset }: { frame: number; opacity: number; sunset: number }) => {
   // CanvasTexture is created synchronously, so the coast never suspends the
   // entire WebGL canvas while a late image asset is fetched on mobile.
   const logoTexture = useMemo(() => createKoleQuantLogoTexture(), []);
 
   return (
     <group>
-      <Yacht brand="eye" frame={frame} opacity={opacity} position={[-39, 0.18, -548]} rotation={0.13} />
-      <group position={[42, 0.08, -558]} rotation={[0, -0.11, 0]} scale={[1.12, 1.12, 1.12]}>
+      <Yacht brand="eye" frame={frame} opacity={opacity} sunset={sunset} position={[-52, 0.18, -638]} rotation={0.13} />
+      <group position={[48, 0.08, -622]} rotation={[0, -0.11, 0]} scale={[1.12, 1.12, 1.12]}>
         <Yacht
           brand="kolequant"
           frame={frame}
           logoTexture={logoTexture}
           opacity={opacity}
+          sunset={sunset}
           position={[0, 0, 0]}
           rotation={0}
         />
@@ -574,67 +550,14 @@ const Yachts = ({ frame, opacity }: { frame: number; opacity: number }) => {
   );
 };
 
-const BirdFlock = ({ frame, opacity }: { frame: number; opacity: number }) => {
-  const birds = useMemo(() => [
-    [-62, 66, -710, 0.8],
-    [-46, 74, -735, 1.15],
-    [-28, 60, -760, 1.7],
-    [-8, 70, -785, 2.25],
-    [14, 58, -810, 2.8],
-    [38, 68, -835, 3.4],
-    [61, 56, -860, 3.9],
-  ] as const, []);
-  const drift = Math.max(0, frame - 1530) * 0.015;
-
-  return (
-    <group>
-      {birds.map(([x, y, z, phase], index) => {
-        const wing = 1.8 + (index % 3) * 0.28;
-        const flap = 0.58 + Math.sin(frame * 0.16 + phase) * 0.24;
-        return (
-          <Line
-            key={`${x}-${z}`}
-            position={[x + drift, y + Math.sin(frame * 0.025 + phase) * 0.4, z]}
-            points={[
-              new Vector3(-wing, 0, 0),
-              new Vector3(0, flap, 0),
-              new Vector3(wing, 0, 0),
-            ]}
-            color="#22323a"
-            lineWidth={2.6}
-            transparent
-            opacity={opacity * 0.88}
-            depthWrite={false}
-          />
-        );
-      })}
-    </group>
-  );
-};
 export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineState }) => {
   const beachGeometry = useMemo(() => createBeachGeometry(), []);
   const beachSurf = useMemo(() => BEACH_EDGE.map(([x, z]) => new Vector3(x, 0.34, z)), []);
-  const leftGeometry = useMemo(() => createShoreGeometry(LEFT_EDGE, -1), []);
-  const rightGeometry = useMemo(() => createShoreGeometry(RIGHT_EDGE, 1), []);
-  const leftSurf = useMemo(
-    () => LEFT_EDGE.map(([x, z]) => new Vector3(x + 1.6, 0.38, z)),
-    [],
-  );
-  const rightSurf = useMemo(
-    () => RIGHT_EDGE.map(([x, z]) => new Vector3(x - 1.6, 0.38, z)),
-    [],
-  );
   const opacity = state.coastProgress;
   const detailOpacity = clamp01((opacity - 0.38) / 0.62);
   const sandColor = new Color('#c69a72')
     .lerp(new Color('#b66d50'), state.goldenHourProgress * 0.62)
     .lerp(new Color('#55303a'), state.sunsetProgress * 0.9);
-  const leftShoreColor = new Color('#172722')
-    .lerp(new Color('#2f2b26'), state.goldenHourProgress * 0.5)
-    .lerp(new Color('#11151d'), state.sunsetProgress * 0.88);
-  const rightShoreColor = new Color('#1d2b25')
-    .lerp(new Color('#3a3028'), state.goldenHourProgress * 0.5)
-    .lerp(new Color('#141721'), state.sunsetProgress * 0.88);
 
   // Reveal opaque coast pixels from the distant horizon toward the camera.
   // This keeps the city spatially continuous during the transition without
@@ -683,30 +606,8 @@ export const FinalCoast = ({ frame, state }: { frame: number; state: TimelineSta
         opacity={detailOpacity * 0.62}
         depthWrite={false}
       />
-      {[leftGeometry, rightGeometry].map((geometry, index) => (
-        <mesh key={index} geometry={geometry}>
-          <shaderMaterial
-            vertexShader={COAST_SURFACE_VERTEX}
-            fragmentShader={COAST_SURFACE_FRAGMENT}
-            uniforms={{
-              uBaseColor: { value: index === 0 ? leftShoreColor : rightShoreColor },
-              uReveal: { value: clamp01((opacity - 0.48) / 0.52) },
-              uNearDepth: { value: 425 },
-              uFarDepth: { value: 895 },
-              uRockiness: { value: 1 },
-              uSunset: { value: state.sunsetProgress },
-            }}
-            side={DoubleSide}
-            depthWrite
-          />
-        </mesh>
-      ))}
-
-      <Line points={leftSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={detailOpacity * 0.54} depthWrite={false} />
-      <Line points={rightSurf} color="#d8f5ef" lineWidth={2.1} transparent opacity={detailOpacity * 0.54} depthWrite={false} />
       <CloudBank frame={frame} opacity={detailOpacity} state={state} />
-      <Yachts frame={frame} opacity={detailOpacity} />
-      <BirdFlock frame={frame} opacity={detailOpacity} />
+      <Yachts frame={frame} opacity={detailOpacity} sunset={state.sunsetProgress} />
     </group>
   );
 };

--- a/src/cinematic/lighting/CinematicLighting.tsx
+++ b/src/cinematic/lighting/CinematicLighting.tsx
@@ -4,6 +4,7 @@ import {
   getCelestialBreath,
   getCelestialEyePosition,
 } from '../celestial/celestialGeometry';
+import type { CinematicQuality } from '../config/cinematicQuality';
 import type { TimelineState } from '../timeline/timeline';
 import { clamp01, lerp, smootherstep } from '../utils/math';
 
@@ -31,12 +32,17 @@ const HALO_VERTEX = `
 const HALO_FRAGMENT = `
   uniform vec3 uColor;
   uniform float uOpacity;
+  uniform float uTime;
   varying vec2 vUv;
   void main() {
-    float radius = length(vUv - vec2(0.5)) * 2.0;
-    float falloff = 1.0 - smoothstep(0.18, 1.0, radius);
-    falloff *= falloff;
-    gl_FragColor = vec4(uColor * 1.12, falloff * uOpacity);
+    vec2 p = vUv - vec2(0.5);
+    float radius = length(p) * 2.0;
+    float angle = atan(p.y, p.x);
+    float bloom = pow(1.0 - smoothstep(0.12, 1.0, radius), 2.1);
+    float inner = pow(1.0 - smoothstep(0.0, 0.58, radius), 1.35);
+    float corona = 0.94 + cos(angle * 9.0 + uTime * 0.018) * 0.06;
+    vec3 color = uColor * (1.02 + inner * 0.72);
+    gl_FragColor = vec4(color, (bloom * corona + inner * 0.28) * uOpacity);
   }
 `;
 const APERTURE_FRAGMENT = `
@@ -104,18 +110,22 @@ const CELESTIAL_FRAGMENT = `
       * sin(vUv.y * 39.0 - uTime * 0.009);
     float solarCellB = sin((vUv.x + vUv.y) * 91.0 - uTime * 0.006)
       * sin((vUv.x - vUv.y) * 63.0 + uTime * 0.008);
+    float driftingCells = sin(vUv.x * 24.0 - uTime * 0.004 + sin(vUv.y * 29.0)) * 0.5 + 0.5;
     float solarLimb = clamp(max(0.0, vNormal.z), 0.0, 1.0);
-    float coreHeat = pow(solarLimb, 0.46);
-    vec3 sunEdge = mix(vec3(1.0, 0.30, 0.055), vec3(0.82, 0.055, 0.018), uSunset);
-    vec3 sunCore = mix(vec3(1.0, 0.88, 0.47), vec3(1.0, 0.43, 0.12), uSunset * 0.82);
-    vec3 sun = mix(sunEdge, sunCore, coreHeat);
-    sun *= 1.0 + solarCellA * 0.045 + solarCellB * 0.022;
-    sun += vec3(1.0, 0.72, 0.28) * pow(solarLimb, 2.2) * 0.12;
-
+    float coreHeat = pow(solarLimb, 0.38);
+    float limbDepth = smoothstep(0.02, 0.92, solarLimb);
+    vec3 sunEdge = mix(vec3(0.88, 0.095, 0.016), vec3(0.58, 0.018, 0.012), uSunset);
+    vec3 sunMid = mix(vec3(1.0, 0.43, 0.08), vec3(0.98, 0.15, 0.025), uSunset * 0.82);
+    vec3 sunCore = mix(vec3(1.0, 0.94, 0.62), vec3(1.0, 0.52, 0.16), uSunset * 0.78);
+    vec3 sun = mix(sunEdge, sunMid, sqrt(coreHeat));
+    sun = mix(sun, sunCore, pow(coreHeat, 2.15));
+    sun *= 0.94 + solarCellA * 0.065 + solarCellB * 0.034 + driftingCells * 0.075;
+    sun += vec3(1.0, 0.62, 0.18) * pow(solarLimb, 2.7) * 0.2;
+    sun *= mix(0.76, 1.08, limbDepth);
     gl_FragColor = vec4(mix(moon, sun, uSunMorph), uOpacity);
   }
 `;
-const CelestialAperture = ({ closure }: { closure: number }) => {
+const CelestialAperture = ({ closure, quality }: { closure: number; quality: CinematicQuality }) => {
   if (closure <= 0.001) return null;
 
   return (
@@ -135,7 +145,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
         />
       </mesh>
       <mesh position={[0, 0, 0.08]}>
-        <ringGeometry args={[CELESTIAL_DISC_RADIUS - 0.28, CELESTIAL_DISC_RADIUS + 0.28, 96]} />
+        <ringGeometry args={[CELESTIAL_DISC_RADIUS - 0.28, CELESTIAL_DISC_RADIUS + 0.28, quality === 'high' ? 72 : 48]} />
         <meshBasicMaterial
           color="#d8fff7"
           transparent
@@ -148,7 +158,7 @@ const CelestialAperture = ({ closure }: { closure: number }) => {
     </group>
   );
 };
-const CelestialBody = ({ state, sunX }: { state: TimelineState; sunX: number }) => {
+const CelestialBody = ({ state, sunX, quality }: { state: TimelineState; sunX: number; quality: CinematicQuality }) => {
   const sunsetOcclusion = 1 - smootherstep(clamp01((state.sunsetProgress - 0.72) / 0.28));
   const sunMorph = state.sunMorph;
   const lunarStrength = 1 - sunMorph;
@@ -192,7 +202,7 @@ const CelestialBody = ({ state, sunX }: { state: TimelineState; sunX: number }) 
         />
       </mesh>
       <mesh scale={[sunVisualScale, sunVisualScale, sunVisualScale]}>
-        <sphereGeometry args={[CELESTIAL_DISC_RADIUS, 64, 48]} />
+        <sphereGeometry args={[CELESTIAL_DISC_RADIUS, quality === 'high' ? 48 : 36, quality === 'high' ? 34 : 24]} />
         <shaderMaterial
           vertexShader={CELESTIAL_VERTEX}
           fragmentShader={CELESTIAL_FRAGMENT}
@@ -212,12 +222,12 @@ const CelestialBody = ({ state, sunX }: { state: TimelineState; sunX: number }) 
         intensity={(moonVisibility * 0.62 + sunVisibility * 1.3) * sunsetOcclusion}
         distance={390}
       />
-      <CelestialAperture closure={state.apertureClosure} />
+      <CelestialAperture closure={state.apertureClosure} quality={quality} />
     </group>
   );
 };
 
-export const CinematicLighting = ({ state }: { state: TimelineState }) => {
+export const CinematicLighting = ({ state, quality }: { state: TimelineState; quality: CinematicQuality }) => {
   const sunX = 22;
   const sunY = 15;
   const moonY = lerp(-42, 138, state.moonProgress);
@@ -240,7 +250,7 @@ export const CinematicLighting = ({ state }: { state: TimelineState }) => {
         intensity={state.moonIntensity * 0.36}
         position={[-120, moonY, -310]}
       />
-      <CelestialBody state={state} sunX={sunX} />
+      <CelestialBody state={state} sunX={sunX} quality={quality} />
     </>
   );
 };

--- a/src/screens/Credits/Credits.css
+++ b/src/screens/Credits/Credits.css
@@ -7,12 +7,24 @@
   background: #02030a;
   overflow: hidden;
   z-index: 1000;
-  opacity: 1;
-  transition: opacity 420ms ease;
 }
 
-.credits-container.is-exiting {
+.credits-end-guard {
+  position: fixed;
+  inset: 0;
+  z-index: 4;
+  background: #02030a;
   opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+}
+
+.credits-end-guard.is-visible {
+  opacity: 1;
+}
+
+.credits-end-guard.is-instant {
+  transition: none;
 }
 
 .credits-stage {

--- a/src/screens/Credits/Credits.tsx
+++ b/src/screens/Credits/Credits.tsx
@@ -23,15 +23,21 @@ export default function Credits() {
   const navigate = useNavigate();
   const exitTimeoutRef = useRef<number | null>(null);
   const playerRef = useRef<PlayerRef | null>(null);
+  const blackoutRef = useRef<HTMLDivElement | null>(null);
   const [initialFrame] = useState(getCreditsSoundtrackFrame);
   const [isExiting, setIsExiting] = useState(false);
   const [needsStart, setNeedsStart] = useState(() => !isCreditsSoundtrackPlaying());
 
-  const onExit = useCallback(() => {
+  const onExit = useCallback((instantBlackout = false) => {
     if (isExiting) {
       return;
     }
 
+    const blackout = blackoutRef.current;
+    if (instantBlackout) {
+      blackout?.classList.add('is-instant');
+    }
+    blackout?.classList.add('is-visible');
     setIsExiting(true);
     playerRef.current?.pause();
     stopCreditsSoundtrack();
@@ -62,7 +68,7 @@ export default function Credits() {
       return;
     }
 
-    const onPlayerEnded = () => onExit();
+    const onPlayerEnded = () => onExit(true);
     player.addEventListener('ended', onPlayerEnded);
 
     if (!player.isPlaying()) {
@@ -138,6 +144,12 @@ export default function Credits() {
           </div>
         )}
       </div>
+      <div
+        ref={blackoutRef}
+        className="credits-end-guard"
+        data-testid="credits-end-guard"
+        aria-hidden="true"
+      />
     </div>
   );
 }

--- a/src/screens/Credits/__tests__/Credits.test.tsx
+++ b/src/screens/Credits/__tests__/Credits.test.tsx
@@ -188,10 +188,15 @@ describe('Credits', () => {
 
     act(() => {
       playerMock.emitEnded();
-      vi.advanceTimersByTime(EXIT_FADE_MS);
     });
 
     expect(playerMock.pause).toHaveBeenCalled();
+    expect(screen.getByTestId('credits-end-guard')).toHaveClass('is-visible', 'is-instant');
+
+    act(() => {
+      vi.advanceTimersByTime(EXIT_FADE_MS);
+    });
+
     expect(screen.getByText('Home screen')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- ships the approved WebGL credits V2 with adaptive mobile quality and smoother playback
- adds dedicated ground-floor shops, umbrella pedestrians, retro street lighting, and refined city/coast visuals
- improves the sun, sea reflection, yacht staging, and end-of-playback blackout handling
- preserves the latest credits text and timing already committed on `main`

## V1 archive

The complete previous version is preserved in the permanent tag `credits-webgl-v1` (commit `8091bacc`). Restore it with:

```bash
git switch -c restore/credits-webgl-v1 credits-webgl-v1
```

The archive is also documented in `docs/BIG_EYE_CINEMATIC.md`.

## Validation

- `npm run typecheck`
- `npx eslint src/cinematic src/screens/Credits`
- `npx vitest run src/cinematic src/screens/Credits/__tests__/Credits.test.tsx` — 8 tests passed
- `npm run build`