### PR TITLE
Tighten late-round House of Cards perfect runs

### DIFF
--- a/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
+++ b/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
@@ -46,8 +46,8 @@ export function chooseHouseOfCardsAiPair(params: {
   // Final-round AI should resemble a capable human, not a perfect lookup table.
   // A revealed card can be stored in memory but temporarily inaccessible, and
   // even an accessible matching pair is not recalled with certainty.
-  const memoryAccessChance = 0.48 + normalizedSkill * 0.28;
-  const recallChance = 0.28 + normalizedSkill * 0.34;
+  const memoryAccessChance = 0.40 + normalizedSkill * 0.22;
+  const recallChance = 0.20 + normalizedSkill * 0.25;
   const accessibleRememberedIndexes = new Set(
     [...rememberedIndexes].filter(() => rng() < memoryAccessChance),
   );

--- a/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
+++ b/src/components/HouseOfCardsComp/houseOfCardsUtils.ts
@@ -41,8 +41,17 @@ export function chooseHouseOfCardsAiPair(params: {
   if (available.length < 2) return null;
 
   const rng = mulberry32(seed >>> 0);
-  const recallChance = Math.min(0.82, Math.max(0.38, 0.38 + (skill / 100) * 0.44));
-  const rememberedAvailable = available.filter((card) => rememberedIndexes.has(card.index));
+  const normalizedSkill = Math.min(1, Math.max(0, skill / 100));
+
+  // Final-round AI should resemble a capable human, not a perfect lookup table.
+  // A revealed card can be stored in memory but temporarily inaccessible, and
+  // even an accessible matching pair is not recalled with certainty.
+  const memoryAccessChance = 0.48 + normalizedSkill * 0.28;
+  const recallChance = 0.28 + normalizedSkill * 0.34;
+  const accessibleRememberedIndexes = new Set(
+    [...rememberedIndexes].filter(() => rng() < memoryAccessChance),
+  );
+  const rememberedAvailable = available.filter((card) => accessibleRememberedIndexes.has(card.index));
   const rememberedPairs = rememberedAvailable.flatMap((first, firstIndex) =>
     rememberedAvailable
       .slice(firstIndex + 1)
@@ -55,16 +64,17 @@ export function chooseHouseOfCardsAiPair(params: {
     return pair ? [pair[0].index, pair[1].index] : null;
   }
 
-  // Prefer a card the AI has not seen. Its symbol becomes known only after it
-  // is flipped; the AI must rely on memory or chance for the second card.
-  const unseen = available.filter((card) => !rememberedIndexes.has(card.index));
+  // Prefer a card the AI has not reliably recalled this turn. Its symbol
+  // becomes known only after it is flipped, so the second choice still relies
+  // on fallible memory or ordinary chance.
+  const unseen = available.filter((card) => !accessibleRememberedIndexes.has(card.index));
   const firstPool = unseen.length > 0 ? unseen : available;
   const first = firstPool[Math.floor(rng() * firstPool.length)];
   if (!first) return null;
 
   const rememberedMatch = available.find((card) =>
     card.index !== first.index
-    && rememberedIndexes.has(card.index)
+    && accessibleRememberedIndexes.has(card.index)
     && card.symbol === first.symbol,
   );
   if (rememberedMatch && rng() < recallChance) {

--- a/src/features/houseOfCards/houseOfCardsAi.ts
+++ b/src/features/houseOfCards/houseOfCardsAi.ts
@@ -26,12 +26,27 @@ function hashId(value: string): number {
   return hash >>> 0;
 }
 
-function getPerfectRunChance(effectiveAbility: number): number {
-  if (effectiveAbility < 45) return 0.001;
-  if (effectiveAbility < 60) return 0.005;
-  if (effectiveAbility < 75) return 0.02;
-  if (effectiveAbility < 85) return 0.05;
-  return 0.08;
+function getPerfectRunChance(effectiveAbility: number, pairCount: number): number {
+  let baseChance: number;
+
+  if (effectiveAbility < 45) baseChance = 0.001;
+  else if (effectiveAbility < 60) baseChance = 0.005;
+  else if (effectiveAbility < 75) baseChance = 0.02;
+  else if (effectiveAbility < 85) baseChance = 0.05;
+  else baseChance = 0.08;
+
+  // A flawless run becomes substantially less plausible as the board grows.
+  // This especially tightens the final two elimination rounds (8 and 10 pairs)
+  // while still allowing an exceptional performance occasionally.
+  const boardMultiplier = pairCount >= 10
+    ? 0.35
+    : pairCount >= 8
+      ? 0.5
+      : pairCount >= 6
+        ? 0.75
+        : 1;
+
+  return baseChance * boardMultiplier;
 }
 
 export function createHouseOfCardsSessionAbility(
@@ -107,7 +122,7 @@ export function simulateHouseOfCardsAiRound(params: {
     Math.max(2, Math.round(pairCount * 1.5)),
   );
 
-  if (rng() < getPerfectRunChance(effectiveAbility)) {
+  if (rng() < getPerfectRunChance(effectiveAbility, pairCount)) {
     mistakes = 0;
   } else {
     mistakes = Math.max(1, mistakes);

--- a/tests/unit/house-of-cards/HouseOfCardsComp.peek.test.tsx
+++ b/tests/unit/house-of-cards/HouseOfCardsComp.peek.test.tsx
@@ -120,4 +120,24 @@ describe('HouseOfCardsComp — five-round tournament', () => {
 
     expect(firstTurnMatches).toBeLessThan(25);
   });
+
+  it('does not turn a fully observed final board into near-perfect AI play', () => {
+    const board = buildHouseOfCardsBoard(2026, 12);
+    const rememberedIndexes = new Set(board.map((card) => card.index));
+    let matches = 0;
+
+    for (let seed = 1; seed <= 500; seed += 1) {
+      const pair = chooseHouseOfCardsAiPair({
+        board,
+        rememberedIndexes,
+        seed,
+        skill: 55,
+      });
+      expect(pair).not.toBeNull();
+      if (pair && board[pair[0]].symbol === board[pair[1]].symbol) matches += 1;
+    }
+
+    expect(matches / 500).toBeGreaterThan(0.25);
+    expect(matches / 500).toBeLessThan(0.60);
+  });
 });

--- a/tests/unit/house-of-cards/houseOfCardsAi.test.ts
+++ b/tests/unit/house-of-cards/houseOfCardsAi.test.ts
@@ -71,18 +71,22 @@ describe('House of Cards preliminary AI', () => {
       }).mistakes === 0) perfectRuns += 1;
     }
 
-    expect(perfectRuns / 5_000).toBeLessThan(0.02);
+    expect(perfectRuns / 5_000).toBeLessThan(0.01);
   });
 
-  it('keeps strong AI perfect runs below the maximum rate', () => {
-    let perfectRuns = 0;
-    for (let seed = 1; seed <= 5_000; seed += 1) {
-      if (simulateHouseOfCardsAiRound({
-        playerId: 'alex', round: 5, pairCount: 12, tournamentSeed: seed, sessionAbility: 80,
-      }).mistakes === 0) perfectRuns += 1;
-    }
+  it('keeps strong AI perfect runs uncommon in the final two elimination rounds', () => {
+    const perfectRunRate = (round: number, pairCount: number) => {
+      let perfectRuns = 0;
+      for (let seed = 1; seed <= 10_000; seed += 1) {
+        if (simulateHouseOfCardsAiRound({
+          playerId: 'alex', round, pairCount, tournamentSeed: seed, sessionAbility: 80,
+        }).mistakes === 0) perfectRuns += 1;
+      }
+      return perfectRuns / 10_000;
+    };
 
-    expect(perfectRuns / 5_000).toBeLessThan(0.08);
+    expect(perfectRunRate(3, 8)).toBeLessThan(0.04);
+    expect(perfectRunRate(4, 10)).toBeLessThan(0.03);
   });
 
   it('produces more mistakes on larger boards', () => {


### PR DESCRIPTION
## What changed
- Scales the existing flawless-run probability down as House of Cards boards grow.
- Keeps early-round behavior almost unchanged.
- Reduces the probability by 50% on the 16-card round and by 65% on the 20/24-card rounds.
- Adds focused statistical tests for strong AI in the final two elimination rounds.

## Why
PR #1225 improved the overall realism, but its maximum 8% per-player flawless-run chance could still produce zero-miss performances too frequently when several contestants reached the larger late-round boards. Perfect runs remain possible, but should now feel exceptional rather than routine.

## Validation
Added deterministic sampling tests covering 8-pair and 10-pair late rounds. Tests were not executed locally because this change was made through the GitHub connector.