### PR TITLE
Fix House of Cards face-up hover and results scrolling

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import { initAdBridge } from './services/ads/adsService'
 import { installE2EStateProbe } from './testSupport/e2eStateProbe'
 import App from './App.tsx'
 import './styles/gameOverResponsiveFixes.css'
+import './styles/houseOfCardsInteractionFix.css'
 
 // Apply html class flags (is-standalone, is-webkit, is-chrome-android) as
 // early as possible so CSS selectors in _ios-standalone-fixes.css and

--- a/src/styles/houseOfCardsInteractionFix.css
+++ b/src/styles/houseOfCardsInteractionFix.css
@@ -1,0 +1,38 @@
+/* House of Cards post-redesign interaction fixes.
+   Scoped overrides keep the original game state and shared results shell intact. */
+
+/* Never apply a hover/focus filter to the 3D transform layer after a card is face-up.
+   Chromium can otherwise briefly composite the back face while the pointer remains over it. */
+.hoc-card[data-flipped='false'][data-matched='false']:not(:disabled):hover .hoc-card-inner,
+.hoc-card[data-flipped='false'][data-matched='false']:not(:disabled):focus-visible .hoc-card-inner {
+  translate: 0 -3px;
+  filter: brightness(1.08);
+}
+
+.hoc-card[data-flipped='true'] .hoc-card-inner,
+.hoc-card[data-matched='true'] .hoc-card-inner,
+.hoc-card[data-flipped='true']:hover .hoc-card-inner,
+.hoc-card[data-flipped='true']:focus-visible .hoc-card-inner,
+.hoc-card[data-matched='true']:hover .hoc-card-inner,
+.hoc-card[data-matched='true']:focus-visible .hoc-card-inner {
+  transform: rotateY(180deg);
+  translate: 0 0;
+  filter: none;
+}
+
+/* Restore the shared completion shell's vertical scrolling. The noir redesign
+   set overflow:hidden on this more specific class, masking content below the fold. */
+.minigame-complete.hoc-complete {
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.minigame-complete.hoc-complete .minigame-placement-list {
+  flex: 0 0 auto;
+  overflow: visible;
+}

--- a/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
+++ b/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
@@ -1,24 +1,22 @@
-import { describe, expect, it } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
 
 const css = fs.readFileSync(
   path.resolve(process.cwd(), 'src/styles/houseOfCardsInteractionFix.css'),
-  'utf8',
-);
+  'utf8'
+)
 
 describe('House of Cards interaction hotfix styles', () => {
   it('keeps face-up cards rotated while hovered or focused', () => {
-    expect(css).toContain(
-      ".hoc-card[data-flipped='true']:hover .hoc-card-inner",
-    );
-    expect(css).toContain('transform: rotateY(180deg)');
-    expect(css).toContain('filter: none');
-  });
+    expect(css).toContain(".hoc-card[data-flipped='true']:hover .hoc-card-inner")
+    expect(css).toContain('transform: rotateY(180deg)')
+    expect(css).toContain('filter: none')
+  })
 
   it('restores vertical scrolling on the complete screen', () => {
-    expect(css).toContain('.minigame-complete.hoc-complete');
-    expect(css).toContain('overflow-y: auto');
-    expect(css).toContain('-webkit-overflow-scrolling: touch');
-  });
-});
+    expect(css).toContain('.minigame-complete.hoc-complete')
+    expect(css).toContain('overflow-y: auto')
+    expect(css).toContain('-webkit-overflow-scrolling: touch')
+  })
+})

--- a/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
+++ b/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
@@ -9,7 +9,9 @@ const css = fs.readFileSync(
 
 describe('House of Cards interaction hotfix styles', () => {
   it('keeps face-up cards rotated while hovered or focused', () => {
-    expect(css).toContain(".hoc-card[data-flipped='true']:hover .hoc-card-inner");
+    expect(css).toContain(
+      ".hoc-card[data-flipped='true']:hover .hoc-card-inner",
+    );
     expect(css).toContain('transform: rotateY(180deg)');
     expect(css).toContain('filter: none');
   });

--- a/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
+++ b/tests/unit/house-of-cards/HouseOfCardsComp.interactionHotfix.styles.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const css = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/styles/houseOfCardsInteractionFix.css'),
+  'utf8',
+);
+
+describe('House of Cards interaction hotfix styles', () => {
+  it('keeps face-up cards rotated while hovered or focused', () => {
+    expect(css).toContain(".hoc-card[data-flipped='true']:hover .hoc-card-inner");
+    expect(css).toContain('transform: rotateY(180deg)');
+    expect(css).toContain('filter: none');
+  });
+
+  it('restores vertical scrolling on the complete screen', () => {
+    expect(css).toContain('.minigame-complete.hoc-complete');
+    expect(css).toContain('overflow-y: auto');
+    expect(css).toContain('-webkit-overflow-scrolling: touch');
+  });
+});


### PR DESCRIPTION
## What changed

- Prevents hover/focus effects from being applied to already face-up or matched cards, so a selected card remains visibly open until the second card resolves the pair.
- Restores vertical scrolling on House of Cards round and final results screens.
- Keeps the fix scoped to House of Cards and leaves gameplay state, scoring, timers, AI and shared minigame layouts unchanged.
- Adds a focused stylesheet regression test for both issues.

## Root causes

- Applying a CSS filter to the transformed 3D card inner layer could make Chromium composite the hidden back face while the pointer remained over the card.
- The noir redesign's more-specific `.hoc-complete { overflow: hidden; }` overrode the shared results shell's `overflow-y: auto` behavior.

## Validation

- Branch changes are limited to one scoped CSS override, its import, and a style regression test.
- Runtime viewport verification is still recommended before merge because the repository connector does not execute the browser test suite.