### PR TITLE
Fix survival navbar, compact overlays, log placement, and music mute

### DIFF
--- a/src/components/ConfirmExitModal/SurvivorRulesModal.css
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.css
@@ -221,6 +221,10 @@
   box-shadow: 0 -12px 24px rgba(3, 6, 14, 0.22);
 }
 
+.survivor-rules-modal__footer--reference {
+  justify-items: end;
+}
+
 .survivor-rules-modal__checkbox {
   display: inline-flex;
   align-items: center;
@@ -249,6 +253,11 @@
   justify-content: flex-end;
 }
 
+.survivor-rules-modal__actions--reference {
+  width: min(13rem, 100%);
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .survivor-rules-modal__btn {
   width: 100%;
   min-width: 0;
@@ -273,32 +282,99 @@
 @media (max-width: 640px) {
   .survivor-rules-modal__backdrop {
     padding:
-      calc(env(safe-area-inset-top, 0px) + 10px)
-      calc(env(safe-area-inset-right, 0px) + 10px)
-      calc(env(safe-area-inset-bottom, 0px) + 10px)
-      calc(env(safe-area-inset-left, 0px) + 10px);
+      calc(env(safe-area-inset-top, 0px) + 8px)
+      calc(env(safe-area-inset-right, 0px) + 8px)
+      calc(env(safe-area-inset-bottom, 0px) + 8px)
+      calc(env(safe-area-inset-left, 0px) + 8px);
   }
 
   .survivor-rules-modal__card {
     height: min(
-      calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 20px),
-      44rem
+      calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 16px),
+      42rem
     );
-    border-radius: 20px;
+    border-radius: 18px;
   }
 
-  .survivor-rules-modal__header,
-  .survivor-rules-modal__rules,
-  .survivor-rules-modal__footer {
-    padding-inline: 1rem;
+  .survivor-rules-modal__header {
+    padding: 0.82rem 0.85rem 0.65rem;
   }
 
-  .survivor-rules-modal__rule {
-    padding: 0.72rem 0.78rem;
+  .survivor-rules-modal__brand {
+    gap: 0.58rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .survivor-rules-modal__logo {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 10px;
+    font-size: 1.22rem;
+  }
+
+  .survivor-rules-modal__eyebrow {
+    font-size: 0.62rem;
+  }
+
+  .survivor-rules-modal__guide-label {
+    font-size: 0.57rem;
+    letter-spacing: 0.06em;
+  }
+
+  .survivor-rules-modal__title {
+    font-size: clamp(1.28rem, 6vw, 1.62rem);
+  }
+
+  .survivor-rules-modal__desc {
+    margin-top: 0.42rem;
+    font-size: 0.8rem;
+    line-height: 1.35;
   }
 
   .survivor-rules-modal__rules {
-    grid-template-columns: minmax(0, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.48rem;
+    padding: 0 0.85rem 0.65rem;
+    scrollbar-gutter: auto;
+  }
+
+  .survivor-rules-modal__rule {
+    min-height: 0;
+    gap: 0.22rem;
+    padding: 0.55rem 0.58rem;
+    border-radius: 9px;
+  }
+
+  .survivor-rules-modal__rule-kicker {
+    padding: 0.08rem 0.36rem;
+    font-size: 0.54rem;
+  }
+
+  .survivor-rules-modal__rule-title {
+    font-size: 0.78rem;
+    line-height: 1.15;
+  }
+
+  .survivor-rules-modal__rule-desc {
+    margin-top: 0.1rem;
+    font-size: 0.7rem;
+    line-height: 1.32;
+  }
+
+  .survivor-rules-modal__footer {
+    gap: 0.5rem;
+    padding: 0.55rem 0.85rem 0.68rem;
+  }
+
+  .survivor-rules-modal__checkbox {
+    width: 100%;
+    padding: 0.5rem 0.65rem;
+    border-radius: 10px;
+    font-size: 0.78rem;
+  }
+
+  .survivor-rules-modal__actions {
+    gap: 0.5rem;
   }
 
   .survivor-rules-modal__btn {
@@ -306,12 +382,16 @@
     min-width: 0;
   }
 
-  .survivor-rules-modal__checkbox {
-    width: 100%;
+  .survivor-rules-modal__btn.game-button {
+    min-height: 42px;
   }
 }
 
-@media (max-width: 360px) {
+@media (max-width: 340px) {
+  .survivor-rules-modal__rules {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .survivor-rules-modal__actions {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -319,18 +399,27 @@
 
 @media (max-height: 700px) {
   .survivor-rules-modal__header {
-    padding-block: 0.85rem 0.7rem;
+    padding-block: 0.65rem 0.5rem;
   }
 
   .survivor-rules-modal__brand {
-    margin-bottom: 0.55rem;
+    margin-bottom: 0.38rem;
   }
 
   .survivor-rules-modal__desc {
-    margin-top: 0.5rem;
+    margin-top: 0.34rem;
+  }
+
+  .survivor-rules-modal__rules {
+    gap: 0.4rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .survivor-rules-modal__rule {
+    padding-block: 0.46rem;
   }
 
   .survivor-rules-modal__footer {
-    padding-block: 0.65rem 0.75rem;
+    padding-block: 0.48rem 0.58rem;
   }
 }

--- a/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
+++ b/src/components/ConfirmExitModal/SurvivorRulesModal.tsx
@@ -3,8 +3,9 @@ import './SurvivorRulesModal.css';
 
 interface Props {
   open: boolean;
-  onContinue: (dontShowAgain: boolean) => void;
+  onContinue?: (dontShowAgain: boolean) => void;
   onCancel: () => void;
+  variant?: 'entry' | 'reference';
 }
 
 const RULES = [
@@ -30,12 +31,13 @@ const RULES = [
   },
 ] as const;
 
-export default function SurvivorRulesModal({ open, onContinue, onCancel }: Props) {
+export default function SurvivorRulesModal({ open, onContinue, onCancel, variant = 'entry' }: Props) {
   const uid = useId();
   const titleId = `${uid}-title`;
   const descId = `${uid}-desc`;
   const cardRef = useRef<HTMLDivElement>(null);
   const [dontShowAgain, setDontShowAgain] = useState(false);
+  const isReference = variant === 'reference';
 
   useEffect(() => {
     if (!open) return;
@@ -63,7 +65,11 @@ export default function SurvivorRulesModal({ open, onContinue, onCancel }: Props
       aria-labelledby={titleId}
       aria-describedby={descId}
     >
-      <div className="survivor-rules-modal__card" tabIndex={-1} ref={cardRef}>
+      <div
+        className={`survivor-rules-modal__card${isReference ? ' survivor-rules-modal__card--reference' : ''}`}
+        tabIndex={-1}
+        ref={cardRef}
+      >
         <div className="survivor-rules-modal__glow survivor-rules-modal__glow--left" aria-hidden="true" />
         <div className="survivor-rules-modal__glow survivor-rules-modal__glow--right" aria-hidden="true" />
 
@@ -94,34 +100,49 @@ export default function SurvivorRulesModal({ open, onContinue, onCancel }: Props
           ))}
         </div>
 
-        <footer className="survivor-rules-modal__footer">
-          <label className="survivor-rules-modal__checkbox">
-            <input
-              type="checkbox"
-              checked={dontShowAgain}
-              onChange={(e) => setDontShowAgain(e.target.checked)}
-            />
-            <span>Don&apos;t show this again</span>
-          </label>
+        {isReference ? (
+          <footer className="survivor-rules-modal__footer survivor-rules-modal__footer--reference">
+            <div className="survivor-rules-modal__actions survivor-rules-modal__actions--reference">
+              <button
+                type="button"
+                className="survivor-rules-modal__btn game-button game-button--primary"
+                onClick={onCancel}
+                autoFocus
+              >
+                Close Rules
+              </button>
+            </div>
+          </footer>
+        ) : (
+          <footer className="survivor-rules-modal__footer">
+            <label className="survivor-rules-modal__checkbox">
+              <input
+                type="checkbox"
+                checked={dontShowAgain}
+                onChange={(e) => setDontShowAgain(e.target.checked)}
+              />
+              <span>Don&apos;t show this again</span>
+            </label>
 
-          <div className="survivor-rules-modal__actions">
-            <button
-              type="button"
-              className="survivor-rules-modal__btn game-button game-button--primary"
-              onClick={() => onContinue(dontShowAgain)}
-              autoFocus
-            >
-              Enter Surveyeval
-            </button>
-            <button
-              type="button"
-              className="survivor-rules-modal__btn game-button game-button--ghost"
-              onClick={onCancel}
-            >
-              Back
-            </button>
-          </div>
-        </footer>
+            <div className="survivor-rules-modal__actions">
+              <button
+                type="button"
+                className="survivor-rules-modal__btn game-button game-button--primary"
+                onClick={() => onContinue?.(dontShowAgain)}
+                autoFocus
+              >
+                Enter Surveyeval
+              </button>
+              <button
+                type="button"
+                className="survivor-rules-modal__btn game-button game-button--ghost"
+                onClick={onCancel}
+              >
+                Back
+              </button>
+            </div>
+          </footer>
+        )}
       </div>
     </div>
   );

--- a/src/components/GameBottomNav/GameBottomNav.css
+++ b/src/components/GameBottomNav/GameBottomNav.css
@@ -177,14 +177,22 @@
   grid-template-columns: repeat(4, minmax(0, 1fr));
   padding-inline: 5%;
 }
+
+.game-bottom-nav__more-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1499;
+  background: transparent;
+}
+
 .game-bottom-nav__more-menu {
   position: fixed;
   right: max(10px, calc((100vw - min(100vw, var(--app-shell-max-width, 480px))) / 2 + 10px + var(--safe-right)));
   bottom: calc(var(--nav-bar-height, 60px) + var(--safe-bottom) + 8px);
   z-index: 1500;
-  display: flex;
-  width: min(184px, calc(100vw - 28px));
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: min(232px, calc(100vw - 28px));
   gap: 5px;
   padding: 6px;
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -194,25 +202,53 @@
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
 }
+
 .game-bottom-nav__more-menu button {
   display: flex;
-  min-height: 44px;
+  min-width: 0;
+  min-height: 58px;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 5px 11px;
+  justify-content: center;
+  gap: 4px;
+  padding: 7px 5px;
   border: 1px solid rgba(255, 255, 255, 0.055);
   border-radius: 10px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.04));
   color: rgba(244, 246, 255, 0.94);
   font: inherit;
-  text-align: left;
+  text-align: center;
   cursor: pointer;
 }
+
 .game-bottom-nav__more-menu button:hover,
-.game-bottom-nav__more-menu button:focus-visible { background: rgba(255, 255, 255, 0.07); }
-.game-bottom-nav__more-menu button:focus-visible { outline: 2px solid rgba(151, 139, 255, 0.88); outline-offset: -2px; }
-.game-bottom-nav__more-menu img { width: 24px; height: 24px; object-fit: contain; opacity: 0.9; }
-.game-bottom-nav__more-menu span { font-size: 0.66rem; font-weight: 800; letter-spacing: 0.04em; text-transform: uppercase; }
+.game-bottom-nav__more-menu button:focus-visible {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.game-bottom-nav__more-menu button:focus-visible {
+  outline: 2px solid rgba(151, 139, 255, 0.88);
+  outline-offset: -2px;
+}
+
+.game-bottom-nav__more-menu img {
+  width: 23px;
+  height: 23px;
+  object-fit: contain;
+  opacity: 0.9;
+}
+
+.game-bottom-nav__more-menu span {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 0.59rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .game-bottom-nav--refined-architecture .game-bottom-nav__item--active::after {
   position: absolute;
   bottom: 2px;

--- a/src/components/GameBottomNav/GameBottomNav.tsx
+++ b/src/components/GameBottomNav/GameBottomNav.tsx
@@ -77,20 +77,33 @@ export default function GameBottomNav({
       <nav className={`game-bottom-nav nav-bar${refined ? ' game-bottom-nav--refined-architecture' : ''}`} aria-label="Main navigation">
         <img className="game-bottom-nav__shell" src={navBarSrc} alt="" aria-hidden="true" draggable={false} />
         {refined && moreOpen && createPortal(
-          <div className="game-bottom-nav__more-menu" id="game-navigation-more" role="menu" aria-label="More destinations">
-            <button type="button" role="menuitem" onClick={() => openDestination('rules')}>
-              <img src={`${BASE}/assets/updated_nav_fab_bar/rules_approved_final.svg`} alt="" aria-hidden="true" />
-              <span>Rules</span>
-            </button>
-            <button type="button" role="menuitem" onClick={() => openDestination('leaderboard')}>
-              <img src={`${BASE}/assets/updated_nav_fab_bar/leaderboard_approved_final.svg`} alt="" aria-hidden="true" />
-              <span>Board</span>
-            </button>
-            <button type="button" role="menuitem" onClick={() => openDestination('store')}>
-              <img src={`${BASE}/assets/icons/shop.svg`} alt="" aria-hidden="true" />
-              <span>Store</span>
-            </button>
-          </div>,
+          <>
+            <div
+              className="game-bottom-nav__more-backdrop"
+              role="presentation"
+              onPointerDown={() => setMoreOpen(false)}
+            />
+            <div
+              className="game-bottom-nav__more-menu"
+              id="game-navigation-more"
+              role="menu"
+              aria-label="More destinations"
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              <button type="button" role="menuitem" onClick={() => openDestination('rules')}>
+                <img src={`${BASE}/assets/updated_nav_fab_bar/rules_approved_final.svg`} alt="" aria-hidden="true" />
+                <span>Rules</span>
+              </button>
+              <button type="button" role="menuitem" onClick={() => openDestination('leaderboard')}>
+                <img src={`${BASE}/assets/updated_nav_fab_bar/leaderboard_approved_final.svg`} alt="" aria-hidden="true" />
+                <span>Board</span>
+              </button>
+              <button type="button" role="menuitem" onClick={() => openDestination('store')}>
+                <img src={`${BASE}/assets/icons/shop.svg`} alt="" aria-hidden="true" />
+                <span>Store</span>
+              </button>
+            </div>
+          </>,
           document.body,
         )}
         <div className="game-bottom-nav__items">

--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -149,6 +149,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
     ? statuses.join('+')
     : (statuses ?? '')
   const badges = getBadgesForPlayer(statusString, finalRank)
+  const suppressSurvivalLeaderStats = isSurvivorRoboTile && statusString.split('+').includes('loh')
 
   // Build aria-label suffix from badges for screen readers
   const badgeLabels = badges.map((b) => b.label).join(', ')
@@ -214,7 +215,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
       e.stopPropagation()
       return
     }
-    if (isSurvivorRoboTile && !isEvicted) {
+    if (isSurvivorRoboTile && !isEvicted && !suppressSurvivalLeaderStats) {
       setStatsOpen(true)
     }
     if (onClick) onClick()
@@ -279,7 +280,7 @@ export default function AvatarTile({ name, avatarUrl, isEvicted, isYou, onClick,
             ? (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
-                  if (isSurvivorRoboTile && !isEvicted) setStatsOpen(true)
+                  if (isSurvivorRoboTile && !isEvicted && !suppressSurvivalLeaderStats) setStatsOpen(true)
                   if (onClick) onClick()
                 }
               }

--- a/src/components/TVLog/TVLog.tsx
+++ b/src/components/TVLog/TVLog.tsx
@@ -148,6 +148,7 @@ export default function TVLog({
       <button
         type="button"
         className="tv-log__launcher"
+        style={{ left: 10, right: 'auto' }}
         aria-label={`Open game log, ${entries.length} events`}
         onClick={() => setLogOpen(true)}
       >

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useStore } from 'react-redux';
 import './NavBar.css';
 import ConfirmExitModal from '../ConfirmExitModal/ConfirmExitModal';
+import SurvivorRulesModal from '../ConfirmExitModal/SurvivorRulesModal';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { resetGame } from '../../store/gameSlice';
 import { selectPendingChallenge } from '../../store/challengeSlice';
@@ -28,6 +29,7 @@ export default function NavBar() {
   // we key visibility off the run state that resetGame/hydrateGame now mark
   // active immediately.
   const isGameActive = useAppSelector((s) => s.game.status === 'active');
+  const gameMode = useAppSelector((s) => s.game.mode);
   const pendingChallenge = useAppSelector(selectPendingChallenge);
   const pendingMinigame = useAppSelector((s) => s.game.pendingMinigame);
   const humanPlayer = useAppSelector((s) => s.game.players.find((player) => player.isUser));
@@ -42,6 +44,7 @@ export default function NavBar() {
 
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [saveError, setSaveError] = useState(false);
+  const [survivalRulesOpen, setSurvivalRulesOpen] = useState(false);
   const humanInPendingChallenge =
     Boolean(pendingChallenge && humanPlayer && pendingChallenge.participants.includes(humanPlayer.id));
   const humanInPendingMinigame =
@@ -68,6 +71,14 @@ export default function NavBar() {
     }
     setSaveError(false);
     setConfirmOpen(true);
+  }
+
+  function handleRulesClick() {
+    if (gameMode === 'survival') {
+      setSurvivalRulesOpen(true);
+      return;
+    }
+    navigate('/rules');
   }
 
   function saveActiveRun(): boolean {
@@ -130,7 +141,7 @@ export default function NavBar() {
       activeTab={getActiveTab()}
       disabled={isGameOverRoute}
       onHomeClick={handleHomeClick}
-      onRulesClick={() => navigate('/rules')}
+      onRulesClick={handleRulesClick}
       onSettingsClick={() => navigate('/settings')}
       onLeaderboardClick={() => navigate('/leaderboard')}
       onProfileClick={() => navigate('/profile', { state: { from: '/game' } })}
@@ -146,6 +157,11 @@ export default function NavBar() {
         onConfirm={canPersistActiveRun ? saveThenReturnHome : quitWithoutSaving}
         onSecondary={canPersistActiveRun ? quitWithoutSaving : undefined}
         onCancel={() => setConfirmOpen(false)}
+      />
+      <SurvivorRulesModal
+        open={survivalRulesOpen}
+        variant="reference"
+        onCancel={() => setSurvivalRulesOpen(false)}
       />
     </GameBottomNav>
   );

--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -16,6 +16,7 @@ export default function AudioStateSync() {
       socialPanelOpen: root.social.panelOpen,
       incomingInboxOpen: root.social.incomingInboxOpen,
       musicScene: root.ui.musicScene,
+      musicOn: root.settings.audio.musicOn,
     }),
     shallowEqual,
   );
@@ -28,8 +29,10 @@ export default function AudioStateSync() {
   }, []);
 
   const desiredMusic = useMemo(
-    () =>
-      resolveDesiredMusic(
+    () => {
+      if (!musicState.musicOn) return 'none';
+
+      return resolveDesiredMusic(
         {
           game: {
             phase: musicState.gamePhase,
@@ -58,7 +61,8 @@ export default function AudioStateSync() {
           },
         },
         hash,
-      ),
+      );
+    },
     [hash, musicState],
   );
 


### PR DESCRIPTION
## What changed

- Routes the in-game **Rules** destination to the Surveyeval rules when the active run is Survival mode, while Classic runs still open the standard rules page.
- Adds a read-only rules presentation for in-game reference and compacts the rules layout so all four cards fit much more naturally on mobile screens.
- Makes the refined **More** panel dismiss when the player taps outside it and reorganizes Rules / Board / Store into a compact three-column panel.
- Prevents the current Survival leader's avatar from opening the robo-stat options sheet, while preserving normal avatar and long-press behavior.
- Moves the Game Log launcher to the lower-left corner of the faux TV so it no longer competes with LIVE and SHOCK indicators.
- Makes the Music Off setting authoritative in the global audio-state synchronizer, preventing subsequent phase transitions from restarting background music.

## Root causes

- The navbar always navigated to the Classic `/rules` route regardless of the active game mode.
- The More menu had no outside-click surface and used a vertically stacked desktop-like layout.
- Mobile rules CSS collapsed all cards into one column, creating unnecessary vertical overflow.
- Survival robo stats opened for every active bot, including the current LOH.
- The log launcher was absolutely anchored on the same right side used by broadcast badges.
- `AudioStateSync` resolved phase music without subscribing to `settings.audio.musicOn`, so phase changes could reassert a desired track after muting.

## Validation

All triggered checks passed:

- formatting check
- ESLint with zero warnings
- TypeScript typecheck
- production dependency audit
- web production build
- Capacitor mobile-mode build
- mobile Chromium core journeys without retries

Closes #1227
Closes #1228
Closes #1229
Closes #1235
Closes #1236
Closes #1240
Closes #1246