### PR TITLE
Modernize Risk Wheel studio presentation

### DIFF
--- a/src/components/RiskWheelComp/RiskWheelComp.css
+++ b/src/components/RiskWheelComp/RiskWheelComp.css
@@ -1,71 +1,162 @@
-/* ─── RiskWheelComp Styles (v2) ──────────────────────────────────────────────── */
+/* ─── Risk Wheel — studio presentation layer ────────────────────────────────
+   Presentation-only modernization. Gameplay timing, state and sector logic
+   remain owned by RiskWheelComp.tsx and the riskWheel feature slice.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  --rw-bg-deep: #050812;
+  --rw-bg-mid: #0b1022;
+  --rw-panel: rgba(16, 23, 42, 0.76);
+  --rw-panel-strong: rgba(12, 18, 34, 0.94);
+  --rw-line: rgba(255, 255, 255, 0.12);
+  --rw-line-strong: rgba(255, 255, 255, 0.2);
+  --rw-text: #f7f8ff;
+  --rw-muted: #9aa7bf;
+  --rw-indigo: #7c83ff;
+  --rw-violet: #9c6dff;
+  --rw-cyan: #57d7ff;
+  --rw-gold: #ffca63;
+  --rw-green: #43d8a5;
+  --rw-red: #ff6b7a;
+}
 
 .rw-root {
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   min-height: 100vh;
   min-height: 100dvh;
-  /* Fallback first; prefer dynamic viewport units when supported. */
   max-height: 100vh;
   max-height: 100dvh;
   padding-top: var(--safe-top);
   padding-bottom: var(--safe-bottom);
-  background: linear-gradient(160deg, #0a0a20 0%, #0f0f25 60%, #150a20 100%);
-  color: #eef2ff;
-  font-family: inherit;
-  position: relative;
   box-sizing: border-box;
+  position: relative;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  color: var(--rw-text);
+  font-family: inherit;
+  background:
+    radial-gradient(circle at 50% 41%, rgba(92, 101, 255, 0.19) 0 12%, rgba(44, 49, 108, 0.1) 28%, transparent 56%),
+    radial-gradient(ellipse at 50% 112%, rgba(79, 148, 255, 0.13), transparent 45%),
+    linear-gradient(155deg, #070a15 0%, #0b1021 46%, #100c20 100%);
 }
 
-/* Loading / idle */
+.rw-root::before,
+.rw-root::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.rw-root::before {
+  background:
+    linear-gradient(116deg, transparent 0 12%, rgba(120, 159, 255, 0.08) 24%, transparent 38%),
+    linear-gradient(244deg, transparent 0 12%, rgba(167, 111, 255, 0.075) 24%, transparent 38%);
+  opacity: 0.9;
+}
+
+.rw-root::after {
+  background:
+    linear-gradient(90deg,
+      rgba(34, 47, 78, 0.4) 0 2px,
+      transparent 2px 7%,
+      rgba(94, 112, 174, 0.09) 7% 7.5%,
+      transparent 7.5% 92.5%,
+      rgba(94, 112, 174, 0.09) 92.5% 93%,
+      transparent 93% 98%,
+      rgba(34, 47, 78, 0.4) 98% 100%),
+    radial-gradient(ellipse at center, transparent 44%, rgba(2, 4, 11, 0.34) 78%, rgba(2, 4, 11, 0.68) 100%);
+}
+
+.rw-root > * {
+  position: relative;
+  z-index: 1;
+}
+
 .rw-loading {
   align-items: center;
   justify-content: center;
-  font-size: 1.1rem;
-  opacity: 0.7;
+  font-size: 1.05rem;
+  color: var(--rw-muted);
 }
 
-/* ─── Devil mode overlay ──────────────────────────────────────────────────── */
-
+/* Replaces the previous rapid 0.18 s flicker with one slow cinematic pulse. */
 .rw-devil-mode {
-  animation: rw-devil-flicker 0.18s steps(1) infinite;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(118, 45, 183, 0.28) 0 16%, rgba(74, 20, 75, 0.18) 35%, transparent 60%),
+    radial-gradient(ellipse at 50% 112%, rgba(125, 27, 69, 0.16), transparent 45%),
+    linear-gradient(155deg, #080610 0%, #160b20 48%, #190910 100%);
 }
 
 .rw-devil-mode::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: rgba(110, 0, 0, 0.35);
-  pointer-events: none;
-  z-index: 10;
-  animation: rw-devil-pulse 0.6s ease-in-out infinite alternate;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(178, 79, 255, 0.2), transparent 43%),
+    linear-gradient(116deg, transparent 0 15%, rgba(148, 73, 198, 0.1) 26%, transparent 39%),
+    linear-gradient(244deg, transparent 0 15%, rgba(175, 47, 94, 0.09) 26%, transparent 39%);
+  animation: rw-devil-atmosphere 1.7s ease-out both;
 }
 
-@keyframes rw-devil-flicker {
-  0%, 90% { opacity: 1; }
-  91%      { opacity: 0.85; }
-  100%     { opacity: 1; }
+.rw-game:has(.rw-result-chip--bankrupt) {
+  animation: rw-bankrupt-stage 850ms ease-out 1 both;
 }
 
-@keyframes rw-devil-pulse {
-  from { opacity: 0.2; }
-  to   { opacity: 0.6; }
+.rw-game:has(.rw-result-chip--bankrupt) .rw-wheel-outer::before {
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(255, 105, 120, 0.96) 0 2.5deg,
+    rgba(255, 105, 120, 0.14) 2.5deg 9deg
+  );
 }
 
-/* ─── Header ──────────────────────────────────────────────────────────────── */
+.rw-game:has(.rw-result-chip--devil) .rw-wheel-outer::before {
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(190, 117, 255, 0.96) 0 2.5deg,
+    rgba(143, 60, 183, 0.14) 2.5deg 9deg
+  );
+}
+
+@keyframes rw-devil-atmosphere {
+  0% { opacity: 0; transform: scale(1.04); }
+  45% { opacity: 1; }
+  100% { opacity: 0.72; transform: scale(1); }
+}
+
+@keyframes rw-bankrupt-stage {
+  0% { box-shadow: inset 0 0 0 rgba(255, 72, 91, 0); }
+  42% { box-shadow: inset 0 0 90px rgba(255, 72, 91, 0.16); }
+  100% { box-shadow: inset 0 0 50px rgba(255, 72, 91, 0.06); }
+}
 
 .rw-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.04);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  gap: 8px;
+  min-height: 54px;
+  padding: 9px max(14px, var(--safe-right)) 9px max(14px, var(--safe-left));
+  gap: 9px;
   flex-shrink: 0;
+  background: linear-gradient(180deg, rgba(9, 13, 27, 0.84), rgba(9, 13, 27, 0.48));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.rw-header::after {
+  content: '';
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  bottom: -1px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(111, 184, 255, 0.62), rgba(156, 109, 255, 0.62), transparent);
+  opacity: 0.65;
+  pointer-events: none;
 }
 
 .rw-header-left {
@@ -77,36 +168,54 @@
 .rw-header-center {
   flex: 1;
   display: flex;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.rw-round-badge,
+.rw-prize-badge,
+.rw-elim-warn {
+  min-height: 27px;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  border-radius: 999px;
+  white-space: nowrap;
+  line-height: 1;
 }
 
 .rw-round-badge {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: #a5b4fc;
+  padding: 0 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: #d8deff;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.07em;
+  background: rgba(124, 131, 255, 0.13);
+  border: 1px solid rgba(144, 151, 255, 0.26);
 }
 
 .rw-prize-badge {
-  font-size: 0.8rem;
-  background: #312e81;
-  color: #c7d2fe;
-  border-radius: 20px;
-  padding: 2px 8px;
+  padding: 0 10px;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  color: #f0eaff;
+  background: rgba(145, 91, 244, 0.16);
+  border: 1px solid rgba(174, 126, 255, 0.27);
 }
 
 .rw-elim-warn {
-  font-size: 0.8rem;
-  color: #fca5a5;
-  background: rgba(153, 27, 27, 0.25);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  border-radius: 20px;
-  padding: 3px 10px;
-  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 10px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: #ffc4ca;
+  background: rgba(189, 47, 66, 0.13);
+  border: 1px solid rgba(255, 99, 116, 0.24);
 }
-
-/* ─── Main play area ─────────────────────────────────────────────────────── */
 
 .rw-game {
   flex: 1;
@@ -116,371 +225,546 @@
 
 .rw-main {
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px 16px 24px;
-  gap: 14px;
-  min-width: 0;
+  padding: 15px 16px 24px;
+  gap: 13px;
+  position: relative;
 }
 
-/* Current player name & score */
+.rw-main::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 255px;
+  width: min(88vw, 430px);
+  height: 145px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse at center, rgba(105, 158, 255, 0.13) 0 10%, rgba(73, 92, 168, 0.09) 35%, transparent 68%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 64%);
+  border-top: 1px solid rgba(151, 184, 255, 0.12);
+  filter: blur(0.1px);
+}
+
+.rw-main > * {
+  position: relative;
+  z-index: 1;
+}
+
 .rw-current-player {
+  min-width: 180px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
+  padding: 8px 18px 9px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(24, 33, 59, 0.7), rgba(12, 18, 34, 0.56));
+  border: 1px solid rgba(173, 190, 255, 0.14);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 10px 28px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(9px);
+  -webkit-backdrop-filter: blur(9px);
 }
 
 .rw-current-label {
-  font-size: 0.9rem;
-  color: #94a3b8;
+  font-size: 0.76rem;
+  font-weight: 800;
+  color: #aebbd2;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.1em;
 }
 
 .rw-score-value {
-  font-size: 2.6rem;
+  font-size: clamp(2.25rem, 8vw, 2.8rem);
   font-weight: 900;
   line-height: 1;
-  transition: color 0.3s ease;
-  text-shadow: 0 0 20px currentColor;
+  letter-spacing: -0.035em;
+  transition: color 280ms ease, text-shadow 280ms ease;
+  text-shadow: 0 0 18px currentColor;
 }
 
 .rw-score-bump {
-  animation: rw-bump 0.3s ease;
+  animation: rw-score-reveal 360ms cubic-bezier(0.2, 0.75, 0.25, 1);
 }
 
-@keyframes rw-bump {
-  0%   { transform: scale(1); }
-  40%  { transform: scale(1.22); }
-  100% { transform: scale(1); }
+@keyframes rw-score-reveal {
+  0% { transform: translateY(2px) scale(0.98); }
+  48% { transform: translateY(-2px) scale(1.09); }
+  100% { transform: translateY(0) scale(1); }
 }
-
-/* ─── Wheel ──────────────────────────────────────────────────────────────── */
 
 .rw-wheel-outer {
   position: relative;
-  width: 272px;
-  height: 272px;
+  width: 278px;
+  height: 278px;
   flex-shrink: 0;
+  margin: 4px 0 2px;
+  filter: drop-shadow(0 18px 24px rgba(0, 0, 0, 0.34));
+}
+
+.rw-wheel-outer::before {
+  content: '';
+  position: absolute;
+  inset: -11px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  background: repeating-conic-gradient(
+    from 0deg,
+    rgba(201, 220, 255, 0.9) 0 2.2deg,
+    rgba(110, 139, 207, 0.12) 2.2deg 9deg
+  );
+  -webkit-mask: radial-gradient(circle, transparent 0 82%, #000 83% 100%);
+  mask: radial-gradient(circle, transparent 0 82%, #000 83% 100%);
+  opacity: 0.72;
+  transition: opacity 300ms ease, filter 300ms ease;
+}
+
+.rw-wheel-outer::after {
+  content: '';
+  position: absolute;
+  left: 9%;
+  right: 9%;
+  bottom: -21px;
+  height: 31px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: -1;
+  background: radial-gradient(ellipse at center, rgba(100, 147, 255, 0.22), rgba(20, 29, 60, 0.08) 48%, transparent 72%);
+  filter: blur(6px);
+  transform: scaleY(0.58);
 }
 
 .rw-wheel-pointer {
   position: absolute;
-  top: -14px;
+  top: -21px;
   left: 50%;
+  width: 34px;
+  height: 38px;
   transform: translateX(-50%);
-  font-size: 1.4rem;
-  color: #f59e0b;
-  text-shadow: 0 0 8px rgba(245, 158, 11, 0.8);
-  z-index: 2;
-  line-height: 1;
+  z-index: 5;
+  overflow: hidden;
+  color: transparent;
+  font-size: 0;
+  line-height: 0;
   pointer-events: none;
+  clip-path: polygon(7% 0, 93% 0, 50% 100%);
+  background: linear-gradient(180deg, #fff6d4 0%, #ffc45b 36%, #e68d20 100%);
+  box-shadow: 0 0 0 2px rgba(255, 238, 185, 0.22);
+  filter:
+    drop-shadow(0 0 7px rgba(255, 195, 79, 0.74))
+    drop-shadow(0 4px 5px rgba(0, 0, 0, 0.54));
+}
+
+.rw-wheel-pointer::after {
+  content: '';
+  position: absolute;
+  left: 37%;
+  top: 8%;
+  width: 26%;
+  height: 46%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.62);
+  filter: blur(1px);
 }
 
 .rw-wheel-svg-wrapper {
+  position: relative;
+  z-index: 1;
   width: 100%;
   height: 100%;
-  border-radius: 50%;
   overflow: hidden;
+  border-radius: 50%;
+  border: 5px solid rgba(176, 192, 225, 0.3);
+  background: #0b1020;
   box-shadow:
-    0 0 0 4px rgba(255, 255, 255, 0.12),
-    0 0 30px rgba(99, 102, 241, 0.25),
-    0 8px 32px rgba(0, 0, 0, 0.5);
+    inset 0 0 0 2px rgba(255, 255, 255, 0.08),
+    inset 0 0 22px rgba(0, 0, 0, 0.52),
+    0 0 0 5px rgba(7, 10, 20, 0.92),
+    0 0 0 7px rgba(133, 157, 212, 0.18),
+    0 0 36px rgba(99, 117, 255, 0.31),
+    0 18px 36px rgba(0, 0, 0, 0.48);
   will-change: transform;
+  transition: box-shadow 320ms ease, filter 320ms ease;
+}
+
+.rw-wheel-svg-wrapper::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 35% 24%, rgba(255, 255, 255, 0.18), transparent 22%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06), transparent 38% 64%, rgba(0, 0, 0, 0.11));
+  mix-blend-mode: screen;
+  opacity: 0.42;
 }
 
 .rw-wheel-svg-wrapper--spinning {
   box-shadow:
-    0 0 0 4px rgba(255, 255, 255, 0.12),
-    0 0 40px rgba(96, 165, 250, 0.55),
-    0 0 70px rgba(124, 58, 237, 0.35),
-    0 8px 32px rgba(0, 0, 0, 0.5);
-  animation: rw-wheel-glow 0.8s ease-in-out infinite alternate;
+    inset 0 0 0 2px rgba(255, 255, 255, 0.1),
+    inset 0 0 22px rgba(0, 0, 0, 0.5),
+    0 0 0 5px rgba(7, 10, 20, 0.92),
+    0 0 0 7px rgba(143, 174, 255, 0.26),
+    0 0 42px rgba(79, 158, 255, 0.5),
+    0 0 70px rgba(128, 74, 255, 0.22),
+    0 18px 36px rgba(0, 0, 0, 0.48);
+  filter: saturate(1.05) brightness(1.045);
+}
+
+.rw-wheel-outer:has(.rw-wheel-svg-wrapper--spinning)::before {
+  opacity: 1;
+  filter: brightness(1.14) drop-shadow(0 0 7px rgba(104, 181, 255, 0.72));
+  animation: rw-ring-sweep 1.1s linear 2;
+}
+
+.rw-game:has(.rw-wheel-svg-wrapper--spinning)::before {
+  opacity: 1;
+  animation: rw-studio-focus 2.2s ease-in-out 1 both;
+}
+
+@keyframes rw-ring-sweep {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes rw-studio-focus {
+  0% { filter: brightness(0.94); }
+  46% { filter: brightness(1.08); }
+  100% { filter: brightness(1); }
 }
 
 .rw-wheel-sector {
-  transition: filter 0.2s ease, stroke-width 0.2s ease;
+  transition: filter 200ms ease, stroke-width 200ms ease, opacity 200ms ease;
 }
 
 .rw-wheel-sector--highlight {
-  filter: brightness(1.5) saturate(1.35);
-  stroke: rgba(255, 255, 255, 0.98);
+  filter: brightness(1.42) saturate(1.28);
+  stroke: rgba(255, 255, 255, 0.96);
   stroke-width: 2.4;
-  animation: rw-sector-flash 0.8s ease-out;
+  animation: rw-sector-reveal 820ms cubic-bezier(0.16, 0.74, 0.3, 1) 1 both;
 }
 
-@keyframes rw-wheel-glow {
-  from {
-    filter: brightness(1);
-  }
-  to {
-    filter: brightness(1.18);
-  }
+@keyframes rw-sector-reveal {
+  0% { filter: brightness(1) saturate(1); stroke-width: 1.2; }
+  48% { filter: brightness(1.62) saturate(1.38); stroke-width: 2.8; }
+  100% { filter: brightness(1.2) saturate(1.16); stroke-width: 2; }
 }
 
-@keyframes rw-sector-flash {
-  0% {
-    filter: brightness(1) saturate(1);
-    stroke-width: 1.2;
-  }
-  30% {
-    filter: brightness(1.75) saturate(1.45);
-    stroke-width: 2.8;
-  }
-  100% {
-    filter: brightness(1) saturate(1);
-    stroke-width: 1.2;
-  }
+.rw-wheel-svg-wrapper svg circle:last-of-type {
+  fill: #11182b;
+  stroke: rgba(218, 227, 255, 0.58);
+  stroke-width: 2.2;
 }
 
-/* ─── Result chip ─────────────────────────────────────────────────────────── */
+.rw-wheel-svg-wrapper svg text:last-of-type {
+  fill: #ffe3a0;
+  filter: drop-shadow(0 0 4px rgba(255, 200, 85, 0.55));
+}
 
 .rw-result-chip {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 14px;
-  padding: 10px 22px;
-  font-size: 1.15rem;
-  font-weight: 800;
+  min-width: min(286px, calc(100vw - 40px));
+  max-width: 360px;
+  padding: 10px 20px;
+  border-radius: 15px;
   text-align: center;
-  color: #e2e8f0;
-  animation: rw-chip-in 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  color: #f7f9ff;
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: 0.015em;
+  background: linear-gradient(180deg, rgba(32, 43, 72, 0.88), rgba(15, 22, 40, 0.92));
+  border: 1px solid rgba(173, 196, 255, 0.24);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.25),
+    0 0 24px rgba(104, 131, 255, 0.11);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  animation: rw-result-in 340ms cubic-bezier(0.16, 0.86, 0.28, 1) 1 both;
 }
 
 .rw-result-chip--devil {
-  background: rgba(124, 58, 237, 0.3);
-  border-color: #7c3aed;
-  color: #ddd6fe;
-  box-shadow: 0 0 20px rgba(124, 58, 237, 0.4);
+  color: #f3ddff;
+  border-color: rgba(204, 128, 255, 0.46);
+  background: linear-gradient(180deg, rgba(81, 33, 105, 0.9), rgba(38, 18, 59, 0.94));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.28),
+    0 0 28px rgba(168, 72, 225, 0.24);
 }
 
 .rw-result-chip--bankrupt {
-  background: rgba(127, 29, 29, 0.4);
-  border-color: #b91c1c;
-  color: #fca5a5;
-  box-shadow: 0 0 20px rgba(185, 28, 28, 0.4);
+  color: #ffd8dc;
+  border-color: rgba(255, 110, 127, 0.5);
+  background: linear-gradient(180deg, rgba(105, 31, 45, 0.92), rgba(49, 17, 28, 0.95));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 10px 24px rgba(0, 0, 0, 0.28),
+    0 0 27px rgba(232, 63, 85, 0.23);
+}
+
+.rw-666-add,
+.rw-666-sub {
+  display: inline-block;
+  margin-left: 3px;
+  font-size: 1.08em;
+  font-weight: 900;
 }
 
 .rw-666-add {
-  color: #4ade80;
-  font-size: 1.15em;
-  text-shadow: 0 0 12px rgba(74, 222, 128, 0.6);
+  color: #77efbd;
+  text-shadow: 0 0 10px rgba(74, 222, 128, 0.34);
 }
 
 .rw-666-sub {
-  color: #f87171;
-  font-size: 1.15em;
-  text-shadow: 0 0 12px rgba(248, 113, 113, 0.6);
+  color: #ff9aa4;
+  text-shadow: 0 0 10px rgba(248, 113, 113, 0.34);
 }
 
-@keyframes rw-chip-in {
-  from { opacity: 0; transform: scale(0.7) translateY(-8px); }
-  to   { opacity: 1; transform: scale(1) translateY(0); }
+@keyframes rw-result-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.975); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
 }
-
-/* ─── Spin counter dots ───────────────────────────────────────────────────── */
 
 .rw-spins-row {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 4px;
+  margin-top: 3px;
 }
 
 .rw-spin-dot {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.15);
-  border: 2px solid rgba(255, 255, 255, 0.25);
+  width: 9px;
+  height: 9px;
   display: inline-block;
-  transition: background 0.3s, border-color 0.3s;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.09);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
+  transition: background 240ms ease, border-color 240ms ease, box-shadow 240ms ease;
 }
 
 .rw-spin-dot--used {
-  background: #a5b4fc;
-  border-color: #6366f1;
-  box-shadow: 0 0 6px rgba(165, 180, 252, 0.5);
+  background: #9da8ff;
+  border-color: #c8ceff;
+  box-shadow: 0 0 8px rgba(137, 148, 255, 0.66);
 }
 
 .rw-spins-label {
-  font-size: 0.8rem;
-  color: #64748b;
-  margin-left: 4px;
+  margin-left: 3px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #8290aa;
 }
-
-/* ─── AI status ───────────────────────────────────────────────────────────── */
 
 .rw-ai-status {
-  font-size: 0.88rem;
-  color: #a5b4fc;
+  margin: 0;
+  padding: 2px 0;
+  color: #bec8ff;
+  font-size: 0.82rem;
+  font-style: normal;
+  font-weight: 650;
   text-align: center;
-  padding: 4px 0;
-  font-style: italic;
-  animation: rw-pulse 1.2s ease-in-out infinite;
+  animation: rw-ai-breathe 1.5s ease-in-out infinite;
 }
 
-@keyframes rw-pulse {
-  0%, 100% { opacity: 0.6; }
-  50%       { opacity: 1; }
+@keyframes rw-ai-breathe {
+  0%, 100% { opacity: 0.62; }
+  50% { opacity: 1; }
 }
-
-/* ─── Action buttons ─────────────────────────────────────────────────────── */
 
 .rw-actions {
+  width: 100%;
+  max-width: 310px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  max-width: 300px;
+  gap: 9px;
 }
 
 .rw-btn {
   width: 100%;
-  padding: 15px 20px;
-  border-radius: 14px;
-  border: none;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 700;
-  transition: opacity 0.15s, transform 0.1s, box-shadow 0.15s;
-  letter-spacing: 0.03em;
+  min-height: 48px;
+  padding: 12px 18px;
   position: relative;
   overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.94rem;
+  font-weight: 800;
+  letter-spacing: 0.025em;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.11),
+    0 9px 20px rgba(0, 0, 0, 0.25);
+  transition: transform 140ms ease, box-shadow 160ms ease, filter 160ms ease, opacity 160ms ease;
+  touch-action: manipulation;
+}
+
+.rw-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(115deg, transparent 15%, rgba(255, 255, 255, 0.12) 50%, transparent 78%);
+  transform: translateX(-130%);
+  transition: transform 420ms ease;
 }
 
 .rw-btn::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0);
-  transition: background 0.15s;
+  inset: 1px;
+  border-radius: 12px;
+  pointer-events: none;
+  border: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-.rw-btn:hover::after {
-  background: rgba(255, 255, 255, 0.08);
+.rw-btn:hover:not(:disabled)::before {
+  transform: translateX(130%);
 }
 
-.rw-btn:active {
-  transform: scale(0.96);
+.rw-btn:hover:not(:disabled) {
+  filter: brightness(1.055);
+  transform: translateY(-1px);
+}
+
+.rw-btn:active:not(:disabled) {
+  transform: translateY(0) scale(0.982);
+}
+
+.rw-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 3px;
 }
 
 .rw-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.42;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .rw-btn--lg {
-  padding: 17px 24px;
-  font-size: 1.05rem;
+  min-height: 52px;
+  padding: 14px 22px;
+  font-size: 0.98rem;
 }
 
 .rw-btn--spin {
-  background: linear-gradient(135deg, #4f46e5, #7c3aed);
-  color: #fff;
-  box-shadow: 0 4px 16px rgba(79, 70, 229, 0.4);
-  padding: 12px 18px;
-  font-size: 0.95rem;
-}
-
-.rw-btn--spin:hover:not(:disabled) {
-  box-shadow: 0 6px 20px rgba(79, 70, 229, 0.6);
+  background: linear-gradient(135deg, #4859e8 0%, #7657df 55%, #984dc7 100%);
+  border-color: rgba(191, 198, 255, 0.32);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    0 9px 22px rgba(68, 76, 220, 0.35),
+    0 0 22px rgba(121, 83, 231, 0.16);
 }
 
 .rw-btn--bank {
-  background: linear-gradient(135deg, #047857, #059669);
-  color: #fff;
-  box-shadow: 0 4px 16px rgba(5, 150, 105, 0.35);
-}
-
-.rw-btn--bank:hover:not(:disabled) {
-  box-shadow: 0 6px 20px rgba(5, 150, 105, 0.5);
+  background: linear-gradient(135deg, #087966 0%, #0b9b76 54%, #13aa83 100%);
+  border-color: rgba(141, 246, 211, 0.28);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    0 9px 22px rgba(7, 122, 91, 0.28),
+    0 0 18px rgba(19, 170, 131, 0.12);
 }
 
 .rw-btn--primary {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: #fff;
-  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.4);
-}
-
-.rw-btn--primary:hover:not(:disabled) {
-  box-shadow: 0 6px 20px rgba(99, 102, 241, 0.6);
+  background: linear-gradient(135deg, #5260eb, #8359dd);
+  border-color: rgba(193, 201, 255, 0.28);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    0 9px 22px rgba(73, 81, 218, 0.3);
 }
 
 .rw-bank-score {
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 2px 7px;
-  font-size: 0.92em;
+  display: inline-flex;
+  align-items: center;
+  min-height: 25px;
   margin-left: 6px;
+  padding: 1px 8px;
+  border-radius: 8px;
+  font-size: 0.9em;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.09);
 }
 
-/* ─── Mini scoreboard ─────────────────────────────────────────────────────── */
-
 .rw-mini-scores {
+  width: 100%;
+  max-width: 410px;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
   justify-content: center;
-  max-width: 380px;
-  margin-top: 4px;
+  gap: 6px;
+  margin-top: 2px;
 }
 
 .rw-mini-score-chip {
-  display: flex;
+  min-height: 32px;
+  display: inline-flex;
   align-items: center;
-  gap: 5px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 20px;
-  padding: 4px 10px 4px 5px;
-  font-size: 0.8rem;
+  gap: 6px;
+  padding: 4px 9px 4px 5px;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  background: rgba(13, 20, 38, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.095);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  backdrop-filter: blur(7px);
+  -webkit-backdrop-filter: blur(7px);
 }
 
 .rw-mini-score-avatar {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  width: 23px;
+  height: 23px;
   flex-shrink: 0;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid rgba(220, 229, 255, 0.25);
 }
 
 .rw-mini-score-chip--out {
-  opacity: 0.4;
-  text-decoration: line-through;
+  opacity: 0.38;
+  filter: grayscale(0.6);
 }
 
 .rw-mini-score-name {
-  color: #94a3b8;
+  max-width: 92px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #aab5ca;
 }
 
 .rw-mini-score-val {
-  font-weight: 700;
-  color: #34d399;
+  font-weight: 800;
+  color: #58e1ae;
 }
 
 .rw-mini-score-val.neg {
-  color: #f87171;
+  color: #ff8e9a;
 }
-
-/* ─── Round summary ──────────────────────────────────────────────────────── */
 
 .rw-round-summary {
   flex: 1;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 26px 18px 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 28px 20px 0;
-  gap: 16px;
-  max-width: 500px;
-  margin: 0 auto;
-  width: 100%;
-  /* Prevent the root from scrolling; the list scrolls internally instead */
+  gap: 15px;
   overflow: hidden;
 }
 
@@ -488,257 +772,420 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 5px;
 }
 
 .rw-summary-round-badge {
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: #a5b4fc;
+  min-height: 27px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  border-radius: 999px;
+  color: #cbd2ff;
+  font-size: 0.76rem;
+  font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  background: rgba(99, 102, 241, 0.15);
-  border-radius: 20px;
-  padding: 3px 12px;
+  background: rgba(104, 113, 255, 0.13);
+  border: 1px solid rgba(139, 149, 255, 0.22);
 }
 
 .rw-summary-title {
-  font-size: 1.7rem;
-  font-weight: 900;
-  color: #e0e7ff;
   margin: 0;
-  text-shadow: 0 0 20px rgba(165, 180, 252, 0.4);
+  color: #f4f5ff;
+  font-size: 1.72rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 22px rgba(130, 143, 255, 0.28);
 }
 
 .rw-summary-list {
   width: 100%;
-  list-style: none;
-  padding: 0;
+  min-height: 0;
+  flex: 1;
   margin: 0;
+  padding: 0 2px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  list-style: none;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  /* Allow the list to scroll when there are many players */
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .rw-summary-row {
+  min-height: 54px;
   display: flex;
   align-items: center;
   gap: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  padding: 11px 14px;
-  transition: background 0.2s;
-  animation: rw-row-in 0.3s ease both;
+  padding: 9px 12px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(26, 35, 59, 0.78), rgba(14, 21, 39, 0.82));
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  animation: rw-summary-row-in 320ms ease both;
 }
 
 .rw-summary-row:nth-child(1) { animation-delay: 0ms; }
-.rw-summary-row:nth-child(2) { animation-delay: 60ms; }
-.rw-summary-row:nth-child(3) { animation-delay: 120ms; }
-.rw-summary-row:nth-child(4) { animation-delay: 180ms; }
-.rw-summary-row:nth-child(5) { animation-delay: 240ms; }
-.rw-summary-row:nth-child(n+6) { animation-delay: 300ms; }
-
-@keyframes rw-row-in {
-  from { opacity: 0; transform: translateX(-12px); }
-  to   { opacity: 1; transform: translateX(0); }
-}
+.rw-summary-row:nth-child(2) { animation-delay: 55ms; }
+.rw-summary-row:nth-child(3) { animation-delay: 110ms; }
+.rw-summary-row:nth-child(4) { animation-delay: 165ms; }
+.rw-summary-row:nth-child(5) { animation-delay: 220ms; }
+.rw-summary-row:nth-child(n+6) { animation-delay: 275ms; }
 
 .rw-summary-row--top {
-  background: rgba(99, 102, 241, 0.15);
-  border-color: rgba(99, 102, 241, 0.35);
-  box-shadow: 0 0 12px rgba(99, 102, 241, 0.2);
+  background: linear-gradient(180deg, rgba(60, 66, 130, 0.62), rgba(25, 29, 64, 0.76));
+  border-color: rgba(151, 161, 255, 0.32);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.055),
+    0 0 22px rgba(106, 119, 255, 0.12);
 }
 
 .rw-summary-row--out {
-  background: rgba(153, 27, 27, 0.2);
-  border-color: rgba(239, 68, 68, 0.25);
-  opacity: 0.75;
-  animation: rw-eliminate 0.5s ease both;
+  opacity: 0.72;
+  background: linear-gradient(180deg, rgba(87, 31, 43, 0.52), rgba(44, 20, 29, 0.72));
+  border-color: rgba(255, 100, 119, 0.21);
+  animation: rw-summary-eliminate 470ms ease both;
 }
 
-@keyframes rw-eliminate {
-  from { transform: scale(1.04); background: rgba(239, 68, 68, 0.35); }
-  to   { transform: scale(1); }
+@keyframes rw-summary-row-in {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes rw-summary-eliminate {
+  0% { opacity: 0; transform: scale(1.025); }
+  100% { opacity: 0.72; transform: scale(1); }
 }
 
 .rw-summary-rank {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: #64748b;
   min-width: 26px;
+  color: #7f8da8;
+  font-size: 0.79rem;
+  font-weight: 800;
 }
 
 .rw-summary-avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255, 255, 255, 0.15);
+  width: 34px;
+  height: 34px;
   flex-shrink: 0;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 2px solid rgba(224, 231, 255, 0.17);
 }
 
 .rw-summary-name {
+  min-width: 0;
   flex: 1;
-  font-weight: 600;
-  font-size: 0.98rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.93rem;
+  font-weight: 700;
 }
 
 .rw-summary-score {
-  font-size: 1.15rem;
+  color: #58e1ae;
+  font-size: 1.05rem;
   font-weight: 900;
-  color: #34d399;
 }
 
 .rw-summary-score--neg {
-  color: #f87171;
+  color: #ff8e9a;
 }
 
 .rw-summary-badge {
-  font-size: 0.72rem;
-  border-radius: 8px;
-  padding: 3px 8px;
-  font-weight: 700;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 7px;
+  border-radius: 7px;
+  font-size: 0.66rem;
+  font-weight: 800;
   white-space: nowrap;
 }
 
 .rw-summary-badge--out {
-  background: rgba(127, 29, 29, 0.6);
-  color: #fca5a5;
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #ffc4cb;
+  background: rgba(143, 40, 57, 0.56);
+  border: 1px solid rgba(255, 107, 125, 0.22);
 }
 
 .rw-summary-badge--top {
-  background: rgba(99, 102, 241, 0.3);
-  color: #c7d2fe;
-  border: 1px solid rgba(99, 102, 241, 0.4);
+  color: #e3e6ff;
+  background: rgba(99, 109, 223, 0.34);
+  border: 1px solid rgba(157, 166, 255, 0.25);
 }
 
 .rw-summary-elim-msg {
-  font-size: 0.92rem;
-  color: #fca5a5;
-  text-align: center;
+  width: 100%;
   margin: 0;
-  background: rgba(153, 27, 27, 0.15);
-  border: 1px solid rgba(239, 68, 68, 0.2);
-  border-radius: 10px;
-  padding: 10px 16px;
+  padding: 9px 13px;
+  border-radius: 11px;
+  text-align: center;
+  color: #ffc1c8;
+  font-size: 0.84rem;
+  background: rgba(119, 31, 47, 0.24);
+  border: 1px solid rgba(255, 99, 117, 0.17);
 }
 
-/* Footer area — always visible; pinned below the scrollable list */
 .rw-summary-footer {
-  flex-shrink: 0;
   width: 100%;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding: 12px 0 calc(16px + env(safe-area-inset-bottom, 0px));
+  gap: 11px;
+  padding: 11px 0 calc(16px + env(safe-area-inset-bottom, 0px));
 }
-
-/* ─── Winner screen ──────────────────────────────────────────────────────── */
 
 .rw-winner-screen {
   flex: 1;
   align-items: center;
   justify-content: center;
+  gap: 13px;
+  padding: 36px 20px;
   text-align: center;
-  padding: 40px 20px;
-  gap: 14px;
-  animation: rw-winner-in 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   position: relative;
   overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 35%, rgba(255, 204, 96, 0.16), transparent 26%),
+    radial-gradient(circle at 50% 50%, rgba(102, 120, 255, 0.14), transparent 48%);
+  animation: rw-winner-in 540ms cubic-bezier(0.16, 0.82, 0.28, 1) 1 both;
+}
+
+.rw-winner-screen::before,
+.rw-winner-screen::after {
+  content: '';
+  position: absolute;
+  top: -12%;
+  width: 34%;
+  height: 82%;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 227, 164, 0.13), transparent 76%);
+  filter: blur(3px);
+}
+
+.rw-winner-screen::before {
+  left: 4%;
+  transform: rotate(17deg);
+}
+
+.rw-winner-screen::after {
+  right: 4%;
+  transform: rotate(-17deg);
 }
 
 @keyframes rw-winner-in {
-  from { opacity: 0; transform: scale(0.85) translateY(24px); }
-  to   { opacity: 1; transform: scale(1) translateY(0); }
+  from { opacity: 0; transform: translateY(16px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 .rw-winner-confetti {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  overflow: hidden;
 }
 
 .rw-confetti-piece {
   position: absolute;
-  font-size: 1.8rem;
-  animation: rw-confetti-fall 3s ease-in-out infinite;
-  opacity: 0.7;
+  top: -12%;
+  width: 7px;
+  height: 15px;
+  border-radius: 2px;
+  color: transparent;
+  font-size: 0;
+  opacity: 0;
+  background: #ffcf65;
+  animation: rw-confetti-fall 2.8s ease-out 1 both;
 }
 
-.rw-confetti-piece:nth-child(1)  { left: 5%;  top: -20%; animation-delay: 0s;   }
-.rw-confetti-piece:nth-child(2)  { left: 20%; top: -20%; animation-delay: 0.3s; }
-.rw-confetti-piece:nth-child(3)  { left: 35%; top: -20%; animation-delay: 0.6s; }
-.rw-confetti-piece:nth-child(4)  { left: 50%; top: -20%; animation-delay: 0.9s; }
-.rw-confetti-piece:nth-child(5)  { left: 65%; top: -20%; animation-delay: 0.4s; }
-.rw-confetti-piece:nth-child(6)  { left: 80%; top: -20%; animation-delay: 0.7s; }
-.rw-confetti-piece:nth-child(7)  { left: 92%; top: -20%; animation-delay: 0.2s; }
+.rw-confetti-piece:nth-child(1) { left: 7%; animation-delay: 0ms; transform: rotate(12deg); }
+.rw-confetti-piece:nth-child(2) { left: 21%; animation-delay: 110ms; background: #7bd7ff; }
+.rw-confetti-piece:nth-child(3) { left: 36%; animation-delay: 220ms; background: #aa8dff; }
+.rw-confetti-piece:nth-child(4) { left: 50%; animation-delay: 70ms; width: 8px; background: #ffe09a; }
+.rw-confetti-piece:nth-child(5) { left: 65%; animation-delay: 180ms; background: #6be0b2; }
+.rw-confetti-piece:nth-child(6) { left: 80%; animation-delay: 260ms; background: #938dff; }
+.rw-confetti-piece:nth-child(7) { left: 92%; animation-delay: 130ms; background: #ffcf65; }
 
 @keyframes rw-confetti-fall {
-  0%   { transform: translateY(0) rotate(0deg); opacity: 0.8; }
-  100% { transform: translateY(110vh) rotate(720deg); opacity: 0; }
+  0% { opacity: 0; transform: translateY(-18px) rotate(0deg); }
+  12% { opacity: 0.78; }
+  100% { opacity: 0; transform: translateY(105vh) rotate(380deg); }
 }
 
 .rw-winner-crown {
-  font-size: 4.5rem;
+  font-size: 4rem;
   line-height: 1;
-  animation: rw-bounce 0.7s ease infinite alternate;
-  filter: drop-shadow(0 0 16px rgba(251, 191, 36, 0.8));
+  filter: drop-shadow(0 0 15px rgba(255, 200, 82, 0.66));
+  animation: rw-crown-settle 760ms cubic-bezier(0.16, 0.84, 0.28, 1) 1 both;
+}
+
+@keyframes rw-crown-settle {
+  0% { opacity: 0; transform: translateY(-12px) scale(0.86); }
+  62% { opacity: 1; transform: translateY(2px) scale(1.04); }
+  100% { transform: translateY(0) scale(1); }
 }
 
 .rw-winner-avatar {
-  width: 88px;
-  height: 88px;
-  border-radius: 50%;
+  width: 90px;
+  height: 90px;
   object-fit: cover;
-  border: 3px solid #fbbf24;
-  box-shadow: 0 0 20px rgba(251, 191, 36, 0.5);
-  animation: rw-winner-in 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-}
-
-@keyframes rw-bounce {
-  from { transform: translateY(0); }
-  to   { transform: translateY(-12px); }
+  border-radius: 50%;
+  border: 3px solid #ffd06a;
+  box-shadow:
+    0 0 0 5px rgba(255, 208, 106, 0.09),
+    0 0 24px rgba(255, 200, 82, 0.32),
+    0 16px 34px rgba(0, 0, 0, 0.3);
 }
 
 .rw-winner-title {
-  font-size: 2.5rem;
-  font-weight: 900;
-  color: #fbbf24;
-  text-shadow: 0 0 30px rgba(251, 191, 36, 0.6);
   margin: 0;
+  color: #ffd36f;
+  font-size: 2.35rem;
+  font-weight: 900;
   letter-spacing: 0.12em;
+  text-shadow: 0 0 24px rgba(255, 200, 82, 0.34);
 }
 
 .rw-winner-name {
-  font-size: 1.8rem;
-  font-weight: 800;
-  color: #e0e7ff;
   margin: 0;
-  text-shadow: 0 0 12px rgba(165, 180, 252, 0.4);
+  color: #f4f5ff;
+  font-size: 1.72rem;
+  font-weight: 800;
+  text-shadow: 0 0 12px rgba(146, 156, 255, 0.26);
 }
 
 .rw-winner-subtitle {
-  font-size: 0.95rem;
-  color: #94a3b8;
+  max-width: 340px;
   margin: 0;
+  color: #a9b4c9;
+  font-size: 0.9rem;
 }
 
-/* ─── Responsive ─────────────────────────────────────────────────────────── */
-
 @media (max-width: 380px) {
+  .rw-header { padding-inline: 10px; }
+
+  .rw-round-badge,
+  .rw-prize-badge,
+  .rw-elim-warn {
+    padding-inline: 8px;
+    font-size: 0.69rem;
+  }
+
+  .rw-main {
+    padding-inline: 11px;
+    gap: 11px;
+  }
+
   .rw-wheel-outer {
-    width: 220px;
-    height: 220px;
+    width: 232px;
+    height: 232px;
   }
-  .rw-score-value {
-    font-size: 2.2rem;
+
+  .rw-main::before {
+    top: 223px;
+    height: 120px;
   }
+
+  .rw-current-player {
+    min-width: 164px;
+    padding-block: 7px;
+  }
+
+  .rw-score-value { font-size: 2.2rem; }
+
+  .rw-result-chip {
+    min-width: min(270px, calc(100vw - 28px));
+    font-size: 0.96rem;
+    padding-inline: 15px;
+  }
+
+  .rw-mini-score-name { max-width: 72px; }
+
+  .rw-summary-row {
+    gap: 8px;
+    padding-inline: 9px;
+  }
+
+  .rw-summary-badge {
+    font-size: 0.6rem;
+    padding-inline: 5px;
+  }
+}
+
+@media (max-height: 700px) and (min-width: 381px) {
+  .rw-header {
+    min-height: 48px;
+    padding-block: 7px;
+  }
+
+  .rw-main {
+    padding-top: 10px;
+    gap: 9px;
+  }
+
+  .rw-current-player { padding-block: 6px; }
+  .rw-score-value { font-size: 2.15rem; }
+
+  .rw-wheel-outer {
+    width: 238px;
+    height: 238px;
+    margin-block: 0;
+  }
+
+  .rw-main::before { top: 220px; }
+  .rw-result-chip { padding-block: 8px; }
+
+  .rw-btn {
+    min-height: 45px;
+    padding-block: 10px;
+  }
+
+  .rw-mini-score-chip { min-height: 29px; }
+}
+
+@media (min-width: 760px) {
+  .rw-main { padding-top: 22px; }
+
+  .rw-wheel-outer {
+    width: 314px;
+    height: 314px;
+  }
+
+  .rw-main::before {
+    top: 292px;
+    width: 500px;
+  }
+
+  .rw-actions { max-width: 330px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rw-root *,
+  .rw-root *::before,
+  .rw-root *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .rw-wheel-outer:has(.rw-wheel-svg-wrapper--spinning)::before {
+    transform: none !important;
+  }
+
+  .rw-confetti-piece { display: none !important; }
+}
+
+body.no-animations .rw-root *,
+body.no-animations .rw-root *::before,
+body.no-animations .rw-root *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+body.no-animations .rw-confetti-piece {
+  display: none !important;
 }


### PR DESCRIPTION
## What changed

- Reworked the Risk Wheel presentation into a restrained television-studio environment using CSS gradients, spotlights, side-light structures, a stage floor and vignette.
- Upgraded the wheel housing with a static perimeter-light ring, metallic frame, illuminated physical pointer, glass treatment and floor reflection.
- Added coordinated spinning-state lighting and a finite perimeter sweep without changing wheel rotation or gameplay timing.
- Added distinct, non-flashing atmospheric treatment for Bankrupt and 666 outcomes.
- Replaced the previous rapid 666 full-screen flicker with one slow cinematic violet/red pulse.
- Refined contestant score presentation, result display, controls, compact scoreboard, round summary and winner reveal.
- Replaced endlessly repeating emoji confetti with a finite geometric confetti pass.
- Added `prefers-reduced-motion` handling and retained compatibility with `body.no-animations`.
- Added responsive tuning for narrow and short mobile viewports.

## Stability boundary

This PR modifies only:

- `src/components/RiskWheelComp/RiskWheelComp.css`

It does not modify Risk Wheel RNG, sectors, probabilities, Redux state, scoring, AI turns, phase transitions, timers, audio triggers, winner resolution or MinigameHost completion behavior.

## Validation

- Confirmed the branch differs from `main` by one CSS file only.
- Confirmed decorative layers use `pointer-events: none`.
- Confirmed the prior rapid repeating devil flicker is no longer present.
- Full build, device rendering and Playwright viewport validation still need to run in a repository-capable development/CI environment before merge.