### PR TITLE
Stabilize compact-mobile deployment recovery flows

### DIFF
--- a/e2e/playwright/core-player-journeys.spec.ts
+++ b/e2e/playwright/core-player-journeys.spec.ts
@@ -20,12 +20,14 @@ const CORRUPT_SAVE_RECOVERY_KEY = 'bbmobilenew:recovery:lastCorruptSave'
 
 async function waitForHome(page: Page): Promise<void> {
   const mainMenu = page.getByRole('navigation', { name: 'Main menu' })
-  await expect(mainMenu).toBeVisible({ timeout: SCREEN_TIMEOUT_MS })
+  await expect(mainMenu).toBeVisible({ timeout: SCREEN_TIMEOUT_MS * 2 })
   await closeDebugPanelIfOpen(page)
 
   await dismissPermissionPromptIfPresent(page)
 
-  await expect(mainMenu.getByRole('button', { name: 'Play', exact: true })).toBeEnabled()
+  await expect(mainMenu.getByRole('button', { name: 'Play', exact: true })).toBeEnabled({
+    timeout: SCREEN_TIMEOUT_MS,
+  })
 }
 
 async function createProfileFromHome(page: Page, playerName: string): Promise<void> {
@@ -798,6 +800,7 @@ test.describe('Real player core journeys', () => {
     )
 
     await page.reload()
+    await page.waitForLoadState('networkidle')
     await waitForHome(page)
 
     const recoveryNotice = page.getByRole('alert')

--- a/e2e/playwright/final4-pov.spec.ts
+++ b/e2e/playwright/final4-pov.spec.ts
@@ -79,6 +79,7 @@ test.describe.serial('Final 4 POS messaging & sequencing @release', () => {
     // POS holder (index 4) must NOT overlap with nominees (indices 2 and 3)
     await forceNominees(page, 2, 3)
     await forcePov(page, 4) // index 4 = fourth alive player (AI)
+    await page.waitForTimeout(500)
 
     // Force the phase to final4_eviction
     const forceF4Btn = page.getByRole('button', { name: 'Force Final 4' })
@@ -87,7 +88,8 @@ test.describe.serial('Final 4 POS messaging & sequencing @release', () => {
 
     // Advance — Continue is visible because the AI is the POS holder (no blocking flag)
     const continueBtn = page.getByRole('button', { name: 'Advance to next phase' })
-    await expect(continueBtn).toBeVisible({ timeout: 3000 })
+    await expect(continueBtn).toBeVisible({ timeout: 10000 })
+    await page.waitForLoadState('networkidle')
     await continueBtn.click()
 
     // After advance(): plea sequence + AI eviction decision should appear in TV feed


### PR DESCRIPTION
Implements the solution from #1222:

- doubles the Home recovery visibility allowance and explicitly waits for the Play action to become enabled
- waits for network idle after reloading a deliberately corrupted save
- allows the Final Four debug state to settle and increases the Continue visibility allowance before advancing

Validation:
- focused Prettier check
- focused ESLint check
- `npm run typecheck`

Closes #1222