### PR TITLE
Fix Tilt Labyrinth freezing at the goal

### DIFF
--- a/src/components/TiltLabyrinthComp/TiltLabyrinthComp.tsx
+++ b/src/components/TiltLabyrinthComp/TiltLabyrinthComp.tsx
@@ -676,7 +676,14 @@ export default function TiltLabyrinthComp({
 
   // â”€â”€ Initialise on mount â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   useEffect(() => {
-    if (initializedCompetitionRef.current === competitionIdentity) return;
+    // Strict Mode replays effects by running cleanup and setup again. The cleanup
+    // resets the slice to idle, so allow that replay to initialize the same
+    // competition again. Once Redux is active, keep guarding against prop-only
+    // rerenders so a completed result is never overwritten.
+    if (
+      initializedCompetitionRef.current === competitionIdentity &&
+      labState?.phase !== 'idle'
+    ) return;
     initializedCompetitionRef.current = competitionIdentity;
 
     const rng = makeRng((seed >>> 0) ^ 0xfeedcafe);
@@ -784,7 +791,16 @@ export default function TiltLabyrinthComp({
 
   // Include all props that supply competition data. The stable identity guard
   // prevents parent rerenders with new array instances from resetting a result.
-  }, [competitionIdentity, dispatch, seed, participantIds, participants, prizeType, gamePlayers]);
+  }, [
+    competitionIdentity,
+    dispatch,
+    seed,
+    participantIds,
+    participants,
+    prizeType,
+    gamePlayers,
+    labState?.phase,
+  ]);
 
   useEffect(() => () => {
     dispatch(resetTiltLabyrinth());

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,7 +14,7 @@ import RouteErrorBoundary   from './components/RouteErrorBoundary/RouteErrorBoun
 import RouteLoadingScreen   from './components/RouteLoadingScreen/RouteLoadingScreen';
 import HomeHub              from './screens/HomeHub/HomeHub';
 import NotFound             from './screens/NotFound/NotFound';
-import { canAccessSpecialSettings } from './utils/debugMode';
+import SettingsAdminRoute from './routes/SettingsAdminRoute';
 import { lazy, Suspense, type ReactNode } from 'react';
 
 const GameRoute = lazy(() => import('./routes/GameRoute'));
@@ -40,14 +40,7 @@ const load = (element: ReactNode) => (
 
 // Keep the deep-link route registered so hash-router startup timing cannot turn
 // a valid QA URL into the catch-all 404. Access is still enforced by the route
-// element below at render time.
-const SettingsAdmin = lazy(() => import('./screens/SettingsAdmin/SettingsAdmin'));
-
-function SettingsAdminRoute() {
-  return import.meta.env.DEV || canAccessSpecialSettings()
-    ? <Suspense fallback={null}><SettingsAdmin /></Suspense>
-    : <NotFound />;
-}
+// element at render time.
 const GameDebug = import.meta.env.DEV
   ? lazy(() => import('./screens/GameDebug/GameDebug'))
   : null;

--- a/src/routes/SettingsAdminRoute.tsx
+++ b/src/routes/SettingsAdminRoute.tsx
@@ -1,0 +1,15 @@
+import { lazy, Suspense } from 'react';
+import NotFound from '../screens/NotFound/NotFound';
+import { canAccessSpecialSettings } from '../utils/debugMode';
+
+const SettingsAdmin = lazy(() => import('../screens/SettingsAdmin/SettingsAdmin'));
+
+export default function SettingsAdminRoute() {
+  return import.meta.env.DEV || canAccessSpecialSettings()
+    ? (
+        <Suspense fallback={null}>
+          <SettingsAdmin />
+        </Suspense>
+      )
+    : <NotFound />;
+}

--- a/tests/unit/tiltLabyrinth/TiltLabyrinthComp.test.tsx
+++ b/tests/unit/tiltLabyrinth/TiltLabyrinthComp.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import type { ReactNode } from 'react';
+import { StrictMode, type ReactNode } from 'react';
 import TiltLabyrinthComp from '../../../src/components/TiltLabyrinthComp/TiltLabyrinthComp';
 import {
   calculateTiltAdjustedTime,
@@ -277,6 +277,35 @@ describe('TiltLabyrinthComp movement hardening', () => {
       authoritativeWinnerId: 'ai-1',
       authoritativeLastPlaceId: null,
     });
+  });
+
+  it('reinitializes Redux state after the Strict Mode effect replay', () => {
+    const store = makeStore();
+
+    render(
+      <StrictMode>
+        <Provider store={store}>
+          <TiltLabyrinthComp
+            participantIds={['human', 'ai-1']}
+            participants={[
+              { id: 'human', name: 'You', isHuman: true, precomputedScore: 0, previousPR: null },
+              { id: 'ai-1', name: 'Alex', isHuman: false, precomputedScore: 0, previousPR: null },
+            ]}
+            prizeType="LOH"
+            seed={42}
+            onComplete={vi.fn()}
+          />
+        </Provider>
+      </StrictMode>,
+    );
+
+    expect(store.getState().tiltLabyrinth.phase).toBe('playing');
+
+    act(() => {
+      store.dispatch(setHumanScore(4321));
+    });
+
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
   });
 
   it('preserves completed results when the parent recreates participant arrays', () => {


### PR DESCRIPTION
## Summary
- reinitialize Tilt Labyrinth state after React Strict Mode's effect cleanup/setup replay
- preserve the existing rerender guard once the Redux competition is active
- add a Strict Mode regression test proving score submission reaches the results screen

## Root cause
The Strict Mode cleanup reset the Redux slice to `idle`, while the component ref still marked the same competition as initialized. Replayed setup was skipped, so reaching the goal stopped the canvas but `setHumanScore` was ignored by the idle slice.