### PR TITLE
Fix Final 4 deadlock in remote QA sessions

### DIFF
--- a/src/utils/__tests__/debugMode.test.ts
+++ b/src/utils/__tests__/debugMode.test.ts
@@ -18,7 +18,7 @@ describe('debugMode gating', () => {
     ).toBe(true);
   });
 
-  it('requires qa=1 on production hosts', () => {
+  it('keeps remote QA sessions on normal gameplay choreography', () => {
     expect(
       detectDebugMode({
         hostname: 'georgi-cole.github.io',
@@ -33,17 +33,17 @@ describe('debugMode gating', () => {
         search: '?debug=1&qa=1',
         hash: '',
       } as unknown as Location),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('accepts hash-router qa flags', () => {
+  it('keeps hash-router remote QA sessions on normal gameplay choreography', () => {
     expect(
       detectDebugMode({
         hostname: 'georgi-cole.github.io',
         search: '',
         hash: '#/game?debug=1&qa=1',
       } as unknown as Location),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('opens the advanced settings route with the same qa debug hash flags', () => {
@@ -66,10 +66,30 @@ describe('debugMode gating', () => {
     ).toBe(false);
   });
 
-  it('treats localhost as an allowed debug host', () => {
+  it('treats localhost as an allowed gameplay debug host', () => {
     const searchParams = new URLSearchParams('debug=1');
 
     expect(isDebugAccessGranted(searchParams, 'localhost')).toBe(true);
     expect(isDebugAccessGranted(searchParams, 'georgi-cole.github.io')).toBe(false);
+    expect(
+      detectDebugMode({
+        hostname: 'localhost',
+        search: '?debug=1',
+        hash: '',
+      } as unknown as Location),
+    ).toBe(true);
+  });
+
+  it('still grants the remote QA panel and special-settings access', () => {
+    const searchParams = new URLSearchParams('debug=1&qa=1');
+
+    expect(isDebugAccessGranted(searchParams, 'georgi-cole.github.io')).toBe(true);
+    expect(
+      canAccessSpecialSettings({
+        hostname: 'georgi-cole.github.io',
+        search: '?debug=1&qa=1',
+        hash: '',
+      } as unknown as Location),
+    ).toBe(true);
   });
 });

--- a/src/utils/debugMode.ts
+++ b/src/utils/debugMode.ts
@@ -26,6 +26,15 @@ function hasDebugQaAccess(locationLike: DebugLocationLike): boolean {
   );
 }
 
+function isRemoteQaSession(locationLike: DebugLocationLike): boolean {
+  if (isLocalDebugHost(locationLike.hostname)) return false;
+
+  return (
+    readQueryParam(locationLike.search, 'qa') === '1' ||
+    readQueryParam(locationLike.hash, 'qa') === '1'
+  );
+}
+
 export function isDebugAccessGranted(
   searchParams: URLSearchParams,
   hostname: string,
@@ -43,14 +52,20 @@ export function canAccessSpecialSettings(locationLike?: DebugLocationLike): bool
 }
 
 /**
- * detectDebugMode returns true when the app is running in a debug or e2e
- * context.
+ * detectDebugMode returns true only for execution contexts that should use
+ * debug gameplay shortcuts.
+ *
+ * Remote QA sessions retain access to the DebugPanel and special settings,
+ * but deliberately use the normal gameplay choreography. Treating a remote
+ * QA session as a gameplay-debug context skipped the Final 4 plea initializer
+ * and could leave the game stuck in final4_eviction with no pending action.
  *
  * Checks (in order):
  *   1. window.__E2E__ === true - set by Playwright / test harnesses
- *   2. debug=1 in the URL plus localhost or qa=1
+ *   2. local debug=1 sessions
  *
- * Returns false in SSR/non-browser environments and in normal production runs.
+ * Returns false in SSR/non-browser environments, normal production runs,
+ * and remote qa=1 sessions.
  */
 export function detectDebugMode(
   locationLike?: DebugLocationLike,
@@ -59,5 +74,6 @@ export function detectDebugMode(
   if ((window as { __E2E__?: boolean }).__E2E__ === true) return true;
 
   const resolvedLocation = locationLike ?? window.location;
+  if (isRemoteQaSession(resolvedLocation)) return false;
   return hasDebugQaAccess(resolvedLocation);
 }


### PR DESCRIPTION
## Summary

Fixes the Final 4 stage becoming permanently blocked when the deployed app is opened with `debug=1&qa=1`.

The Final 4 choreography intentionally bypasses its plea initializer in gameplay-debug mode and expects a manual debug advance. In a remote QA session this left `final4Stage` at `idle`, so the AI POS holder never cast the sole vote and no pending eviction was created.

## Changes

- keep remote QA sessions on the normal gameplay choreography
- preserve DebugPanel and advanced-settings access for `debug=1&qa=1`
- preserve gameplay-debug shortcuts for localhost and Playwright/E2E sessions
- update debug-mode regression tests for the split between QA access and gameplay-debug behavior

## Expected result

At Final 4 in a deployed QA session, the nominee plea sequence now initializes normally, the POS holder makes the sole eviction decision, and the game proceeds to Final 3 instead of becoming stuck.

## Validation

Added focused unit coverage in `src/utils/__tests__/debugMode.test.ts`. CI should run the full typecheck/build/test suite.