### PR TITLE
Add human-like Quick Tap balancing and Seasons spin-off

### DIFF
--- a/scripts/check-localization.mjs
+++ b/scripts/check-localization.mjs
@@ -827,6 +827,7 @@ function shouldScanFile(file) {
     'src/experiments/',
     'src/screens/FindYourTwin2/',
     'src/screens/FindYourTwinExperiment/',
+    'src/screens/QuickTapExperiment/',
     'src/i18n/',
     'src/test/',
     'tests/',

--- a/src/ai/competition/bracketTemplate.ts
+++ b/src/ai/competition/bracketTemplate.ts
@@ -40,6 +40,7 @@ export interface ClassicCampaignContext {
  */
 export const CLASSIC_CAMPAIGN_ELIGIBLE_GAME_KEYS = [
   'quickTap',
+  'quickTapSeasons',
   'memoryMatch',
   'timingBar',
   'estimationGame',
@@ -252,6 +253,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'wildcardWestern',
     ],
     pos: [
+      'quickTapSeasons',
       'logicLocks',
       'hangman',
       'tiltLabyrinth',
@@ -283,6 +285,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'houseOfDarkness',
     ],
     pos: [
+      'quickTapSeasons',
       'bigSpender',
       'logicLocks',
       'hangman',
@@ -311,6 +314,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'houseOfDarkness',
     ],
     pos: [
+      'quickTapSeasons',
       'bigSpender',
       'logicLocks',
       'hangman',
@@ -342,6 +346,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'houseOfDarkness',
     ],
     pos: [
+      'quickTapSeasons',
       'bigSpender',
       'logicLocks',
       'hangman',
@@ -375,6 +380,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'houseOfDarkness',
     ],
     pos: [
+      'quickTapSeasons',
       'bigSpender',
       'logicLocks',
       'hangman',
@@ -408,6 +414,7 @@ export const DEFAULT_BRACKET_TEMPLATE: BracketTemplate = [
       'houseOfDarkness',
     ],
     pos: [
+      'quickTapSeasons',
       'bigSpender',
       'logicLocks',
       'hangman',

--- a/src/ai/competition/minigameAiRegistry.ts
+++ b/src/ai/competition/minigameAiRegistry.ts
@@ -128,6 +128,16 @@ export const minigameAiRegistry: Record<string, MinigameAiModel> = {
       'Routing via simulateMinigameAiScore() ensures both session and challenge flows ' +
       'use the same authoritative scorer.',
   },
+  quickTapSeasons: {
+    key: 'quickTapSeasons',
+    category: 'physical',
+    scoreDirection: 'higher-is-better',
+    volatility: VOLATILITY_HYBRID,
+    weights: WEIGHTS_PHYSICAL_TAP,
+    minScore: 120,
+    maxScore: 320,
+    notes: 'Season effects add strategic volatility to a 40-second tapping race.',
+  },
   laneRacers: {
     key: 'laneRacers',
     category: 'physical',

--- a/src/experiments/quickTapHumanAi/quickTapHumanAi.ts
+++ b/src/experiments/quickTapHumanAi/quickTapHumanAi.ts
@@ -1,0 +1,352 @@
+import {
+  selectBoosterPrompts,
+  simulateQuickTapAiScore,
+  type BoosterType,
+} from '../../ai/competition/quickTapSimulation'
+import { mulberry32 } from '../../store/rng'
+
+export type QuickTapExperimentDifficulty = 'friendly' | 'balanced' | 'competitive'
+
+/** Clean real-phone run used as the strong-human physical calibration anchor. */
+export const QUICK_TAP_PHONE_BASELINE = {
+  elapsedSeconds: 33.01,
+  rawTaps: 248,
+  sustainedTapsPerSecond: 7.51,
+  peakOneSecondTaps: 13,
+  medianInterTapMs: 99,
+  fastestInterTapMs: 47,
+  maxConcurrentPointers: 2,
+} as const
+
+export interface QuickTapHumanAiConfig {
+  id: string
+  name: string
+  baseTapsPerSecond: number
+  fatigue: number
+  burstiness: number
+  boosterRisk: number
+  reactionMinMs: number
+  reactionMaxMs: number
+}
+
+export interface QuickTapAiAction {
+  atMs: number
+  type: 'tap' | 'booster'
+  boosterType?: BoosterType
+  scoreAfter: number
+}
+
+export interface QuickTapBoosterDecision {
+  type: BoosterType
+  scheduledAtMs: number
+  taken: boolean
+  reactionMs: number | null
+  beneficial: boolean
+}
+
+export interface QuickTapHumanAiResult {
+  id: string
+  name: string
+  effectiveScore: number
+  rawTaps: number
+  averageTapsPerSecond: number
+  openingReactionMs: number
+  elapsedMs: number
+  bandTargetScore: number
+  scoreGap: number
+  targetReached: boolean
+  boosters: QuickTapBoosterDecision[]
+  actions: QuickTapAiAction[]
+}
+
+export const QUICK_TAP_EXPERIMENT_FIELD: readonly QuickTapHumanAiConfig[] = [
+  {
+    id: 'sprinter',
+    name: 'Nova — fast starter',
+    baseTapsPerSecond: 7.56,
+    fatigue: 0.28,
+    burstiness: 0.3,
+    boosterRisk: 0.66,
+    reactionMinMs: 180,
+    reactionMaxMs: 340,
+  },
+  {
+    id: 'steady',
+    name: 'Milo — steady rhythm',
+    baseTapsPerSecond: 6.93,
+    fatigue: 0.08,
+    burstiness: 0.12,
+    boosterRisk: 0.56,
+    reactionMinMs: 250,
+    reactionMaxMs: 470,
+  },
+  {
+    id: 'gambler',
+    name: 'Zara — booster hunter',
+    baseTapsPerSecond: 7.25,
+    fatigue: 0.17,
+    burstiness: 0.22,
+    boosterRisk: 0.88,
+    reactionMinMs: 210,
+    reactionMaxMs: 410,
+  },
+] as const
+
+const DIFFICULTY_TARGET_SCALE: Record<QuickTapExperimentDifficulty, number> = {
+  friendly: 0.85,
+  balanced: 1.1,
+  competitive: 1.23,
+}
+
+const MIN_PLAUSIBLE_TAPS_PER_SECOND = 3.5
+const MAX_PLAUSIBLE_TAPS_PER_SECOND = 12
+const ACCEPTABLE_SCORE_GAP = 3
+
+const COMPETITIVE_RHYTHM_BAND = { min: 7.1, max: 8.7 } as const
+
+function rhythmBandDistance(
+  averageTapsPerSecond: number,
+  difficulty: QuickTapExperimentDifficulty
+): number {
+  if (difficulty === 'friendly') return 0
+  if (averageTapsPerSecond < COMPETITIVE_RHYTHM_BAND.min) {
+    return COMPETITIVE_RHYTHM_BAND.min - averageTapsPerSecond
+  }
+  if (averageTapsPerSecond > COMPETITIVE_RHYTHM_BAND.max) {
+    return averageTapsPerSecond - COMPETITIVE_RHYTHM_BAND.max
+  }
+  return 0
+}
+
+function hashIdentity(value: string): number {
+  let hash = 0x811c9dc5 >>> 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function ranged(rng: () => number, min: number, max: number): number {
+  return min + rng() * (max - min)
+}
+
+/**
+ * Experimental action-based Quick Tap opponent.
+ *
+ * Unlike the production score-band model, this creates the same actions a human
+ * can create: delayed taps, variable rhythm, pauses, fatigue, and mystery-booster
+ * choices. Booster acceptance is rolled before its revealed effect is applied, so
+ * the opponent never uses hidden knowledge to avoid a harmful pickup.
+ */
+function simulateActionTrace({
+  seed,
+  config,
+  baseTapsPerSecond,
+  durationSeconds = 30,
+}: {
+  seed: number
+  config: QuickTapHumanAiConfig
+  baseTapsPerSecond: number
+  durationSeconds?: number
+}): Omit<QuickTapHumanAiResult, 'bandTargetScore' | 'scoreGap' | 'targetReached'> {
+  const rng = mulberry32(((seed >>> 0) ^ hashIdentity(config.id) ^ 0x71a9c3e5) >>> 0)
+  const prompts = selectBoosterPrompts(seed)
+  const openingReactionMs = Math.round(ranged(rng, config.reactionMinMs, config.reactionMaxMs))
+
+  // Decide whether to take each mystery box without consulting its hidden type.
+  const boosterPlans = prompts.map((prompt) => {
+    const taken = rng() < config.boosterRisk
+    const reactionMs = taken ? Math.round(ranged(rng, 260, 920)) : null
+    return {
+      prompt,
+      taken,
+      reactionMs,
+      // Skips still get an event at prompt time so later prompts remain reachable.
+      activationAtMs: prompt.scheduleAt * 1000 + (reactionMs ?? 0),
+    }
+  })
+
+  let finishAtMs = durationSeconds * 1000
+  let nextTapAtMs = openingReactionMs
+  let boosterIndex = 0
+  let rawTaps = 0
+  let effectiveScore = 0
+  let activeMultiplier = 1
+  let multiplierEndsAtMs = 0
+  let drainInertiaTapsRemaining = 0
+  const actions: QuickTapAiAction[] = []
+
+  while (true) {
+    const nextBoosterAtMs = boosterPlans[boosterIndex]?.activationAtMs ?? Number.POSITIVE_INFINITY
+    const nextEventAtMs = Math.min(nextTapAtMs, nextBoosterAtMs)
+    if (nextEventAtMs >= finishAtMs) break
+
+    if (nextBoosterAtMs <= nextTapAtMs) {
+      const plan = boosterPlans[boosterIndex]
+      boosterIndex += 1
+      const visibleUntilMs = (plan.prompt.scheduleAt + plan.prompt.visibleFor) * 1000
+      if (!plan.taken || nextBoosterAtMs > visibleUntilMs) continue
+
+      if (plan.prompt.kind === 'time') {
+        finishAtMs = Math.max(nextBoosterAtMs, finishAtMs + (plan.prompt.timeDelta ?? 0) * 1000)
+      } else {
+        activeMultiplier = plan.prompt.multiplier ?? 1
+        multiplierEndsAtMs = nextBoosterAtMs + plan.prompt.activeDuration * 1000
+        if (activeMultiplier < 0) {
+          // A small number of momentum taps slip through before the opponent
+          // recognizes the revealed drain and stops.
+          drainInertiaTapsRemaining = 1 + Math.floor(rng() * 3)
+        }
+      }
+      actions.push({
+        atMs: Math.round(nextBoosterAtMs),
+        type: 'booster',
+        boosterType: plan.prompt.type,
+        scoreAfter: effectiveScore,
+      })
+      continue
+    }
+
+    if (nextTapAtMs >= multiplierEndsAtMs) {
+      activeMultiplier = 1
+      drainInertiaTapsRemaining = 0
+    }
+    rawTaps += 1
+    effectiveScore += activeMultiplier
+    actions.push({
+      atMs: Math.round(nextTapAtMs),
+      type: 'tap',
+      scoreAfter: effectiveScore,
+    })
+
+    const progress = clamp(nextTapAtMs / Math.max(1, finishAtMs), 0, 1)
+    const fatigueScale = 1 - config.fatigue * progress
+    const rhythmNoise = 1 + (rng() - 0.5) * config.burstiness
+    const tapsPerSecond = Math.max(1, baseTapsPerSecond * fatigueScale * rhythmNoise)
+    let intervalMs = 1000 / tapsPerSecond
+
+    // Short bursts and occasional hesitations keep the trace from looking metronomic.
+    const behaviorRoll = rng()
+    if (behaviorRoll < 0.08) intervalMs *= ranged(rng, 0.62, 0.84)
+    else if (behaviorRoll > 0.95) intervalMs += ranged(rng, 180, 520)
+    intervalMs += (rng() + rng() + rng() - 1.5) * 42
+    nextTapAtMs += clamp(intervalMs, 72, 780)
+    if (activeMultiplier < 0) {
+      drainInertiaTapsRemaining -= 1
+      if (drainInertiaTapsRemaining <= 0) {
+        nextTapAtMs = Math.max(nextTapAtMs, multiplierEndsAtMs)
+      }
+    }
+  }
+
+  const boosters: QuickTapBoosterDecision[] = boosterPlans.map((plan) => ({
+    type: plan.prompt.type,
+    scheduledAtMs: plan.prompt.scheduleAt * 1000,
+    taken: plan.taken,
+    reactionMs: plan.reactionMs,
+    beneficial: plan.prompt.beneficial,
+  }))
+
+  return {
+    id: config.id,
+    name: config.name,
+    effectiveScore,
+    rawTaps,
+    averageTapsPerSecond: Number((rawTaps / Math.max(1, finishAtMs / 1000)).toFixed(2)),
+    openingReactionMs,
+    elapsedMs: Math.round(finishAtMs),
+    boosters,
+    actions,
+  }
+}
+
+/**
+ * Hybrid experimental opponent: production's weighted score bands establish the
+ * fair result target, while an action trace has to earn that score using bounded
+ * human-like tapping and the same mystery-booster sequence as the player.
+ * Unreachable targets remain visible as a score gap instead of being fabricated.
+ */
+export function simulateHumanlikeQuickTapAi({
+  seed,
+  config,
+  difficulty = 'balanced',
+  durationSeconds = 30,
+  forceAllBoosters = false,
+}: {
+  seed: number
+  config: QuickTapHumanAiConfig
+  difficulty?: QuickTapExperimentDifficulty
+  durationSeconds?: number
+  forceAllBoosters?: boolean
+}): QuickTapHumanAiResult {
+  const productionBandScore = simulateQuickTapAiScore({
+    seed,
+    playerId: config.id,
+    timeLimitSeconds: durationSeconds,
+  })
+  const bandTargetScore = Math.round(productionBandScore * DIFFICULTY_TARGET_SCALE[difficulty])
+
+  let bestRate = MIN_PLAUSIBLE_TAPS_PER_SECOND
+  let best = simulateActionTrace({
+    seed,
+    config: forceAllBoosters ? { ...config, boosterRisk: 1 } : config,
+    baseTapsPerSecond: bestRate,
+    durationSeconds,
+  })
+
+  for (
+    let rate = MIN_PLAUSIBLE_TAPS_PER_SECOND + 0.1;
+    rate <= MAX_PLAUSIBLE_TAPS_PER_SECOND + 0.001;
+    rate += 0.1
+  ) {
+    const candidate = simulateActionTrace({
+      seed,
+      config: forceAllBoosters ? { ...config, boosterRisk: 1 } : config,
+      baseTapsPerSecond: rate,
+      durationSeconds,
+    })
+    const candidateGap = Math.abs(candidate.effectiveScore - bandTargetScore)
+    const bestGap = Math.abs(best.effectiveScore - bandTargetScore)
+    const candidateRhythmDistance = rhythmBandDistance(candidate.averageTapsPerSecond, difficulty)
+    const bestRhythmDistance = rhythmBandDistance(best.averageTapsPerSecond, difficulty)
+    if (
+      candidateRhythmDistance < bestRhythmDistance ||
+      (candidateRhythmDistance === bestRhythmDistance &&
+        (candidateGap < bestGap ||
+          (candidateGap === bestGap &&
+            Math.abs(rate - config.baseTapsPerSecond) <
+              Math.abs(bestRate - config.baseTapsPerSecond))))
+    ) {
+      best = candidate
+      bestRate = rate
+    }
+  }
+
+  const scoreGap = best.effectiveScore - bandTargetScore
+  return {
+    ...best,
+    bandTargetScore,
+    scoreGap,
+    targetReached: Math.abs(scoreGap) <= ACCEPTABLE_SCORE_GAP,
+  }
+}
+
+export function simulateHumanlikeQuickTapField(
+  seed: number,
+  difficulty: QuickTapExperimentDifficulty,
+  options: { forceAllBoosters?: boolean } = {}
+): QuickTapHumanAiResult[] {
+  return QUICK_TAP_EXPERIMENT_FIELD.map((config) =>
+    simulateHumanlikeQuickTapAi({
+      seed,
+      config,
+      difficulty,
+      forceAllBoosters: options.forceAllBoosters,
+    })
+  )
+}

--- a/src/experiments/quickTapSeasons/quickTapSeasons.ts
+++ b/src/experiments/quickTapSeasons/quickTapSeasons.ts
@@ -1,0 +1,95 @@
+import { mulberry32 } from '../../store/rng'
+
+export const SEASONS_DURATION = 40
+export const SEASON_LENGTH = 8
+export const SEASON_BOX_TIMES = [6, 18, 30] as const
+export type TapSeason = 'winter' | 'summer' | 'autumn' | 'spring'
+
+export const SEASONS: Record<
+  TapSeason,
+  { label: string; emoji: string; multiplier: number; effect: string }
+> = {
+  winter: { label: 'Winter', emoji: '❄️', multiplier: -1, effect: 'Slippery · −1×' },
+  summer: { label: 'Summer', emoji: '☀️', multiplier: 0.5, effect: 'Too hot · ½×' },
+  autumn: { label: 'Autumn', emoji: '🍂', multiplier: 1, effect: 'Leafy · 1×' },
+  spring: { label: 'Spring', emoji: '🐦', multiplier: 1.25, effect: 'Chirpy · 1¼×' },
+}
+const SEASON_KEYS = Object.keys(SEASONS) as TapSeason[]
+
+function pickOther(rng: () => number, current?: TapSeason): TapSeason {
+  const choices = current ? SEASON_KEYS.filter((season) => season !== current) : SEASON_KEYS
+  return choices[Math.floor(rng() * choices.length)]
+}
+
+export function buildSeasonSchedule(seed: number) {
+  const rng = mulberry32((seed ^ 0x52ea50a5) >>> 0)
+  const result: Array<{ at: number; season: TapSeason }> = []
+  let current: TapSeason | undefined
+  for (let at = 0; at < SEASONS_DURATION; at += SEASON_LENGTH) {
+    current = pickOther(rng, current)
+    result.push({ at, season: current })
+  }
+  return result
+}
+
+export function rerollSeason(seed: number, boxIndex: number, current: TapSeason): TapSeason {
+  const rng = mulberry32((seed ^ Math.imul(boxIndex + 1, 0x9e3779b9) ^ 0xb07b07) >>> 0)
+  return pickOther(rng, current)
+}
+
+function hash(value: string): number {
+  let result = 0x811c9dc5 >>> 0
+  for (const character of value) {
+    result ^= character.charCodeAt(0)
+    result = Math.imul(result, 0x01000193) >>> 0
+  }
+  return result
+}
+
+export function simulateSeasonsAiField(seed: number) {
+  const field = [
+    { id: 'nova', name: 'Nova', rate: 7.25, boxChance: 0.55 },
+    { id: 'milo', name: 'Milo', rate: 7.65, boxChance: 0.72 },
+    { id: 'zara', name: 'Zara', rate: 8.15, boxChance: 0.88 },
+  ]
+  const schedule = buildSeasonSchedule(seed)
+
+  return field.map((opponent) => {
+    const rng = mulberry32((seed ^ hash(opponent.id) ^ 0xa15ea50a) >>> 0)
+    let season = schedule[0].season
+    let seasonIndex = 1
+    let boxIndex = 0
+    let rawTaps = 0
+    let score = 0
+    let winterInertia = season === 'winter' ? 1 + Math.floor(rng() * 3) : 0
+    let nextTap = 0.18 + rng() * 0.28
+
+    while (nextTap < SEASONS_DURATION) {
+      while (seasonIndex < schedule.length && schedule[seasonIndex].at <= nextTap) {
+        season = schedule[seasonIndex++].season
+        winterInertia = season === 'winter' ? 1 + Math.floor(rng() * 3) : 0
+      }
+      while (boxIndex < SEASON_BOX_TIMES.length && SEASON_BOX_TIMES[boxIndex] <= nextTap) {
+        if (rng() < opponent.boxChance) {
+          season = rerollSeason(seed ^ hash(opponent.id), boxIndex, season)
+          winterInertia = season === 'winter' ? 1 + Math.floor(rng() * 3) : 0
+        }
+        boxIndex += 1
+      }
+      if (season !== 'winter' || winterInertia > 0) {
+        rawTaps += 1
+        score += SEASONS[season].multiplier
+        if (season === 'winter') winterInertia -= 1
+      }
+      const fatigue = 1 - (nextTap / SEASONS_DURATION) * (opponent.id === 'nova' ? 0.14 : 0.07)
+      nextTap += 1 / Math.max(3, opponent.rate * fatigue * (0.92 + rng() * 0.16))
+      if (rng() > 0.965) nextTap += 0.12 + rng() * 0.22
+    }
+    return {
+      id: opponent.id,
+      name: opponent.name,
+      score: Number(score.toFixed(2)),
+      rawTaps,
+    }
+  })
+}

--- a/src/minigames/quickTapRace/QuickTapRaceCanvasGame.tsx
+++ b/src/minigames/quickTapRace/QuickTapRaceCanvasGame.tsx
@@ -28,7 +28,7 @@ import { useQuickTapRaceAudio } from '../../hooks/useQuickTapRaceAudio';
 import { resolveHybridAiScores } from '../../ai/competition/hybridScoreResolver';
 import { cryptoSeed } from '../../features/riskWheel/cryptoSpin';
 import { QuickTapRaceCanvasEngine } from './engine/quickTapRaceCanvasEngine';
-import type { QTREngineSnapshot } from './engine/types';
+import type { QTREngineSnapshot, QTRTimingDiagnostics } from './engine/types';
 import './QuickTapRaceCanvasGame.css';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -73,6 +73,16 @@ interface Props {
     precomputedScore: number;
     previousPR: number | null;
   }>;
+  /** Dev-only experiment hook. Ignored in production builds. */
+  experimental?: {
+    seed: number;
+    onFinish: (result: {
+      effectiveScore: number;
+      rawTaps: number;
+      modifiers: string[];
+      timing: QTRTimingDiagnostics;
+    }) => void;
+  };
 }
 
 // Stable empty-array sentinels.
@@ -99,6 +109,7 @@ export default function QuickTapRaceCanvasGame({
   onFinish,
   seed: _seed,
   autoStart = false,
+  experimental,
 }: Props) {
   const dispatch = useAppDispatch();
   const humanId = useAppSelector((s) => s.game.players.find((p) => p.isUser)?.id);
@@ -123,7 +134,11 @@ export default function QuickTapRaceCanvasGame({
   // In the LOH/POS path session.seed is already a fresh invocationSeed generated
   // by startMinigame, so determinism is preserved there.
   const [resolvedSeed] = useState(() =>
-    (session?.seed && session.seed !== 0) ? session.seed : cryptoSeed(),
+    import.meta.env.DEV && experimental
+      ? experimental.seed
+      : session?.seed && session.seed !== 0
+        ? session.seed
+        : cryptoSeed(),
   );
   const [resolvedDuration] = useState(() => session?.options.timeLimit ?? GAME_DURATION);
   const [resolvedAutoStart] = useState(() => autoStart);
@@ -132,6 +147,7 @@ export default function QuickTapRaceCanvasGame({
     players,
     humanId,
     onFinish,
+    experimental,
   });
   const latestAudioRef = useRef({
     playTap: () => {},
@@ -150,8 +166,9 @@ export default function QuickTapRaceCanvasGame({
       players,
       humanId,
       onFinish,
+      experimental,
     };
-  }, [session, players, humanId, onFinish]);
+  }, [session, players, humanId, onFinish, experimental]);
 
   useEffect(() => {
     latestAudioRef.current = {
@@ -164,12 +181,26 @@ export default function QuickTapRaceCanvasGame({
   // ── Finish handler ─────────────────────────────────────────────────────────
 
   const handleEngineFinish = useCallback(
-    (finalScore: number, rawTaps: number, modifiers: string[]) => {
-      const { session: currentSession, players: currentPlayers, humanId: currentHumanId, onFinish: currentOnFinish } =
-        latestFinishContextRef.current;
+    (
+      finalScore: number,
+      rawTaps: number,
+      modifiers: string[],
+      timing: QTRTimingDiagnostics,
+    ) => {
+      const {
+        session: currentSession,
+        players: currentPlayers,
+        humanId: currentHumanId,
+        onFinish: currentOnFinish,
+        experimental: currentExperiment,
+      } = latestFinishContextRef.current;
       if (completionRef.current) return;
       completionRef.current = true;
       setAppliedModifiers(modifiers);
+
+      if (import.meta.env.DEV && currentExperiment) {
+        currentExperiment.onFinish({ effectiveScore: finalScore, rawTaps, modifiers, timing });
+      }
 
       if (currentSession) {
         // LOH/POS path — build full leaderboard and transition to results.
@@ -251,10 +282,12 @@ export default function QuickTapRaceCanvasGame({
     let engine: QuickTapRaceCanvasEngine | null = null;
 
     try {
-        engine = new QuickTapRaceCanvasEngine(canvas, {
+      engine = new QuickTapRaceCanvasEngine(canvas, {
         seed: resolvedSeed,
         duration: resolvedDuration,
         autoStart: resolvedAutoStart,
+        strictWallClock: Boolean(import.meta.env.DEV && experimental),
+        lowLatencyInput: Boolean(import.meta.env.DEV && experimental),
         onTick: (next) => {
           setSnapshot(next);
         },
@@ -321,7 +354,7 @@ export default function QuickTapRaceCanvasGame({
       engine?.destroy();
       return undefined;
     }
-  }, [handleEngineFinish, resolvedAutoStart, resolvedDuration, resolvedSeed]);
+  }, [experimental, handleEngineFinish, resolvedAutoStart, resolvedDuration, resolvedSeed]);
 
   // ── Pointer forwarding to engine ───────────────────────────────────────────
 
@@ -332,7 +365,11 @@ export default function QuickTapRaceCanvasGame({
     engineRef.current.handlePointerDown(e.pointerId, {
       x: e.clientX - rect.left,
       y: e.clientY - rect.top,
-    }, e.timeStamp);
+    }, e.timeStamp, performance.now(), e.pointerType);
+  }, []);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLCanvasElement>) => {
+    engineRef.current?.handlePointerUp(e.pointerId);
   }, []);
 
   // ── Derived HUD values ─────────────────────────────────────────────────────
@@ -508,6 +545,8 @@ export default function QuickTapRaceCanvasGame({
               data-testid="quick-tap-race-canvas"
               aria-label="Quick Tap Race canvas — tap the button as fast as possible"
               onPointerDown={handlePointerDown}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
             />
             {uiPhase === 'fallback' && (
               <div className="qtr-canvas__fallback" role="alert">

--- a/src/minigames/quickTapRace/engine/quickTapRaceCanvasEngine.ts
+++ b/src/minigames/quickTapRace/engine/quickTapRaceCanvasEngine.ts
@@ -6,6 +6,7 @@ import type {
   QTREngineSnapshot,
   QTRLayout,
   QTRParticle,
+  QTRTimingDiagnostics,
 } from './types';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -173,6 +174,28 @@ export class QuickTapRaceCanvasEngine {
 
   private finishReported = false;
 
+  private playingStartedAtMs: number | null = null;
+
+  private strictDeadlineMs: number | null = null;
+
+  private longestFrameMs = 0;
+
+  private staleTapsRejected = 0;
+
+  private afterDeadlineTapsRejected = 0;
+
+  private lastLowLatencyUiUpdateMs = 0;
+
+  private readonly acceptedTapTimesMs: number[] = [];
+
+  private readonly uniquePointerIds = new Set<number>();
+
+  private readonly activePointerIds = new Set<number>();
+
+  private maxConcurrentPointers = 0;
+
+  private readonly pointerTypeCounts: Record<string, number> = {};
+
   private readonly boosterTimeouts: ReturnType<typeof setTimeout>[] = [];
 
   constructor(canvas: HTMLCanvasElement, options: QTREngineOptions) {
@@ -244,12 +267,24 @@ export class QuickTapRaceCanvasEngine {
    * to the engine for hit testing against the tap button and booster prompt.
    */
   handlePointerDown(
-    _pointerId: number,
+    pointerId: number,
     point: { x: number; y: number },
     eventTimeStampMs?: number,
     nowMs: number = performance.now(),
+    pointerType = 'unknown',
   ): void {
     if (this.isDestroyed || this.phase !== 'playing') return;
+
+    if (
+      this.options.strictWallClock &&
+      this.strictDeadlineMs !== null &&
+      nowMs >= this.strictDeadlineMs
+    ) {
+      this.afterDeadlineTapsRejected += 1;
+      this.timeLeftMs = 0;
+      this.finishGame(nowMs);
+      return;
+    }
 
     // Ignore stale, backlogged taps that the browser delivered late after a
     // main-thread jank, so old taps don't "catch up" once the player has lifted
@@ -257,6 +292,7 @@ export class QuickTapRaceCanvasEngine {
     if (typeof eventTimeStampMs === 'number') {
       const latency = nowMs - eventTimeStampMs;
       if (latency > STALE_TAP_MIN_LATENCY_MS && latency < STALE_TAP_MAX_LATENCY_MS) {
+        this.staleTapsRejected += 1;
         return;
       }
     }
@@ -281,23 +317,48 @@ export class QuickTapRaceCanvasEngine {
     const dy = point.y - this.layout.tapBtnCy;
     const dist = Math.sqrt(dx * dx + dy * dy);
     if (dist <= this.layout.tapBtnRadius * 1.2) {
-      this.registerTap(point);
+      this.registerTap(pointerId, point, nowMs, pointerType);
     }
+  }
+
+  handlePointerUp(pointerId: number): void {
+    this.activePointerIds.delete(pointerId);
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
 
-  private registerTap(point: { x: number; y: number }): void {
+  private registerTap(
+    pointerId: number,
+    point: { x: number; y: number },
+    nowMs: number,
+    pointerType: string,
+  ): void {
     this.recentTapTimestamps.push(this.gameElapsedMs);
     this.lastTapMs = this.gameElapsedMs;
 
     const multiplier = this.activeMultiplier ?? 1;
     this.tapCount += 1;
     this.effectiveScore += multiplier;
+    this.acceptedTapTimesMs.push(nowMs);
+    this.uniquePointerIds.add(pointerId);
+    this.activePointerIds.add(pointerId);
+    this.maxConcurrentPointers = Math.max(this.maxConcurrentPointers, this.activePointerIds.size);
+    const normalizedPointerType = pointerType || 'unknown';
+    this.pointerTypeCounts[normalizedPointerType] =
+      (this.pointerTypeCounts[normalizedPointerType] ?? 0) + 1;
 
-    this.spawnParticles(point.x, point.y);
-    this.options.onTap?.();
-    this.emitTick();
+    if (this.options.lowLatencyInput) {
+      // Keep the hot path light enough that the measurement does not create its
+      // own event backlog. Canvas feedback still renders on the regular RAF.
+      if (this.gameElapsedMs - this.lastLowLatencyUiUpdateMs >= 100) {
+        this.lastLowLatencyUiUpdateMs = this.gameElapsedMs;
+        this.emitTick();
+      }
+    } else {
+      this.spawnParticles(point.x, point.y);
+      this.options.onTap?.();
+      this.emitTick();
+    }
   }
 
   private activateBooster(booster: ScheduledBoosterPrompt): void {
@@ -305,6 +366,9 @@ export class QuickTapRaceCanvasEngine {
 
     if (booster.kind === 'time' && typeof booster.timeDelta === 'number') {
       this.timeLeftMs = Math.max(0, this.timeLeftMs + booster.timeDelta * 1000);
+      if (this.options.strictWallClock && this.strictDeadlineMs !== null) {
+        this.strictDeadlineMs += booster.timeDelta * 1000;
+      }
       this.appliedModifiers.push(booster.label);
     } else if (booster.kind === 'multiplier' && typeof booster.multiplier === 'number') {
       this.activeMultiplier = booster.multiplier;
@@ -339,6 +403,10 @@ export class QuickTapRaceCanvasEngine {
 
   private startPlaying(): void {
     this.phase = 'playing';
+    this.playingStartedAtMs = performance.now();
+    if (this.options.strictWallClock) {
+      this.strictDeadlineMs = this.playingStartedAtMs + this.timeLeftMs;
+    }
     this.scheduleBoosterPrompts();
     this.emitTick();
   }
@@ -371,7 +439,7 @@ export class QuickTapRaceCanvasEngine {
     });
   }
 
-  private finishGame(): void {
+  private finishGame(nowMs: number = performance.now()): void {
     if (this.finishReported) return;
     this.finishReported = true;
     this.phase = 'finished';
@@ -384,10 +452,47 @@ export class QuickTapRaceCanvasEngine {
     this.boosterTimeouts.length = 0;
     this.visibleBooster = null;
     this.render();
+    const wallClockElapsedMs =
+      this.playingStartedAtMs === null ? 0 : Math.max(0, nowMs - this.playingStartedAtMs);
+    const intervals = this.acceptedTapTimesMs
+      .slice(1)
+      .map((time, index) => Math.max(0, time - this.acceptedTapTimesMs[index]))
+      .sort((left, right) => left - right);
+    let peakOneSecondTaps = 0;
+    let windowStart = 0;
+    for (let windowEnd = 0; windowEnd < this.acceptedTapTimesMs.length; windowEnd += 1) {
+      while (
+        this.acceptedTapTimesMs[windowEnd] - this.acceptedTapTimesMs[windowStart] >= 1000
+      ) {
+        windowStart += 1;
+      }
+      peakOneSecondTaps = Math.max(peakOneSecondTaps, windowEnd - windowStart + 1);
+    }
+    const averageTapsPerSecond =
+      wallClockElapsedMs > 0 ? this.tapCount / (wallClockElapsedMs / 1000) : 0;
+    const medianInterTapMs =
+      intervals.length === 0 ? null : intervals[Math.floor(intervals.length / 2)];
+    const fastestInterTapMs = intervals.length === 0 ? null : intervals[0];
+    const timing: QTRTimingDiagnostics = {
+      wallClockElapsedMs,
+      longestFrameMs: this.longestFrameMs,
+      staleTapsRejected: this.staleTapsRejected,
+      afterDeadlineTapsRejected: this.afterDeadlineTapsRejected,
+      averageTapsPerSecond: Number(averageTapsPerSecond.toFixed(2)),
+      peakOneSecondTaps,
+      medianInterTapMs: medianInterTapMs === null ? null : Number(medianInterTapMs.toFixed(1)),
+      fastestInterTapMs: fastestInterTapMs === null ? null : Number(fastestInterTapMs.toFixed(1)),
+      uniquePointerCount: this.uniquePointerIds.size,
+      maxConcurrentPointers: this.maxConcurrentPointers,
+      pointerTypeCounts: { ...this.pointerTypeCounts },
+      inputRateFlag:
+        averageTapsPerSecond > 12 || peakOneSecondTaps > 14 ? 'high-rate-review' : 'typical',
+    };
     this.options.onFinish(
       Math.round(this.effectiveScore),
       this.tapCount,
       [...this.appliedModifiers],
+      timing,
     );
   }
 
@@ -404,7 +509,8 @@ export class QuickTapRaceCanvasEngine {
     }
     if (this.lastTimestamp === 0) this.lastTimestamp = timestamp;
     const rawDt = Math.max(0, timestamp - this.lastTimestamp || 16.67);
-    const dt = Math.min(48, rawDt);
+    this.longestFrameMs = Math.max(this.longestFrameMs, rawDt);
+    const dt = this.options.strictWallClock ? rawDt : Math.min(48, rawDt);
     this.lastTimestamp = timestamp;
     this.update(dt);
     this.render();

--- a/src/minigames/quickTapRace/engine/types.ts
+++ b/src/minigames/quickTapRace/engine/types.ts
@@ -55,6 +55,21 @@ export interface QTREngineSnapshot {
   visibleBooster: ScheduledBoosterPrompt | null;
 }
 
+export interface QTRTimingDiagnostics {
+  wallClockElapsedMs: number;
+  longestFrameMs: number;
+  staleTapsRejected: number;
+  afterDeadlineTapsRejected: number;
+  averageTapsPerSecond: number;
+  peakOneSecondTaps: number;
+  medianInterTapMs: number | null;
+  fastestInterTapMs: number | null;
+  uniquePointerCount: number;
+  maxConcurrentPointers: number;
+  pointerTypeCounts: Record<string, number>;
+  inputRateFlag: 'typical' | 'high-rate-review';
+}
+
 // ── Options ───────────────────────────────────────────────────────────────────
 
 export interface QTREngineOptions {
@@ -63,10 +78,19 @@ export interface QTREngineOptions {
   duration?: number;
   /** When true the ready countdown is skipped entirely. */
   autoStart?: boolean;
+  /** Dev-lab mode: the deadline follows elapsed wall time even when rendering stalls. */
+  strictWallClock?: boolean;
+  /** Dev-lab mode: reduce per-tap rendering/audio/state work while measuring input speed. */
+  lowLatencyInput?: boolean;
   /** Fired on every meaningful state change. */
   onTick: (snapshot: QTREngineSnapshot) => void;
   /** Fired when the game timer reaches zero. */
-  onFinish: (finalScore: number, rawTaps: number, modifiers: string[]) => void;
+  onFinish: (
+    finalScore: number,
+    rawTaps: number,
+    modifiers: string[],
+    timing: QTRTimingDiagnostics,
+  ) => void;
   /** Audio callback: fired on every player tap. */
   onTap?: () => void;
   /** Audio callback: fired when a booster is activated. */

--- a/src/minigames/reactComponents.ts
+++ b/src/minigames/reactComponents.ts
@@ -33,6 +33,7 @@ import ClosestWithoutGoingOverComp from '../components/ClosestWithoutGoingOverCo
 import HoldTheWallComp from '../components/HoldTheWallComp/HoldTheWallComp';
 import CastleRescueGame, { BennyLennyCastleRescueGame } from './castleRescue/CastleRescueGame';
 import QuickTapRace from './quickTapRace/QuickTapRaceCanvasGame';
+import QuickTapSeasons from '../screens/QuickTapSeasons/QuickTapSeasons';
 import LaneRacers from './laneRacers/LaneRacersCanvasGame';
 import TravelingDots from '../components/TravelingDots/TravelingDots';
 import EstimationGame from '../components/EstimationGame/EstimationGame';
@@ -96,6 +97,7 @@ const reactComponents: Record<string, ComponentType<GenericMinigameProps>> = {
   CastleRescue: CastleRescueGame as ComponentType<GenericMinigameProps>,
   CastleRescue2: BennyLennyCastleRescueGame as ComponentType<GenericMinigameProps>,
   QuickTapRace: QuickTapRace as ComponentType<GenericMinigameProps>,
+  QuickTapSeasons: QuickTapSeasons as ComponentType<GenericMinigameProps>,
   LaneRacers: LaneRacers as ComponentType<GenericMinigameProps>,
   TravelingDots: TravelingDots as ComponentType<GenericMinigameProps>,
   EstimationGame: EstimationGame as ComponentType<GenericMinigameProps>,

--- a/src/minigames/registryBase.ts
+++ b/src/minigames/registryBase.ts
@@ -148,6 +148,36 @@ const REGISTRY: Record<string, GameRegistryEntry> = {
     retired: false,
   },
 
+  quickTapSeasons: {
+    key: 'quickTapSeasons',
+    // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+    title: 'Quick Tap Race 2: Seasons',
+    description:
+      // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+      'Race through a shifting year where every season changes the rhythm and value of your taps.',
+    instructions: [
+      // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+      'Wait for the start signal, then tap the play area as quickly as you can.',
+      // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+      'Adapt when the season changes because each one affects your score differently.',
+      // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+      'Open mystery boxes to transform the race conditions.',
+      // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+      'Keep tapping until the 40-second race ends. The highest score wins.',
+    ],
+    metricKind: 'points',
+    metricLabel: 'Points', // i18n-ignore: Minigame registry metadata is localized centrally once the shared rules modal supports translation keys.
+    timeLimitMs: 40_000,
+    authoritative: false,
+    scoringAdapter: 'raw',
+    implementation: 'react' as const,
+    reactComponentKey: 'QuickTapSeasons',
+    legacy: false,
+    weight: 1,
+    category: 'arcade',
+    retired: false,
+  },
+
   laneRacers: {
     key: 'laneRacers',
     title: 'Lane Racers',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -110,6 +110,11 @@ const FindYourTwin2 = import.meta.env.DEV
   ? lazy(() => import('./screens/FindYourTwin2/FindYourTwin2'))
   : null
 
+// Dev-only, fully isolated Quick Tap AI experiment.
+const QuickTapExperiment = import.meta.env.DEV
+  ? lazy(() => import('./screens/QuickTapExperiment/QuickTapExperiment'))
+  : null
+
 export const router = createHashRouter([
   {
     path: '/cinematic',
@@ -305,6 +310,18 @@ export const router = createHashRouter([
               element: (
                 <Suspense fallback={null}>
                   <FindYourTwin2 />
+                </Suspense>
+              ),
+            },
+          ]
+        : []),
+      ...(import.meta.env.DEV && QuickTapExperiment != null
+        ? [
+            {
+              path: 'quick-tap-experiment',
+              element: (
+                <Suspense fallback={null}>
+                  <QuickTapExperiment />
                 </Suspense>
               ),
             },

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -115,6 +115,11 @@ const QuickTapExperiment = import.meta.env.DEV
   ? lazy(() => import('./screens/QuickTapExperiment/QuickTapExperiment'))
   : null
 
+// Dev-only direct route for tuning the Seasons spin-off.
+const QuickTapSeasons = import.meta.env.DEV
+  ? lazy(() => import('./screens/QuickTapSeasons/QuickTapSeasons'))
+  : null
+
 export const router = createHashRouter([
   {
     path: '/cinematic',
@@ -322,6 +327,18 @@ export const router = createHashRouter([
               element: (
                 <Suspense fallback={null}>
                   <QuickTapExperiment />
+                </Suspense>
+              ),
+            },
+          ]
+        : []),
+      ...(import.meta.env.DEV && QuickTapSeasons != null
+        ? [
+            {
+              path: 'quick-tap-seasons',
+              element: (
+                <Suspense fallback={null}>
+                  <QuickTapSeasons />
                 </Suspense>
               ),
             },

--- a/src/screens/QuickTapExperiment/QuickTapExperiment.css
+++ b/src/screens/QuickTapExperiment/QuickTapExperiment.css
@@ -1,0 +1,187 @@
+.qtr-experiment {
+  min-height: 100%;
+  box-sizing: border-box;
+  overflow: auto;
+  padding: 32px 18px 72px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(124, 58, 237, 0.3), transparent 34%),
+    radial-gradient(circle at 90% 18%, rgba(249, 115, 22, 0.18), transparent 30%), #080b14;
+  color: #f8fafc;
+}
+
+.qtr-experiment__hero,
+.qtr-experiment__panel,
+.qtr-experiment__traces,
+.qtr-experiment__reveal {
+  width: min(760px, 100%);
+  margin: 0 auto;
+}
+
+.qtr-experiment__hero h1 {
+  margin: 6px 0 10px;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  line-height: 0.98;
+}
+
+.qtr-experiment__hero > p:last-child {
+  max-width: 620px;
+  color: #cbd5e1;
+  line-height: 1.6;
+}
+
+.qtr-experiment__eyebrow {
+  margin: 0;
+  color: #a78bfa;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.qtr-experiment__panel,
+.qtr-experiment__traces article,
+.qtr-experiment__reveal {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.34);
+}
+
+.qtr-experiment__panel {
+  display: grid;
+  gap: 16px;
+  margin-top: 28px;
+  padding: 24px;
+  border-radius: 24px;
+}
+
+.qtr-experiment__panel label {
+  display: grid;
+  gap: 7px;
+  color: #cbd5e1;
+  font-weight: 700;
+}
+
+.qtr-experiment__panel input,
+.qtr-experiment__panel select {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 13px;
+  background: #111827;
+  color: #f8fafc;
+  padding: 12px 14px;
+  font: inherit;
+}
+
+.qtr-experiment__start,
+.qtr-experiment__secondary {
+  border: 0;
+  border-radius: 13px;
+  padding: 13px 16px;
+  color: white;
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+.qtr-experiment__start {
+  background: linear-gradient(135deg, #7c3aed, #ea580c);
+}
+.qtr-experiment__secondary {
+  background: rgba(255, 255, 255, 0.09);
+}
+.qtr-experiment__hint {
+  margin: -8px 0 0;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+.qtr-experiment__boosters {
+  display: grid;
+  gap: 5px;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(96, 165, 250, 0.1);
+  color: #bfdbfe;
+}
+
+.qtr-experiment__standings {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.qtr-experiment__standings li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3px 12px;
+  padding: 13px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.05);
+}
+.qtr-experiment__standings small {
+  grid-column: 1 / -1;
+  color: #94a3b8;
+}
+.qtr-experiment__standings .qtr-experiment__human {
+  outline: 1px solid #a78bfa;
+  background: rgba(124, 58, 237, 0.14);
+}
+.qtr-experiment__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.qtr-experiment__traces {
+  margin-top: 30px;
+}
+.qtr-experiment__traces article {
+  margin-top: 12px;
+  padding: 18px;
+  border-radius: 18px;
+}
+.qtr-experiment__traces h3 {
+  margin: 0 0 12px;
+}
+.qtr-experiment__traces dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+.qtr-experiment__traces dl div {
+  padding: 10px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.045);
+}
+.qtr-experiment__traces dt {
+  color: #94a3b8;
+  font-size: 0.78rem;
+}
+.qtr-experiment__traces dd {
+  margin: 3px 0 0;
+  font-weight: 800;
+}
+.qtr-experiment__traces ul {
+  margin-bottom: 0;
+  padding-left: 20px;
+  color: #cbd5e1;
+}
+.qtr-experiment__reveal {
+  margin-top: 18px;
+  padding: 16px 20px;
+  border-radius: 16px;
+}
+
+@media (max-width: 560px) {
+  .qtr-experiment {
+    padding-inline: 12px;
+  }
+  .qtr-experiment__panel {
+    padding: 18px;
+  }
+  .qtr-experiment__traces dl {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/screens/QuickTapExperiment/QuickTapExperiment.tsx
+++ b/src/screens/QuickTapExperiment/QuickTapExperiment.tsx
@@ -1,0 +1,300 @@
+import { useMemo, useState } from 'react'
+import QuickTapRace from '../../components/QuickTapRace/QuickTapRace'
+import type { QTRTimingDiagnostics } from '../../minigames/quickTapRace/engine/types'
+import { selectBoosterPrompts } from '../../ai/competition/quickTapSimulation'
+import {
+  QUICK_TAP_PHONE_BASELINE,
+  simulateHumanlikeQuickTapField,
+  type QuickTapExperimentDifficulty,
+  type QuickTapHumanAiResult,
+} from '../../experiments/quickTapHumanAi/quickTapHumanAi'
+import './QuickTapExperiment.css'
+
+interface HumanResult {
+  effectiveScore: number
+  rawTaps: number
+  modifiers: string[]
+  timing: QTRTimingDiagnostics
+}
+
+const DIFFICULTY_COPY: Record<QuickTapExperimentDifficulty, string> = {
+  friendly: 'Uses 85% of the existing fixed-band target.',
+  balanced: 'Uses 110% of the existing fixed-band target.',
+  competitive: 'Uses 123% of the existing fixed-band target.',
+}
+
+function freshSeed(): number {
+  return Math.floor(Math.random() * 2_000_000_000)
+}
+
+export default function QuickTapExperiment() {
+  const [seed, setSeed] = useState(424242)
+  const [difficulty, setDifficulty] = useState<QuickTapExperimentDifficulty>('balanced')
+  const [forceAllBoosters, setForceAllBoosters] = useState(true)
+  const [phase, setPhase] = useState<'setup' | 'playing' | 'results'>('setup')
+  const [runKey, setRunKey] = useState(0)
+  const [aiResults, setAiResults] = useState<QuickTapHumanAiResult[]>([])
+  const [humanResult, setHumanResult] = useState<HumanResult | null>(null)
+
+  const boosters = useMemo(() => selectBoosterPrompts(seed), [seed])
+
+  const startRun = () => {
+    setAiResults(simulateHumanlikeQuickTapField(seed, difficulty, { forceAllBoosters }))
+    setHumanResult(null)
+    setRunKey((current) => current + 1)
+    setPhase('playing')
+  }
+
+  const standings = useMemo(() => {
+    if (!humanResult) return []
+    return [
+      {
+        id: 'human',
+        name: 'You',
+        score: humanResult.effectiveScore,
+        rawTaps: humanResult.rawTaps,
+        isHuman: true,
+      },
+      ...aiResults.map((result) => ({
+        id: result.id,
+        name: result.name,
+        score: result.effectiveScore,
+        rawTaps: result.rawTaps,
+        isHuman: false,
+      })),
+    ].sort((left, right) => right.score - left.score)
+  }, [aiResults, humanResult])
+
+  if (phase === 'playing') {
+    return (
+      <QuickTapRace
+        key={runKey}
+        seed={seed}
+        onFinish={() => {}}
+        experimental={{
+          seed,
+          onFinish: ({ effectiveScore, rawTaps, modifiers, timing }) => {
+            setHumanResult({ effectiveScore, rawTaps, modifiers, timing })
+            setPhase('results')
+          },
+        }}
+      />
+    )
+  }
+
+  return (
+    <main className="qtr-experiment" data-testid="quick-tap-experiment">
+      <section className="qtr-experiment__hero">
+        <p className="qtr-experiment__eyebrow">Dev-only sandbox · production unchanged</p>
+        <h1>Quick Tap: Human AI Lab</h1>
+        <p>
+          Existing fixed bands set each opponent&apos;s target. The lab then checks whether
+          human-like taps, pauses, fatigue, and booster decisions can honestly reproduce it. Human
+          input uses a low-lag measurement path and a strict wall-clock deadline.
+        </p>
+      </section>
+
+      {phase === 'setup' ? (
+        <section className="qtr-experiment__panel" aria-label="Experiment setup">
+          <label>
+            <span>Shared seed</span>
+            <input
+              aria-label="Shared seed"
+              type="number"
+              value={seed}
+              onChange={(event) =>
+                setSeed(Math.max(0, Math.trunc(event.currentTarget.valueAsNumber || 0)))
+              }
+            />
+          </label>
+          <button
+            type="button"
+            className="qtr-experiment__secondary"
+            onClick={() => setSeed(freshSeed())}
+          >
+            New seed
+          </button>
+
+          <label>
+            <span>AI field</span>
+            <select
+              aria-label="AI field"
+              value={difficulty}
+              onChange={(event) =>
+                setDifficulty(event.currentTarget.value as QuickTapExperimentDifficulty)
+              }
+            >
+              <option value="friendly">Friendly</option>
+              <option value="balanced">Balanced</option>
+              <option value="competitive">Competitive</option>
+            </select>
+          </label>
+          <p className="qtr-experiment__hint">{DIFFICULTY_COPY[difficulty]}</p>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={forceAllBoosters}
+              onChange={(event) => setForceAllBoosters(event.currentTarget.checked)}
+            />
+            <span>AIs take all three mystery boxes</span>
+          </label>
+          {forceAllBoosters && (
+            <p className="qtr-experiment__hint">
+              Controlled booster test: collect all three boxes yourself for an equal comparison.
+            </p>
+          )}
+
+          <div className="qtr-experiment__boosters" aria-label="Shared mystery sequence">
+            <strong>Shared mystery sequence</strong>
+            <span>All four racers receive prompts at 6s, 15s, and 23s from this seed.</span>
+          </div>
+
+          <div className="qtr-experiment__boosters" aria-label="Phone calibration anchor">
+            <strong>Strong-phone anchor</strong>
+            <span>
+              {QUICK_TAP_PHONE_BASELINE.sustainedTapsPerSecond} sustained taps/s ·{' '}
+              {QUICK_TAP_PHONE_BASELINE.peakOneSecondTaps} peak taps in 1s ·{' '}
+              {QUICK_TAP_PHONE_BASELINE.medianInterTapMs}ms median gap
+            </span>
+          </div>
+
+          <button type="button" className="qtr-experiment__start" onClick={startRun}>
+            Start experimental race
+          </button>
+        </section>
+      ) : (
+        <>
+          <section className="qtr-experiment__panel" aria-label="Experiment results">
+            <p className="qtr-experiment__eyebrow">
+              Seed {seed} · {difficulty}
+              {forceAllBoosters ? ' · all boxes controlled' : ''}
+            </p>
+            <h2>
+              {standings[0]?.isHuman ? 'You won the experiment' : `${standings[0]?.name} won`}
+            </h2>
+            <ol className="qtr-experiment__standings">
+              {standings.map((entry, index) => (
+                <li key={entry.id} className={entry.isHuman ? 'qtr-experiment__human' : ''}>
+                  <span>
+                    {index + 1}. {entry.name}
+                  </span>
+                  <strong>{entry.score} pts</strong>
+                  <small>{entry.rawTaps} raw taps</small>
+                </li>
+              ))}
+            </ol>
+            {humanResult && (
+              <div className="qtr-experiment__human-audit">
+                <p className="qtr-experiment__hint">
+                  Your revealed effects:{' '}
+                  {humanResult.modifiers.length > 0
+                    ? humanResult.modifiers.join(', ')
+                    : 'none taken'}
+                </p>
+                <p className="qtr-experiment__hint">
+                  Input timing audit: {(humanResult.timing.wallClockElapsedMs / 1000).toFixed(2)}s
+                  elapsed · longest frame {humanResult.timing.longestFrameMs.toFixed(0)}ms ·{' '}
+                  {humanResult.timing.staleTapsRejected} queued taps rejected ·{' '}
+                  {humanResult.timing.afterDeadlineTapsRejected} late taps rejected
+                </p>
+                <p className="qtr-experiment__hint">
+                  Input profile: {humanResult.timing.averageTapsPerSecond.toFixed(2)} taps/s average
+                  · {humanResult.timing.peakOneSecondTaps} peak taps in 1s · median gap{' '}
+                  {humanResult.timing.medianInterTapMs?.toFixed(1) ?? '—'}ms · fastest gap{' '}
+                  {humanResult.timing.fastestInterTapMs?.toFixed(1) ?? '—'}ms
+                </p>
+                <p className="qtr-experiment__hint">
+                  Pointer profile: {humanResult.timing.uniquePointerCount} pointer IDs · max{' '}
+                  {humanResult.timing.maxConcurrentPointers} simultaneous ·{' '}
+                  {Object.entries(humanResult.timing.pointerTypeCounts)
+                    .map(([type, count]) => `${type}: ${count}`)
+                    .join(', ') || 'unknown'}{' '}
+                  ·{' '}
+                  {humanResult.timing.inputRateFlag === 'typical'
+                    ? 'typical rate'
+                    : 'high rate — review only'}
+                </p>
+              </div>
+            )}
+            <div className="qtr-experiment__actions">
+              <button type="button" className="qtr-experiment__start" onClick={startRun}>
+                Replay same seed
+              </button>
+              <button
+                type="button"
+                className="qtr-experiment__secondary"
+                onClick={() => {
+                  setSeed(freshSeed())
+                  setPhase('setup')
+                }}
+              >
+                Configure new race
+              </button>
+            </div>
+          </section>
+
+          <section className="qtr-experiment__traces" aria-label="AI behavior report">
+            <h2>AI behavior report</h2>
+            {aiResults.map((result) => (
+              <article key={result.id}>
+                <h3>{result.name}</h3>
+                <dl>
+                  <div>
+                    <dt>Opening reaction</dt>
+                    <dd>{result.openingReactionMs} ms</dd>
+                  </div>
+                  <div>
+                    <dt>Average rhythm</dt>
+                    <dd>{result.averageTapsPerSecond} taps/s</dd>
+                  </div>
+                  <div>
+                    <dt>Fixed-band target</dt>
+                    <dd>{result.bandTargetScore} pts</dd>
+                  </div>
+                  <div>
+                    <dt>Simulation audit</dt>
+                    <dd>
+                      {result.targetReached
+                        ? `credible (${result.scoreGap >= 0 ? '+' : ''}${result.scoreGap})`
+                        : `unreachable (${result.scoreGap >= 0 ? '+' : ''}${result.scoreGap})`}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Race time</dt>
+                    <dd>{(result.elapsedMs / 1000).toFixed(0)} s</dd>
+                  </div>
+                  <div>
+                    <dt>Trace actions</dt>
+                    <dd>{result.actions.length}</dd>
+                  </div>
+                </dl>
+                <ul>
+                  {result.boosters.map((booster, index) => (
+                    <li key={`${booster.type}-${index}`}>
+                      {index + 1}:{' '}
+                      {booster.taken ? `took after ${booster.reactionMs} ms` : 'skipped'} — revealed{' '}
+                      {booster.type}
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </section>
+
+          <details className="qtr-experiment__reveal">
+            <summary>Reveal the shared booster order</summary>
+            <ol>
+              {boosters.map((booster) => (
+                <li key={`${booster.scheduleAt}-${booster.type}`}>
+                  {booster.scheduleAt}s: {booster.label} (
+                  {booster.beneficial ? 'beneficial' : 'harmful'})
+                </li>
+              ))}
+            </ol>
+          </details>
+        </>
+      )}
+    </main>
+  )
+}

--- a/src/screens/QuickTapSeasons/QuickTapSeasons.css
+++ b/src/screens/QuickTapSeasons/QuickTapSeasons.css
@@ -1,0 +1,260 @@
+.qts {
+  --a: #86efac;
+  --b: #38bdf8;
+  --bg: #07111c;
+  min-height: 100%;
+  box-sizing: border-box;
+  overflow: auto;
+  padding: 28px 14px 80px;
+  background:
+    radial-gradient(
+      circle at 50% -10%,
+      color-mix(in srgb, var(--a) 35%, transparent),
+      transparent 42%
+    ),
+    var(--bg);
+  color: #f8fafc;
+  transition: background 0.5s;
+}
+.qts--winter {
+  --a: #bae6fd;
+  --b: #e0f2fe;
+  --bg: #071827;
+}
+.qts--summer {
+  --a: #facc15;
+  --b: #fb7185;
+  --bg: #281306;
+}
+.qts--autumn {
+  --a: #fb923c;
+  --b: #dc2626;
+  --bg: #211007;
+}
+.qts--spring {
+  --a: #86efac;
+  --b: #f9a8d4;
+  --bg: #071b16;
+}
+.qts__weather {
+  width: min(720px, 100%);
+  margin: 0 auto 10px;
+  text-align: center;
+  font-size: 1.5rem;
+  letter-spacing: 1.2rem;
+}
+.qts__card {
+  width: min(720px, 100%);
+  box-sizing: border-box;
+  margin: auto;
+  padding: 24px;
+  border: 1px solid color-mix(in srgb, var(--a) 28%, transparent);
+  border-radius: 26px;
+  background: rgba(7, 12, 24, 0.9);
+  box-shadow: 0 28px 80px #0007;
+}
+.qts__eyebrow {
+  margin: 0;
+  color: var(--a);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.qts h1 {
+  margin: 6px 0 12px;
+  font-size: clamp(2rem, 8vw, 3.4rem);
+  line-height: 0.98;
+}
+.qts__intro {
+  color: #cbd5e1;
+  line-height: 1.55;
+}
+.qts__rules {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 22px 0;
+}
+.qts__rules div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  padding: 12px;
+  border-radius: 14px;
+  background: #ffffff0e;
+}
+.qts__rules div > span {
+  grid-row: 1/3;
+  font-size: 1.55rem;
+}
+.qts small,
+.qts__rules small {
+  color: #94a3b8;
+}
+.qts__seed {
+  display: grid;
+  gap: 6px;
+  font-weight: 800;
+}
+.qts__seed input {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid #ffffff24;
+  border-radius: 12px;
+  padding: 12px;
+  background: #0f172a;
+  color: white;
+  font: inherit;
+}
+.qts__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 18px;
+}
+.qts button {
+  border: 0;
+  border-radius: 14px;
+  padding: 13px 17px;
+  background: #ffffff1a;
+  color: white;
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.qts button.qts__primary {
+  flex: 1;
+  color: #08111c;
+  background: linear-gradient(135deg, var(--a), var(--b));
+}
+.qts__hud {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr 1fr;
+  gap: 8px;
+  margin-top: 20px;
+}
+.qts__hud > div {
+  display: grid;
+  place-items: center;
+  padding: 10px;
+  border-radius: 14px;
+  background: #ffffff0e;
+}
+.qts__hud strong {
+  font-size: 1.3rem;
+}
+.qts__hud span {
+  font-size: 1.5rem;
+}
+.qts__progress {
+  height: 7px;
+  margin: 14px 0;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #ffffff14;
+}
+.qts__progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--a), var(--b));
+}
+.qts__arena {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 390px;
+  overflow: hidden;
+  border-radius: 24px;
+  background:
+    radial-gradient(circle, color-mix(in srgb, var(--a) 22%, transparent), transparent 55%),
+    #ffffff09;
+}
+.qts__tap {
+  width: 190px;
+  height: 190px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  border-radius: 50% !important;
+  color: #08111c !important;
+  background: linear-gradient(145deg, var(--a), var(--b)) !important;
+  box-shadow: 0 18px 50px color-mix(in srgb, var(--a) 36%, transparent);
+  font-size: 2.3rem !important;
+  user-select: none;
+}
+.qts__tap:active {
+  transform: scale(0.96);
+}
+.qts__tap span {
+  font-size: 2.2rem;
+}
+.qts__mystery {
+  position: absolute;
+  z-index: 4;
+  top: 18px;
+  background: linear-gradient(135deg, #7c3aed, #ec4899) !important;
+  animation: qts-pop 0.6s ease-in-out infinite alternate;
+}
+.qts__leaf {
+  position: absolute;
+  z-index: 3;
+  bottom: 34%;
+  font-size: 1.5rem;
+  pointer-events: none;
+  animation: qts-leaf 0.9s ease-out forwards;
+}
+.qts__raw {
+  text-align: center;
+  color: #94a3b8;
+}
+.qts__standings {
+  display: grid;
+  gap: 10px;
+  margin: 18px 0;
+  padding: 0;
+  list-style: none;
+}
+.qts__standings li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 12px;
+  padding: 14px;
+  border-radius: 14px;
+  background: #ffffff0e;
+}
+.qts__standings small {
+  grid-column: 1/-1;
+}
+.qts__standings .qts__human {
+  outline: 2px solid var(--a);
+}
+@keyframes qts-pop {
+  to {
+    transform: translateY(4px) scale(1.03);
+  }
+}
+@keyframes qts-leaf {
+  to {
+    opacity: 0;
+    transform: translate(35px, -170px) rotate(260deg);
+  }
+}
+@media (max-width: 520px) {
+  .qts {
+    padding-inline: 9px;
+  }
+  .qts__card {
+    padding: 17px;
+  }
+  .qts__rules {
+    grid-template-columns: 1fr;
+  }
+  .qts__arena {
+    min-height: 350px;
+  }
+  .qts__tap {
+    width: 170px;
+    height: 170px;
+  }
+}

--- a/src/screens/QuickTapSeasons/QuickTapSeasons.tsx
+++ b/src/screens/QuickTapSeasons/QuickTapSeasons.tsx
@@ -1,0 +1,276 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  SEASON_BOX_TIMES,
+  SEASONS,
+  SEASONS_DURATION,
+  buildSeasonSchedule,
+  rerollSeason,
+  simulateSeasonsAiField,
+  type TapSeason,
+} from '../../experiments/quickTapSeasons/quickTapSeasons'
+import './QuickTapSeasons.css'
+import type { GenericMinigameProps } from '../../minigames/reactComponents'
+
+type Phase = 'ready' | 'playing' | 'results'
+type Leaf = { id: number; x: number; glyph: string }
+const scoreText = (value: number) =>
+  Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/0+$/, '')
+
+export default function QuickTapSeasons({
+  seed: competitionSeed,
+  autoStart = false,
+  participants,
+  onFinish,
+}: GenericMinigameProps = {}) {
+  const [seed, setSeed] = useState(competitionSeed ?? 20260802)
+  const [phase, setPhase] = useState<Phase>('ready')
+  const [season, setSeason] = useState<TapSeason>('spring')
+  const [timeLeft, setTimeLeft] = useState(SEASONS_DURATION)
+  const [rawTaps, setRawTaps] = useState(0)
+  const [score, setScore] = useState(0)
+  const [visibleBox, setVisibleBox] = useState<number | null>(null)
+  const [leaves, setLeaves] = useState<Leaf[]>([])
+  const seasonRef = useRef<TapSeason>('spring')
+  const phaseRef = useRef<Phase>('ready')
+  const startAt = useRef(0)
+  const raf = useRef(0)
+  const seasonIndex = useRef(1)
+  const usedBoxes = useRef(new Set<number>())
+  const leafId = useRef(0)
+  const scoreRef = useRef(0)
+  const schedule = useMemo(() => buildSeasonSchedule(seed), [seed])
+  const aiResults = useMemo(() => simulateSeasonsAiField(seed), [seed])
+  const details = SEASONS[season]
+
+  const changeSeason = useCallback((next: TapSeason) => {
+    seasonRef.current = next
+    setSeason(next)
+  }, [])
+
+  const finish = useCallback(() => {
+    phaseRef.current = 'results'
+    setPhase('results')
+    setTimeLeft(0)
+    setVisibleBox(null)
+    cancelAnimationFrame(raf.current)
+    onFinish?.(scoreRef.current)
+  }, [onFinish])
+
+  const tick = useCallback(
+    (now: number) => {
+      if (phaseRef.current !== 'playing') return
+      const elapsed = (now - startAt.current) / 1000
+      if (elapsed >= SEASONS_DURATION) return finish()
+      setTimeLeft(SEASONS_DURATION - elapsed)
+      while (seasonIndex.current < schedule.length && schedule[seasonIndex.current].at <= elapsed) {
+        changeSeason(schedule[seasonIndex.current++].season)
+      }
+      const nextBox = SEASON_BOX_TIMES.findIndex(
+        (at, index) => !usedBoxes.current.has(index) && elapsed >= at && elapsed < at + 4
+      )
+      setVisibleBox(nextBox < 0 ? null : nextBox)
+      raf.current = requestAnimationFrame(tick)
+    },
+    [changeSeason, finish, schedule]
+  )
+
+  const start = () => {
+    phaseRef.current = 'playing'
+    seasonIndex.current = 1
+    usedBoxes.current = new Set()
+    changeSeason(schedule[0].season)
+    setRawTaps(0)
+    setScore(0)
+    scoreRef.current = 0
+    setLeaves([])
+    setVisibleBox(null)
+    setTimeLeft(SEASONS_DURATION)
+    setPhase('playing')
+    startAt.current = performance.now()
+    raf.current = requestAnimationFrame(tick)
+  }
+
+  useEffect(() => () => cancelAnimationFrame(raf.current), [])
+
+  useEffect(() => {
+    if (autoStart && phaseRef.current === 'ready') start()
+    // Hosted competition inputs are stable for the lifetime of the game.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoStart])
+
+  const tap = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (phaseRef.current !== 'playing') return
+    setRawTaps((value) => value + 1)
+    const nextScore = scoreRef.current + SEASONS[seasonRef.current].multiplier
+    scoreRef.current = nextScore
+    setScore(nextScore)
+    if (seasonRef.current !== 'autumn') return
+    const rect = event.currentTarget.getBoundingClientRect()
+    const leaf = {
+      id: leafId.current++,
+      x: Math.max(8, Math.min(92, ((event.clientX - rect.left) / rect.width) * 100)),
+      glyph: Math.random() > 0.5 ? '🍂' : '🍁',
+    }
+    setLeaves((items) => [...items.slice(-20), leaf])
+    setTimeout(() => setLeaves((items) => items.filter((item) => item.id !== leaf.id)), 900)
+  }
+
+  const useBox = () => {
+    if (visibleBox === null) return
+    usedBoxes.current.add(visibleBox)
+    changeSeason(rerollSeason(seed, visibleBox, seasonRef.current))
+    setVisibleBox(null)
+  }
+
+  const hostedAiResults = useMemo(
+    () =>
+      participants
+        ?.filter((participant) => !participant.isHuman)
+        .map((participant) => ({
+          id: participant.id,
+          name: participant.name,
+          score: participant.precomputedScore,
+          rawTaps: Math.max(0, Math.round(participant.precomputedScore)),
+        })),
+    [participants]
+  )
+  const humanName = participants?.find((participant) => participant.isHuman)?.name ?? 'You'
+  const standings = useMemo(
+    () =>
+      [
+        { id: 'you', name: humanName, score, rawTaps, human: true },
+        ...(hostedAiResults ?? aiResults).map((result) => ({ ...result, human: false })),
+      ].sort((a, b) => b.score - a.score),
+    [aiResults, hostedAiResults, humanName, rawTaps, score]
+  )
+
+  return (
+    <main className={`qts qts--${season}`}>
+      <div className="qts__weather" aria-hidden="true">
+        {season === 'winter'
+          ? '❄️ ✦ ❄️'
+          : season === 'summer'
+            ? '☀️ 〰️ ☀️'
+            : season === 'autumn'
+              ? '🍁 🍂 🍁'
+              : '🌸 🐦 🌼'}
+      </div>
+      <section className="qts__card">
+        {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+        <p className="qts__eyebrow">Experimental spin-off</p>
+        {/* i18n-ignore: The minigame title is a fixed product name. */}
+        <h1>Quick Tap Race 2: Seasons</h1>
+        {phase === 'ready' && (
+          <>
+            {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+            <p className="qts__intro">
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              Tap through a shifting year of seasonal surprises. Each season changes the value and
+              feel of your taps, and mystery boxes can transform the conditions without warning.
+            </p>
+            <div className="qts__rules">
+              {Object.entries(SEASONS).map(([key, item]) => (
+                <div key={key}>
+                  <span>{item.emoji}</span>
+                  <strong>{item.label}</strong>
+                  <small>{item.effect}</small>
+                </div>
+              ))}
+            </div>
+            {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+            <label className="qts__seed">
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              Seed
+              <input
+                type="number"
+                value={seed}
+                onChange={(e) => setSeed(Math.max(0, e.currentTarget.valueAsNumber || 0))}
+              />
+            </label>
+            <div className="qts__actions">
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              <button onClick={() => setSeed(Math.floor(Math.random() * 2e9))}>New seed</button>
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              <button className="qts__primary" onClick={start}>
+                {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+                Start 40s race
+              </button>
+            </div>
+          </>
+        )}
+        {phase === 'playing' && (
+          <>
+            <div className="qts__hud">
+              <div>
+                {/* i18n-ignore: Compact arcade HUD label remains English with the current minigame host. */}
+                <small>Score</small>
+                <strong>{scoreText(score)}</strong>
+              </div>
+              <div>
+                <span>{details.emoji}</span>
+                <strong>{details.label}</strong>
+                <small>{details.effect}</small>
+              </div>
+              <div>
+                {/* i18n-ignore: Compact arcade HUD label remains English with the current minigame host. */}
+                <small>Time</small>
+                {/* i18n-ignore: Seconds is a language-neutral abbreviated unit in this arcade HUD. */}
+                <strong>{timeLeft.toFixed(1)}s</strong>
+              </div>
+            </div>
+            <div className="qts__progress">
+              <span style={{ width: `${(timeLeft / 40) * 100}%` }} />
+            </div>
+            <div className="qts__arena">
+              {leaves.map((leaf) => (
+                <span key={leaf.id} className="qts__leaf" style={{ left: `${leaf.x}%` }}>
+                  {leaf.glyph}
+                </span>
+              ))}
+              {visibleBox !== null && (
+                /* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */
+                <button className="qts__mystery" onClick={useBox}>
+                  {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+                  🎁 Change season
+                </button>
+              )}
+              <button className="qts__tap" onPointerDown={tap}>
+                <span>{details.emoji}</span>TAP<small>{details.multiplier}×</small>
+              </button>
+            </div>
+            {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+            <p className="qts__raw">{rawTaps} raw taps</p>
+          </>
+        )}
+        {phase === 'results' && (
+          <>
+            {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+            <h2>{standings[0]?.human ? 'You won the seasons' : `${standings[0]?.name} won`}</h2>
+            <ol className="qts__standings">
+              {standings.map((entry, index) => (
+                <li key={entry.id} className={entry.human ? 'qts__human' : ''}>
+                  <span>
+                    {index + 1}. {entry.name}
+                  </span>
+                  {/* i18n-ignore: Compact result units remain English with the current minigame host. */}
+                  <strong>{scoreText(entry.score)} pts</strong>
+                  {/* i18n-ignore: Compact result units remain English with the current minigame host. */}
+                  <small>{entry.rawTaps} raw taps</small>
+                </li>
+              ))}
+            </ol>
+            <div className="qts__actions">
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              <button onClick={() => setPhase('ready')}>Configure</button>
+              {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+              <button className="qts__primary" onClick={start}>
+                {/* i18n-ignore: This experimental minigame UI remains English until the minigame host exposes localized game copy. */}
+                Replay seed
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/tests/unit/competition-ai/bracketTemplate.test.ts
+++ b/tests/unit/competition-ai/bracketTemplate.test.ts
@@ -169,6 +169,31 @@ describe('getBracketPoolForContext compatibility resolver', () => {
 })
 
 describe('getClassicCampaignPoolForContext', () => {
+  it('adds Seasons only to POS after jury begins', () => {
+    const preJuryPos = getClassicCampaignPoolForContext({
+      day: 6,
+      playerCount: 10,
+      compType: 'POS',
+      phase: 'pos_comp',
+    })
+    const juryPos = getClassicCampaignPoolForContext({
+      day: 7,
+      playerCount: 9,
+      compType: 'POS',
+      phase: 'pos_comp',
+    })
+    const juryLoh = getClassicCampaignPoolForContext({
+      day: 7,
+      playerCount: 9,
+      compType: 'LOH',
+      phase: 'loh_comp',
+    })
+
+    expect(preJuryPos).not.toContain('quickTapSeasons')
+    expect(juryPos).toContain('quickTapSeasons')
+    expect(juryLoh).not.toContain('quickTapSeasons')
+  })
+
   it('uses the fixed premiere pool on day 1', () => {
     expect(
       getClassicCampaignPoolForContext({

--- a/tests/unit/competition-ai/quickTapHumanAiExperiment.test.ts
+++ b/tests/unit/competition-ai/quickTapHumanAiExperiment.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  QUICK_TAP_EXPERIMENT_FIELD,
+  simulateHumanlikeQuickTapAi,
+  simulateHumanlikeQuickTapField,
+} from '../../../src/experiments/quickTapHumanAi/quickTapHumanAi'
+
+describe('Quick Tap human-AI experiment', () => {
+  it('is deterministic for the same seed, opponent, and difficulty', () => {
+    const config = QUICK_TAP_EXPERIMENT_FIELD[0]
+    const first = simulateHumanlikeQuickTapAi({ seed: 42, config, difficulty: 'balanced' })
+    const second = simulateHumanlikeQuickTapAi({ seed: 42, config, difficulty: 'balanced' })
+    expect(second).toEqual(first)
+  })
+
+  it('produces actual tap and booster action traces', () => {
+    const result = simulateHumanlikeQuickTapAi({
+      seed: 424242,
+      config: QUICK_TAP_EXPERIMENT_FIELD[2],
+      difficulty: 'balanced',
+    })
+    expect(result.actions.filter((action) => action.type === 'tap').length).toBe(result.rawTaps)
+    expect(result.actions.some((action) => action.type === 'booster')).toBe(true)
+    expect(result.openingReactionMs).toBeGreaterThanOrEqual(200)
+    expect(result.averageTapsPerSecond).toBeGreaterThan(2)
+    expect(result.averageTapsPerSecond).toBeLessThan(9)
+    expect(result.bandTargetScore).toBeGreaterThan(0)
+    expect(result.scoreGap).toBe(result.effectiveScore - result.bandTargetScore)
+  })
+
+  it('keeps every booster decision inside the human-visible response window', () => {
+    for (let seed = 1; seed <= 200; seed += 1) {
+      for (const result of simulateHumanlikeQuickTapField(seed, 'balanced')) {
+        for (const booster of result.boosters) {
+          if (!booster.taken) continue
+          expect(booster.reactionMs).not.toBeNull()
+          expect(booster.reactionMs ?? 0).toBeGreaterThanOrEqual(260)
+          expect(booster.reactionMs ?? 0).toBeLessThan(4_000)
+        }
+      }
+    }
+  })
+
+  it('raises average field scores as difficulty increases', () => {
+    const totals = { friendly: 0, balanced: 0, competitive: 0 }
+    for (let seed = 1; seed <= 500; seed += 1) {
+      for (const difficulty of ['friendly', 'balanced', 'competitive'] as const) {
+        totals[difficulty] += simulateHumanlikeQuickTapField(seed, difficulty).reduce(
+          (sum, result) => sum + result.effectiveScore,
+          0
+        )
+      }
+    }
+    expect(totals.balanced).toBeGreaterThan(totals.friendly)
+    expect(totals.competitive).toBeGreaterThan(totals.balanced)
+  })
+
+  it('anchors sustained balanced rhythm inside the 7.1-8.7 taps-per-second band', () => {
+    const results = Array.from({ length: 300 }, (_, index) =>
+      simulateHumanlikeQuickTapField(index + 1, 'balanced')
+    ).flat()
+    const mean =
+      results.reduce((sum, result) => sum + result.averageTapsPerSecond, 0) / results.length
+    const inBandRatio =
+      results.filter(
+        (result) => result.averageTapsPerSecond >= 7.1 && result.averageTapsPerSecond <= 8.7
+      ).length / results.length
+
+    expect(mean).toBeGreaterThanOrEqual(7.1)
+    expect(mean).toBeLessThanOrEqual(8.7)
+    expect(inBandRatio).toBeGreaterThanOrEqual(0.97)
+  })
+
+  it('audits fixed-band targets instead of fabricating unreachable action scores', () => {
+    const results = Array.from({ length: 100 }, (_, index) =>
+      simulateHumanlikeQuickTapField(index + 1, 'balanced')
+    ).flat()
+
+    expect(results.some((result) => result.targetReached)).toBe(true)
+    expect(results.every((result) => result.actions.length >= result.rawTaps)).toBe(true)
+  })
+
+  it('can force every AI to accept all three boxes for a controlled comparison', () => {
+    const results = simulateHumanlikeQuickTapField(424242, 'balanced', {
+      forceAllBoosters: true,
+    })
+
+    expect(results.every((result) => result.boosters.every((booster) => booster.taken))).toBe(true)
+  })
+
+  it('allows 1-3 inertia taps, then stops during a revealed -1x drain', () => {
+    let drainSeed = 1
+    while (
+      !simulateHumanlikeQuickTapAi({
+        seed: drainSeed,
+        config: QUICK_TAP_EXPERIMENT_FIELD[0],
+        forceAllBoosters: true,
+      }).boosters.some((booster) => booster.type === '-1x')
+    ) {
+      drainSeed += 1
+    }
+
+    const result = simulateHumanlikeQuickTapAi({
+      seed: drainSeed,
+      config: QUICK_TAP_EXPERIMENT_FIELD[0],
+      forceAllBoosters: true,
+    })
+    const drainActivation = result.actions.find(
+      (action) => action.type === 'booster' && action.boosterType === '-1x'
+    )
+    expect(drainActivation).toBeDefined()
+    const drainWindowTaps = result.actions.filter(
+      (action) =>
+        action.type === 'tap' &&
+        action.atMs > (drainActivation?.atMs ?? 0) &&
+        action.atMs < (drainActivation?.atMs ?? 0) + 4_000
+    )
+    expect(drainWindowTaps.length).toBeGreaterThanOrEqual(1)
+    expect(drainWindowTaps.length).toBeLessThanOrEqual(3)
+    expect(
+      result.actions.some(
+        (action) => action.type === 'tap' && action.atMs >= (drainActivation?.atMs ?? 0) + 4_000
+      )
+    ).toBe(true)
+  })
+})

--- a/tests/unit/competition-ai/quickTapSeasonsExperiment.test.ts
+++ b/tests/unit/competition-ai/quickTapSeasonsExperiment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SEASONS,
+  buildSeasonSchedule,
+  rerollSeason,
+  simulateSeasonsAiField,
+} from '../../../src/experiments/quickTapSeasons/quickTapSeasons'
+import { getGame } from '../../../src/minigames/registryBase'
+
+describe('Quick Tap Race 2: Seasons', () => {
+  it('changes to a different season every eight seconds', () => {
+    const schedule = buildSeasonSchedule(42)
+    expect(schedule.map((change) => change.at)).toEqual([0, 8, 16, 24, 32])
+    for (let index = 1; index < schedule.length; index += 1)
+      expect(schedule[index].season).not.toBe(schedule[index - 1].season)
+  })
+  it('uses the requested multipliers', () => {
+    expect([
+      SEASONS.winter.multiplier,
+      SEASONS.summer.multiplier,
+      SEASONS.autumn.multiplier,
+      SEASONS.spring.multiplier,
+    ]).toEqual([-1, 0.5, 1, 1.25])
+  })
+  it('mystery boxes always select another season', () => {
+    for (let seed = 1; seed <= 100; seed += 1)
+      expect(rerollSeason(seed, 0, 'winter')).not.toBe('winter')
+  })
+  it('creates a deterministic three-AI field', () => {
+    expect(simulateSeasonsAiField(7)).toEqual(simulateSeasonsAiField(7))
+    expect(simulateSeasonsAiField(7)).toHaveLength(3)
+  })
+  it('keeps hidden timing and reroll mechanics out of player-facing rules', () => {
+    const rules = getGame('quickTapSeasons')?.instructions.join(' ').toLowerCase() ?? ''
+    expect(rules).not.toContain('8 seconds')
+    expect(rules).not.toContain('reroll')
+    expect(rules).not.toContain('only')
+  })
+})

--- a/tests/unit/quickTapRace/quickTapRaceCanvasEngine.test.ts
+++ b/tests/unit/quickTapRace/quickTapRaceCanvasEngine.test.ts
@@ -328,4 +328,65 @@ describe('QuickTapRaceCanvasEngine', () => {
     engine.handlePointerDown(1, { x: 160, y: 280 }, 0, 1_700_000_000_000);
     expect(engine.getSnapshot().tapCount).toBe(beforeTaps + 1);
   });
+
+  it('strict wall-clock mode rejects queued input after the real deadline', async () => {
+    const onFinish = vi.fn();
+    const canvas = makeCanvas();
+    const engine = new QuickTapRaceCanvasEngine(canvas, {
+      seed: 42,
+      autoStart: true,
+      duration: 1,
+      strictWallClock: true,
+      onTick: vi.fn(),
+      onFinish,
+    });
+
+    engine.resize(320, 400, 1);
+    engine.start();
+    await vi.advanceTimersByTimeAsync(32);
+
+    engine.handlePointerDown(1, { x: 160, y: 280 }, 900, performance.now() + 2_000);
+
+    expect(engine.getSnapshot().tapCount).toBe(0);
+    expect(onFinish).toHaveBeenCalledOnce();
+    expect(onFinish.mock.calls[0][3]).toEqual(
+      expect.objectContaining({ afterDeadlineTapsRejected: 1 }),
+    );
+  });
+
+  it('reports input-rate and pointer telemetry without changing the score', async () => {
+    const onFinish = vi.fn();
+    const canvas = makeCanvas();
+    const engine = new QuickTapRaceCanvasEngine(canvas, {
+      seed: 42,
+      autoStart: true,
+      duration: 1,
+      strictWallClock: true,
+      lowLatencyInput: true,
+      onTick: vi.fn(),
+      onFinish,
+    });
+
+    engine.resize(320, 400, 1);
+    engine.start();
+    await vi.advanceTimersByTimeAsync(32);
+    const clock = performance.now();
+    engine.handlePointerDown(10, { x: 160, y: 280 }, clock + 100, clock + 100, 'touch');
+    engine.handlePointerUp(10);
+    engine.handlePointerDown(11, { x: 160, y: 280 }, clock + 200, clock + 200, 'touch');
+    engine.handlePointerUp(11);
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    expect(onFinish).toHaveBeenCalledOnce();
+    expect(onFinish.mock.calls[0][1]).toBe(2);
+    expect(onFinish.mock.calls[0][3]).toEqual(
+      expect.objectContaining({
+        peakOneSecondTaps: 2,
+        medianInterTapMs: 100,
+        uniquePointerCount: 2,
+        maxConcurrentPointers: 1,
+        pointerTypeCounts: { touch: 2 },
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## What changed

- Tunes the original Quick Tap Race experiment around observed human mobile tapping, including human-like AI rhythms, drain inertia, fixed-band audits, and input telemetry.
- Adds **Quick Tap Race 2: Seasons**, a 40-second seasonal tapping spin-off with winter, summer, autumn, and spring effects.
- Registers Seasons in the minigame pool with player-facing rules that do not expose cadence or mystery-box implementation details.
- Makes Seasons eligible only for POS competitions from the jury-stage campaign map onward.

## Why

Phone testing showed that realistic alternating-finger play consistently outperformed the original AI behavior. The first commit preserves the resulting human-calibrated experiment; the second turns the lightweight Seasons prototype into a registry-backed competition challenge.

## Validation

- `npm run typecheck`
- 53 focused Vitest tests across Quick Tap, Seasons, AI behavior, and competition-map eligibility
- `npm run build`
- Production debug-global check passed

## Commit structure

1. `Improve Quick Tap Race human-AI behavior`
2. `Add Quick Tap Race 2 Seasons to jury POS`
