### PR TITLE
Connect public legal and support site

### DIFF
--- a/.env.android.example
+++ b/.env.android.example
@@ -16,7 +16,7 @@ VITE_NO_ADS_PRODUCT_ID=com.georgicole.thebigeye.noads
 # VITE_BIG_EYE_AI_ENABLED=true
 # VITE_BIG_EYE_VIP_API_URL=https://api.example.com
 
-# Public store/support pages. Replace before store submission.
-VITE_PRIVACY_POLICY_URL=https://example.com/privacy
-VITE_TERMS_URL=https://example.com/terms
-VITE_SUPPORT_URL=https://example.com/support
+# Public store/support pages hosted separately so the game repository can be private.
+VITE_PRIVACY_POLICY_URL=https://georgi-cole.github.io/big-eye-legal/privacy-policy.html
+VITE_TERMS_URL=https://georgi-cole.github.io/big-eye-legal/terms-of-use.html
+VITE_SUPPORT_URL=https://georgi-cole.github.io/big-eye-legal/support.html

--- a/.env.ios.example
+++ b/.env.ios.example
@@ -16,7 +16,7 @@ VITE_NO_ADS_PRODUCT_ID=com.georgicole.thebigeye.noads
 # VITE_BIG_EYE_AI_ENABLED=true
 # VITE_BIG_EYE_VIP_API_URL=https://api.example.com
 
-# Public store/support pages. Replace before store submission.
-VITE_PRIVACY_POLICY_URL=https://example.com/privacy
-VITE_TERMS_URL=https://example.com/terms
-VITE_SUPPORT_URL=https://example.com/support
+# Public store/support pages hosted separately so the game repository can be private.
+VITE_PRIVACY_POLICY_URL=https://georgi-cole.github.io/big-eye-legal/privacy-policy.html
+VITE_TERMS_URL=https://georgi-cole.github.io/big-eye-legal/terms-of-use.html
+VITE_SUPPORT_URL=https://georgi-cole.github.io/big-eye-legal/support.html

--- a/public/legal/privacy-policy.html
+++ b/public/legal/privacy-policy.html
@@ -82,8 +82,10 @@
       <h2>Security, retention, and choices</h2>
       <p>
         Network services use HTTPS. You may deny or revoke location permission. Local game data
-        remains until reset or uninstall. For privacy or deletion requests, use the developer
-        contact information on the official store listing.
+        remains until reset or uninstall. For privacy or deletion requests, email
+        <a href="mailto:kolequant@gmail.com">kolequant@gmail.com</a> or visit the
+        <a href="https://georgi-cole.github.io/big-eye-legal/support.html">official support page</a
+        >.
       </p>
       <h2>Changes</h2>
       <p>

--- a/public/legal/terms-of-use.html
+++ b/public/legal/terms-of-use.html
@@ -74,8 +74,10 @@
       </p>
       <h2>Support</h2>
       <p>
-        For purchase, privacy, accessibility, or gameplay help, use the official support contact
-        shown on the app's store listing.
+        For purchase, privacy, accessibility, or gameplay help, email
+        <a href="mailto:kolequant@gmail.com">kolequant@gmail.com</a> or visit the
+        <a href="https://georgi-cole.github.io/big-eye-legal/support.html">official support page</a
+        >.
       </p>
     </main>
   </body>

--- a/src/components/FamousFiguresComp/FamousFiguresComp.tsx
+++ b/src/components/FamousFiguresComp/FamousFiguresComp.tsx
@@ -905,4 +905,156 @@ export default function FamousFiguresComp({
           <p className="ff-base-clue">{figure.baseClueFact}</p>
           {effectiveHintsRevealed > 0 && (
             <ul className="ff-hint-list" aria-label="Revealed hints">
-              {Array.from({ le
+              {Array.from({ length: effectiveHintsRevealed }, (_, i) => (
+                <li key={i} className="ff-hint-item">
+                  <span className="ff-hint-num">#{i + 1}</span>
+                  <span>
+                    {i === VISIBLE_HINT_INDICES.length
+                      ? getFinalNameHintText(figure)
+                      : getHintText(figure, VISIBLE_HINT_INDICES[i])}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Request hint button */}
+      <button
+        className="ff-hint-btn"
+        onClick={handleRequestHint}
+        disabled={!canRequestHint}
+        aria-label={`Request hint (${MAX_VISIBLE_HINTS - effectiveHintsRevealed} remaining)`}
+      >
+        💡 Request Hint ({effectiveHintsRevealed}/{MAX_VISIBLE_HINTS} used)
+      </button>
+
+      {/* Success confirmation overlay — shown for CONFIRM_MS after a correct guess */}
+      {successOverlay && (
+        <div
+          className="ff-success-overlay"
+          role="status"
+          aria-live="assertive"
+          data-testid="ff-success-overlay"
+        >
+          <div className="ff-success-overlay-inner">
+            <div className="ff-success-checkmark" aria-hidden="true">
+              ✅
+            </div>
+            <div className="ff-success-title">Correct!</div>
+            <div className="ff-success-figure">{successOverlay.figureName}</div>
+            <div className="ff-success-points">+{successOverlay.points} points</div>
+          </div>
+        </div>
+      )}
+
+      {humanCorrect && successOverlay === null && ff.status === 'round_active' && (
+        <button className="ff-fastforward-btn" onClick={handleFastForwardRound} type="button">
+          {ff.currentRound + 1 >= ff.totalRounds ? 'Finish Round' : 'Next Round'}
+        </button>
+      )}
+
+      {/* Guess input */}
+      <div className="ff-input-area">
+        <div className="ff-input-row">
+          <input
+            ref={inputRef}
+            className={inputFieldClass}
+            type="text"
+            value={guessInput}
+            onChange={(e) => setGuessInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type your guess…"
+            aria-label="Guess the famous figure"
+            disabled={
+              ff.status !== 'round_active' ||
+              successOverlay !== null ||
+              humanCorrect ||
+              humanId === null ||
+              humanCursor >= ff.totalRounds
+            }
+          />
+          <button
+            className="ff-submit-btn"
+            onClick={handleSubmitGuess}
+            disabled={
+              ff.status !== 'round_active' ||
+              successOverlay !== null ||
+              humanCorrect ||
+              humanId === null ||
+              guessInput.trim().length === 0 ||
+              humanCursor >= ff.totalRounds
+            }
+            aria-label="Submit guess"
+          >
+            Submit
+          </button>
+        </div>
+        <div className={feedbackClass} aria-live="assertive">
+          {feedbackMsg}
+        </div>
+      </div>
+
+      {/* Scoreboard */}
+      {renderScoreboard(ff, participantIds, humanId, displayName, playerAvatar)}
+    </div>
+  )
+}
+
+// ─── Scoreboard helper ────────────────────────────────────────────────────────
+
+function renderScoreboard(
+  ff: FamousFiguresState,
+  participantIds: string[],
+  humanId: string | null,
+  displayName: (id: string) => string,
+  playerAvatar: (id: string) => string
+) {
+  const sorted = [...participantIds].sort(
+    (a, b) => (ff.playerScores[b] ?? 0) - (ff.playerScores[a] ?? 0)
+  )
+
+  return (
+    <div className="ff-scoreboard" aria-label="Scoreboard">
+      <div className="ff-scoreboard-title">Scoreboard</div>
+      <div className="ff-scoreboard-list">
+        {sorted.map((id) => {
+          const isHuman = id === humanId
+          const name = displayName(id)
+          const total = ff.playerScores[id] ?? 0
+          const roundScores = ff.playerRoundScores[id] ?? []
+          const correct = ff.playerCorrect[id]
+          return (
+            <div key={id} className="ff-scoreboard-row">
+              <span className="ff-scoreboard-avatar-wrap">
+                <img
+                  className="ff-scoreboard-avatar"
+                  src={playerAvatar(id)}
+                  alt=""
+                  aria-hidden="true"
+                  onError={(e) => {
+                    const img = e.currentTarget
+                    // one-shot fallback to Dicebear to avoid infinite onError loop
+                    img.onerror = null
+                    img.src = `https://api.dicebear.com/7.x/pixel-art/svg?seed=${encodeURIComponent(name)}`
+                  }}
+                />
+              </span>
+              <span className={`ff-scoreboard-name${isHuman ? ' ff-scoreboard-name--you' : ''}`}>
+                {isHuman ? 'You' : name}
+              </span>
+              <span className="ff-scoreboard-round">[{roundScores.join(', ')}]</span>
+              <span className="ff-scoreboard-total">{total}</span>
+              {correct && (
+                <span className="ff-scoreboard-correct" aria-label="Correct this round">
+                  ✓
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/screens/Legal/Legal.tsx
+++ b/src/screens/Legal/Legal.tsx
@@ -6,9 +6,15 @@ function externalUrl(value: string | undefined): string | null {
   return url && /^https:\/\//i.test(url) ? url : null
 }
 
-const privacyUrl = externalUrl(import.meta.env.VITE_PRIVACY_POLICY_URL)
-const termsUrl = externalUrl(import.meta.env.VITE_TERMS_URL)
-const supportUrl = externalUrl(import.meta.env.VITE_SUPPORT_URL)
+const privacyUrl =
+  externalUrl(import.meta.env.VITE_PRIVACY_POLICY_URL) ??
+  'https://georgi-cole.github.io/big-eye-legal/privacy-policy.html'
+const termsUrl =
+  externalUrl(import.meta.env.VITE_TERMS_URL) ??
+  'https://georgi-cole.github.io/big-eye-legal/terms-of-use.html'
+const supportUrl =
+  externalUrl(import.meta.env.VITE_SUPPORT_URL) ??
+  'https://georgi-cole.github.io/big-eye-legal/support.html'
 
 export default function Legal() {
   const navigate = useNavigate()
@@ -71,8 +77,8 @@ export default function Legal() {
       <section>
         <h2>Support</h2>
         <p>
-          For purchase, privacy, accessibility, or gameplay help, use the official support contact
-          shown on the app&apos;s store listing.
+          For purchase, privacy, accessibility, or gameplay help, visit the official support page or
+          email kolequant@gmail.com.
         </p>
         {supportUrl && (
           <a href={supportUrl} target="_blank" rel="noreferrer">

--- a/store-assets/release-blockers.md
+++ b/store-assets/release-blockers.md
@@ -14,14 +14,14 @@ The repository-side release blockers have been addressed. The game is still **no
 - Enroll in Play App Signing and securely back up the upload key.
 - Apple: select the Apple Developer team, create distribution certificates/profiles, and archive with the current required Xcode/iOS SDK.
 
-## 3. Publish legal and support pages
+## 3. Connect the published legal and support pages
 
-- Publish `public/legal/privacy-policy.html` and `public/legal/terms-of-use.html` at stable public HTTPS URLs.
-- Create a public support page and a monitored support/developer email.
-- Copy `.env.android.example` and `.env.ios.example` to the ignored real files, replace the three `example.com` legal/support URLs, and run:
+- Privacy, Terms, and support are published from the separate public `georgi-cole/big-eye-legal` repository.
+- The monitored support email is `kolequant@gmail.com`.
+- Copy `.env.android.example` and `.env.ios.example` to the ignored real files and run:
   - `npm run verify:store-env:android`
   - `npm run verify:store-env:ios`
-- Enter the same privacy and support URLs in both store consoles.
+- Enter the published privacy and support URLs in both store consoles.
 
 ## 4. Configure the four released purchases
 

--- a/tests/release-readiness.audit.test.ts
+++ b/tests/release-readiness.audit.test.ts
@@ -48,6 +48,8 @@ const STORE_APP_ICON = join(ROOT, 'store-assets', 'apple', 'app-store-icon-1024.
 const LEGAL_SCREEN = join(SRC_DIR, 'screens', 'Legal', 'Legal.tsx')
 const PUBLIC_PRIVACY_POLICY = join(PUBLIC_DIR, 'legal', 'privacy-policy.html')
 const PUBLIC_TERMS = join(PUBLIC_DIR, 'legal', 'terms-of-use.html')
+const ANDROID_ENV_EXAMPLE = join(ROOT, '.env.android.example')
+const IOS_ENV_EXAMPLE = join(ROOT, '.env.ios.example')
 
 const PHASE_RANK: Record<string, number> = {
   week_start: 0,
@@ -445,6 +447,24 @@ describe('release readiness metadata', () => {
     expect(existsSync(LEGAL_SCREEN)).toBe(true)
     expect(existsSync(PUBLIC_PRIVACY_POLICY)).toBe(true)
     expect(existsSync(PUBLIC_TERMS)).toBe(true)
+  })
+
+  it('connects store builds to the separately hosted public legal site', () => {
+    const expectedUrls = [
+      'https://georgi-cole.github.io/big-eye-legal/privacy-policy.html',
+      'https://georgi-cole.github.io/big-eye-legal/terms-of-use.html',
+      'https://georgi-cole.github.io/big-eye-legal/support.html',
+    ]
+    const releaseSurfaces = [
+      readText(ANDROID_ENV_EXAMPLE),
+      readText(IOS_ENV_EXAMPLE),
+      readText(LEGAL_SCREEN),
+    ]
+
+    for (const url of expectedUrls) {
+      for (const surface of releaseSurfaces) expect(surface).toContain(url)
+    }
+    expect(readText(LEGAL_SCREEN)).toContain('kolequant@gmail.com')
   })
 
   it('does not offer unfinished or unavailable products in release 1.0', () => {


### PR DESCRIPTION
## What changed

- Points Android and iOS release templates to the new public `big-eye-legal` GitHub Pages site.
- Gives the in-app Legal screen production fallbacks for Privacy, Terms, and Support.
- Adds the monitored support email to bundled legal surfaces.
- Updates the release checklist to reflect that the public resources are published.
- Adds a release-readiness regression test for all three production URLs and the support email.

## Why

The game repository can now be made private without removing public access to store-required legal and support resources.

## Validation

- Verified Privacy Policy, Terms of Use, Support, and site home live over HTTPS.
- `npm run format:check` passed after synchronization with current `main`.
- `npm run audit:release` passed (10 tests).
- `git diff --check` passed.
- `npm run typecheck` passed before synchronization. Current `main` now fails independently in `FamousFiguresComp.tsx` because JSX elements at lines 874–908 are not closed; this PR does not modify that file.
