### PR TITLE
Slow and separate the Public Save presentation

### DIFF
--- a/src/components/AudienceVerdictReveal/AudienceVerdictReveal.css
+++ b/src/components/AudienceVerdictReveal/AudienceVerdictReveal.css
@@ -182,12 +182,13 @@
   top: var(--avr-pulse-y);
   z-index: 9000;
   color: #8fc6ff;
-  font-size: 1.25rem;
+  font-size: 1.85rem;
   line-height: 1;
   pointer-events: none;
-  filter: drop-shadow(0 0 8px rgba(128, 190, 255, 0.88));
-  transform: translate(-50%, -50%) scale(0.55);
-  animation: avrExtract 1.05s cubic-bezier(0.2, 0.75, 0.25, 1) forwards;
+  filter: drop-shadow(0 0 12px rgba(128, 190, 255, 1))
+    drop-shadow(0 0 24px rgba(95, 150, 255, 0.72));
+  transform: translate(-50%, -50%) scale(0.72);
+  animation: avrExtract 2.2s cubic-bezier(0.2, 0.75, 0.25, 1) forwards;
 }
 
 @keyframes avrSignal {
@@ -212,15 +213,18 @@
 
 @keyframes avrExtract {
   0% {
-    transform: translate(-50%, -50%) scale(0.55);
+    transform: translate(-50%, -50%) scale(0.72);
     opacity: 0;
   }
-  15% {
+  12% {
+    opacity: 1;
+  }
+  72% {
     opacity: 1;
   }
   100% {
     transform: translate(calc(-50% + var(--avr-pulse-dx)), calc(-50% + var(--avr-pulse-dy)))
-      scale(1.35);
+      scale(1.65);
     opacity: 0;
   }
 }

--- a/src/components/AudienceVerdictReveal/AudienceVerdictReveal.tsx
+++ b/src/components/AudienceVerdictReveal/AudienceVerdictReveal.tsx
@@ -20,11 +20,11 @@ type PulseMetrics = {
   deltaY: number
 }
 
-const LINEUP_MS = 500
-const SETTLING_MS = 2200
-const RESULT_MS = 3400
-const EXIT_MS = 5400
-const DONE_MS = 6200
+const LINEUP_MS = 700
+const SETTLING_MS = 2800
+const RESULT_MS = 5000
+const EXIT_MS = 10000
+const DONE_MS = 10800
 const CLOSE_VOTE_MARGIN = 2
 
 function formatShare(value: number): string {
@@ -115,8 +115,8 @@ export default function AudienceVerdictReveal({
     clearTimers()
     setPhase('result')
     timersRef.current = [
-      window.setTimeout(() => setPhase('exiting'), 1500),
-      window.setTimeout(fireDone, 2100),
+      window.setTimeout(() => setPhase('exiting'), 4200),
+      window.setTimeout(fireDone, 5000),
     ]
   }, [clearTimers, fireDone, resultVisible])
 
@@ -178,13 +178,7 @@ export default function AudienceVerdictReveal({
         {phase === 'settling' && closeVote && (
           <div className="avr__close-call">TOO CLOSE TO CALL</div>
         )}
-
-        {resultVisible && savedPlayer && (
-          <div className="avr__lower-third" aria-live="assertive">
-            <strong>{savedPlayer.name.toUpperCase()} SAVED BY THE PUBLIC</strong>
-            <span>{formatShare(winningShare)} of the save vote</span>
-          </div>
-        )}
+        {/* The saved-player result is announced on the next TV screen so this vote panel stays readable. */}
       </div>
 
       {pulseMetrics &&

--- a/src/components/CeremonyOverlay/CeremonyOverlay.css
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.css
@@ -14,8 +14,19 @@
   transition: opacity 0.35s ease;
 }
 
-.ceremony-overlay--visible { opacity: 1; }
-.ceremony-overlay--exiting { opacity: 0; }
+.ceremony-overlay--visible {
+  opacity: 1;
+}
+.ceremony-overlay--exiting {
+  opacity: 0;
+}
+
+.ceremony-overlay__extract-wash {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 10, 24, 0.38);
+  backdrop-filter: blur(1px);
+}
 
 /* ── Dim backdrop with SVG-mask cutouts ────────────────────────────────────── */
 .ceremony-overlay__dim {
@@ -39,7 +50,7 @@
   z-index: 8701;
   font-size: 2rem;
   line-height: 1;
-  filter: drop-shadow(0 2px 12px rgba(0,0,0,0.65));
+  filter: drop-shadow(0 2px 12px rgba(0, 0, 0, 0.65));
   opacity: 0;
   /* Base translate so left/top position the badge by its anchor point.
      All @keyframes must include this translate to avoid overriding it. */
@@ -55,38 +66,52 @@
 
 /* Phase 1: badge appears and scales in at the start position (centre or off-screen) */
 .ceremony-overlay__badge--appearing {
-  animation: badgeAppear 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: badgeAppear var(--ceremony-badge-appear-duration, 0.45s)
+    cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
 
-.ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--appearing {
-  animation: badgeExtractAppear 0.3s ease-out forwards;
+.ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--appearing {
+  animation: badgeExtractAppear var(--ceremony-badge-appear-duration, 0.3s) ease-out forwards;
 }
 
 @keyframes badgeAppear {
-  from { opacity: 0; transform: translate(-50%, -100%) scale(0.2); }
-  to   { opacity: 1; transform: translate(-50%, -100%) scale(1);   }
+  from {
+    opacity: 0;
+    transform: translate(-50%, -100%) scale(0.2);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -100%) scale(1);
+  }
 }
 
 @keyframes badgeExtractAppear {
-  from { opacity: 0; transform: translate(-50%, -100%) scale(0.82); }
-  to   { opacity: 1; transform: translate(-50%, -100%) scale(1); }
+  from {
+    opacity: 0;
+    transform: translate(-50%, -100%) scale(0.82);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -100%) scale(1);
+  }
 }
 
 /* Phase 2: badge flies to its target tile */
 .ceremony-overlay__badge--flying {
   opacity: 1;
-  transition: left 0.5s cubic-bezier(0.22, 1, 0.36, 1),
-              top  0.5s cubic-bezier(0.22, 1, 0.36, 1);
+  transition:
+    left var(--ceremony-badge-flight-duration, 0.5s) cubic-bezier(0.22, 1, 0.36, 1),
+    top var(--ceremony-badge-flight-duration, 0.5s) cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--flying {
+.ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--flying {
   opacity: 0;
-  transform: translate(-50%, -165%) scale(0.4);
+  transform: translate(-50%, -185%) scale(0.68);
   transition:
-    left 0.5s cubic-bezier(0.22, 1, 0.36, 1),
-    top 0.5s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.5s ease,
-    transform 0.5s ease;
+    left var(--ceremony-badge-flight-duration, 0.5s) cubic-bezier(0.22, 1, 0.36, 1),
+    top var(--ceremony-badge-flight-duration, 0.5s) cubic-bezier(0.22, 1, 0.36, 1),
+    transform var(--ceremony-badge-flight-duration, 0.5s) ease,
+    opacity 0.45s ease calc(var(--ceremony-badge-flight-duration, 0.5s) - 0.45s);
 }
 
 /* Phase 3: badge lands with a settle pulse */
@@ -96,8 +121,12 @@
 }
 
 @keyframes badgeLand {
-  from { transform: translate(-50%, -100%) scale(1.3); }
-  to   { transform: translate(-50%, -100%) scale(1);   }
+  from {
+    transform: translate(-50%, -100%) scale(1.3);
+  }
+  to {
+    transform: translate(-50%, -100%) scale(1);
+  }
 }
 
 /* Phase 4: badge lingers with a gentle pulse */
@@ -106,16 +135,20 @@
   animation: badgeHoldPulse 0.8s ease infinite alternate;
 }
 
-.ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--landed,
-.ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--holding {
+.ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--landed,
+.ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--holding {
   opacity: 0;
   animation: none;
   transform: translate(-50%, -165%) scale(0.4);
 }
 
 @keyframes badgeHoldPulse {
-  from { transform: translate(-50%, -100%) scale(0.95); }
-  to   { transform: translate(-50%, -100%) scale(1.1);  }
+  from {
+    transform: translate(-50%, -100%) scale(0.95);
+  }
+  to {
+    transform: translate(-50%, -100%) scale(1.1);
+  }
 }
 
 /* ── Tile highlight glow (placed over cutout area) ─────────────────────────── */
@@ -124,30 +157,35 @@
   border-radius: 10px;
   pointer-events: none;
   z-index: 8700;
-  box-shadow: 0 0 18px 4px rgba(255, 215, 0, 0.45),
-              inset 0 0 8px rgba(255, 215, 0, 0.2);
+  box-shadow:
+    0 0 18px 4px rgba(255, 215, 0, 0.45),
+    inset 0 0 8px rgba(255, 215, 0, 0.2);
   opacity: 0;
   transition: opacity 0.35s ease;
 }
 
 .ceremony-overlay__glow--gold {
-  box-shadow: 0 0 18px 4px rgba(255, 215, 0, 0.45),
-              inset 0 0 8px rgba(255, 215, 0, 0.2);
+  box-shadow:
+    0 0 18px 4px rgba(255, 215, 0, 0.45),
+    inset 0 0 8px rgba(255, 215, 0, 0.2);
 }
 
 .ceremony-overlay__glow--danger {
-  box-shadow: 0 0 20px 4px rgba(239, 68, 68, 0.5),
-              inset 0 0 9px rgba(239, 68, 68, 0.22);
+  box-shadow:
+    0 0 20px 4px rgba(239, 68, 68, 0.5),
+    inset 0 0 9px rgba(239, 68, 68, 0.22);
 }
 
 .ceremony-overlay__glow--warning {
-  box-shadow: 0 0 20px 4px rgba(249, 115, 22, 0.44),
-              inset 0 0 9px rgba(251, 146, 60, 0.18);
+  box-shadow:
+    0 0 20px 4px rgba(249, 115, 22, 0.44),
+    inset 0 0 9px rgba(251, 146, 60, 0.18);
 }
 
 .ceremony-overlay__glow--success {
-  box-shadow: 0 0 20px 4px rgba(34, 197, 94, 0.48),
-              inset 0 0 9px rgba(74, 222, 128, 0.2);
+  box-shadow:
+    0 0 20px 4px rgba(34, 197, 94, 0.48),
+    inset 0 0 9px rgba(74, 222, 128, 0.2);
 }
 
 .ceremony-overlay--visible .ceremony-overlay__glow {
@@ -201,8 +239,14 @@
 }
 
 @keyframes captionIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0);   }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 .ceremony-overlay--exiting .ceremony-overlay__caption {
@@ -215,7 +259,7 @@
   font-size: 1.1rem;
   font-weight: 700;
   color: #fff;
-  text-shadow: 0 2px 12px rgba(0,0,0,0.85);
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.85);
   letter-spacing: 0.04em;
 }
 
@@ -236,7 +280,9 @@
     animation: none !important;
     transition: none !important;
   }
-  .ceremony-overlay--visible { opacity: 1; }
+  .ceremony-overlay--visible {
+    opacity: 1;
+  }
   .ceremony-overlay__badge--appearing,
   .ceremony-overlay__badge--flying,
   .ceremony-overlay__badge--landed,
@@ -246,12 +292,16 @@
     animation: none !important;
     transition: none !important;
   }
-  .ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--appearing,
-  .ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--flying,
-  .ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--landed,
-  .ceremony-overlay__badge[data-badge-motion="extract"].ceremony-overlay__badge--holding {
+  .ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--appearing,
+  .ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--flying,
+  .ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--landed,
+  .ceremony-overlay__badge[data-badge-motion='extract'].ceremony-overlay__badge--holding {
     opacity: 0;
   }
-  .ceremony-overlay__caption--visible { opacity: 1; }
-  .ceremony-overlay--visible .ceremony-overlay__glow { opacity: 1; }
+  .ceremony-overlay__caption--visible {
+    opacity: 1;
+  }
+  .ceremony-overlay--visible .ceremony-overlay__glow {
+    opacity: 1;
+  }
 }

--- a/src/components/CeremonyOverlay/CeremonyOverlay.tsx
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.tsx
@@ -77,11 +77,13 @@ export interface CeremonyOverlayProps {
 /** Badge animation phases with timing (ms from overlay mount) */
 const APPEAR_DELAY = 200;
 const APPEAR_DURATION = 450;
-const FLY_DELAY = APPEAR_DELAY + APPEAR_DURATION; // 650
 const FLY_DURATION = 500;
-const LAND_DELAY = FLY_DELAY + FLY_DURATION; // 1150
 const LAND_DURATION = 350;
-const HOLD_DELAY = LAND_DELAY + LAND_DURATION; // 1500
+const EXTRACT_APPEAR_DELAY = 350;
+const EXTRACT_APPEAR_DURATION = 700;
+const EXTRACT_FLY_DURATION = 1800;
+const EXTRACT_LAND_DURATION = 450;
+const EXTRACT_MIN_DURATION = 5000;
 const COMPACT_LABEL_BREAKPOINT = '(max-width: 560px)';
 const COMPACT_TILE_LABELS: Record<string, string> = {
   'LOH Nominee': 'NOMINEE',
@@ -105,7 +107,7 @@ const LABEL_VERTICAL_OFFSET_STEP = 28;
 const LABEL_VERTICAL_OFFSET_MAX = 56;
 // Extraction motion lifts the badge just above the tile without jumping into
 // the TV chrome near the top edge on compact mobile layouts.
-const BADGE_EXTRACT_Y_OFFSET = 28;
+const BADGE_EXTRACT_Y_OFFSET = 72;
 const BADGE_EXTRACT_MIN_TOP = 12;
 // Safe small-screen fallback dimensions for non-browser/SSR rendering paths.
 const SSR_VIEWPORT_WIDTH = 390;
@@ -218,6 +220,21 @@ export default function CeremonyOverlay({
     (t) => t.rect != null && (t.rect.width > 0 || t.rect.height > 0),
   );
   const hasValidTiles = validTiles.length > 0;
+  const hasExtractMotion = validTiles.some((tile) => tile.badgeMotion === 'extract');
+  const appearDelay = hasExtractMotion ? EXTRACT_APPEAR_DELAY : APPEAR_DELAY;
+  const appearDuration = hasExtractMotion ? EXTRACT_APPEAR_DURATION : APPEAR_DURATION;
+  const flyDelay = appearDelay + appearDuration;
+  const flyDuration = hasExtractMotion ? EXTRACT_FLY_DURATION : FLY_DURATION;
+  const landDelay = flyDelay + flyDuration;
+  const landDuration = hasExtractMotion ? EXTRACT_LAND_DURATION : LAND_DURATION;
+  const holdDelay = landDelay + landDuration;
+  const effectiveDurationMs = hasExtractMotion
+    ? Math.max(durationMs, EXTRACT_MIN_DURATION)
+    : durationMs;
+  const badgeTimingStyle = {
+    '--ceremony-badge-appear-duration': `${appearDuration}ms`,
+    '--ceremony-badge-flight-duration': `${flyDuration}ms`,
+  } as React.CSSProperties;
   // Track whether we're still waiting for resolveTiles to run
   const pendingResolve = resolveTiles != null && resolvedTiles === null;
 
@@ -251,20 +268,20 @@ export default function CeremonyOverlay({
     }
 
     // Badge animation timeline
-    addTimer(() => setBadgePhase('appearing'), APPEAR_DELAY);
-    addTimer(() => setBadgePhase('flying'), FLY_DELAY);
-    addTimer(() => setBadgePhase('landed'), LAND_DELAY);
-    addTimer(() => setBadgePhase('holding'), HOLD_DELAY);
+    addTimer(() => setBadgePhase('appearing'), appearDelay);
+    addTimer(() => setBadgePhase('flying'), flyDelay);
+    addTimer(() => setBadgePhase('landed'), landDelay);
+    addTimer(() => setBadgePhase('holding'), holdDelay);
 
     // Exit sequence
     addTimer(() => {
       setVisible(false);
       addTimer(onDone, 350);
-    }, durationMs);
+    }, effectiveDurationMs);
 
     return clearTimers;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasValidTiles, durationMs, pendingResolve]);
+  }, [hasValidTiles, effectiveDurationMs, pendingResolve, appearDelay, flyDelay, landDelay, holdDelay]);
 
   // Compute cutout rects for the SVG mask
   const cutouts = validTiles.map((t) => {
@@ -345,10 +362,11 @@ export default function CeremonyOverlay({
 
   const labelLayouts = useMemo(() => {
     return validTiles.reduce<LabelLayout[]>((layouts, tile, i) => {
-      if (!tile.label) return layouts;
+      const label = tile.label ?? (tile.badgeMotion === 'extract' ? 'SAVED' : undefined);
+      if (!label) return layouts;
 
       const cutout = cutouts[i];
-      const displayLabel = getDisplayTileLabel(tile.label, useCompactTileLabels);
+      const displayLabel = getDisplayTileLabel(label, useCompactTileLabels);
       const estimatedWidth = calculateLabelWidth(displayLabel, useCompactTileLabels);
       const clampedLeft = Math.min(
         Math.max(cutout.x + (cutout.w / 2), estimatedWidth / 2 + LABEL_EDGE_MARGIN),
@@ -408,6 +426,8 @@ export default function CeremonyOverlay({
         aria-live="assertive"
         aria-label={ariaLabel ?? caption}
       >
+        {hasExtractMotion && <div className="ceremony-overlay__extract-wash" aria-hidden="true" />}
+
         {/* SVG dim layer with mask cutouts */}
         {showDim && (
           <div className="ceremony-overlay__dim">
@@ -486,6 +506,7 @@ export default function CeremonyOverlay({
             className={`ceremony-overlay__badge ${getBadgeClass(badgePhase)}`}
             style={{
               ...getBadgeStyle(i),
+              ...badgeTimingStyle,
               zIndex: 8701,
               position: 'fixed',
             }}

--- a/src/components/PublicSaveReveal/PublicSaveReveal.tsx
+++ b/src/components/PublicSaveReveal/PublicSaveReveal.tsx
@@ -21,10 +21,10 @@ export interface PublicSaveRevealProps {
 type AnimPhase = 'entering' | 'revealing' | 'saved' | 'exiting'
 
 const ENTER_TO_REVEAL_MS = 900
-const REVEAL_VALUES_MS = 5000
-const SHOW_SAVED_MS = 7600
-const EXIT_MS = 9300
-const DONE_MS = 10000
+const REVEAL_VALUES_MS = 3600
+const SHOW_SAVED_MS = 9600
+const EXIT_MS = 12200
+const DONE_MS = 13000
 
 function formatShare(value: number): string {
   return `${Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1)}%`

--- a/src/components/PublicSaveReveal/__tests__/PublicSaveReveal.test.tsx
+++ b/src/components/PublicSaveReveal/__tests__/PublicSaveReveal.test.tsx
@@ -39,7 +39,7 @@ describe('PublicSaveReveal in Normal Mode', () => {
     document.body.classList.remove('no-animations')
   })
 
-  it('keeps vote shares hidden until the existing five-second reveal point', () => {
+  it('keeps vote shares hidden until the slower 3.6-second reveal point', () => {
     const expectedShares = normalisePublicSaveVoteShares(
       nominees.map((nominee) => nominee.id),
       rawApprovals
@@ -57,7 +57,7 @@ describe('PublicSaveReveal in Normal Mode', () => {
     expect(screen.getAllByText('?? %')).toHaveLength(3)
 
     act(() => {
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(3600)
     })
 
     expect(screen.queryByText('?? %')).toBeNull()
@@ -77,7 +77,7 @@ describe('PublicSaveReveal in Normal Mode', () => {
     )
 
     act(() => {
-      vi.advanceTimersByTime(5000)
+      vi.advanceTimersByTime(3600)
     })
 
     expect(screen.getAllByText('40%')).toHaveLength(2)
@@ -85,7 +85,7 @@ describe('PublicSaveReveal in Normal Mode', () => {
     expect(screen.queryByText('39.9%')).toBeNull()
   })
 
-  it('preserves the current Normal Mode timing and saved-player treatment', () => {
+  it('holds the vote distribution long enough before the saved-player treatment', () => {
     const onDone = vi.fn()
     render(
       <PublicSaveReveal
@@ -97,12 +97,12 @@ describe('PublicSaveReveal in Normal Mode', () => {
     )
 
     act(() => {
-      vi.advanceTimersByTime(7600)
+      vi.advanceTimersByTime(9600)
     })
     expect(document.querySelector('.psr__nominee--saved')).toBeTruthy()
 
     act(() => {
-      vi.advanceTimersByTime(2399)
+      vi.advanceTimersByTime(3399)
     })
     expect(onDone).not.toHaveBeenCalled()
 
@@ -121,7 +121,7 @@ describe('PublicSaveReveal in Normal Mode', () => {
     )
 
     act(() => {
-      vi.advanceTimersByTime(10000)
+      vi.advanceTimersByTime(13000)
     })
 
     expect(onDone).toHaveBeenCalledTimes(1)

--- a/src/screens/GameScreen/flows/useTwistFlow.ts
+++ b/src/screens/GameScreen/flows/useTwistFlow.ts
@@ -50,7 +50,7 @@ import {
 } from '../battleBackFlow'
 import { usePersistedGameScreenKey } from '../gameScreenPersistence'
 
-const PUBLIC_SAVE_RESULT_DELAY_MS = 5000
+const PUBLIC_SAVE_RESULT_DELAY_MS = 6500
 const EMPTY_PLAYER_IDS: string[] = []
 export const BATTLE_BACK_RETRY_LIMIT = 3
 
@@ -218,6 +218,9 @@ export function useTwistFlow({
   // ── Pre-veto public save ─────────────────────────────────────────────────
   const [pendingPublicSaveResult, setPendingPublicSaveResult] =
     useState<PendingPublicSaveResult | null>(null)
+  const [publicSavePresentationStage, setPublicSavePresentationStage] = useState<
+    'announcement' | 'ceremony'
+  >('announcement')
   const [publicSaveCeremonyConsumedKey, setPublicSaveCeremonyConsumedKey] =
     usePersistedGameScreenKey('public-save-ceremony', `${game.gameId}:${game.season}`)
 
@@ -246,38 +249,34 @@ export function useTwistFlow({
   }, [showPublicSaveReveal, game.nomineeIds, publicOpinionProfiles])
 
   const publicSaveResultAnnouncement = useMemo<Announcement | null>(() => {
-    if (!pendingPublicSaveResult) return null
+    if (!pendingPublicSaveResult || publicSavePresentationStage !== 'announcement') return null
     const savedPlayer = game.players.find((player) => player.id === pendingPublicSaveResult.savedId)
     if (!savedPlayer) return null
-    const remainingNomineeNames = game.nomineeIds
-      .filter((id) => id !== pendingPublicSaveResult.savedId)
-      .map((id) => game.players.find((player) => player.id === id)?.name)
-      .filter((name): name is string => Boolean(name))
     const subtitle =
-      pendingPublicSaveResult.supportPercent != null && remainingNomineeNames.length === 2
-        ? `${savedPlayer.name} was saved with ${Math.round(pendingPublicSaveResult.supportPercent)}% of the public support. ${remainingNomineeNames.join(' and ')} are still in danger.`
-        : remainingNomineeNames.length === 2
-          ? `${savedPlayer.name} was saved by the public. ${remainingNomineeNames.join(' and ')} are still in danger.`
-          : `${savedPlayer.name} was saved by the public.`
+      pendingPublicSaveResult.supportPercent != null
+        ? `${Math.round(pendingPublicSaveResult.supportPercent)}% of the save vote. Their nomination is now being removed.`
+        : 'The public has removed their nomination.'
     return {
       key: 'public_save_result',
-      title: 'Public Save Result',
+      title: `${savedPlayer.name} is saved by the public!`,
       subtitle,
       isLive: true,
       autoDismissMs: PUBLIC_SAVE_RESULT_DELAY_MS,
     }
-  }, [game.nomineeIds, game.players, pendingPublicSaveResult])
+  }, [game.players, pendingPublicSaveResult, publicSavePresentationStage])
 
   const publicSaveCeremonyKey = pendingPublicSaveResult
     ? `w${game.week}-public-save-${pendingPublicSaveResult.savedId}`
     : ''
   const showPublicSaveCeremony =
     isPublicModeEnabled(game.mode) &&
+    publicSavePresentationStage === 'ceremony' &&
     publicSaveCeremonyKey !== '' &&
     publicSaveCeremonyKey !== publicSaveCeremonyConsumedKey
 
   const handlePublicSaveDone = useCallback(() => {
     if (!publicSaveWinnerId) return
+    setPublicSavePresentationStage('announcement')
     setPendingPublicSaveResult({
       savedId: publicSaveWinnerId,
       supportPercent: publicSaveApprovals[publicSaveWinnerId],
@@ -286,14 +285,16 @@ export function useTwistFlow({
 
   const handlePublicSaveResultDismiss = useCallback(() => {
     if (!pendingPublicSaveResult) return
-    dispatch(commitPublicSave(pendingPublicSaveResult))
-    setPendingPublicSaveResult(null)
-  }, [dispatch, pendingPublicSaveResult])
+    setPublicSavePresentationStage('ceremony')
+  }, [pendingPublicSaveResult])
 
   const handlePublicSaveCeremonyDone = useCallback(() => {
-    if (!publicSaveCeremonyKey) return
+    if (!pendingPublicSaveResult || !publicSaveCeremonyKey) return
+    dispatch(commitPublicSave(pendingPublicSaveResult))
     setPublicSaveCeremonyConsumedKey(publicSaveCeremonyKey)
-  }, [publicSaveCeremonyKey, setPublicSaveCeremonyConsumedKey])
+    setPendingPublicSaveResult(null)
+    setPublicSavePresentationStage('announcement')
+  }, [dispatch, pendingPublicSaveResult, publicSaveCeremonyKey, setPublicSaveCeremonyConsumedKey])
 
   const publicSaveNominees = useMemo(
     () =>

--- a/tests/integration/ceremony.fixes.test.tsx
+++ b/tests/integration/ceremony.fixes.test.tsx
@@ -340,10 +340,11 @@ describe('Ceremony fix: AI LOH tiebreak choreography', () => {
   })
 })
 
-describe('Ceremony fix: public save follow-up announcement', () => {
+describe('Ceremony fix: staged public save presentation', () => {
   beforeEach(() => {
     capturedOnExternalAnnouncementDismiss = null
     vi.useFakeTimers()
+    localStorage.clear()
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       x: 50,
       y: 100,
@@ -362,7 +363,7 @@ describe('Ceremony fix: public save follow-up announcement', () => {
     vi.restoreAllMocks()
   })
 
-  it('holds the public save result on screen before entering the POS announcement', async () => {
+  it('shows a separate concise TV result before the extraction ceremony', async () => {
     const players = makePlayers(6)
     players[2].status = 'nominated'
     players[3].status = 'nominated'
@@ -378,65 +379,67 @@ describe('Ceremony fix: public save follow-up announcement', () => {
 
     renderWithStore(store)
     await act(async () => {})
-
-    screen.getByTestId('public-save-reveal')
-    await act(async () => {
-      screen.getByText('Public save done').click()
-    })
+    await act(async () => screen.getByText('Public save done').click())
 
     expect(store.getState().game.phase).toBe('pre_veto_public_save')
-    expect(screen.getByTestId('external-announcement')).toHaveTextContent('Public Save Result')
     expect(screen.getByTestId('external-announcement')).toHaveTextContent(
-      'Player 2 was saved with 50% of the public support.'
+      'Player 2 is saved by the public!'
     )
-    expect(screen.getByTestId('external-announcement')).toHaveTextContent(
-      'Player 3 and Player 4 are still in danger.'
+    expect(screen.getByTestId('external-announcement')).toHaveTextContent('50% of the save vote.')
+    expect(screen.queryByRole('status', { name: /public save ceremony/i })).toBeNull()
+
+    await act(async () => capturedOnExternalAnnouncementDismiss?.())
+
+    expect(store.getState().game.phase).toBe('pre_veto_public_save')
+    expect(screen.queryByTestId('external-announcement')).toBeNull()
+    expect(screen.getByRole('status').getAttribute('aria-label')).toBe(
+      'Public save ceremony: Player 2 is safe'
     )
+
+    await act(async () => vi.advanceTimersByTime(5350))
+    expect(store.getState().game.phase).toBe('pos_comp_announcement')
+  })
+
+  it('makes the nomination-badge extraction slow and visually explicit', async () => {
+    const players = makePlayers(6)
+    players[2].status = 'nominated'
+    players[3].status = 'nominated'
+    players[4].status = 'nominated'
+
+    const store = makeStore({
+      phase: 'pre_veto_public_save',
+      publicModeEnabled: true,
+      awaitingPublicSave: true,
+      nomineeIds: ['p2', 'p3', 'p4'],
+      players,
+    })
+
+    renderWithStore(store)
+    await act(async () => {})
+    await act(async () => fireEvent.click(screen.getByText('Public save done')))
+    expect(document.querySelector('.ceremony-overlay__extract-wash')).toBeNull()
 
     await act(async () => {
       capturedOnExternalAnnouncementDismiss?.()
     })
-
-    expect(store.getState().game.phase).toBe('pos_comp_announcement')
-  })
-
-  it('keeps the public-save ceremony to a green glow while extracting the nomination badge', async () => {
-    const players = makePlayers(6)
-    players[2].status = 'nominated'
-    players[3].status = 'nominated'
-    players[4].status = 'nominated'
-
-    const store = makeStore({
-      phase: 'pre_veto_public_save',
-      publicModeEnabled: true,
-      awaitingPublicSave: true,
-      nomineeIds: ['p2', 'p3', 'p4'],
-      players,
-    })
-
-    renderWithStore(store)
-    await act(async () => {})
-
     await act(async () => {
-      fireEvent.click(screen.getByText('Public save done'))
-    })
-    await act(async () => {
-      vi.advanceTimersByTime(700)
+      vi.advanceTimersByTime(1100)
     })
 
-    expect(screen.getByRole('status').getAttribute('aria-label')).toBe(
-      'Public save ceremony: Player 2 is safe'
-    )
     expect(
       document.querySelectorAll('.ceremony-overlay__glow[data-ceremony-tone="success"]')
     ).toHaveLength(1)
+    expect(document.querySelector('.ceremony-overlay__extract-wash')).toBeTruthy()
     expect(document.querySelector('.ceremony-overlay__dim')).toBeNull()
     expect(document.querySelector('.ceremony-overlay__caption')).toBeNull()
-    expect(screen.queryByText('Player 2 is safe!')).toBeNull()
-    expect(screen.queryByText('🗳️ Saved by the public')).toBeNull()
+    expect(screen.getByText('SAVED')).toBeTruthy()
     expect(
       document.querySelectorAll('.ceremony-overlay__badge[data-badge-motion="extract"]')
     ).toHaveLength(1)
+    expect(store.getState().game.phase).toBe('pre_veto_public_save')
+
+    await act(async () => vi.advanceTimersByTime(4250))
+    expect(store.getState().game.phase).toBe('pos_comp_announcement')
     expect(document.querySelectorAll('[title="Nominated"]')).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Problem

The Public Save flow overlapped the vote reveal, saved-player result, and nomination-badge extraction. Drama Mode also inserted a saved-player lower third into the already compact faux-TV panel. The sequence was too fast to read, upper content could be cropped, and the extraction pulse was easy to miss.

## New presentation sequence

1. Show and hold the vote distribution.
2. Clear the reveal and show a separate concise TV message naming the saved player.
3. After that message ends, run a dedicated extraction ceremony on the saved player’s housemate tile.
4. Commit the gameplay save after the extraction ceremony completes.

## Timing and visual changes

- Normal Public Save reveal now runs for 13 seconds instead of 10 seconds.
- Drama/Audience Verdict now runs for 10.8 seconds instead of 6.2 seconds.
- The final vote distribution remains readable for several seconds before transition.
- The separate save message remains on the TV for 6.5 seconds.
- The crowded Drama lower third has been removed from the vote panel.
- Badge extraction now has a 1.8-second travel, a minimum 5-second ceremony, a larger movement path, stronger glow, subtle backdrop wash, and an explicit `SAVED` label.
- Reveal, result message, and extraction no longer render simultaneously.

## Validation

- 22 focused Public Save and ceremony tests passed.
- Changed-file formatting passed.
- Focused and repository lint passed with zero warnings.
- Type checking passed.
- Production dependency audit passed.
- Web production build passed.
- Capacitor mobile build passed.
- Real mobile-Chromium core journeys passed without retries.

The branch was rebuilt as one clean commit on the latest `main` after concurrent changes landed.