### PR TITLE
Enforce exclusive challenge group 1 music

### DIFF
--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -53,10 +53,7 @@ export default function AudioStateSync() {
 
   useEffect(() => {
     const configuredGame = getMinigameMusicConfig(musicState.pendingChallengeGameKey);
-    if (!configuredGame) {
-      setHostedMinigamePlaying(false);
-      return undefined;
-    }
+    if (!configuredGame) return undefined;
 
     return observeHostedMinigamePlaying(setHostedMinigamePlaying);
   }, [musicState.pendingChallengeGameKey]);

--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -5,9 +5,11 @@ import { SoundManager } from './SoundManager';
 import { resolveDesiredMusic } from './resolveDesiredMusic';
 import type { MusicTrack } from './musicTracks';
 import {
+  getMinigameMusicConfig,
   getMinigameMusicConfigByTrack,
   MINIGAME_MUSIC_CONFIGS,
 } from './minigameMusicConfig';
+import { observeHostedMinigamePlaying } from './minigameHostPhaseObserver';
 
 const VOLUME_RAMP_STEP_MS = 50;
 
@@ -29,6 +31,7 @@ export default function AudioStateSync() {
     shallowEqual,
   );
   const [hash, setHash] = useState(() => window.location.hash);
+  const [hostedMinigamePlaying, setHostedMinigamePlaying] = useState(false);
   const previousDesiredRef = useRef<MusicTrack>('none');
   const latestDesiredRef = useRef<MusicTrack>('none');
   const fadeInTimerRef = useRef<number | null>(null);
@@ -47,7 +50,17 @@ export default function AudioStateSync() {
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
 
-  const desiredMusic = useMemo(
+  useEffect(() => {
+    const configuredGame = getMinigameMusicConfig(musicState.pendingChallengeGameKey);
+    if (!configuredGame) {
+      setHostedMinigamePlaying(false);
+      return undefined;
+    }
+
+    return observeHostedMinigamePlaying(setHostedMinigamePlaying);
+  }, [musicState.pendingChallengeGameKey]);
+
+  const resolvedMusic = useMemo(
     () => {
       if (!musicState.musicOn) return 'none';
 
@@ -84,6 +97,21 @@ export default function AudioStateSync() {
     },
     [hash, musicState],
   );
+
+  const desiredMusic = useMemo<MusicTrack>(() => {
+    if (musicState.musicOn && hostedMinigamePlaying) {
+      const configuredTrack = getMinigameMusicConfig(
+        musicState.pendingChallengeGameKey,
+      )?.track;
+      if (configuredTrack) return configuredTrack;
+    }
+    return resolvedMusic;
+  }, [
+    hostedMinigamePlaying,
+    musicState.musicOn,
+    musicState.pendingChallengeGameKey,
+    resolvedMusic,
+  ]);
 
   useEffect(() => {
     latestDesiredRef.current = desiredMusic;

--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -105,6 +105,10 @@ export default function AudioStateSync() {
       )?.track;
       if (configuredTrack) return configuredTrack;
     }
+
+    // For configured challenges, resolvedMusic is deliberately `none` before
+    // gameplay. This prevents the generic competition track from sharing the
+    // channel with, or bleeding into, the configured minigame track.
     return resolvedMusic;
   }, [
     hostedMinigamePlaying,

--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -34,6 +34,7 @@ export default function AudioStateSync() {
   const [hostedMinigamePlaying, setHostedMinigamePlaying] = useState(false);
   const previousDesiredRef = useRef<MusicTrack>('none');
   const latestDesiredRef = useRef<MusicTrack>('none');
+  const heldConfiguredTrackRef = useRef<MusicTrack | null>(null);
   const fadeInTimerRef = useRef<number | null>(null);
   const postGameTimerRef = useRef<number | null>(null);
   const transitionTokenRef = useRef(0);
@@ -119,9 +120,17 @@ export default function AudioStateSync() {
 
   useEffect(() => {
     latestDesiredRef.current = desiredMusic;
+    const enteringConfig = getMinigameMusicConfigByTrack(desiredMusic);
+
+    // Once a configured track begins its winner-badge hold/fade, later resolver
+    // updates are only remembered as the eventual fallback. They must not stop
+    // the hold, cancel the fade, or start generic competition music underneath.
+    if (musicState.musicOn && heldConfiguredTrackRef.current && !enteringConfig) {
+      return;
+    }
+
     const previousDesired = previousDesiredRef.current;
     previousDesiredRef.current = desiredMusic;
-    const enteringConfig = getMinigameMusicConfigByTrack(desiredMusic);
     const leavingConfig = getMinigameMusicConfigByTrack(previousDesired);
     const transitionToken = ++transitionTokenRef.current;
 
@@ -142,6 +151,7 @@ export default function AudioStateSync() {
 
     if (!musicState.musicOn) {
       clearPostGameTimer();
+      heldConfiguredTrackRef.current = null;
       SoundManager.setMusicVolume(musicState.musicVolume);
       void SoundManager.setDesiredMusic('none', `resolver:${hash || '#/'}`);
       return;
@@ -149,6 +159,7 @@ export default function AudioStateSync() {
 
     if (enteringConfig) {
       clearPostGameTimer();
+      heldConfiguredTrackRef.current = null;
 
       if (previousDesired === desiredMusic) {
         SoundManager.setMusicVolume(musicState.musicVolume);
@@ -171,13 +182,16 @@ export default function AudioStateSync() {
 
     if (leavingConfig) {
       clearPostGameTimer();
+      heldConfiguredTrackRef.current = previousDesired;
       postGameTimerRef.current = window.setTimeout(() => {
         postGameTimerRef.current = null;
         void SoundManager.fadeOutMusic(leavingConfig.fadeOutMs).then(() => {
-          SoundManager.setMusicVolume(musicState.musicVolume);
           if (transitionTokenRef.current !== transitionToken) return;
+          heldConfiguredTrackRef.current = null;
+          SoundManager.setMusicVolume(musicState.musicVolume);
           const nextTrack = latestDesiredRef.current;
           if (getMinigameMusicConfigByTrack(nextTrack)) return;
+          previousDesiredRef.current = nextTrack;
           void SoundManager.setDesiredMusic(nextTrack, `minigame-config:complete:${previousDesired}`);
         });
       }, leavingConfig.postGameHoldMs);
@@ -192,6 +206,7 @@ export default function AudioStateSync() {
   useEffect(
     () => () => {
       transitionTokenRef.current += 1;
+      heldConfiguredTrackRef.current = null;
       if (fadeInTimerRef.current != null) window.clearInterval(fadeInTimerRef.current);
       if (postGameTimerRef.current != null) window.clearTimeout(postGameTimerRef.current);
     },

--- a/src/services/sound/minigameHostPhaseObserver.ts
+++ b/src/services/sound/minigameHostPhaseObserver.ts
@@ -1,0 +1,32 @@
+const PLAYING_SELECTOR = '.minigame-host-playing'
+
+export function isHostedMinigamePlaying(root: ParentNode = document): boolean {
+  return root.querySelector(PLAYING_SELECTOR) != null
+}
+
+export function observeHostedMinigamePlaying(
+  onChange: (playing: boolean) => void,
+  doc: Document = document
+): () => void {
+  let lastValue = isHostedMinigamePlaying(doc)
+  onChange(lastValue)
+
+  const target = doc.body ?? doc.documentElement
+  if (!target || typeof MutationObserver === 'undefined') return () => undefined
+
+  const observer = new MutationObserver(() => {
+    const nextValue = isHostedMinigamePlaying(doc)
+    if (nextValue === lastValue) return
+    lastValue = nextValue
+    onChange(nextValue)
+  })
+
+  observer.observe(target, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  })
+
+  return () => observer.disconnect()
+}

--- a/src/services/sound/resolveDesiredMusic.ts
+++ b/src/services/sound/resolveDesiredMusic.ts
@@ -6,11 +6,12 @@
  *  1. MusicScene override (ui.musicScene) — covers finale acts and cinematic scenes.
  *  2. seasonFinale.phase === 'seasonComplete'.
  *  3. `#/game-over` route.
- *  4. Active minigame (challenge.pending.phase === 'playing') — per-game track.
- *  5. Spectator mode active.
- *  6. Social module open.
- *  7. Game phase.
- *  8. Fallback — 'none' (silence).
+ *  4. Configured minigame ownership — silence before gameplay, configured track while playing.
+ *  5. Other active minigames — per-game track.
+ *  6. Spectator mode active.
+ *  7. Social module open.
+ *  8. Game phase.
+ *  9. Fallback — 'none' (silence).
  */
 import type { RootState } from '../../store/store';
 import type { MusicTrack } from './musicTracks';
@@ -58,9 +59,6 @@ function isGameOverHash(hash: string): boolean {
 }
 
 function trackForMinigame(gameKey: string | null | undefined): MusicTrack {
-  const configuredTrack = getMinigameMusicConfig(gameKey)?.track;
-  if (configuredTrack) return configuredTrack;
-
   switch (gameKey) {
     case 'riskWheel':
       return 'risk_wheel';
@@ -88,9 +86,15 @@ export function resolveDesiredMusic(
   if (state.game.seasonFinale?.phase === 'seasonComplete') return 'final_modal';
   if (isGameOverHash(hash)) return 'final_modal';
 
+  const pendingChallenge = state.challenge.pending;
+  const configuredMinigame = getMinigameMusicConfig(pendingChallenge?.game?.key);
+  if (configuredMinigame) {
+    return pendingChallenge?.phase === 'playing' ? configuredMinigame.track : 'none';
+  }
+
   const minigameTrack =
-    state.challenge.pending?.phase === 'playing'
-      ? trackForMinigame(state.challenge.pending.game?.key)
+    pendingChallenge?.phase === 'playing'
+      ? trackForMinigame(pendingChallenge.game?.key)
       : 'none';
   if (minigameTrack !== 'none') return minigameTrack;
 

--- a/tests/unit/sound/minigameHostPhaseObserver.test.ts
+++ b/tests/unit/sound/minigameHostPhaseObserver.test.ts
@@ -1,0 +1,33 @@
+import { waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isHostedMinigamePlaying,
+  observeHostedMinigamePlaying,
+} from '../../../src/services/sound/minigameHostPhaseObserver'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('hosted minigame phase observer', () => {
+  it('tracks the real shared host playing view', async () => {
+    const onChange = vi.fn()
+    const stop = observeHostedMinigamePlaying(onChange)
+
+    expect(isHostedMinigamePlaying()).toBe(false)
+    expect(onChange).toHaveBeenLastCalledWith(false)
+
+    const playingView = document.createElement('div')
+    playingView.className = 'minigame-host-playing'
+    document.body.appendChild(playingView)
+
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(true))
+    expect(isHostedMinigamePlaying()).toBe(true)
+
+    playingView.remove()
+    await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(false))
+
+    stop()
+  })
+})

--- a/tests/unit/sound/minigameMusicConfig.test.ts
+++ b/tests/unit/sound/minigameMusicConfig.test.ts
@@ -33,7 +33,7 @@ function makeState(gameKey: string, phase = 'playing'): MusicResolverState {
 }
 
 describe('centralized minigame music configuration', () => {
-  it.each(GROUP_GAME_KEYS)('routes %s to challenge group 1 music while playing', (gameKey) => {
+  it.each(GROUP_GAME_KEYS)('routes %s exclusively to challenge group 1 while playing', (gameKey) => {
     expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1')
   })
 

--- a/tests/unit/sound/minigameMusicConfig.test.ts
+++ b/tests/unit/sound/minigameMusicConfig.test.ts
@@ -37,9 +37,12 @@ describe('centralized minigame music configuration', () => {
     expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1')
   })
 
-  it('does not route the track before the playing phase', () => {
-    expect(resolveDesiredMusic(makeState('bigSpender', 'countdown'), '#/game')).toBe('competition')
-  })
+  it.each(['rules', 'countdown', 'done'])(
+    'suppresses generic competition music during configured challenge phase %s',
+    (phase) => {
+      expect(resolveDesiredMusic(makeState('bigSpender', phase), '#/game')).toBe('none')
+    }
+  )
 
   it('stores the requested asset and lifecycle timings in one config', () => {
     const config = getMinigameMusicConfig('bigSpender')

--- a/tests/unit/sound/minigameMusicConfig.test.ts
+++ b/tests/unit/sound/minigameMusicConfig.test.ts
@@ -33,9 +33,12 @@ function makeState(gameKey: string, phase = 'playing'): MusicResolverState {
 }
 
 describe('centralized minigame music configuration', () => {
-  it.each(GROUP_GAME_KEYS)('routes %s exclusively to challenge group 1 while playing', (gameKey) => {
-    expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1')
-  })
+  it.each(GROUP_GAME_KEYS)(
+    'routes %s exclusively to challenge group 1 while playing',
+    (gameKey) => {
+      expect(resolveDesiredMusic(makeState(gameKey), '#/game')).toBe('challenge_group_1')
+    }
+  )
 
   it.each(['rules', 'countdown', 'done'])(
     'suppresses generic competition music during configured challenge phase %s',


### PR DESCRIPTION
## Root cause

PR #1294 had two runtime problems:

1. `MinigameHost` owns countdown/gameplay state locally, so Redux stayed on `rules` and the configured track was not selected reliably.
2. When the configured challenge ended, the generic competition resolver could request its track before the winner-badge hold and 2-second fade completed, causing both tracks to overlap.

## Fix

- Keep all behavior in the central audio system.
- For Big Spender, Serpentine, Find Your Twin, and Battery Low, suppress the generic competition track as soon as the configured challenge is selected.
- During rules and the 3-second countdown, keep the music channel silent; the existing countdown SFX still plays.
- When the shared MinigameHost gameplay surface appears, start only `challenge_group_1_audio.mp3` with a 500 ms fade-in.
- Retain exclusive ownership through the winner-badge hold and 2-second fade-out.
- Queue any later generic phase-music request as the eventual fallback instead of starting it underneath the configured track.
- Resume normal phase music only after the configured fade has fully completed.
- No individual minigame component is changed.

## Regression coverage

- Verifies all four configured game keys route to `challenge_group_1` during gameplay.
- Verifies rules, countdown, and done states return `none` rather than generic competition music.
- Verifies unrelated games retain their existing routes.
- Verifies the runtime shared-host gameplay signal.

## Validation

CI should run formatting, type checking, and unit tests. Local npm execution is unavailable in this environment.