### PR TITLE
Fix Surveyeval launcher access

### DIFF
--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -47,7 +47,6 @@ import {
   selectRemoteIntroHubOverlay,
 } from '../../remoteConfig/remoteConfigSlice';
 import { buildAchievementSummary } from '../../store/achievementSummary';
-import { selectHasSurvivalModeAccess } from '../../store/vipSlice';
 import './HomeHub.css';
 
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -230,8 +229,6 @@ export default function HomeHub() {
   const dayCount = week;
   const activeProfileId = useAppSelector(selectActiveProfileId);
   const isGuest = useAppSelector(selectIsGuest);
-  const hasSurvivalMode = useAppSelector(selectHasSurvivalModeAccess);
-  const canUseSurvivalMode = hasSurvivalMode || import.meta.env.DEV;
   const { url: bgUrl } = useBackgroundTheme();
   const remoteBgUrl = useAppSelector(selectRemoteIntroHubBg);
   const remoteOverlayOpacity = useAppSelector(selectRemoteIntroHubOverlay);
@@ -397,10 +394,6 @@ export default function HomeHub() {
 
   function openSurvivorMode() {
     SoundManager.unlockFromGesture();
-    if (!canUseSurvivalMode) {
-      navigate('/store');
-      return;
-    }
     if (survivorSnapshot) {
       setSurvivorPrompt('resume-or-new');
       return;
@@ -462,7 +455,7 @@ export default function HomeHub() {
     },
     {
       key: 'survival',
-      label: canUseSurvivalMode ? 'Surveyeval' : 'Surveyeval · Store',
+      label: 'Surveyeval',
       icon: <HomeHubButtonIcon name="survival" />,
       variant: 'secondary_wide',
       onClick: () => startOrResumeMode('survival'),

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -398,7 +398,7 @@ describe('HomeHub', () => {
     );
   });
 
-  it('shows Surveyeval rules before starting a fresh Surveyeval run', async () => {
+  it('starts the Surveyeval flow without VIP or survivalMode access instead of opening Store', async () => {
     const view = renderHomeHub();
 
     fireEvent.click(screen.getByTestId('kolequant-splash'));
@@ -410,6 +410,7 @@ describe('HomeHub', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Play' }));
     fireEvent.click(screen.getByRole('button', { name: 'Surveyeval' }));
 
+    expect(mockNavigate).not.toHaveBeenCalledWith('/store');
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText(/don't show this again/i));
     fireEvent.click(screen.getByRole('button', { name: 'Enter Surveyeval' }));


### PR DESCRIPTION
## What changed

Surveyeval is now always labeled `Surveyeval` in the HomeHub Play menu and launches its existing start/resume flow directly.

## Why

The HomeHub launcher incorrectly treated Surveyeval as a Store/VIP entitlement and redirected users without `survivalMode` access to `/store`.

## Impact

All users can start or resume Surveyeval without a VIP or Store entitlement. Existing rules, confirmation, and internal `survival` mode behavior are unchanged.

## Validation

- `vitest run --run src/screens/HomeHub/__tests__/HomeHub.test.tsx`
- `tsc -b`