### PR TITLE
Expose Cupid activation in debug controls

### DIFF
--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -20,6 +20,7 @@ import {
   queueForcedShock,
   clearForcedShock,
   completeMission,
+  activateCupidArrowNow,
   setCupidArrowSchedule,
   breakCupidArrowNow,
 } from '../../store/gameSlice'
@@ -596,6 +597,14 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                   disabled={!game.pendingForcedShock}
                 >
                   Clear
+                </button>
+                <button
+                  className="dbg-btn"
+                  type="button"
+                  onClick={() => dispatch(activateCupidArrowNow())}
+                  disabled={game.cupidArrow?.status === 'active'}
+                >
+                  Activate Cupid
                 </button>
               </div>
 


### PR DESCRIPTION
Adds a dedicated **Activate Cupid** button beside the existing Force Shock controls.

This is a small follow-up to the merged Cupid's Arrow PR. It activates Cupid's Arrow immediately in the current test season, while the existing season field remains available for scheduled activation.

Validation:
- `npm run typecheck`
- Debug Panel tests