### PR TITLE
Centralize challenge group 1 music

### DIFF
--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import type { RootState } from '../../store/store';
 import { SoundManager } from './SoundManager';
 import { resolveDesiredMusic } from './resolveDesiredMusic';
+import type { MusicTrack } from './musicTracks';
+import {
+  getMinigameMusicConfigByTrack,
+  MINIGAME_MUSIC_CONFIGS,
+} from './minigameMusicConfig';
+
+const VOLUME_RAMP_STEP_MS = 50;
 
 export default function AudioStateSync() {
   const musicState = useSelector(
@@ -17,10 +24,22 @@ export default function AudioStateSync() {
       incomingInboxOpen: root.social.incomingInboxOpen,
       musicScene: root.ui.musicScene,
       musicOn: root.settings.audio.musicOn,
+      musicVolume: root.settings.audio.musicVolume,
     }),
     shallowEqual,
   );
   const [hash, setHash] = useState(() => window.location.hash);
+  const previousDesiredRef = useRef<MusicTrack>('none');
+  const latestDesiredRef = useRef<MusicTrack>('none');
+  const fadeInTimerRef = useRef<number | null>(null);
+  const postGameTimerRef = useRef<number | null>(null);
+  const transitionTokenRef = useRef(0);
+
+  useEffect(() => {
+    for (const config of MINIGAME_MUSIC_CONFIGS) {
+      SoundManager.registerDynamic(config.sound);
+    }
+  }, []);
 
   useEffect(() => {
     const onHashChange = () => setHash(window.location.hash);
@@ -67,8 +86,85 @@ export default function AudioStateSync() {
   );
 
   useEffect(() => {
+    latestDesiredRef.current = desiredMusic;
+    const previousDesired = previousDesiredRef.current;
+    previousDesiredRef.current = desiredMusic;
+    const enteringConfig = getMinigameMusicConfigByTrack(desiredMusic);
+    const leavingConfig = getMinigameMusicConfigByTrack(previousDesired);
+    const transitionToken = ++transitionTokenRef.current;
+
+    const clearFadeIn = () => {
+      if (fadeInTimerRef.current != null) {
+        window.clearInterval(fadeInTimerRef.current);
+        fadeInTimerRef.current = null;
+      }
+    };
+    const clearPostGameTimer = () => {
+      if (postGameTimerRef.current != null) {
+        window.clearTimeout(postGameTimerRef.current);
+        postGameTimerRef.current = null;
+      }
+    };
+
+    clearFadeIn();
+
+    if (!musicState.musicOn) {
+      clearPostGameTimer();
+      SoundManager.setMusicVolume(musicState.musicVolume);
+      void SoundManager.setDesiredMusic('none', `resolver:${hash || '#/'}`);
+      return;
+    }
+
+    if (enteringConfig) {
+      clearPostGameTimer();
+
+      if (previousDesired === desiredMusic) {
+        SoundManager.setMusicVolume(musicState.musicVolume);
+        return;
+      }
+
+      SoundManager.setMusicVolume(0);
+      void SoundManager.setDesiredMusic(desiredMusic, `minigame-config:start:${desiredMusic}`).then(() => {
+        if (transitionTokenRef.current !== transitionToken) return;
+        const steps = Math.max(1, Math.ceil(enteringConfig.fadeInMs / VOLUME_RAMP_STEP_MS));
+        let step = 0;
+        fadeInTimerRef.current = window.setInterval(() => {
+          step += 1;
+          SoundManager.setMusicVolume(musicState.musicVolume * Math.min(1, step / steps));
+          if (step >= steps) clearFadeIn();
+        }, VOLUME_RAMP_STEP_MS);
+      });
+      return;
+    }
+
+    if (leavingConfig) {
+      clearPostGameTimer();
+      postGameTimerRef.current = window.setTimeout(() => {
+        postGameTimerRef.current = null;
+        void SoundManager.fadeOutMusic(leavingConfig.fadeOutMs).then(() => {
+          SoundManager.setMusicVolume(musicState.musicVolume);
+          if (transitionTokenRef.current !== transitionToken) return;
+          const nextTrack = latestDesiredRef.current;
+          if (getMinigameMusicConfigByTrack(nextTrack)) return;
+          void SoundManager.setDesiredMusic(nextTrack, `minigame-config:complete:${previousDesired}`);
+        });
+      }, leavingConfig.postGameHoldMs);
+      return;
+    }
+
+    clearPostGameTimer();
+    SoundManager.setMusicVolume(musicState.musicVolume);
     void SoundManager.setDesiredMusic(desiredMusic, `resolver:${hash || '#/'}`);
-  }, [desiredMusic, hash]);
+  }, [desiredMusic, hash, musicState.musicOn, musicState.musicVolume]);
+
+  useEffect(
+    () => () => {
+      transitionTokenRef.current += 1;
+      if (fadeInTimerRef.current != null) window.clearInterval(fadeInTimerRef.current);
+      if (postGameTimerRef.current != null) window.clearTimeout(postGameTimerRef.current);
+    },
+    [],
+  );
 
   return null;
 }

--- a/src/services/sound/minigameMusicConfig.ts
+++ b/src/services/sound/minigameMusicConfig.ts
@@ -1,17 +1,17 @@
-import type { SoundEntry } from './sounds';
-import type { MusicTrack } from './musicTracks';
+import type { SoundEntry } from './sounds'
+import type { MusicTrack } from './musicTracks'
 
 export interface MinigameMusicConfig {
-  track: MusicTrack;
-  sound: SoundEntry;
-  gameKeys: readonly string[];
-  fadeInMs: number;
+  track: MusicTrack
+  sound: SoundEntry
+  gameKeys: readonly string[]
+  fadeInMs: number
   /** Keep the track playing while the winner badge animation and sting complete. */
-  postGameHoldMs: number;
-  fadeOutMs: number;
+  postGameHoldMs: number
+  fadeOutMs: number
 }
 
-const soundsBase = `${import.meta.env.BASE_URL ?? '/'}assets/sounds/`;
+const soundsBase = `${import.meta.env.BASE_URL ?? '/'}assets/sounds/`
 
 export const MINIGAME_MUSIC_CONFIGS: readonly MinigameMusicConfig[] = [
   {
@@ -29,17 +29,17 @@ export const MINIGAME_MUSIC_CONFIGS: readonly MinigameMusicConfig[] = [
     postGameHoldMs: 2800,
     fadeOutMs: 2000,
   },
-] as const;
+] as const
 
 export function getMinigameMusicConfig(
-  gameKey: string | null | undefined,
+  gameKey: string | null | undefined
 ): MinigameMusicConfig | undefined {
-  if (!gameKey) return undefined;
-  return MINIGAME_MUSIC_CONFIGS.find((config) => config.gameKeys.includes(gameKey));
+  if (!gameKey) return undefined
+  return MINIGAME_MUSIC_CONFIGS.find((config) => config.gameKeys.includes(gameKey))
 }
 
 export function getMinigameMusicConfigByTrack(
-  track: MusicTrack,
+  track: MusicTrack
 ): MinigameMusicConfig | undefined {
-  return MINIGAME_MUSIC_CONFIGS.find((config) => config.track === track);
+  return MINIGAME_MUSIC_CONFIGS.find((config) => config.track === track)
 }

--- a/src/services/sound/minigameMusicConfig.ts
+++ b/src/services/sound/minigameMusicConfig.ts
@@ -38,8 +38,6 @@ export function getMinigameMusicConfig(
   return MINIGAME_MUSIC_CONFIGS.find((config) => config.gameKeys.includes(gameKey))
 }
 
-export function getMinigameMusicConfigByTrack(
-  track: MusicTrack
-): MinigameMusicConfig | undefined {
+export function getMinigameMusicConfigByTrack(track: MusicTrack): MinigameMusicConfig | undefined {
   return MINIGAME_MUSIC_CONFIGS.find((config) => config.track === track)
 }

--- a/src/services/sound/minigameMusicConfig.ts
+++ b/src/services/sound/minigameMusicConfig.ts
@@ -1,0 +1,45 @@
+import type { SoundEntry } from './sounds';
+import type { MusicTrack } from './musicTracks';
+
+export interface MinigameMusicConfig {
+  track: MusicTrack;
+  sound: SoundEntry;
+  gameKeys: readonly string[];
+  fadeInMs: number;
+  /** Keep the track playing while the winner badge animation and sting complete. */
+  postGameHoldMs: number;
+  fadeOutMs: number;
+}
+
+const soundsBase = `${import.meta.env.BASE_URL ?? '/'}assets/sounds/`;
+
+export const MINIGAME_MUSIC_CONFIGS: readonly MinigameMusicConfig[] = [
+  {
+    track: 'challenge_group_1',
+    sound: {
+      key: 'music:challenge_group_1',
+      category: 'music',
+      src: `${soundsBase}challenge_group_1_audio.mp3`,
+      preload: false,
+      volume: 0.4,
+      loop: true,
+    },
+    gameKeys: ['bigSpender', 'snake', 'castleRescue', 'batteryLow'],
+    fadeInMs: 500,
+    postGameHoldMs: 2800,
+    fadeOutMs: 2000,
+  },
+] as const;
+
+export function getMinigameMusicConfig(
+  gameKey: string | null | undefined,
+): MinigameMusicConfig | undefined {
+  if (!gameKey) return undefined;
+  return MINIGAME_MUSIC_CONFIGS.find((config) => config.gameKeys.includes(gameKey));
+}
+
+export function getMinigameMusicConfigByTrack(
+  track: MusicTrack,
+): MinigameMusicConfig | undefined {
+  return MINIGAME_MUSIC_CONFIGS.find((config) => config.track === track);
+}

--- a/src/services/sound/musicTracks.ts
+++ b/src/services/sound/musicTracks.ts
@@ -9,6 +9,7 @@ export type MusicTrack =
   | 'glass_bridge'
   | 'quick_tap'
   | 'wildcard_western'
+  | 'challenge_group_1'
   | 'season_recap'
   | 'jury_voting'
   | 'public_voting'
@@ -24,6 +25,7 @@ export const MUSIC_TRACK_SOUND_KEYS: Readonly<Record<Exclude<MusicTrack, 'none'>
   glass_bridge: 'music:gb_main',
   quick_tap: 'music:quicktap_main',
   wildcard_western: 'music:wildcard_western_main',
+  challenge_group_1: 'music:challenge_group_1',
   season_recap: 'music:season_recap',
   jury_voting: 'music:jury_voting_bg',
   public_voting: 'music:public_voting',
@@ -41,6 +43,7 @@ const SOUND_KEY_TO_TRACK: Readonly<Record<string, MusicTrack>> = {
   'music:gb_main': 'glass_bridge',
   'music:quicktap_main': 'quick_tap',
   'music:wildcard_western_main': 'wildcard_western',
+  'music:challenge_group_1': 'challenge_group_1',
   'music:season_recap': 'season_recap',
   'music:jury_voting_bg': 'jury_voting',
   'music:public_voting': 'public_voting',

--- a/src/services/sound/resolveDesiredMusic.ts
+++ b/src/services/sound/resolveDesiredMusic.ts
@@ -106,6 +106,11 @@ function trackForMinigame(gameKey: string | null | undefined): MusicTrack {
       return 'quick_tap';
     case 'wildcardWestern':
       return 'wildcard_western';
+    case 'bigSpender':
+    case 'snake':
+    case 'castleRescue':
+    case 'batteryLow':
+      return 'challenge_group_1';
     default:
       return 'none';
   }

--- a/src/services/sound/resolveDesiredMusic.ts
+++ b/src/services/sound/resolveDesiredMusic.ts
@@ -4,25 +4,18 @@
  *
  * Resolution priority (highest → lowest):
  *  1. MusicScene override (ui.musicScene) — covers finale acts and cinematic scenes.
- *     'tribunal_part1' and 'jury_voting' both return the jury_voting track.
- *     'season_recap' returns the dedicated season recap track.
- *     'public_voting' returns the dedicated public-voting track.
- *  2. seasonFinale.phase === 'seasonComplete' — final modal music as soon as
- *     the finale fully completes, even before navigation finishes.
- *  3. `#/game-over` route — final modal music on the season results screen.
+ *  2. seasonFinale.phase === 'seasonComplete'.
+ *  3. `#/game-over` route.
  *  4. Active minigame (challenge.pending.phase === 'playing') — per-game track.
- *  5. Spectator mode active — spectator track.
- *  6. Social module open (panel or inbox) — social track.
- *  7. Game phase (loh_comp/results, nominations, pos_ceremony etc.).
+ *  5. Spectator mode active.
+ *  6. Social module open.
+ *  7. Game phase.
  *  8. Fallback — 'none' (silence).
- *
- * The complete phase model and audio rules are documented in:
- *   src/services/sound/audioPhases.ts
- *   docs/AUDIO_PHASE_SYSTEM.md
  */
 import type { RootState } from '../../store/store';
 import type { MusicTrack } from './musicTracks';
 import type { MusicScene } from '../../store/uiSlice';
+import { getMinigameMusicConfig } from './minigameMusicConfig';
 
 export interface MusicResolverState {
   game: Pick<RootState['game'], 'gameId' | 'phase' | 'spectatorActive'> & {
@@ -38,48 +31,19 @@ export interface MusicResolverState {
   ui: { musicScene: MusicScene };
 }
 
-/**
- * Game phases that use the competition (LOH / HOH general) music track.
- * Including results screens so the track keeps playing through them without
- * an abrupt cut when the phase advances.
- */
 const COMPETITION_PHASES = new Set(['loh_comp', 'loh_results', 'pos_comp', 'pos_results']);
-
-/**
- * Game phases that use the nominations music track.
- * Includes nomination_results and pre_veto_public_save so the track is
- * continuous through the nominations flow before veto.
- */
 const NOMINATION_PHASES = new Set([
   'nominations',
   'nomination_results',
   'pre_veto_public_save',
 ]);
-
-/**
- * Game phases that use the veto (POS ceremony) music track.
- * Includes pos_ceremony_results so the track is continuous.
- */
 const VETO_PHASES = new Set(['pos_ceremony', 'pos_ceremony_results']);
 
-/**
- * Maps a MusicScene override to the desired MusicTrack.
- *
- * 'tribunal_part1'  — FinalFaceoff 'clues' act (hidden votes).  Uses the
- *                     same jury_voting track as 'revealVotes' so there is no
- *                     jarring silence while jurors send their cryptic messages.
- * 'jury_voting'     — FinalFaceoff 'revealVotes' act; vote chips revealed.
- * 'season_recap'    — FinalFaceoff 'recap' act; plays the dedicated
- *                     season recap music track.
- * 'public_voting'   — SeasonFinaleOverlay public-favourite flow.
- * 'none'            — No override; resolver falls through to game-phase logic.
- */
 function trackForMusicScene(scene: MusicScene): MusicTrack {
   switch (scene) {
     case 'season_recap':
       return 'season_recap';
     case 'tribunal_part1':
-      return 'jury_voting';
     case 'jury_voting':
       return 'jury_voting';
     case 'public_voting':
@@ -94,6 +58,9 @@ function isGameOverHash(hash: string): boolean {
 }
 
 function trackForMinigame(gameKey: string | null | undefined): MusicTrack {
+  const configuredTrack = getMinigameMusicConfig(gameKey)?.track;
+  if (configuredTrack) return configuredTrack;
+
   switch (gameKey) {
     case 'riskWheel':
       return 'risk_wheel';
@@ -106,69 +73,32 @@ function trackForMinigame(gameKey: string | null | undefined): MusicTrack {
       return 'quick_tap';
     case 'wildcardWestern':
       return 'wildcard_western';
-    case 'bigSpender':
-    case 'snake':
-    case 'castleRescue':
-    case 'batteryLow':
-      return 'challenge_group_1';
     default:
       return 'none';
   }
 }
 
-/**
- * Resolve the desired background music track from current application state.
- *
- * This is a **pure function** with no side effects.  It is called by
- * AudioStateSync on every relevant state change and the result is forwarded
- * to SoundManager.setDesiredMusic().
- *
- * @param state    Slice of Redux state needed for resolution.
- * @param _hash    Current window.location.hash.
- * @returns The desired MusicTrack, or 'none' for silence.
- */
 export function resolveDesiredMusic(
   state: MusicResolverState,
-  _hash: string,
+  hash: string,
 ): MusicTrack {
   const sceneTrack = trackForMusicScene(state.ui.musicScene);
-  if (sceneTrack !== 'none') {
-    return sceneTrack;
-  }
+  if (sceneTrack !== 'none') return sceneTrack;
 
-  if (state.game.seasonFinale?.phase === 'seasonComplete') {
-    return 'final_modal';
-  }
-
-  if (isGameOverHash(_hash)) {
-    return 'final_modal';
-  }
+  if (state.game.seasonFinale?.phase === 'seasonComplete') return 'final_modal';
+  if (isGameOverHash(hash)) return 'final_modal';
 
   const minigameTrack =
     state.challenge.pending?.phase === 'playing'
       ? trackForMinigame(state.challenge.pending.game?.key)
       : 'none';
-  if (minigameTrack !== 'none') {
-    return minigameTrack;
-  }
+  if (minigameTrack !== 'none') return minigameTrack;
 
-  if (state.game.spectatorActive) {
-    return 'spectator';
-  }
-
-  if (state.social.panelOpen || state.social.incomingInboxOpen) {
-    return 'social';
-  }
-
-  if (COMPETITION_PHASES.has(state.game.phase)) {
-    return 'competition';
-  }
-  if (NOMINATION_PHASES.has(state.game.phase)) {
-    return 'nominations';
-  }
-  if (VETO_PHASES.has(state.game.phase)) {
-    return 'veto';
-  }
+  if (state.game.spectatorActive) return 'spectator';
+  if (state.social.panelOpen || state.social.incomingInboxOpen) return 'social';
+  if (COMPETITION_PHASES.has(state.game.phase)) return 'competition';
+  if (NOMINATION_PHASES.has(state.game.phase)) return 'nominations';
+  if (VETO_PHASES.has(state.game.phase)) return 'veto';
 
   return 'none';
 }

--- a/tests/unit/sound/minigameMusicConfig.test.ts
+++ b/tests/unit/sound/minigameMusicConfig.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest'
 import {
   getMinigameMusicConfig,
   getMinigameMusicConfigByTrack,
-} from '../../../src/services/sound/minigameMusicConfig';
-import { resolveDesiredMusic, type MusicResolverState } from '../../../src/services/sound/resolveDesiredMusic';
+} from '../../../src/services/sound/minigameMusicConfig'
+import {
+  resolveDesiredMusic,
+  type MusicResolverState,
+} from '../../../src/services/sound/resolveDesiredMusic'
 
-const GROUP_GAME_KEYS = ['bigSpender', 'snake', 'castleRescue', 'batteryLow'] as const;
+const GROUP_GAME_KEYS = ['bigSpender', 'snake', 'castleRescue', 'batteryLow'] as const
 
 function makeState(gameKey: string, phase = 'playing'): MusicResolverState {
   return {
@@ -26,30 +29,30 @@ function makeState(gameKey: string, phase = 'playing'): MusicResolverState {
       incomingInboxOpen: false,
     },
     ui: { musicScene: 'none' },
-  };
+  }
 }
 
 describe('centralized minigame music configuration', () => {
   it.each(GROUP_GAME_KEYS)('routes %s to challenge group 1 music while playing', (gameKey) => {
-    expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1');
-  });
+    expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1')
+  })
 
   it('does not route the track before the playing phase', () => {
-    expect(resolveDesiredMusic(makeState('bigSpender', 'countdown'), '#/game')).toBe('competition');
-  });
+    expect(resolveDesiredMusic(makeState('bigSpender', 'countdown'), '#/game')).toBe('competition')
+  })
 
   it('stores the requested asset and lifecycle timings in one config', () => {
-    const config = getMinigameMusicConfig('bigSpender');
-    expect(config?.sound.src).toContain('assets/sounds/challenge_group_1_audio.mp3');
-    expect(config?.sound.loop).toBe(true);
-    expect(config?.fadeInMs).toBe(500);
-    expect(config?.postGameHoldMs).toBe(2800);
-    expect(config?.fadeOutMs).toBe(2000);
-    expect(getMinigameMusicConfigByTrack('challenge_group_1')).toBe(config);
-  });
+    const config = getMinigameMusicConfig('bigSpender')
+    expect(config?.sound.src).toContain('assets/sounds/challenge_group_1_audio.mp3')
+    expect(config?.sound.loop).toBe(true)
+    expect(config?.fadeInMs).toBe(500)
+    expect(config?.postGameHoldMs).toBe(2800)
+    expect(config?.fadeOutMs).toBe(2000)
+    expect(getMinigameMusicConfigByTrack('challenge_group_1')).toBe(config)
+  })
 
   it('leaves unrelated minigames on their existing audio routes', () => {
-    expect(getMinigameMusicConfig('riskWheel')).toBeUndefined();
-    expect(resolveDesiredMusic(makeState('riskWheel'), '#/game')).toBe('risk_wheel');
-  });
-});
+    expect(getMinigameMusicConfig('riskWheel')).toBeUndefined()
+    expect(resolveDesiredMusic(makeState('riskWheel'), '#/game')).toBe('risk_wheel')
+  })
+})

--- a/tests/unit/sound/minigameMusicConfig.test.ts
+++ b/tests/unit/sound/minigameMusicConfig.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMinigameMusicConfig,
+  getMinigameMusicConfigByTrack,
+} from '../../../src/services/sound/minigameMusicConfig';
+import { resolveDesiredMusic, type MusicResolverState } from '../../../src/services/sound/resolveDesiredMusic';
+
+const GROUP_GAME_KEYS = ['bigSpender', 'snake', 'castleRescue', 'batteryLow'] as const;
+
+function makeState(gameKey: string, phase = 'playing'): MusicResolverState {
+  return {
+    game: {
+      gameId: 'test-game',
+      phase: 'loh_comp',
+      spectatorActive: false,
+      seasonFinale: null,
+    },
+    challenge: {
+      pending: {
+        phase,
+        game: { key: gameKey },
+      },
+    },
+    social: {
+      panelOpen: false,
+      incomingInboxOpen: false,
+    },
+    ui: { musicScene: 'none' },
+  };
+}
+
+describe('centralized minigame music configuration', () => {
+  it.each(GROUP_GAME_KEYS)('routes %s to challenge group 1 music while playing', (gameKey) => {
+    expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1');
+  });
+
+  it('does not route the track before the playing phase', () => {
+    expect(resolveDesiredMusic(makeState('bigSpender', 'countdown'), '#/game')).toBe('competition');
+  });
+
+  it('stores the requested asset and lifecycle timings in one config', () => {
+    const config = getMinigameMusicConfig('bigSpender');
+    expect(config?.sound.src).toContain('assets/sounds/challenge_group_1_audio.mp3');
+    expect(config?.sound.loop).toBe(true);
+    expect(config?.fadeInMs).toBe(500);
+    expect(config?.postGameHoldMs).toBe(2800);
+    expect(config?.fadeOutMs).toBe(2000);
+    expect(getMinigameMusicConfigByTrack('challenge_group_1')).toBe(config);
+  });
+
+  it('leaves unrelated minigames on their existing audio routes', () => {
+    expect(getMinigameMusicConfig('riskWheel')).toBeUndefined();
+    expect(resolveDesiredMusic(makeState('riskWheel'), '#/game')).toBe('risk_wheel');
+  });
+});


### PR DESCRIPTION
## What changed

- Added one centralized `minigameMusicConfig` entry for `challenge_group_1_audio.mp3`.
- Routed only these active games through that config:
  - Big Spender (`bigSpender`)
  - Serpentine (`snake`)
  - Find Your Twin (`castleRescue`)
  - Battery Low (`batteryLow`)
- Starts the track only when the shared challenge state enters `playing`, so the existing 3-second countdown completes first.
- Applies a 500 ms fade-in.
- Keeps the track alive through the shared winner-badge ceremony window, then applies a 2-second fade-out before restoring the next centrally resolved track.
- Added unit coverage for routing, timing values, asset registration, countdown exclusion, and unrelated-game behavior.

## Architecture

No individual minigame component was changed. Asset metadata, eligible game keys, looping, volume, fade-in, post-game hold, and fade-out are declarative in one central config. `resolveDesiredMusic` and `AudioStateSync` remain the single runtime owners.

## Validation

Static unit tests were added. Local execution was unavailable in this environment, so CI should run the repository checks on the PR.