### PR TITLE
Disable mobile edge-swipe navigation

### DIFF
--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -20,7 +20,10 @@ body:has(.game-screen-shell) .app-shell {
   flex: 1 1 0;
   overflow-y: auto;
   overflow-x: hidden;
-  overscroll-behavior-y: contain;
+  /* Do not let horizontal edge drags invoke browser/WebView history navigation.
+     Screen changes remain explicit through the in-game controls. */
+  overscroll-behavior: contain;
+  touch-action: pan-y;
   padding-top: var(--app-safe-area-top);
   padding-right: var(--safe-right);
   padding-bottom: 0;


### PR DESCRIPTION
## What changed

- Disable horizontal edge-drag history navigation in the main app shell.
- Preserve vertical scrolling and the game’s existing button and arrow navigation.

## Why

Accidental side-edge drags on mobile could navigate to a previous page, which is disruptive during gameplay.

## Validation

- `npx vitest run tests/unit/layout/safeArea.styles.test.ts`