### PR TITLE
Map competitions by season day

### DIFF
--- a/src/ai/competition/bracketTemplate.ts
+++ b/src/ai/competition/bracketTemplate.ts
@@ -35,15 +35,17 @@ export interface ClassicCampaignContext {
 /**
  * Explicitly approved normal-campaign games. Registry activation alone is not
  * enough: entries only belong here after gameplay QA and campaign approval.
- * Special-purpose games such as Capitalization are intentionally absent.
  */
 export const CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS = [
   'quickTap',
   'memoryMatch',
+  'timingBar',
+  'estimationGame',
   'holdWall',
   'famousFigures',
   'silentSaboteur',
   'majorityRules',
+  'pressurePlank',
   'colorMatch',
   'logicLocks',
   'snake',
@@ -54,17 +56,16 @@ export const CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS = [
   'tetris',
   'minesweeps',
   'dontGoOver',
-  'blackjackTournament',
-  'riskWheel',
-  'wildcardWestern',
+  'capitalization',
   'castleRescue',
   'glass_bridge_brutal',
   'crystal_path_shattered',
+  'wildcardWestern',
   'trapAuction',
-  'gridOfLuck',
   'bigSpender',
   'chainOfGreed',
   'batteryLow',
+  'houseOfDarkness',
 ] as const
 
 /** Per-game story prerequisites that apply in addition to the roster map. */
@@ -84,36 +85,46 @@ export function getApprovedCompetitionGameKeys(
 /**
  * Design rules represented below:
  *
- * - Day 1 uses immediately readable, parallel-play games at every normal
- *   cast size, so a smaller configured starting cast still gets a strong hook.
+ * - Each regular season day has its own pool, targeting the expected house
+ *   count with a one-player tolerance for twists and double evictions.
+ * - Day 1 is a fixed two-game premiere: Majority Rules for LOH and Quick Tap
+ *   Race for POS.
  * - With many housemates, LOH uses fixed-round or simultaneous games and POS
- *   stays short. Sequential/turn-heavy formats wait until the cast is smaller.
+ *   stays short. Sequential/turn-heavy formats remain in the large-cast days.
  * - LOH becomes longer and more technical as the season progresses.
  * - POS increasingly permits shorter, simpler, and chance-driven formats.
  * - Final 4 only uses games that make sense with four players.
- * - Each Final 3 part has a distinct style and an escalating difficulty curve.
+ * - Elimination ladders, turn-order spectacles, and social-deduction formats
+ *   stay in the large-cast portion of the season. They lose their tension when
+ *   only a few housemates remain.
+ * - Final 3 uses sustained individual challenges: endurance, precision, and
+ *   multi-round score formats that do not collapse after one elimination.
  */
 export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
   {
-    label: 'Day 1 hook',
+    label: 'Day 1 · premiere',
     minPlayers: 5,
     maxPlayers: 16,
     minDay: 1,
     maxDay: 1,
-    loh: ['holdWall', 'majorityRules', 'memoryMatch'],
-    pos: ['quickTap', 'colorMatch', 'dontGoOver'],
+    loh: ['majorityRules'],
+    pos: ['quickTap'],
   },
   {
-    label: '16-13 players',
-    minPlayers: 13,
+    label: 'Day 2 · 15 housemates (±1)',
+    minPlayers: 14,
     maxPlayers: 16,
+    minDay: 2,
+    maxDay: 2,
     loh: ['holdWall', 'memoryMatch', 'famousFigures', 'majorityRules', 'batteryLow', 'trapAuction'],
     pos: ['quickTap', 'colorMatch', 'cardClash', 'hangman', 'dontGoOver', 'tiltLabyrinth'],
   },
   {
-    label: '12-10 players',
-    minPlayers: 10,
-    maxPlayers: 12,
+    label: 'Day 3 · 14 housemates (±1)',
+    minPlayers: 13,
+    maxPlayers: 15,
+    minDay: 3,
+    maxDay: 3,
     loh: [
       'memoryMatch',
       'famousFigures',
@@ -134,9 +145,88 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
     ],
   },
   {
-    label: '9-8 players',
+    label: 'Day 4 · 13 housemates (±1)',
+    minPlayers: 12,
+    maxPlayers: 14,
+    minDay: 4,
+    maxDay: 4,
+    loh: [
+      'memoryMatch',
+      'famousFigures',
+      'silentSaboteur',
+      'majorityRules',
+      'batteryLow',
+      'trapAuction',
+    ],
+    pos: [
+      'quickTap',
+      'colorMatch',
+      'cardClash',
+      'logicLocks',
+      'hangman',
+      'tiltLabyrinth',
+      'dontGoOver',
+      'threeDigitsQuiz',
+    ],
+  },
+  {
+    label: 'Day 5 · 12 housemates (±1)',
+    minPlayers: 11,
+    maxPlayers: 13,
+    minDay: 5,
+    maxDay: 5,
+    loh: [
+      'snake',
+      'memoryMatch',
+      'famousFigures',
+      'silentSaboteur',
+      'chainOfGreed',
+      'batteryLow',
+      'trapAuction',
+    ],
+    pos: [
+      'quickTap',
+      'colorMatch',
+      'cardClash',
+      'logicLocks',
+      'hangman',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'tiltLabyrinth',
+    ],
+  },
+  {
+    label: 'Day 6 · 11 housemates (±1)',
+    minPlayers: 10,
+    maxPlayers: 12,
+    minDay: 6,
+    maxDay: 6,
+    loh: [
+      'snake',
+      'memoryMatch',
+      'famousFigures',
+      'silentSaboteur',
+      'chainOfGreed',
+      'batteryLow',
+      'trapAuction',
+    ],
+    pos: [
+      'quickTap',
+      'colorMatch',
+      'cardClash',
+      'logicLocks',
+      'hangman',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'tiltLabyrinth',
+    ],
+  },
+  {
+    label: 'Day 7 · 9 housemates (±1)',
     minPlayers: 8,
-    maxPlayers: 9,
+    maxPlayers: 10,
+    minDay: 7,
+    maxDay: 7,
     loh: [
       'snake',
       'memoryMatch',
@@ -145,6 +235,9 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'batteryLow',
       'chainOfGreed',
       'trapAuction',
+      'glass_bridge_brutal',
+      'crystal_path_shattered',
+      'wildcardWestern',
     ],
     pos: [
       'logicLocks',
@@ -158,33 +251,165 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
     ],
   },
   {
-    label: '7-5 players',
-    minPlayers: 5,
-    maxPlayers: 7,
-    loh: ['castleRescue', 'glass_bridge_brutal', 'chainOfGreed', 'silentSaboteur', 'batteryLow'],
+    label: 'Day 8 · 8 housemates (±1)',
+    minPlayers: 7,
+    maxPlayers: 9,
+    minDay: 8,
+    maxDay: 8,
+    loh: [
+      'castleRescue',
+      'memoryMatch',
+      'famousFigures',
+      'majorityRules',
+      'timingBar',
+      'estimationGame',
+      'holdWall',
+      'pressurePlank',
+      'capitalization',
+      'chainOfGreed',
+      'batteryLow',
+      'houseOfDarkness',
+    ],
     pos: [
-      'riskWheel',
-      'blackjackTournament',
       'bigSpender',
       'logicLocks',
       'hangman',
       'minesweeps',
       'tetris',
+      'threeDigitsQuiz',
+      'dontGoOver',
     ],
   },
   {
-    label: '4 players',
+    label: 'Day 9 · 7 housemates (±1)',
+    minPlayers: 6,
+    maxPlayers: 8,
+    minDay: 9,
+    maxDay: 9,
+    loh: [
+      'memoryMatch',
+      'famousFigures',
+      'timingBar',
+      'holdWall',
+      'pressurePlank',
+      'capitalization',
+      'chainOfGreed',
+      'batteryLow',
+      'houseOfDarkness',
+    ],
+    pos: [
+      'bigSpender',
+      'logicLocks',
+      'hangman',
+      'minesweeps',
+      'tetris',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'quickTap',
+      'colorMatch',
+      'tiltLabyrinth',
+    ],
+  },
+  {
+    label: 'Day 10 · 6 housemates (±1)',
+    minPlayers: 5,
+    maxPlayers: 7,
+    minDay: 10,
+    maxDay: 10,
+    loh: [
+      'castleRescue',
+      'memoryMatch',
+      'timingBar',
+      'estimationGame',
+      'holdWall',
+      'pressurePlank',
+      'capitalization',
+      'batteryLow',
+      'houseOfDarkness',
+    ],
+    pos: [
+      'bigSpender',
+      'logicLocks',
+      'hangman',
+      'minesweeps',
+      'tetris',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'quickTap',
+      'colorMatch',
+      'tiltLabyrinth',
+    ],
+  },
+  {
+    label: 'Day 11 · 5 housemates (±1)',
     minPlayers: 4,
-    maxPlayers: 4,
-    loh: ['crystal_path_shattered', 'chainOfGreed', 'batteryLow', 'holdWall'],
-    pos: ['gridOfLuck', 'riskWheel', 'blackjackTournament', 'bigSpender', 'tetris'],
+    maxPlayers: 6,
+    minDay: 11,
+    maxDay: 11,
+    loh: [
+      'memoryMatch',
+      'famousFigures',
+      'timingBar',
+      'estimationGame',
+      'holdWall',
+      'pressurePlank',
+      'threeDigitsQuiz',
+      'capitalization',
+      'chainOfGreed',
+      'batteryLow',
+      'houseOfDarkness',
+    ],
+    pos: [
+      'bigSpender',
+      'logicLocks',
+      'hangman',
+      'minesweeps',
+      'tetris',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'quickTap',
+      'colorMatch',
+      'tiltLabyrinth',
+    ],
+  },
+  {
+    label: 'Day 12 · 4 housemates (±1)',
+    minPlayers: 3,
+    maxPlayers: 5,
+    minDay: 12,
+    maxDay: 12,
+    loh: [
+      'memoryMatch',
+      'famousFigures',
+      'timingBar',
+      'estimationGame',
+      'holdWall',
+      'pressurePlank',
+      'threeDigitsQuiz',
+      'capitalization',
+      'chainOfGreed',
+      'batteryLow',
+      'houseOfDarkness',
+    ],
+    pos: [
+      'bigSpender',
+      'logicLocks',
+      'hangman',
+      'minesweeps',
+      'tetris',
+      'threeDigitsQuiz',
+      'dontGoOver',
+      'quickTap',
+      'colorMatch',
+      'tiltLabyrinth',
+    ],
   },
   {
     label: 'Final 3 - Part 1 endurance',
     minPlayers: 3,
     maxPlayers: 3,
     phases: ['final3_comp1', 'final3_comp1_minigame'],
-    loh: ['holdWall', 'glass_bridge_brutal'],
+    loh: ['holdWall', 'pressurePlank', 'houseOfDarkness'],
     pos: [],
   },
   {
@@ -192,7 +417,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
     minPlayers: 3,
     maxPlayers: 3,
     phases: ['final3_comp2', 'final3_comp2_minigame'],
-    loh: ['memoryMatch', 'famousFigures', 'castleRescue', 'batteryLow'],
+    loh: ['memoryMatch', 'famousFigures', 'timingBar', 'estimationGame'],
     pos: [],
   },
   {
@@ -200,7 +425,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
     minPlayers: 3,
     maxPlayers: 3,
     phases: ['final3_comp3', 'final3_comp3_minigame'],
-    loh: ['crystal_path_shattered', 'chainOfGreed', 'wildcardWestern'],
+    loh: ['threeDigitsQuiz', 'capitalization', 'chainOfGreed', 'batteryLow'],
     pos: [],
   },
   {
@@ -210,14 +435,16 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
     maxPlayers: 3,
     loh: [
       'holdWall',
-      'glass_bridge_brutal',
+      'pressurePlank',
+      'houseOfDarkness',
       'memoryMatch',
       'famousFigures',
-      'castleRescue',
+      'timingBar',
+      'estimationGame',
+      'threeDigitsQuiz',
+      'capitalization',
       'batteryLow',
-      'crystal_path_shattered',
       'chainOfGreed',
-      'wildcardWestern',
     ],
     pos: [],
   },
@@ -239,6 +466,33 @@ function applyGameStoryPrerequisites(pool: string[], day: number): string[] {
   })
 }
 
+function getRosterFallbackBand(
+  playerCount: number,
+  template: BracketTemplate
+): BracketBand | undefined {
+  const dayGuideBands = template.filter(
+    (band) =>
+      !band.phases && band.minDay !== undefined && band.maxDay !== undefined && band.minDay !== 1
+  )
+
+  return dayGuideBands.sort((left, right) => {
+    const distance = (band: BracketBand) =>
+      playerCount < band.minPlayers
+        ? band.minPlayers - playerCount
+        : playerCount > band.maxPlayers
+          ? playerCount - band.maxPlayers
+          : 0
+    const midpointDistance = (band: BracketBand) =>
+      Math.abs((band.minPlayers + band.maxPlayers) / 2 - playerCount)
+
+    return (
+      distance(left) - distance(right) ||
+      midpointDistance(left) - midpointDistance(right) ||
+      (left.minDay ?? 0) - (right.minDay ?? 0)
+    )
+  })[0]
+}
+
 /**
  * Resolve the exact classic-campaign pool for a day/housemate/phase context.
  * Counts above the supported cast size use the widest large-house band. Counts
@@ -248,6 +502,8 @@ export function getClassicCampaignPoolForContext(
   context: ClassicCampaignContext,
   template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE
 ): string[] {
+  if (context.playerCount < 3) return []
+
   const matched = template
     .filter((band) => matchesCampaignContext(band, context))
     .sort((left, right) => {
@@ -260,14 +516,12 @@ export function getClassicCampaignPoolForContext(
     return applyGameStoryPrerequisites(pool, context.day)
   }
 
-  if (context.playerCount > 16) {
-    const widest = template.find(
-      (band) => band.minPlayers === 13 && band.maxPlayers === 16 && !band.minDay && !band.phases
-    )
-    if (widest) {
-      const pool = context.compType === 'POS' ? widest.pos : widest.loh
-      return applyGameStoryPrerequisites(pool, context.day)
-    }
+  // A twist can put the roster outside a day's +/- 1 guide. Use the closest
+  // safe day row rather than abandoning the curated campaign map altogether.
+  const fallback = getRosterFallbackBand(context.playerCount, template)
+  if (fallback) {
+    const pool = context.compType === 'POS' ? fallback.pos : fallback.loh
+    return applyGameStoryPrerequisites(pool, context.day)
   }
 
   return []
@@ -275,17 +529,38 @@ export function getClassicCampaignPoolForContext(
 
 /**
  * Backwards-compatible count-only resolver used by admin tools and existing
- * callers. Day-specific and Final 3 phase-specific rows are skipped because
- * those callers do not have enough context to select them safely.
+ * callers. It finds the closest roster-safe day-guide row when a caller does
+ * not know the current season day.
  */
 export function getBracketPoolForContext(
   playerCount: number,
   compType: 'LOH' | 'POS',
   template: BracketTemplate = DEFAULT_BRACKET_TEMPLATE
 ): string[] {
-  const genericTemplate = template.filter((band) => !band.minDay && !band.maxDay && !band.phases)
-  return getClassicCampaignPoolForContext(
-    { day: Number.MAX_SAFE_INTEGER, playerCount, compType },
-    genericTemplate
+  if (playerCount < 3) return []
+
+  const final3Compatibility = template.find(
+    (band) =>
+      playerCount === 3 &&
+      band.minPlayers === 3 &&
+      band.maxPlayers === 3 &&
+      !band.minDay &&
+      !band.maxDay &&
+      !band.phases
   )
+  if (final3Compatibility) {
+    const pool = compType === 'POS' ? final3Compatibility.pos : final3Compatibility.loh
+    return applyGameStoryPrerequisites(pool, Number.MAX_SAFE_INTEGER)
+  }
+
+  const fallback = getRosterFallbackBand(playerCount, template)
+  if (!fallback) {
+    const genericTemplate = template.filter((band) => !band.minDay && !band.maxDay && !band.phases)
+    return getClassicCampaignPoolForContext(
+      { day: Number.MAX_SAFE_INTEGER, playerCount, compType },
+      genericTemplate
+    )
+  }
+  const pool = compType === 'POS' ? fallback.pos : fallback.loh
+  return applyGameStoryPrerequisites(pool, Number.MAX_SAFE_INTEGER)
 }

--- a/tests/unit/competition-ai/bracketTemplate.test.ts
+++ b/tests/unit/competition-ai/bracketTemplate.test.ts
@@ -1,55 +1,53 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest'
 import {
   CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS,
   DEFAULT_BRACKET_TEMPLATE,
   getBracketPoolForContext,
   getClassicCampaignPoolForContext,
   type BracketTemplate,
-} from '../../../src/ai/competition/bracketTemplate';
-import { getGame } from '../../../src/minigames/registry';
+} from '../../../src/ai/competition/bracketTemplate'
+import { getGame, supportsPlayerCount } from '../../../src/minigames/registry'
 
 function allKeys(template: BracketTemplate): string[] {
-  return template.flatMap((band) => [...band.loh, ...band.pos]);
+  return template.flatMap((band) => [...band.loh, ...band.pos])
 }
 
 describe('classic campaign map registry integrity', () => {
   it('only references active registry games', () => {
-    const unknown = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => !getGame(key));
-    const retired = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => getGame(key)?.retired);
-    expect(unknown).toEqual([]);
-    expect(retired).toEqual([]);
-  });
+    const unknown = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => !getGame(key))
+    const retired = allKeys(DEFAULT_BRACKET_TEMPLATE).filter((key) => getGame(key)?.retired)
+    expect(unknown).toEqual([])
+    expect(retired).toEqual([])
+  })
 
   it('only schedules explicitly QA-approved campaign games', () => {
-    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE));
-    const approved = new Set<string>(CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS);
-    expect([...scheduled].filter((key) => !approved.has(key))).toEqual([]);
-    expect([...approved].filter((key) => !scheduled.has(key))).toEqual([]);
-  });
+    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE))
+    const approved = new Set<string>(CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS)
+    expect([...scheduled].filter((key) => !approved.has(key))).toEqual([])
+    expect([...approved].filter((key) => !scheduled.has(key))).toEqual([])
+  })
 
-  it('excludes unavailable and special-purpose games from normal campaign pools', () => {
-    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE));
-    expect(scheduled).not.toContain('timingBar');
-    expect(scheduled).not.toContain('estimationGame');
-    expect(scheduled).not.toContain('pressurePlank');
-    expect(scheduled).not.toContain('rescueTheKing');
-    expect(scheduled).not.toContain('capitalization');
-    expect(scheduled).not.toContain('targetPractice');
-    expect(getGame('targetPractice')?.retired).toBe(true);
-  });
+  it('excludes unavailable, special-purpose, and low-field spectacle games from normal campaign pools', () => {
+    const scheduled = new Set(allKeys(DEFAULT_BRACKET_TEMPLATE))
+    expect(scheduled).not.toContain('rescueTheKing')
+    expect(scheduled).not.toContain('targetPractice')
+    expect(scheduled).not.toContain('blackjackTournament')
+    expect(scheduled).not.toContain('riskWheel')
+    expect(getGame('targetPractice')?.retired).toBe(true)
+  })
 
   it('keeps Vault Cracker, Verdict Board, and Fit Me In POS-only and Battery Low LOH-only', () => {
-    const allLoh = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.loh);
-    const allPos = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.pos);
-    expect(allLoh).not.toContain('logicLocks');
-    expect(allLoh).not.toContain('hangman');
-    expect(allLoh).not.toContain('tetris');
-    expect(allPos).not.toContain('batteryLow');
-    expect(allPos).toContain('logicLocks');
-    expect(allPos).toContain('hangman');
-    expect(allPos).toContain('tetris');
-    expect(allLoh).toContain('batteryLow');
-  });
+    const allLoh = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.loh)
+    const allPos = DEFAULT_BRACKET_TEMPLATE.flatMap((band) => band.pos)
+    expect(allLoh).not.toContain('logicLocks')
+    expect(allLoh).not.toContain('hangman')
+    expect(allLoh).not.toContain('tetris')
+    expect(allPos).not.toContain('batteryLow')
+    expect(allPos).toContain('logicLocks')
+    expect(allPos).toContain('hangman')
+    expect(allPos).toContain('tetris')
+    expect(allLoh).toContain('batteryLow')
+  })
 
   it('delays Silent Saboteur until housemates have had time to get acquainted', () => {
     const tooEarly = getClassicCampaignPoolForContext({
@@ -57,33 +55,81 @@ describe('classic campaign map registry integrity', () => {
       playerCount: 10,
       compType: 'LOH',
       phase: 'loh_comp',
-    });
+    })
     const laterHouse = getClassicCampaignPoolForContext({
       day: 4,
-      playerCount: 7,
+      playerCount: 9,
       compType: 'LOH',
       phase: 'loh_comp',
-    });
-    expect(tooEarly).not.toContain('silentSaboteur');
-    expect(laterHouse).toContain('silentSaboteur');
-  });
+    })
+    expect(tooEarly).not.toContain('silentSaboteur')
+    expect(laterHouse).toContain('silentSaboteur')
+  })
 
-  it('keeps bands ordered from the largest roster to Final 3', () => {
-    const maxValues = DEFAULT_BRACKET_TEMPLATE.map((band) => band.maxPlayers);
-    for (let index = 1; index < maxValues.length; index += 1) {
-      expect(maxValues[index]).toBeLessThanOrEqual(maxValues[index - 1]);
-    }
-  });
+  it('keeps the regular-season guide ordered by day', () => {
+    const dayBands = DEFAULT_BRACKET_TEMPLATE.filter((band) => band.minDay !== undefined)
+    const minDays = dayBands.map((band) => band.minDay!)
+    expect(minDays).toEqual([...minDays].sort((left, right) => left - right))
+  })
 
   it('has LOH games in every band and no Final 3 POS games', () => {
-    expect(DEFAULT_BRACKET_TEMPLATE.every((band) => band.loh.length > 0)).toBe(true);
+    expect(DEFAULT_BRACKET_TEMPLATE.every((band) => band.loh.length > 0)).toBe(true)
     const final3Bands = DEFAULT_BRACKET_TEMPLATE.filter(
-      (band) => band.minPlayers === 3 && band.maxPlayers === 3,
-    );
-    expect(final3Bands.length).toBeGreaterThan(0);
-    expect(final3Bands.every((band) => band.pos.length === 0)).toBe(true);
-  });
-});
+      (band) => band.minPlayers === 3 && band.maxPlayers === 3
+    )
+    expect(final3Bands.length).toBeGreaterThan(0)
+    expect(final3Bands.every((band) => band.pos.length === 0)).toBe(true)
+  })
+
+  it('keeps field-size-dependent spectacles out of low-roster and Final 3 pools', () => {
+    const lowRosterBands = DEFAULT_BRACKET_TEMPLATE.filter((band) => band.maxPlayers <= 7)
+    const lowRosterGames = new Set(lowRosterBands.flatMap((band) => [...band.loh, ...band.pos]))
+
+    ;[
+      'silentSaboteur',
+      'glass_bridge_brutal',
+      'crystal_path_shattered',
+      'wildcardWestern',
+      'riskWheel',
+      'blackjackTournament',
+    ].forEach((key) => expect(lowRosterGames).not.toContain(key))
+  })
+
+  it('only maps each game to player counts the registry marks as supported', () => {
+    DEFAULT_BRACKET_TEMPLATE.forEach((band) => {
+      for (let players = band.minPlayers; players <= band.maxPlayers; players += 1) {
+        ;[...band.loh, ...band.pos].forEach((key) => {
+          const game = getGame(key)
+          expect(game, `${key} is missing from the registry`).toBeDefined()
+          expect(
+            supportsPlayerCount(game!, players),
+            `${key} does not support ${players} players`
+          ).toBe(true)
+        })
+      }
+    })
+  })
+
+  it('fills the Final 3 with sustained endurance, precision, and multi-round score games', () => {
+    const final3Games = new Set(
+      DEFAULT_BRACKET_TEMPLATE.filter(
+        (band) => band.minPlayers === 3 && band.maxPlayers === 3
+      ).flatMap((band) => band.loh)
+    )
+
+    expect([...final3Games]).toEqual(
+      expect.arrayContaining([
+        'holdWall',
+        'pressurePlank',
+        'memoryMatch',
+        'timingBar',
+        'threeDigitsQuiz',
+        'capitalization',
+        'batteryLow',
+      ])
+    )
+  })
+})
 
 describe('getBracketPoolForContext compatibility resolver', () => {
   it.each([
@@ -91,104 +137,101 @@ describe('getBracketPoolForContext compatibility resolver', () => {
     [13, 'POS', 'quickTap'],
     [10, 'LOH', 'memoryMatch'],
     [9, 'POS', 'tetris'],
-    [5, 'POS', 'riskWheel'],
+    [5, 'POS', 'quickTap'],
     [4, 'LOH', 'batteryLow'],
-    [3, 'LOH', 'wildcardWestern'],
+    [3, 'LOH', 'capitalization'],
   ] as const)('maps %i players / %s to %s', (playerCount, compType, expectedKey) => {
-    expect(getBracketPoolForContext(playerCount, compType)).toContain(expectedKey);
-  });
+    expect(getBracketPoolForContext(playerCount, compType)).toContain(expectedKey)
+  })
 
   it('returns no POS pool at Final 3 or pool below Final 3', () => {
-    expect(getBracketPoolForContext(3, 'POS')).toEqual([]);
-    expect(getBracketPoolForContext(2, 'POS')).toEqual([]);
-    expect(getBracketPoolForContext(1, 'LOH')).toEqual([]);
-  });
+    expect(getBracketPoolForContext(3, 'POS')).toEqual([])
+    expect(getBracketPoolForContext(2, 'POS')).toEqual([])
+    expect(getBracketPoolForContext(1, 'LOH')).toEqual([])
+  })
 
   it('uses the widest safe band for oversized casts', () => {
-    expect(getBracketPoolForContext(99, 'LOH')).toContain('holdWall');
-  });
+    expect(getBracketPoolForContext(99, 'LOH')).toContain('holdWall')
+  })
 
   it('returns fresh arrays and supports custom templates', () => {
-    const first = getBracketPoolForContext(16, 'LOH');
-    const second = getBracketPoolForContext(16, 'LOH');
-    first.push('EXTRA');
-    expect(second).not.toContain('EXTRA');
+    const first = getBracketPoolForContext(16, 'LOH')
+    const second = getBracketPoolForContext(16, 'LOH')
+    first.push('EXTRA')
+    expect(second).not.toContain('EXTRA')
 
     const custom: BracketTemplate = [
       { label: 'test', minPlayers: 1, maxPlayers: 99, loh: ['quickTap'], pos: ['laneRacers'] },
-    ];
-    expect(getBracketPoolForContext(10, 'LOH', custom)).toEqual(['quickTap']);
-    expect(getBracketPoolForContext(10, 'POS', custom)).toEqual(['laneRacers']);
-  });
-});
+    ]
+    expect(getBracketPoolForContext(10, 'LOH', custom)).toEqual(['quickTap'])
+    expect(getBracketPoolForContext(10, 'POS', custom)).toEqual(['laneRacers'])
+  })
+})
 
 describe('getClassicCampaignPoolForContext', () => {
-  it('uses the hook pool on day 1 even for a smaller starting cast', () => {
-    expect(getClassicCampaignPoolForContext({
-      day: 1,
-      playerCount: 10,
-      compType: 'LOH',
-      phase: 'loh_comp',
-    })).toEqual(['holdWall', 'majorityRules', 'memoryMatch']);
-  });
+  it('uses the fixed premiere pool on day 1', () => {
+    expect(
+      getClassicCampaignPoolForContext({
+        day: 1,
+        playerCount: 10,
+        compType: 'LOH',
+        phase: 'loh_comp',
+      })
+    ).toEqual(['majorityRules'])
+  })
 
-  it('widens the eligible pool after day 1 so fresh games keep entering', () => {
+  it('moves from the fixed premiere game to Day 2’s curated pool', () => {
     const day1 = getClassicCampaignPoolForContext({
       day: 1,
       playerCount: 16,
       compType: 'LOH',
       phase: 'loh_comp',
-    });
+    })
     const day2 = getClassicCampaignPoolForContext({
       day: 2,
       playerCount: 16,
       compType: 'LOH',
       phase: 'loh_comp',
-    });
-    expect(day2.length).toBeGreaterThan(day1.length);
-    expect(day2).toEqual(expect.arrayContaining(day1));
-  });
+    })
+    expect(day1).toEqual(['majorityRules'])
+    expect(day2.length).toBeGreaterThan(day1.length)
+    expect(day2).toContain('holdWall')
+  })
 
   it('moves to the roster-specific pool after the opening hook', () => {
     const pool = getClassicCampaignPoolForContext({
       day: 3,
-      playerCount: 10,
+      playerCount: 14,
       compType: 'LOH',
       phase: 'loh_comp',
-    });
-    expect(pool).toContain('memoryMatch');
-    expect(pool).not.toContain('targetPractice');
-  });
+    })
+    expect(pool).toContain('memoryMatch')
+    expect(pool).not.toContain('targetPractice')
+  })
 
-  it('keeps turn-heavy Grid of Luck to the 2-4 compatible endgame context', () => {
-    const final4 = getClassicCampaignPoolForContext({
+  it('keeps Grid of Luck out of the day guide because its 2-4 limit conflicts with a +/- 1 row', () => {
+    const lateDay = getClassicCampaignPoolForContext({
       day: 13,
       playerCount: 4,
       compType: 'POS',
       phase: 'pos_comp',
-    });
-    const final5 = getClassicCampaignPoolForContext({
-      day: 12,
-      playerCount: 5,
-      compType: 'POS',
-      phase: 'pos_comp',
-    });
-    expect(final4).toContain('gridOfLuck');
-    expect(final5).not.toContain('gridOfLuck');
-  });
+    })
+    expect(lateDay).not.toContain('gridOfLuck')
+  })
 
   it('uses a disjoint, escalating pool for each Final 3 part', () => {
-    const resolve = (phase: 'final3_comp1_minigame' | 'final3_comp2_minigame' | 'final3_comp3_minigame') =>
-      getClassicCampaignPoolForContext({ day: 14, playerCount: 3, compType: 'LOH', phase });
-    const part1 = resolve('final3_comp1_minigame');
-    const part2 = resolve('final3_comp2_minigame');
-    const part3 = resolve('final3_comp3_minigame');
+    const resolve = (
+      phase: 'final3_comp1_minigame' | 'final3_comp2_minigame' | 'final3_comp3_minigame'
+    ) => getClassicCampaignPoolForContext({ day: 14, playerCount: 3, compType: 'LOH', phase })
+    const part1 = resolve('final3_comp1_minigame')
+    const part2 = resolve('final3_comp2_minigame')
+    const part3 = resolve('final3_comp3_minigame')
 
-    expect(part1).toContain('holdWall');
-    expect(part2).toContain('memoryMatch');
-    expect(part3).toContain('wildcardWestern');
+    expect(part1).toContain('holdWall')
+    expect(part2).toContain('memoryMatch')
+    expect(part3).toContain('capitalization')
     expect(new Set([...part1, ...part2, ...part3]).size).toBe(
-      part1.length + part2.length + part3.length,
-    );
-  });
-});
+      part1.length + part2.length + part3.length
+    )
+  })
+})

--- a/tests/unit/minigameLogicRevamps.test.ts
+++ b/tests/unit/minigameLogicRevamps.test.ts
@@ -118,11 +118,11 @@ describe('minigame logic revamps', () => {
 
   it('restricts Trap Auction to rosters of at least 8 and removes it from endgame', () => {
     expect(getGame('trapAuction')?.minPlayers).toBe(8)
-    expect(getClassicCampaignPoolForContext({ day: 5, playerCount: 8, compType: 'LOH' })).toContain(
+    expect(getClassicCampaignPoolForContext({ day: 7, playerCount: 8, compType: 'LOH' })).toContain(
       'trapAuction'
     )
     expect(
-      getClassicCampaignPoolForContext({ day: 5, playerCount: 7, compType: 'LOH' })
+      getClassicCampaignPoolForContext({ day: 8, playerCount: 7, compType: 'LOH' })
     ).not.toContain('trapAuction')
     expect(
       getClassicCampaignPoolForContext({ day: 12, playerCount: 4, compType: 'LOH' })


### PR DESCRIPTION
## What changed
Replaces the broad Classic/Vox Populi competition roster bands with a day-by-day guide that targets each expected house count with a +/-1 tolerance for double evictions and other twists.

Day 1 is now fixed to Majority Rules for LOH and Quick Tap Race for POS. Late-season and Final 3 pools use sustained endurance, precision, trivia, and score formats instead of field-size-dependent spectacle games.

## Why
Several spectacle and elimination-ladder games could reach a very small cast, where they resolve too quickly to feel like meaningful competitions.

## Validation
- `npm test -- tests/unit/competition-ai/bracketTemplate.test.ts tests/unit/minigameLogicRevamps.test.ts`
- `npm test -- tests/integration/challenge.flow.dispatch.test.tsx`
- `npm run typecheck`