### PR TITLE
Balance House of Cards preliminary AI

### DIFF
--- a/src/components/HouseOfCardsComp/HouseOfCardsComp.tsx
+++ b/src/components/HouseOfCardsComp/HouseOfCardsComp.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
-import { mulberry32 } from '../../store/rng';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import type { RootState } from '../../store/store';
 import {
@@ -12,6 +11,10 @@ import {
   type PlayerOutcome,
 } from '../../features/houseOfCards/houseOfCardsSlice';
 import { resolveHouseOfCardsOutcome } from '../../features/houseOfCards/thunks';
+import {
+  createHouseOfCardsAiProfiles,
+  simulateHouseOfCardsAiRound,
+} from '../../features/houseOfCards/houseOfCardsAi';
 import { cryptoSeed } from '../../features/riskWheel/cryptoSpin';
 import { useHouseOfCardsAudio } from '../../hooks/useHouseOfCardsAudio';
 import MinigameCompleteWrapper from '../MinigameHost/MinigameCompleteWrapper';
@@ -67,23 +70,6 @@ function hashId(value: string): number {
   return hash >>> 0;
 }
 
-function simulateRound(playerId: string, round: number, pairCount: number, seed: number, skill = 55): RoundPerformance {
-  const rng = mulberry32((seed ^ hashId(playerId) ^ Math.imul(round, 0x9e3779b9)) >>> 0);
-  const normalizedSkill = Math.max(0.15, Math.min(0.95, skill / 100));
-  const mistakes = Math.floor(rng() * (2 + (1 - normalizedSkill) * pairCount * 0.65));
-  const timeMs = Math.round(
-    pairCount * (720 + (1 - normalizedSkill) * 720)
-    + mistakes * (820 + rng() * 520)
-    + 1_400
-    + rng() * 2_600,
-  );
-  return {
-    mistakes,
-    timeMs,
-    score: Math.max(1, pairCount * 1_000 - mistakes * 90 - Math.floor(timeMs / 1_000)),
-  };
-}
-
 function boardColumns(tileCount: number): number {
   if (tileCount <= 8) return 4;
   if (tileCount <= 16) return 4;
@@ -102,9 +88,9 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
     (id: string) => participants?.find((participant) => participant.id === id)?.name ?? id,
     [participants],
   );
-  const skillFor = useCallback(
-    (id: string) => participants?.find((participant) => participant.id === id)?.precomputedScore ?? 55,
-    [participants],
+  const aiProfiles = useMemo(
+    () => createHouseOfCardsAiProfiles(participantIds, humanId, sessionSeed),
+    [participantIds, humanId, sessionSeed],
   );
   const hoc = useAppSelector(
     (state: RootState) => (state as RootState & { houseOfCards?: HouseOfCardsState }).houseOfCards,
@@ -213,7 +199,13 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
           score: Math.max(1, pairs * 1_000 - mistakes * 90 - Math.floor(timeMs / 1_000) + bestStreak * 15),
         };
       } else {
-        roundScores[id] = simulateRound(id, round, pairs, sessionSeed, skillFor(id));
+        roundScores[id] = simulateHouseOfCardsAiRound({
+          playerId: id,
+          round,
+          pairCount: pairs,
+          tournamentSeed: sessionSeed,
+          sessionAbility: aiProfiles[id]?.sessionAbility ?? 55,
+        });
       }
     });
     const nextScores = { ...cumulativeScores };
@@ -232,7 +224,7 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
     setCumulativeScores(nextScores);
     setRoundSummary({ round, rankedIds, eliminatedIds, nextActiveIds, roundScores, cumulativeScores: nextScores });
     setPhase('round_results');
-  }, [activeIds, bestStreak, cumulativeScores, humanId, mistakes, round, sessionSeed, skillFor]);
+  }, [activeIds, aiProfiles, bestStreak, cumulativeScores, humanId, mistakes, round, sessionSeed]);
 
   useEffect(() => {
     if (phase === 'playing' && matchedPairs >= targetPairs) finishPreliminaryRound();
@@ -249,14 +241,20 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
       const pairs = HOUSE_OF_CARDS_TILE_COUNTS[simulatedRound - 1] / 2;
       const performances = Object.fromEntries(ids.map((id) => [
         id,
-        simulateRound(id, simulatedRound, pairs, sessionSeed, skillFor(id)),
+        simulateHouseOfCardsAiRound({
+          playerId: id,
+          round: simulatedRound,
+          pairCount: pairs,
+          tournamentSeed: sessionSeed,
+          sessionAbility: aiProfiles[id]?.sessionAbility ?? 55,
+        }),
       ]));
       ids.forEach((id) => { scores[id] = (scores[id] ?? 0) + performances[id].score; });
       ids.sort((a, b) => scores[b] - scores[a] || performances[b].score - performances[a].score);
       ids = simulatedRound === 4 ? ids.slice(0, 2) : ids.length > 2 ? ids.slice(0, -1) : ids;
     }
     startFinal(ids, scores);
-  }, [sessionSeed, skillFor, startFinal]);
+  }, [aiProfiles, sessionSeed, startFinal]);
 
   const continueRound = useCallback(() => {
     if (!roundSummary) return;
@@ -349,7 +347,7 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
         board,
         rememberedIndexes: aiMemoryRef.current,
         seed: (sessionSeed ^ hashId(finalTurnId) ^ turn) >>> 0,
-        skill: skillFor(finalTurnId),
+        skill: 55,
       });
       if (!pair) return;
       const [firstIndex, secondIndex] = pair;
@@ -359,7 +357,7 @@ export default function HouseOfCardsComp({ participantIds, participants, prizeTy
       resolvePair(firstIndex, secondIndex);
     }, 850 + (aiTurnRef.current % 3) * 260);
     return () => window.clearTimeout(timer);
-  }, [board, finalTurnId, humanId, locked, matchedPairs, phase, resolvePair, sessionSeed, skillFor, targetPairs]);
+  }, [board, finalTurnId, humanId, locked, matchedPairs, phase, resolvePair, sessionSeed, targetPairs]);
 
   useEffect(() => {
     if (phase !== 'final_playing' || matchedPairs < targetPairs || finalCompletedRef.current || finalists.length < 2) return;

--- a/src/features/houseOfCards/houseOfCardsAi.ts
+++ b/src/features/houseOfCards/houseOfCardsAi.ts
@@ -1,0 +1,141 @@
+import { mulberry32 } from '../../store/rng';
+
+export interface HouseOfCardsAiSessionProfile {
+  playerId: string;
+  sessionAbility: number;
+}
+
+export interface HouseOfCardsRoundPerformance {
+  score: number;
+  mistakes: number;
+  timeMs: number;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function hashId(value: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function getPerfectRunChance(effectiveAbility: number): number {
+  if (effectiveAbility < 45) return 0.001;
+  if (effectiveAbility < 60) return 0.005;
+  if (effectiveAbility < 75) return 0.02;
+  if (effectiveAbility < 85) return 0.05;
+  return 0.08;
+}
+
+export function createHouseOfCardsSessionAbility(
+  playerId: string,
+  tournamentSeed: number,
+): number {
+  const rng = mulberry32(
+    (tournamentSeed ^ hashId(playerId) ^ 0x517cc1b7) >>> 0,
+  );
+  const centered =
+    (rng() + rng() + rng() + rng()) / 4 - 0.5;
+
+  return Math.round(
+    clamp(55 + centered * 80, 25, 85),
+  );
+}
+
+export function createHouseOfCardsAiProfiles(
+  participantIds: string[],
+  humanId: string | null,
+  tournamentSeed: number,
+): Record<string, HouseOfCardsAiSessionProfile> {
+  return Object.fromEntries(
+    participantIds
+      .filter((playerId) => playerId !== humanId)
+      .map((playerId) => [
+        playerId,
+        {
+          playerId,
+          sessionAbility: createHouseOfCardsSessionAbility(playerId, tournamentSeed),
+        },
+      ]),
+  );
+}
+
+export function simulateHouseOfCardsAiRound(params: {
+  playerId: string;
+  round: number;
+  pairCount: number;
+  tournamentSeed: number;
+  sessionAbility: number;
+}): HouseOfCardsRoundPerformance {
+  const { playerId, round, pairCount, tournamentSeed, sessionAbility } = params;
+  const rng = mulberry32(
+    (
+      tournamentSeed
+      ^ hashId(playerId)
+      ^ Math.imul(round, 0x9e3779b9)
+    ) >>> 0,
+  );
+  const roundCentered =
+    (rng() + rng() + rng() + rng()) / 4 - 0.5;
+  const roundForm = roundCentered * 28;
+  const effectiveAbility = clamp(
+    sessionAbility + roundForm,
+    20,
+    90,
+  );
+  const ability01 = effectiveAbility / 100;
+  const expectedMistakes =
+    pairCount * (0.9 - ability01 * 0.62);
+  const variation =
+    ((rng() + rng() + rng() + rng()) / 4 - 0.5)
+    * pairCount
+    * 0.7;
+  let mistakes = Math.round(
+    expectedMistakes + variation,
+  );
+
+  mistakes = clamp(
+    mistakes,
+    0,
+    Math.max(2, Math.round(pairCount * 1.5)),
+  );
+
+  if (rng() < getPerfectRunChance(effectiveAbility)) {
+    mistakes = 0;
+  } else {
+    mistakes = Math.max(1, mistakes);
+  }
+
+  const basePerPairMs =
+    850 + (1 - ability01) * 650;
+  const mistakeDelayMs =
+    mistakes * (850 + rng() * 500);
+  const timeMs = Math.max(
+    3000,
+    Math.round(
+      pairCount * basePerPairMs
+        + mistakeDelayMs
+        + 1200
+        + rng() * 2500,
+    ),
+  );
+  const score = Math.max(
+    1,
+    pairCount * 1000
+      - mistakes * 90
+      - Math.floor(timeMs / 1000),
+  );
+
+  return {
+    mistakes,
+    timeMs,
+    score,
+  };
+}

--- a/tests/unit/house-of-cards/houseOfCardsAi.test.ts
+++ b/tests/unit/house-of-cards/houseOfCardsAi.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createHouseOfCardsAiProfiles,
+  createHouseOfCardsSessionAbility,
+  simulateHouseOfCardsAiRound,
+} from '../../../src/features/houseOfCards/houseOfCardsAi';
+
+function average(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+describe('House of Cards preliminary AI', () => {
+  it('is deterministic for the same tournament inputs', () => {
+    const params = {
+      playerId: 'alex',
+      round: 3,
+      pairCount: 8,
+      tournamentSeed: 2026,
+      sessionAbility: 55,
+    };
+
+    expect(simulateHouseOfCardsAiRound(params)).toEqual(simulateHouseOfCardsAiRound(params));
+  });
+
+  it('redistributes a player ability between tournament seeds', () => {
+    const abilities = new Set(
+      Array.from({ length: 20 }, (_, index) =>
+        createHouseOfCardsSessionAbility('alex', index + 1),
+      ),
+    );
+
+    expect(abilities.size).toBeGreaterThan(1);
+  });
+
+  it('creates profiles for every AI participant but not the human', () => {
+    const profiles = createHouseOfCardsAiProfiles(
+      ['human', 'alex', 'bea'],
+      'human',
+      2026,
+    );
+
+    expect(profiles.human).toBeUndefined();
+    expect(Object.keys(profiles).sort()).toEqual(['alex', 'bea']);
+  });
+
+  it('keeps session ability within its configured limits', () => {
+    for (let seed = 1; seed <= 1_000; seed += 1) {
+      const ability = createHouseOfCardsSessionAbility('alex', seed);
+      expect(ability).toBeGreaterThanOrEqual(25);
+      expect(ability).toBeLessThanOrEqual(85);
+    }
+  });
+
+  it('does not give a permanent advantage to one participant', () => {
+    const alexAbilities: number[] = [];
+    const beaAbilities: number[] = [];
+    for (let seed = 1; seed <= 1_000; seed += 1) {
+      alexAbilities.push(createHouseOfCardsSessionAbility('alex', seed));
+      beaAbilities.push(createHouseOfCardsSessionAbility('bea', seed));
+    }
+
+    expect(Math.abs(average(alexAbilities) - average(beaAbilities))).toBeLessThan(2);
+  });
+
+  it('makes average AI perfect runs rare on a 24-card board', () => {
+    let perfectRuns = 0;
+    for (let seed = 1; seed <= 5_000; seed += 1) {
+      if (simulateHouseOfCardsAiRound({
+        playerId: 'alex', round: 5, pairCount: 12, tournamentSeed: seed, sessionAbility: 55,
+      }).mistakes === 0) perfectRuns += 1;
+    }
+
+    expect(perfectRuns / 5_000).toBeLessThan(0.02);
+  });
+
+  it('keeps strong AI perfect runs below the maximum rate', () => {
+    let perfectRuns = 0;
+    for (let seed = 1; seed <= 5_000; seed += 1) {
+      if (simulateHouseOfCardsAiRound({
+        playerId: 'alex', round: 5, pairCount: 12, tournamentSeed: seed, sessionAbility: 80,
+      }).mistakes === 0) perfectRuns += 1;
+    }
+
+    expect(perfectRuns / 5_000).toBeLessThan(0.08);
+  });
+
+  it('produces more mistakes on larger boards', () => {
+    const mistakesFor = (pairCount: number) => {
+      const mistakes: number[] = [];
+      for (let seed = 1; seed <= 1_000; seed += 1) {
+        mistakes.push(simulateHouseOfCardsAiRound({
+          playerId: 'alex', round: 3, pairCount, tournamentSeed: seed, sessionAbility: 55,
+        }).mistakes);
+      }
+      return average(mistakes);
+    };
+
+    const average4 = mistakesFor(4);
+    const average8 = mistakesFor(8);
+    const average12 = mistakesFor(12);
+    expect(average4).toBeLessThan(average8);
+    expect(average8).toBeLessThan(average12);
+  });
+
+  it('rewards higher ability with fewer mistakes and less time on average', () => {
+    const lowerAbility = { mistakes: [] as number[], timeMs: [] as number[] };
+    const higherAbility = { mistakes: [] as number[], timeMs: [] as number[] };
+    for (let seed = 1; seed <= 1_000; seed += 1) {
+      const base = { playerId: 'alex', round: 3, pairCount: 12, tournamentSeed: seed };
+      const lowerPerformance = simulateHouseOfCardsAiRound({ ...base, sessionAbility: 40 });
+      const higherPerformance = simulateHouseOfCardsAiRound({ ...base, sessionAbility: 70 });
+      lowerAbility.mistakes.push(lowerPerformance.mistakes);
+      lowerAbility.timeMs.push(lowerPerformance.timeMs);
+      higherAbility.mistakes.push(higherPerformance.mistakes);
+      higherAbility.timeMs.push(higherPerformance.timeMs);
+    }
+
+    expect(average(higherAbility.mistakes)).toBeLessThan(average(lowerAbility.mistakes));
+    expect(average(higherAbility.timeMs)).toBeLessThan(average(lowerAbility.timeMs));
+  });
+});


### PR DESCRIPTION
## What changed
- Adds deterministic, seed-based temporary AI ability profiles for House of Cards preliminary rounds.
- Replaces persistent `precomputedScore` influence with per-tournament ability and per-round form variation.
- Adds focused fairness, determinism, perfect-run, board-size, and ability-performance tests.

## Why
The previous preliminary simulation made some contestants permanently stronger and produced too many flawless runs. The new model redistributes ability for each tournament seed while keeping outcomes deterministic and profiles stable within a tournament.

## Validation
- `npm test -- tests/unit/house-of-cards/houseOfCardsAi.test.ts`
- `npm test -- tests/unit/house-of-cards`
- `npm run typecheck`
- ESLint on modified files