### PR TITLE
Make Advanced Drama Mode override effective everywhere

### DIFF
--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -126,7 +126,12 @@ const SECTIONS: SettingSection[] = [
         gated: true,
         lockedFeature: 'Drama Mode',
         get: (s) => s.gameUX.dramaMode,
-        onChange: (dispatch, val) => dispatch(setGameUX({ dramaMode: val })),
+        onChange: (dispatch, val) =>
+          dispatch(
+            setGameUX(
+              val ? { dramaMode: true } : { dramaMode: false, dramaModeAdminOverride: false }
+            )
+          ),
       },
       {
         type: 'toggle',
@@ -216,7 +221,7 @@ export default function Settings() {
       case 'toggle': {
         const hasAccess =
           item.id === 'dramaMode'
-            ? hasDramaMode
+            ? hasDramaMode || settings.gameUX.dramaModeAdminOverride
             : item.id === 'publicMode'
               ? hasPublicMode || settings.sim.publicModeAdminOverride
               : item.id === 'tribunalHouse'

--- a/src/screens/SettingsAdmin/SettingsAdmin.tsx
+++ b/src/screens/SettingsAdmin/SettingsAdmin.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
-import { buildViewportMetaContent } from '../../components/layout/viewportMeta';
-import { useNavigate } from 'react-router';
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { useState, useEffect, useCallback } from 'react'
+import { buildViewportMetaContent } from '../../components/layout/viewportMeta'
+import { useNavigate } from 'react-router'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import {
   selectSettings,
   setAudio,
@@ -10,82 +10,90 @@ import {
   setSim,
   setVisual,
   type ThemePreset,
-} from '../../store/settingsSlice';
-import CompSelection from '../../components/CompSelection';
-import type { CompGame, CompSelectionPayload } from '../../components/compSelectionUtils';
-import { getAllGames, type GameCategory } from '../../minigames/registry';
-import { restartApp } from '../../utils/restartApp';
-import { APP_VERSION } from '../../appVersion';
-import './SettingsAdmin.css';
+} from '../../store/settingsSlice'
+import CompSelection from '../../components/CompSelection'
+import type { CompGame, CompSelectionPayload } from '../../components/compSelectionUtils'
+import { getAllGames, type GameCategory } from '../../minigames/registry'
+import { restartApp } from '../../utils/restartApp'
+import { APP_VERSION } from '../../appVersion'
+import './SettingsAdmin.css'
 
 /** Maps the minigame registry GameCategory to the CompGame category vocabulary. */
-function registryCategoryToCompCategory(
-  category: GameCategory,
-): CompGame['category'] {
+function registryCategoryToCompCategory(category: GameCategory): CompGame['category'] {
   switch (category) {
-    case 'arcade':    return 'physical';
-    case 'endurance': return 'endurance';
-    case 'logic':     return 'mental';
-    case 'trivia':    return 'mental';
+    case 'arcade':
+      return 'physical'
+    case 'endurance':
+      return 'endurance'
+    case 'logic':
+      return 'mental'
+    case 'trivia':
+      return 'mental'
   }
 }
 
 const REGISTRY_CATEGORY_ICONS: Record<GameCategory, string> = {
-  arcade:    '🕹️',
+  arcade: '🕹️',
   endurance: '⏱️',
-  logic:     '🧩',
-  trivia:    '❓',
-};
+  logic: '🧩',
+  trivia: '❓',
+}
 
 /** Builds the CompGame list from the in-repo minigame registry. */
 function buildCompGamesFromRegistry(): CompGame[] {
   return getAllGames()
     .filter((g) => !g.retired)
     .map((g) => ({
-      id:       g.key,
-      name:     g.title,
-      icon:     REGISTRY_CATEGORY_ICONS[g.category],
+      id: g.key,
+      name: g.title,
+      icon: REGISTRY_CATEGORY_ICONS[g.category],
       category: registryCategoryToCompCategory(g.category),
-      enabled:  true,
-    }));
+      enabled: true,
+    }))
 }
 
-type Tab = 'audio' | 'display' | 'gameux' | 'about';
+type Tab = 'audio' | 'display' | 'gameux' | 'about'
 
 const TABS: { id: Tab; label: string }[] = [
-  { id: 'audio',   label: '🔊 Audio'    },
-  { id: 'display', label: '🎨 Display'  },
-  { id: 'gameux',  label: '🎮 Game UX'  },
-  { id: 'about',   label: 'ℹ️ About'    },
-];
+  { id: 'audio', label: '🔊 Audio' },
+  { id: 'display', label: '🎨 Display' },
+  { id: 'gameux', label: '🎮 Game UX' },
+  { id: 'about', label: 'ℹ️ About' },
+]
 
 const THEME_PRESETS: { id: ThemePreset; label: string; swatch: string }[] = [
   { id: 'midnight', label: 'Midnight', swatch: '#6366f1' },
-  { id: 'neon',     label: 'Neon',     swatch: '#22d3ee' },
-  { id: 'sunset',   label: 'Sunset',   swatch: '#f97316' },
-  { id: 'ocean',    label: 'Ocean',    swatch: '#0ea5e9' },
-];
+  { id: 'neon', label: 'Neon', swatch: '#22d3ee' },
+  { id: 'sunset', label: 'Sunset', swatch: '#f97316' },
+  { id: 'ocean', label: 'Ocean', swatch: '#0ea5e9' },
+]
 
 export default function SettingsAdmin() {
-  const [activeTab, setActiveTab] = useState<Tab>('audio');
-  const dispatch = useAppDispatch();
-  const navigate = useNavigate();
-  const settings = useAppSelector(selectSettings);
-  const [castSizeInput, setCastSizeInput] = useState<string>(String(settings.gameUX.castSize));
-  const [showRestartModal, setShowRestartModal] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>('audio')
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const settings = useAppSelector(selectSettings)
+  const [castSizeInput, setCastSizeInput] = useState<string>(String(settings.gameUX.castSize))
+  const [showRestartModal, setShowRestartModal] = useState(false)
 
-  // Migrate values enabled by the earlier Advanced Settings implementation.
+  // Migrate values enabled by earlier Advanced Settings implementations.
   useEffect(() => {
-    if (settings.sim.publicMode && !settings.sim.publicModeAdminOverride) {
-      dispatch(setSim({ publicModeAdminOverride: true }));
+    if (settings.gameUX.dramaMode && !settings.gameUX.dramaModeAdminOverride) {
+      dispatch(setGameUX({ dramaModeAdminOverride: true }))
     }
-  }, [dispatch, settings.sim.publicMode, settings.sim.publicModeAdminOverride]);
+    if (settings.sim.publicMode && !settings.sim.publicModeAdminOverride) {
+      dispatch(setSim({ publicModeAdminOverride: true }))
+    }
+  }, [
+    dispatch,
+    settings.gameUX.dramaMode,
+    settings.gameUX.dramaModeAdminOverride,
+    settings.sim.publicMode,
+    settings.sim.publicModeAdminOverride,
+  ])
 
   // Stable fetchGames callback for CompSelection — builds list from registry once.
-  const fetchGames = useCallback(
-    () => Promise.resolve(buildCompGamesFromRegistry()),
-    [],
-  );
+  const fetchGames = useCallback(() => Promise.resolve(buildCompGamesFromRegistry()), [])
 
   // Persist comp selection changes immediately via setGameUX.
   const handleCompSelectionChange = useCallback(
@@ -93,11 +101,11 @@ export default function SettingsAdmin() {
       const mergedCompSelection = {
         ...settings.gameUX.compSelection,
         ...payload,
-      };
-      dispatch(setGameUX({ compSelection: mergedCompSelection }));
+      }
+      dispatch(setGameUX({ compSelection: mergedCompSelection }))
     },
-    [dispatch, settings.gameUX.compSelection],
-  );
+    [dispatch, settings.gameUX.compSelection]
+  )
 
   /**
    * Commit any pending cast-size input to Redux and return the committed value.
@@ -105,48 +113,42 @@ export default function SettingsAdmin() {
    * numeric input for changes to be detected or applied.
    */
   const commitCastSizeInput = (): number => {
-    const parsed = parseInt(castSizeInput, 10);
-    const clamped = isNaN(parsed)
-      ? settings.gameUX.castSize
-      : Math.min(16, Math.max(4, parsed));
-    setCastSizeInput(String(clamped));
+    const parsed = parseInt(castSizeInput, 10)
+    const clamped = isNaN(parsed) ? settings.gameUX.castSize : Math.min(16, Math.max(4, parsed))
+    setCastSizeInput(String(clamped))
     if (clamped !== settings.gameUX.castSize) {
-      dispatch(setGameUX({ castSize: clamped }));
+      dispatch(setGameUX({ castSize: clamped }))
     }
-    return clamped;
-  };
+    return clamped
+  }
 
   const handleSave = () => {
-    commitCastSizeInput();
-    setShowRestartModal(true);
-  };
+    commitCastSizeInput()
+    setShowRestartModal(true)
+  }
 
   const handleRestartNow = () => {
-    setShowRestartModal(false);
-    restartApp('#/game');
-  };
+    setShowRestartModal(false)
+    restartApp('#/game')
+  }
 
   const handleNotNow = () => {
-    setShowRestartModal(false);
-  };
+    setShowRestartModal(false)
+  }
 
   // Keep the viewport meta tag in sync with the enableZoom setting.
-  const enableZoom = settings.visual?.enableZoom ?? false;
+  const enableZoom = settings.visual?.enableZoom ?? false
   useEffect(() => {
-    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+    const meta = document.querySelector<HTMLMetaElement>('meta[name="viewport"]')
     if (meta) {
-      meta.content = buildViewportMetaContent(enableZoom);
+      meta.content = buildViewportMetaContent(enableZoom)
     }
-  }, [enableZoom]);
+  }, [enableZoom])
 
   return (
     <div className="settings-screen">
       <header className="settings-screen__header">
-        <button
-          className="settings-screen__back"
-          onClick={() => navigate(-1)}
-          aria-label="Go back"
-        >
+        <button className="settings-screen__back" onClick={() => navigate(-1)} aria-label="Go back">
           ←
         </button>
         <h1 className="settings-screen__title">⚙️ Settings</h1>
@@ -169,7 +171,6 @@ export default function SettingsAdmin() {
 
       {/* Tab panels */}
       <div className="settings-content" role="tabpanel">
-
         {/* ── Audio ─────────────────────────────────────────────────────── */}
         {activeTab === 'audio' && (
           <section className="settings-section">
@@ -353,7 +354,14 @@ export default function SettingsAdmin() {
                   type="checkbox"
                   className="settings-toggle"
                   checked={settings.gameUX.dramaMode}
-                  onChange={(e) => dispatch(setGameUX({ dramaMode: e.target.checked }))}
+                  onChange={(e) =>
+                    dispatch(
+                      setGameUX({
+                        dramaMode: e.target.checked,
+                        dramaModeAdminOverride: e.target.checked,
+                      })
+                    )
+                  }
                   aria-label="Toggle drama mode"
                 />
               </div>
@@ -374,16 +382,16 @@ export default function SettingsAdmin() {
                       setSim({
                         publicMode: e.target.checked,
                         publicModeAdminOverride: e.target.checked,
-                      }),
+                      })
                     )
                   }
                   aria-label="Toggle public mode"
                 />
               </div>
               <p className="settings-helper-text">
-                Off uses the original 2-nominee rules. On enables the public-influence mode:
-                a 3rd nominee is auto-added in normal weeks and the public saves one nominee
-                before veto. Takes effect next season (requires restart to apply to the current run).
+                Off uses the original 2-nominee rules. On enables the public-influence mode: a 3rd
+                nominee is auto-added in normal weeks and the public saves one nominee before veto.
+                Takes effect next season (requires restart to apply to the current run).
               </p>
             </div>
 
@@ -410,13 +418,12 @@ export default function SettingsAdmin() {
                   max={100}
                   step={5}
                   value={settings.sim.battleBackChance ?? 30}
-                  onChange={(e) =>
-                    dispatch(setSim({ battleBackChance: Number(e.target.value) }))
-                  }
+                  onChange={(e) => dispatch(setSim({ battleBackChance: Number(e.target.value) }))}
                   aria-label="Back 2 the Game chance percentage"
                 />
                 <p className="settings-helper-text">
-                  Probability that a Tribunal Return twist activates after each eligible eviction (requires Twists on).
+                  Probability that a Tribunal Return twist activates after each eligible eviction
+                  (requires Twists on).
                 </p>
               </div>
             )}
@@ -439,7 +446,8 @@ export default function SettingsAdmin() {
                   aria-label="Double Elimination chance percentage"
                 />
                 <p className="settings-helper-text">
-                  Per-week chance that a Double Elimination activates (mid-season only, after 5 evictions and above final 5). Up to 2 per season.
+                  Per-week chance that a Double Elimination activates (mid-season only, after 5
+                  evictions and above final 5). Up to 2 per season.
                 </p>
               </div>
             )}
@@ -462,7 +470,9 @@ export default function SettingsAdmin() {
                   aria-label="Special Safety chance percentage"
                 />
                 <p className="settings-helper-text">
-                  Per-week chance (checked during POS results, after 5 evictions, with 6+ players and no Double Elimination) for a season-limited special safety power to activate. Only one special safety may occur per season.
+                  Per-week chance (checked during POS results, after 5 evictions, with 6+ players
+                  and no Double Elimination) for a season-limited special safety power to activate.
+                  Only one special safety may occur per season.
                 </p>
               </div>
             )}
@@ -485,7 +495,8 @@ export default function SettingsAdmin() {
                   aria-label="Morning Shock chance percentage"
                 />
                 <p className="settings-helper-text">
-                  Chance that a Day 3+ morning shock removes an active housemate before the LOH comp starts. Only fires when more than 4 housemates are still alive.
+                  Chance that a Day 3+ morning shock removes an active housemate before the LOH comp
+                  starts. Only fires when more than 4 housemates are still alive.
                 </p>
               </div>
             )}
@@ -531,7 +542,10 @@ export default function SettingsAdmin() {
                  This slider is for development & QA use only.
                  Remove or hide behind a build flag before shipping to live players.
                  ──────────────────────────────────────────────────────────── */}
-            <p className="settings-section__heading" style={{ marginTop: '1.25rem', color: '#f97316' }}>
+            <p
+              className="settings-section__heading"
+              style={{ marginTop: '1.25rem', color: '#f97316' }}
+            >
               🧪 Testing / Debug
             </p>
             <div className="settings-row settings-row--col">
@@ -549,15 +563,15 @@ export default function SettingsAdmin() {
                 step={1}
                 value={settings.sim.secretMissionTriggerOverride ?? -1}
                 onChange={(e) => {
-                  const v = Number(e.target.value);
-                  dispatch(setSim({ secretMissionTriggerOverride: v < 0 ? null : v }));
+                  const v = Number(e.target.value)
+                  dispatch(setSim({ secretMissionTriggerOverride: v < 0 ? null : v }))
                 }}
                 aria-label="Secret mission trigger override (debug)"
               />
               <p className="settings-helper-text" style={{ color: '#f97316' }}>
-                DEBUG ONLY. Set to 100 to guarantee a trigger on Day 5; set to 0 to prevent
-                any trigger. Slide to the left-most position to restore default chances.
-                Remove this slider before shipping to live players.
+                DEBUG ONLY. Set to 100 to guarantee a trigger on Day 5; set to 0 to prevent any
+                trigger. Slide to the left-most position to restore default chances. Remove this
+                slider before shipping to live players.
               </p>
             </div>
             <div className="settings-row settings-row--col">
@@ -575,14 +589,14 @@ export default function SettingsAdmin() {
                 step={1}
                 value={settings.sim.secretMissionTriggerWeekOverride ?? 0}
                 onChange={(e) => {
-                  const v = Number(e.target.value);
-                  dispatch(setSim({ secretMissionTriggerWeekOverride: v <= 0 ? null : v }));
+                  const v = Number(e.target.value)
+                  dispatch(setSim({ secretMissionTriggerWeekOverride: v <= 0 ? null : v }))
                 }}
                 aria-label="Secret mission force week (debug)"
               />
               <p className="settings-helper-text" style={{ color: '#f97316' }}>
-                DEBUG ONLY. Force the secret mission to trigger on an exact week_start.
-                Set to 0 to disable. When set, this takes precedence over the chance slider above.
+                DEBUG ONLY. Force the secret mission to trigger on an exact week_start. Set to 0 to
+                disable. When set, this takes precedence over the chance slider above.
               </p>
             </div>
 
@@ -609,9 +623,7 @@ export default function SettingsAdmin() {
             </div>
 
             <div className="settings-row settings-row--col">
-              <label className="settings-row__label">
-                Houseguests
-              </label>
+              <label className="settings-row__label">Houseguests</label>
               <input
                 type="number"
                 className="settings-number"
@@ -620,10 +632,12 @@ export default function SettingsAdmin() {
                 value={castSizeInput}
                 onChange={(e) => setCastSizeInput(e.target.value)}
                 onBlur={() => {
-                  const parsed = parseInt(castSizeInput, 10);
-                  const clamped = isNaN(parsed) ? settings.gameUX.castSize : Math.min(16, Math.max(4, parsed));
-                  setCastSizeInput(String(clamped));
-                  dispatch(setGameUX({ castSize: clamped }));
+                  const parsed = parseInt(castSizeInput, 10)
+                  const clamped = isNaN(parsed)
+                    ? settings.gameUX.castSize
+                    : Math.min(16, Math.max(4, parsed))
+                  setCastSizeInput(String(clamped))
+                  dispatch(setGameUX({ castSize: clamped }))
                 }}
                 aria-label="Cast size"
               />
@@ -641,10 +655,7 @@ export default function SettingsAdmin() {
             />
 
             <div className="settings-actions">
-              <button
-                className="settings-actions__save-btn"
-                onClick={handleSave}
-              >
+              <button className="settings-actions__save-btn" onClick={handleSave}>
                 Save
               </button>
             </div>
@@ -654,15 +665,14 @@ export default function SettingsAdmin() {
         {/* ── About ─────────────────────────────────────────────────────── */}
         {activeTab === 'about' && (
           <section className="settings-section settings-section--about">
-            <div className="settings-about__hero" aria-hidden="true">📺</div>
+            <div className="settings-about__hero" aria-hidden="true">
+              📺
+            </div>
             <h2 className="settings-about__name">The Big Eye</h2>
             <p className="settings-about__version">Version {APP_VERSION}</p>
             <p className="settings-about__tagline">AI Edition — React + TypeScript + Vite</p>
 
-            <button
-              className="settings-about__credits-btn"
-              onClick={() => navigate('/credits')}
-            >
+            <button className="settings-about__credits-btn" onClick={() => navigate('/credits')}>
               🎬 View Credits
             </button>
           </section>
@@ -699,5 +709,5 @@ export default function SettingsAdmin() {
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/src/social/__tests__/socialPremiumHardening.test.ts
+++ b/src/social/__tests__/socialPremiumHardening.test.ts
@@ -26,7 +26,7 @@ describe('Social premium hardening', () => {
     setRemoteSocialRuntimeConfig(null)
   })
 
-  it('requires entitlement and locks to an existing season ruleset snapshot', () => {
+  it('requires entitlement or an admin override and locks normal users to the season snapshot', () => {
     expect(
       getEffectiveSocialMode({
         settings: { gameUX: { dramaMode: true } },
@@ -41,6 +41,16 @@ describe('Social premium hardening', () => {
         vip: { entitlements: { dramaMode: true } },
       })
     ).toBe('normal')
+
+    expect(
+      getEffectiveSocialMode({
+        game: { dramaSocialMode: false },
+        settings: {
+          gameUX: { dramaMode: true, dramaModeAdminOverride: true },
+        },
+        vip: { isActive: false, entitlements: { dramaMode: false } },
+      })
+    ).toBe('drama')
 
     expect(
       getEffectiveSocialMode({

--- a/src/social/socialMiddleware.ts
+++ b/src/social/socialMiddleware.ts
@@ -89,7 +89,7 @@ interface GameState {
 
 interface StateWithGame {
   game: GameState
-  settings?: { gameUX?: { dramaMode?: boolean } }
+  settings?: { gameUX?: { dramaMode?: boolean; dramaModeAdminOverride?: boolean } }
   vip?: {
     isActive?: boolean
     entitlements?: { dramaMode?: boolean }

--- a/src/social/socialMode.ts
+++ b/src/social/socialMode.ts
@@ -8,6 +8,7 @@ interface SocialModeState {
   settings?: {
     gameUX?: {
       dramaMode?: boolean
+      dramaModeAdminOverride?: boolean
     }
   }
   vip?: {
@@ -26,13 +27,15 @@ interface SocialModeState {
  * historical settings-only behavior.
  */
 export function getEffectiveSocialMode(state: SocialModeState): SocialMode {
-  const selected =
-    state.game?.dramaSocialMode !== undefined
+  const adminOverride = state.settings?.gameUX?.dramaModeAdminOverride === true
+  const selected = adminOverride
+    ? state.settings?.gameUX?.dramaMode === true
+    : state.game?.dramaSocialMode !== undefined
       ? state.game.dramaSocialMode
       : state.settings?.gameUX?.dramaMode === true
   if (!selected) return 'normal'
 
-  if (state.vip === undefined) return 'drama'
+  if (adminOverride || state.vip === undefined) return 'drama'
   const entitled = state.vip.isActive === true || state.vip.entitlements?.dramaMode === true
   return entitled ? 'drama' : 'normal'
 }

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -1,76 +1,78 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { RootState } from './store';
-import type { CompSelectionPayload } from '../components/compSelectionUtils';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from './store'
+import type { CompSelectionPayload } from '../components/compSelectionUtils'
 
-export const STORAGE_KEY = 'bbmobilenew_settings_v1';
+export const STORAGE_KEY = 'bbmobilenew_settings_v1'
 
-export type ThemePreset = 'midnight' | 'neon' | 'sunset' | 'ocean';
+export type ThemePreset = 'midnight' | 'neon' | 'sunset' | 'ocean'
 
 export interface SettingsState {
   audio: {
-    musicOn: boolean;
-    sfxOn: boolean;
-    musicVolume: number; // 0–1
-    sfxVolume: number;   // 0–1
-  };
+    musicOn: boolean
+    sfxOn: boolean
+    musicVolume: number // 0–1
+    sfxVolume: number // 0–1
+  }
   display: {
-    themePreset: ThemePreset;
-    reduceMotion: boolean;
-    highContrast: boolean;
-  };
+    themePreset: ThemePreset
+    reduceMotion: boolean
+    highContrast: boolean
+  }
   gameUX: {
-    confirmMajorActions: boolean;
-    showTooltips: boolean;
-    compactRoster: boolean;
-    houseFeed: boolean;
-    useHaptics: boolean;
-    animations: boolean;
-    spectatorMode: boolean;
+    confirmMajorActions: boolean
+    showTooltips: boolean
+    compactRoster: boolean
+    houseFeed: boolean
+    useHaptics: boolean
+    animations: boolean
+    spectatorMode: boolean
     /** Enables richer, context-driven social simulation and reactions. */
-    dramaMode: boolean;
-    castSize: number;
+    dramaMode: boolean
+    /** Persistent entitlement bypass set only by hidden Advanced Settings. */
+    dramaModeAdminOverride: boolean
+    castSize: number
     /** Comp Selection configuration: which games are eligible, optional weekly draw limit, and category filter. */
-    compSelection: CompSelectionPayload;
-  };
+    compSelection: CompSelectionPayload
+  }
   sim: {
     /** Enables the public-influence ruleset (3rd nominee + pre-veto public save). */
-    publicMode: boolean;
+    publicMode: boolean
     /** Persistent entitlement bypass set only by hidden Advanced Settings. */
-    publicModeAdminOverride: boolean;
-    enableJuryHouse: boolean;
-    enableFanFavorite: boolean;
-    enableTwists: boolean;
-    allowSelfEvict: boolean;
+    publicModeAdminOverride: boolean
+    enableJuryHouse: boolean
+    enableFanFavorite: boolean
+    enableTwists: boolean
+    allowSelfEvict: boolean
     /** Probability (0–100) that the Battle Back twist activates after an eligible eviction. */
-    battleBackChance: number;
+    battleBackChance: number
     /** Probability (0–100) that a special safety twist activates after the POS winner is revealed on eligible weeks (after ≥5 evictions, with more than 5 players still in, and only if no other twist has already fired via `twistActivatedThisWeek`). */
-    specialSafetyChance: number;
+    specialSafetyChance: number
     /** Probability (0–100) that a Double Eviction activates on each eligible week (after 5 evictions, above final 5). */
-    doubleEvictionChance: number;
+    doubleEvictionChance: number
     /** Probability (0–100) that a random day-start shock eliminates an active housemate before the LOH flow begins. */
-    dayStartShockChance: number;
+    dayStartShockChance: number
     /** When true, show the "Public's Favorite Player" vote after the finale winner reveal. */
-    enableFavoritePlayer: boolean;
+    enableFavoritePlayer: boolean
     /** Cash prize (USD) awarded to the Public's Favorite Player winner. */
-    favoritePlayerAwardAmount: number;
+    favoritePlayerAwardAmount: number
     /**
      * DEBUG/TESTING ONLY — overrides the secret mission trigger chance for all eligible days.
      * Set to 100 to guarantee a trigger on Day 5; set to 0 to prevent any trigger.
      * Set to null to use the default per-day chances from the trigger table.
      * Remove or ignore this field in production builds.
      */
-    secretMissionTriggerOverride: number | null;
+    secretMissionTriggerOverride: number | null
     /**
      * DEBUG/TESTING ONLY — force the secret mission to trigger on an exact week.
      * Set to null to disable. When set, this takes precedence over the percent
      * override and the mission will trigger on that exact week_start entry.
      */
-    secretMissionTriggerWeekOverride: number | null;
-  };
+    secretMissionTriggerWeekOverride: number | null
+  }
   visual: {
     /** Allow pinch-to-zoom on touch devices. Default false (fixed layout). */
-    enableZoom: boolean;
-  };
+    enableZoom: boolean
+  }
 }
 
 function isLegacyEmptyUserSelection(compSelection?: Partial<CompSelectionPayload>): boolean {
@@ -81,34 +83,33 @@ function isLegacyEmptyUserSelection(compSelection?: Partial<CompSelectionPayload
     (compSelection.enabledIds?.length ?? 0) === 0 &&
     (compSelection.weeklyLimit ?? null) === null &&
     (compSelection.filterCategory ?? null) === null
-  );
+  )
 }
 
 function normalizeCompSelection(
-  compSelection?: Partial<CompSelectionPayload>,
+  compSelection?: Partial<CompSelectionPayload>
 ): CompSelectionPayload {
   const merged: CompSelectionPayload = {
     ...DEFAULT_SETTINGS.gameUX.compSelection,
     ...(compSelection ?? {}),
-  };
+  }
 
   if (compSelection?.mode === undefined || isLegacyEmptyUserSelection(compSelection)) {
-    merged.mode = 'unique';
+    merged.mode = 'unique'
   }
 
-  return merged;
+  return merged
 }
 
-function normalizeGameUX(
-  gameUX?: Partial<SettingsState['gameUX']>,
-): SettingsState['gameUX'] {
-  const legacyCompactRosterLayout = (gameUX as { compactRosterLayout?: unknown } | undefined)?.compactRosterLayout;
-  const merged = { ...DEFAULT_SETTINGS.gameUX, ...(gameUX ?? {}) };
-  merged.compSelection = normalizeCompSelection(gameUX?.compSelection);
+function normalizeGameUX(gameUX?: Partial<SettingsState['gameUX']>): SettingsState['gameUX'] {
+  const legacyCompactRosterLayout = (gameUX as { compactRosterLayout?: unknown } | undefined)
+    ?.compactRosterLayout
+  const merged = { ...DEFAULT_SETTINGS.gameUX, ...(gameUX ?? {}) }
+  merged.compSelection = normalizeCompSelection(gameUX?.compSelection)
   if (legacyCompactRosterLayout === 'small') {
-    merged.compactRoster = true;
+    merged.compactRoster = true
   }
-  return merged;
+  return merged
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -132,6 +133,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
     animations: true,
     spectatorMode: true,
     dramaMode: false,
+    dramaModeAdminOverride: false,
     castSize: 16,
     compSelection: {
       mode: 'unique' as const,
@@ -161,47 +163,46 @@ export const DEFAULT_SETTINGS: SettingsState = {
   visual: {
     enableZoom: false,
   },
-};
+}
 
 type LegacySimSettings = Partial<SettingsState['sim']> & {
   /** Backwards-compatibility key used before the special-safety rename. */
-  specialVetoChance?: number;
-};
+  specialVetoChance?: number
+}
 
 // ── localStorage helpers ──────────────────────────────────────────────────────
 
 export function loadSettings(): SettingsState {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return DEFAULT_SETTINGS;
-    const parsed = JSON.parse(raw) as Partial<SettingsState>;
-    const mergedGameUX = normalizeGameUX(parsed.gameUX);
-    const parsedSim = parsed.sim as LegacySimSettings | undefined;
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_SETTINGS
+    const parsed = JSON.parse(raw) as Partial<SettingsState>
+    const mergedGameUX = normalizeGameUX(parsed.gameUX)
+    const parsedSim = parsed.sim as LegacySimSettings | undefined
     const normalizedSim: Partial<SettingsState['sim']> = parsedSim
       ? (({ specialVetoChance: legacyVetoChance, ...rest }) => ({
           ...rest,
-          ...(parsedSim.specialSafetyChance === undefined &&
-          typeof legacyVetoChance === 'number'
+          ...(parsedSim.specialSafetyChance === undefined && typeof legacyVetoChance === 'number'
             ? { specialSafetyChance: legacyVetoChance }
             : {}),
         }))(parsedSim)
-      : {};
-    const mergedSim = { ...DEFAULT_SETTINGS.sim, ...normalizedSim };
+      : {}
+    const mergedSim = { ...DEFAULT_SETTINGS.sim, ...normalizedSim }
     return {
-      audio:   { ...DEFAULT_SETTINGS.audio,   ...parsed.audio },
+      audio: { ...DEFAULT_SETTINGS.audio, ...parsed.audio },
       display: { ...DEFAULT_SETTINGS.display, ...parsed.display },
-      gameUX:  mergedGameUX,
-      sim:     mergedSim,
-      visual:  { ...DEFAULT_SETTINGS.visual,  ...parsed.visual },
-    };
+      gameUX: mergedGameUX,
+      sim: mergedSim,
+      visual: { ...DEFAULT_SETTINGS.visual, ...parsed.visual },
+    }
   } catch {
-    return DEFAULT_SETTINGS;
+    return DEFAULT_SETTINGS
   }
 }
 
 export function saveSettings(state: SettingsState): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
   } catch {
     // ignore write errors (e.g. private browsing quota)
   }
@@ -209,7 +210,7 @@ export function saveSettings(state: SettingsState): void {
 
 export function clearSettingsStorage(): void {
   try {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(STORAGE_KEY)
   } catch {
     // ignore
   }
@@ -222,41 +223,41 @@ const settingsSlice = createSlice({
   initialState: DEFAULT_SETTINGS,
   reducers: {
     setAudio(state, action: PayloadAction<Partial<SettingsState['audio']>>) {
-      Object.assign(state.audio, action.payload);
+      Object.assign(state.audio, action.payload)
     },
     setDisplay(state, action: PayloadAction<Partial<SettingsState['display']>>) {
-      Object.assign(state.display, action.payload);
+      Object.assign(state.display, action.payload)
     },
     setGameUX(state, action: PayloadAction<Partial<SettingsState['gameUX']>>) {
-      Object.assign(state.gameUX, action.payload);
+      Object.assign(state.gameUX, action.payload)
       if (action.payload.compSelection !== undefined) {
-        state.gameUX.compSelection = normalizeCompSelection(action.payload.compSelection);
+        state.gameUX.compSelection = normalizeCompSelection(action.payload.compSelection)
       }
     },
     setSim(state, action: PayloadAction<Partial<SettingsState['sim']>>) {
-      Object.assign(state.sim, action.payload);
+      Object.assign(state.sim, action.payload)
     },
     setVisual(state, action: PayloadAction<Partial<SettingsState['visual']>>) {
-      Object.assign(state.visual, action.payload);
+      Object.assign(state.visual, action.payload)
     },
     resetSettings() {
-      return DEFAULT_SETTINGS;
+      return DEFAULT_SETTINGS
     },
     importSettings(_state, action: PayloadAction<SettingsState>) {
       return {
-        audio:   { ...DEFAULT_SETTINGS.audio,   ...action.payload.audio },
+        audio: { ...DEFAULT_SETTINGS.audio, ...action.payload.audio },
         display: { ...DEFAULT_SETTINGS.display, ...action.payload.display },
-        gameUX:  normalizeGameUX(action.payload.gameUX),
-        sim:     { ...DEFAULT_SETTINGS.sim,     ...action.payload.sim },
-        visual:  { ...DEFAULT_SETTINGS.visual,  ...action.payload.visual },
-      };
+        gameUX: normalizeGameUX(action.payload.gameUX),
+        sim: { ...DEFAULT_SETTINGS.sim, ...action.payload.sim },
+        visual: { ...DEFAULT_SETTINGS.visual, ...action.payload.visual },
+      }
     },
   },
-});
+})
 
 export const { setAudio, setDisplay, setGameUX, setSim, setVisual, resetSettings, importSettings } =
-  settingsSlice.actions;
+  settingsSlice.actions
 
-export const selectSettings = (state: RootState) => state.settings;
+export const selectSettings = (state: RootState) => state.settings
 
-export default settingsSlice.reducer;
+export default settingsSlice.reducer

--- a/tests/settings.screen.test.tsx
+++ b/tests/settings.screen.test.tsx
@@ -15,7 +15,12 @@ vi.mock('../src/utils/restartApp', () => ({
   restartApp: vi.fn(),
 }))
 
-function makeStore(vipActive = false, publicModeOwned = false, tribunalHouseOwned = false, dramaModeOwned = false) {
+function makeStore(
+  vipActive = false,
+  publicModeOwned = false,
+  tribunalHouseOwned = false,
+  dramaModeOwned = false
+) {
   const store = configureStore({
     reducer: {
       game: gameReducer,
@@ -55,7 +60,9 @@ function renderSettings(
   dramaModeActive = false
 ) {
   const store = makeStore(vipActive, publicModeOwned, tribunalHouseOwned, dramaModeOwned)
-  if (dramaModeActive) store.dispatch(setGameUX({ dramaMode: true }))
+  if (dramaModeActive) {
+    store.dispatch(setGameUX({ dramaMode: true, dramaModeAdminOverride: true }))
+  }
   render(
     <Provider store={store}>
       <MemoryRouter initialEntries={initialEntries} initialIndex={initialEntries.length - 1}>
@@ -165,6 +172,17 @@ describe('Settings screen', () => {
     expect(screen.queryByLabelText(/compact roster layout/i)).toBeNull()
   })
 
+  it('persists a Drama Mode admin override from Advanced Settings', async () => {
+    const { store } = renderSettingsAdmin()
+
+    fireEvent.click(screen.getByRole('tab', { name: /game ux/i }))
+    const dramaModeToggle = await screen.findByLabelText(/toggle drama mode/i)
+    fireEvent.click(dramaModeToggle)
+
+    expect(store.getState().settings.gameUX.dramaMode).toBe(true)
+    expect(store.getState().settings.gameUX.dramaModeAdminOverride).toBe(true)
+  })
+
   it('shows Public Mode in normal Settings as a store-gated toggle', async () => {
     const { store } = renderSettings()
 
@@ -223,6 +241,7 @@ describe('Settings screen', () => {
     fireEvent.click(dramaModeToggle)
 
     expect(store.getState().settings.gameUX.dramaMode).toBe(false)
+    expect(store.getState().settings.gameUX.dramaModeAdminOverride).toBe(false)
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 


### PR DESCRIPTION
## Root cause

Advanced Settings only persisted `gameUX.dramaMode`. Normal Settings still required the paid entitlement and therefore rendered the toggle off. Separately, the Social ruleset resolver also rechecked the paid entitlement and could keep an existing season snapshot in Normal Mode.

## Fix

- add a persistent `dramaModeAdminOverride` controlled by hidden Advanced Settings
- migrate Drama Mode values enabled through the previous Advanced Settings implementation when that screen is reopened
- make normal Settings recognise the override and display Drama Mode as enabled
- allow normal Settings to disable Drama Mode without a store prompt, clearing the override at the same time
- make the Social runtime recognise the override as valid access
- allow the explicit debug override to supersede a stale `dramaSocialMode: false` season snapshot for testing
- preserve the normal store/VIP restriction when no admin override exists

## Regression coverage

- Advanced Settings creates both the Drama Mode value and its persistent override
- normal Settings displays and can disable a debug-enabled Drama Mode
- standard users remain store-gated
- the Social engine remains Normal without entitlement, but resolves Drama with the hidden admin override even when an existing season snapshot is false

No commercial entitlement is granted to normal users, and no save data is removed.