### PR TITLE
Adapt House Feed rows to available screen height

### DIFF
--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -66,6 +66,10 @@ const MOBILE_TV_LOG_ROW_HEIGHT = 32
 const WIDE_TV_LOG_ROW_HEIGHT = 36
 const TV_CHROME_HEIGHT = 88
 const MAX_INLINE_TV_LOG_ROWS = 3
+const AUTO_TV_LOG_RESERVE = 12
+const PHONE_SMALL_MAX_TV_VIEWPORT_EXPANSION = 32
+const PHONE_MEDIUM_MAX_TV_VIEWPORT_EXPANSION = 48
+const PHONE_LARGE_MAX_TV_VIEWPORT_EXPANSION = 64
 const SHORT_ROSTER_MAX_PLAYERS = ROSTER_COLUMNS * 2
 const SURVIVOR_STANDOUT_GAP_ALLOWANCE = 10
 const SURVIVOR_FULL_STANDOUT_MIN_SPACE = 72
@@ -130,6 +134,23 @@ function getSurvivorStandoutHeight(mode: SurvivorStandoutLayoutMode) {
 
 function resolveAdaptiveTvLogRows(extraAfterFeature: number, rowHeight: number) {
   return clamp(1 + Math.floor(extraAfterFeature / rowHeight), 1, MAX_INLINE_TV_LOG_ROWS)
+}
+
+function resolveAutomaticTvLogRows(extraAfterFeature: number, rowHeight: number) {
+  const rowBudget = Math.max(0, extraAfterFeature - AUTO_TV_LOG_RESERVE)
+  return clamp(Math.floor(rowBudget / rowHeight), 0, MAX_INLINE_TV_LOG_ROWS)
+}
+
+function resolveTvViewportExpansionLimit(layoutSize: GameLayoutSize) {
+  switch (layoutSize) {
+    case 'phone-small':
+      return PHONE_SMALL_MAX_TV_VIEWPORT_EXPANSION
+    case 'phone-medium':
+      return PHONE_MEDIUM_MAX_TV_VIEWPORT_EXPANSION
+    case 'phone-large':
+    default:
+      return PHONE_LARGE_MAX_TV_VIEWPORT_EXPANSION
+  }
 }
 
 function buildDebugLabel(
@@ -227,8 +248,9 @@ export function computeResponsiveGameLayout(
     rosterRows * compactTileSize + (rosterRows - 1) * ROSTER_GAP + ROSTER_HEADER_HEIGHT
   const minTvViewportHeight =
     layoutSize === 'phone-small' ? 112 : layoutSize === 'phone-medium' ? 132 : 144
-  // Refined chrome moves history into an on-demand module. Reserve inline-log
-  // height only when rows are actually rendered, so the roster gets the space.
+  // The setting is an explicit force-on override. In the default state the
+  // layout engine starts from the Log-only minimum and adds 0–3 rows only when
+  // the measured surplus can contain them without crowding the roster.
   const tvLogRowHeight = viewportWidth <= 480 ? MOBILE_TV_LOG_ROW_HEIGHT : WIDE_TV_LOG_ROW_HEIGHT
   const minTvHeight = minTvViewportHeight + TV_CHROME_HEIGHT + (input.inlineLogVisible ? tvLogRowHeight : 0)
   const normalWithoutHeader = normalRosterHeight - ROSTER_HEADER_HEIGHT
@@ -273,10 +295,19 @@ export function computeResponsiveGameLayout(
   const extraAfterFeature = Math.max(0, extraAfterMandatory - featureReserve)
   const tvLogRows = input.inlineLogVisible
     ? resolveAdaptiveTvLogRows(extraAfterFeature, tvLogRowHeight)
-    : 0
-  const extraLogRows = Math.max(0, tvLogRows - 1)
-  const breathingRoom = clamp(extraAfterFeature - extraLogRows * tvLogRowHeight, 0, 20)
-  const tvHeight = minTvHeight + extraLogRows * tvLogRowHeight + breathingRoom
+    : resolveAutomaticTvLogRows(extraAfterFeature, tvLogRowHeight)
+  const baseLogRows = input.inlineLogVisible ? 1 : 0
+  const logRowsFromExtra = Math.max(0, tvLogRows - baseLogRows)
+  const remainingAfterLogRows = Math.max(
+    0,
+    extraAfterFeature - logRowsFromExtra * tvLogRowHeight
+  )
+  const breathingRoom = clamp(
+    remainingAfterLogRows,
+    0,
+    resolveTvViewportExpansionLimit(layoutSize)
+  )
+  const tvHeight = minTvHeight + logRowsFromExtra * tvLogRowHeight + breathingRoom
   const tvViewportHeight = minTvViewportHeight + breathingRoom
   const compactRoster = baseRosterMode === 'compact-small'
   const rosterMaxHeight = rosterMode === 'scroll'

--- a/tests/unit/layout/adaptiveHouseFeed.test.ts
+++ b/tests/unit/layout/adaptiveHouseFeed.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeResponsiveGameLayout,
+  type ResponsiveGameLayoutInput,
+} from '../../../src/screens/GameScreen/useResponsiveGameLayout'
+
+function makeInput(overrides: Partial<ResponsiveGameLayoutInput> = {}): ResponsiveGameLayoutInput {
+  return {
+    viewportWidth: 393,
+    viewportHeight: 852,
+    stageWidth: 393,
+    stageHeight: 699,
+    safeTop: 0,
+    safeBottom: 34,
+    navHeight: 94,
+    dockHeight: 70,
+    hasDock: true,
+    playerCount: 16,
+    userCompactRoster: false,
+    inlineLogVisible: false,
+    ...overrides,
+  }
+}
+
+function readCssPx(budget: ReturnType<typeof computeResponsiveGameLayout>, name: string): number {
+  return Number.parseFloat((budget.cssVars as Record<string, string>)[name])
+}
+
+describe('adaptive House Feed allocation', () => {
+  it('uses Log-only mode when a full feed row would crowd a four-row roster', () => {
+    const budget = computeResponsiveGameLayout(makeInput())
+
+    expect(budget.tvLogRows).toBe(0)
+    expect(budget.cssVars).toMatchObject({ '--game-tv-log-rows': '0' })
+    expect(budget.rosterMode).toBe('normal')
+  })
+
+  it('adds two feed rows on a medium-height phone when they fit cleanly', () => {
+    const budget = computeResponsiveGameLayout(
+      makeInput({
+        stageHeight: 780,
+      })
+    )
+
+    expect(budget.tvLogRows).toBe(2)
+    expect(budget.cssVars).toMatchObject({ '--game-tv-log-rows': '2' })
+  })
+
+  it('caps the inline feed at three rows on a tall phone', () => {
+    const budget = computeResponsiveGameLayout(
+      makeInput({
+        viewportWidth: 430,
+        viewportHeight: 950,
+        stageWidth: 430,
+        stageHeight: 900,
+        dockHeight: 74,
+      })
+    )
+
+    expect(budget.tvLogRows).toBe(3)
+    expect(budget.cssVars).toMatchObject({ '--game-tv-log-rows': '3' })
+  })
+
+  it('keeps at least one row when the House Feed setting explicitly requests it', () => {
+    const budget = computeResponsiveGameLayout(
+      makeInput({
+        viewportWidth: 320,
+        viewportHeight: 667,
+        stageWidth: 320,
+        stageHeight: 560,
+        dockHeight: 62,
+        inlineLogVisible: true,
+      })
+    )
+
+    expect(budget.tvLogRows).toBeGreaterThanOrEqual(1)
+  })
+
+  it('expands the TV viewport with sub-row surplus instead of leaving a dead gap', () => {
+    const budget = computeResponsiveGameLayout(makeInput())
+
+    expect(budget.tvLogRows).toBe(0)
+    expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThan(144)
+  })
+})


### PR DESCRIPTION
## Summary
- makes the default House Feed behavior adaptive instead of treating the disabled setting as a hard zero-row layout
- chooses 0–3 inline feed rows from the real surplus height after the TV minimum, roster, dock, navigation, and Survival standout reserve
- preserves the existing House Feed toggle as a force-on override, guaranteeing at least one row when explicitly enabled
- redistributes sub-row surplus into a bounded TV viewport expansion so tall devices do not retain the large dead gap shown in the Pixel 10 Pro XL screenshots

## Expected behavior
- constrained four-row roster: Log button only
- medium-height phone: one or two feed rows, depending on measured space
- tall phone: up to three feed rows
- House Feed enabled in Settings: at least one feed row remains visible

## Test coverage
Added focused layout cases for:
- Log-only fallback on constrained screens
- two-row allocation on a medium-height phone
- three-row cap on tall phones
- force-on minimum of one row
- TV viewport expansion when the remaining space is smaller than a feed row

## Validation
The replacement branch was created from the latest `main`. CI validates changed-file formatting, focused-test guards, zero-warning lint, TypeScript, dependency audit, web/mobile production builds, and real mobile-Chromium player journeys.