### PR TITLE
Unify splash screen loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
+    <!-- Fetch the complete splash artwork before React/CSS evaluation so the
+         first branded frame can be presented as one composition. -->
+    <link rel="preload" as="image" href="%BASE_URL%assets/kolequant.png" />
+    <link rel="preload" as="image" href="%BASE_URL%assets/splash-city-skyline-photographic.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>The Big Eye</title>
     <!-- iOS PWA / A2HS support -->

--- a/src/components/KolequantSplash/KolequantSplash.css
+++ b/src/components/KolequantSplash/KolequantSplash.css
@@ -51,6 +51,23 @@
   animation: kq-splash-exit 360ms ease forwards;
 }
 
+.kq-splash__composition {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: inherit;
+  box-sizing: border-box;
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.kq-splash--artwork-ready .kq-splash__composition {
+  opacity: 1;
+}
+
 .kq-splash__skyline {
   position: absolute;
   z-index: 0;
@@ -58,11 +75,19 @@
   height: min(36dvh, 340px);
   overflow: hidden;
   opacity: 0.78;
-  background:
-    linear-gradient(to top, rgba(1, 3, 10, 0.92), rgba(3, 8, 24, 0.36) 52%, transparent),
-    url('/assets/splash-city-skyline-photographic.png') center bottom / cover no-repeat;
+  background: linear-gradient(to top, rgba(1, 3, 10, 0.92), rgba(3, 8, 24, 0.36) 52%, transparent);
   mask-image: linear-gradient(to bottom, transparent 0%, #000 29%, #000 100%);
   pointer-events: none;
+}
+
+.kq-splash__skyline > img {
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center bottom;
 }
 
 .kq-splash__skyline::after {
@@ -89,6 +114,7 @@
   opacity: 0;
   transform: scale(0.96) translateY(8px);
   animation: kq-logo-in 640ms cubic-bezier(0.22, 1, 0.36, 1) 80ms forwards;
+  animation-play-state: paused;
 }
 
 .kq-splash__logo {
@@ -109,6 +135,7 @@
   opacity: 0.25;
   filter: brightness(1.35) saturate(1.35) drop-shadow(0 0 8px rgba(85, 211, 255, 0.7));
   animation: kq-dna-pulse 1800ms ease-in-out 720ms infinite alternate;
+  animation-play-state: paused;
 }
 
 .kq-splash__preload {
@@ -120,6 +147,7 @@
   opacity: 0;
   transform: translateY(8px);
   animation: kq-preload-in 560ms ease 420ms forwards;
+  animation-play-state: paused;
 }
 
 .kq-splash__preload-row {
@@ -179,6 +207,14 @@
   text-transform: uppercase;
   opacity: 0;
   animation: kq-preload-in 560ms ease 560ms forwards;
+  animation-play-state: paused;
+}
+
+.kq-splash--artwork-ready .kq-splash__logo-wrap,
+.kq-splash--artwork-ready .kq-splash__dna-glow,
+.kq-splash--artwork-ready .kq-splash__preload,
+.kq-splash--artwork-ready .kq-splash__copyright {
+  animation-play-state: running;
 }
 
 @keyframes kq-logo-in {

--- a/src/components/KolequantSplash/KolequantSplash.tsx
+++ b/src/components/KolequantSplash/KolequantSplash.tsx
@@ -13,6 +13,7 @@ interface Props {
 }
 
 const LOGO_SRC = `${import.meta.env.BASE_URL}assets/kolequant.png`;
+const SKYLINE_SRC = `${import.meta.env.BASE_URL}assets/splash-city-skyline-photographic.png`;
 const EXIT_MS = 360;
 
 const DEFAULT_MESSAGES = [
@@ -41,51 +42,64 @@ export default function KolequantSplash({
   const [minimumElapsed, setMinimumElapsed] = useState(false);
   const [exiting, setExiting] = useState(false);
   const [messageIndex, setMessageIndex] = useState(0);
-  const exitStartedRef = useRef(false);
+  const [loadedArtwork, setLoadedArtwork] = useState(0);
+  const onFinishRef = useRef(onFinish);
   const clampedProgress = clampProgress(progress);
   const activeMessages = useMemo(
     () => (messages.length > 0 ? messages : DEFAULT_MESSAGES),
     [messages],
   );
   const progressLabel = status ?? activeMessages[messageIndex];
+  const artworkReady = loadedArtwork === 7;
+
+  function markArtworkSettled(bit: number) {
+    setLoadedArtwork((current) => current | bit);
+  }
+
+  function markArtworkDecoded(image: HTMLImageElement, bit: number) {
+    if (typeof image.decode !== 'function') {
+      markArtworkSettled(bit);
+      return;
+    }
+
+    void image.decode().catch(() => undefined).then(() => markArtworkSettled(bit));
+  }
 
   useEffect(() => {
-    exitStartedRef.current = false;
+    onFinishRef.current = onFinish;
+  }, [onFinish]);
+
+  useEffect(() => {
+    if (!artworkReady) return;
+    setMinimumElapsed(false);
     const timer = window.setTimeout(() => setMinimumElapsed(true), duration);
     return () => window.clearTimeout(timer);
-  }, [duration]);
+  }, [artworkReady, duration]);
 
   useEffect(() => {
-    if (activeMessages.length <= 1 || exiting) return;
+    if (status || activeMessages.length <= 1 || exiting) return;
     const timer = window.setInterval(() => {
       setMessageIndex((current) => (current + 1) % activeMessages.length);
     }, 1350);
     return () => window.clearInterval(timer);
-  }, [activeMessages.length, exiting]);
+  }, [activeMessages.length, exiting, status]);
 
   useEffect(() => {
-    if (!ready || !minimumElapsed || exitStartedRef.current) return;
+    if (!ready || !artworkReady || !minimumElapsed || exiting) return;
+    setExiting(true);
+  }, [artworkReady, exiting, minimumElapsed, ready]);
 
-    exitStartedRef.current = true;
-    let finishTimer: number | undefined;
-    const exitTimer = window.setTimeout(() => {
-      setExiting(true);
-      finishTimer = window.setTimeout(() => onFinish?.(), EXIT_MS);
-    }, 0);
-
-    return () => {
-      window.clearTimeout(exitTimer);
-      if (finishTimer != null) {
-        window.clearTimeout(finishTimer);
-      }
-    };
-  }, [minimumElapsed, onFinish, ready]);
+  useEffect(() => {
+    if (!exiting) return;
+    const timer = window.setTimeout(() => onFinishRef.current?.(), EXIT_MS);
+    return () => window.clearTimeout(timer);
+  }, [exiting]);
 
   const splashStyle = {
     '--kq-splash-min-duration': `${duration}ms`,
     '--kq-splash-progress': `${clampedProgress}%`,
   } as CSSProperties;
-  const className = `kq-splash${exiting ? ' kq-splash--exiting' : ''}`;
+  const className = `kq-splash${artworkReady ? ' kq-splash--artwork-ready' : ''}${exiting ? ' kq-splash--exiting' : ''}`;
 
   return (
     <div
@@ -95,33 +109,51 @@ export default function KolequantSplash({
       aria-live="polite"
       aria-label={`${progressLabel} ${clampedProgress}%`}
     >
-      <div className="kq-splash__skyline" aria-hidden="true" />
-      <div className="kq-splash__logo-wrap">
-        <img
-          src={LOGO_SRC}
-          alt="Kolequant"
-          className="kq-splash__logo"
-          draggable={false}
-          decoding="async"
-        />
-        <img
-          src={LOGO_SRC}
-          alt=""
-          className="kq-splash__dna-glow"
-          draggable={false}
-          aria-hidden="true"
-        />
-      </div>
-      <div className="kq-splash__preload" aria-hidden="true">
-        <div className="kq-splash__preload-row">
-          <span>{activeMessages[messageIndex]}</span>
-          <span>{clampedProgress}%</span>
+      <div className="kq-splash__composition">
+        <div className="kq-splash__skyline" aria-hidden="true">
+          <img
+            src={SKYLINE_SRC}
+            alt=""
+            draggable={false}
+            decoding="async"
+            fetchPriority="high"
+            onLoad={(event) => markArtworkDecoded(event.currentTarget, 1)}
+            onError={() => markArtworkSettled(1)}
+          />
         </div>
-        <div className="kq-splash__bar-track">
-          <div className="kq-splash__bar-fill" />
+        <div className="kq-splash__logo-wrap">
+          <img
+            src={LOGO_SRC}
+            alt="Kolequant"
+            className="kq-splash__logo"
+            draggable={false}
+            decoding="async"
+            fetchPriority="high"
+            onLoad={(event) => markArtworkDecoded(event.currentTarget, 2)}
+            onError={() => markArtworkSettled(2)}
+          />
+          <img
+            src={LOGO_SRC}
+            alt=""
+            className="kq-splash__dna-glow"
+            draggable={false}
+            aria-hidden="true"
+            decoding="async"
+            onLoad={(event) => markArtworkDecoded(event.currentTarget, 4)}
+            onError={() => markArtworkSettled(4)}
+          />
         </div>
+        <div className="kq-splash__preload" aria-hidden="true">
+          <div className="kq-splash__preload-row">
+            <span>{progressLabel}</span>
+            <span>{clampedProgress}%</span>
+          </div>
+          <div className="kq-splash__bar-track">
+            <div className="kq-splash__bar-fill" />
+          </div>
+        </div>
+        <div className="kq-splash__copyright">© 2026</div>
       </div>
-      <div className="kq-splash__copyright">© 2026</div>
     </div>
   );
 }

--- a/src/components/KolequantSplash/__tests__/KolequantSplash.test.tsx
+++ b/src/components/KolequantSplash/__tests__/KolequantSplash.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import KolequantSplash from '../KolequantSplash';
 
@@ -23,6 +23,7 @@ describe('KolequantSplash', () => {
     expect(container.querySelector('.kq-splash__dna-glow')).toBeInTheDocument();
     expect(container.querySelector('.kq-splash__electric')).toBeNull();
     expect(container.querySelector('.kq-splash__logo-frame')).toBeNull();
+    expect(container.firstChild).not.toHaveClass('kq-splash--artwork-ready');
     expect(container.firstChild).toHaveStyle({
       '--kq-splash-min-duration': '2400ms',
       '--kq-splash-progress': '42%',
@@ -33,6 +34,15 @@ describe('KolequantSplash', () => {
     const onFinish = vi.fn();
 
     const view = render(<KolequantSplash duration={1500} ready={false} onFinish={onFinish} />);
+
+    fireEvent.load(view.container.querySelector('.kq-splash__skyline img')!);
+    expect(view.container.firstChild).not.toHaveClass('kq-splash--artwork-ready');
+
+    fireEvent.load(view.container.querySelector('.kq-splash__logo')!);
+    expect(view.container.firstChild).not.toHaveClass('kq-splash--artwork-ready');
+
+    fireEvent.load(view.container.querySelector('.kq-splash__dna-glow')!);
+    expect(view.container.firstChild).toHaveClass('kq-splash--artwork-ready');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1500);
@@ -45,5 +55,35 @@ describe('KolequantSplash', () => {
       await vi.advanceTimersByTimeAsync(400);
     });
     expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows caller status instead of rotating generic messages', () => {
+    render(<KolequantSplash status="Loading the house exterior." progress={18} />);
+
+    expect(screen.getByText('Loading the house exterior.')).toBeInTheDocument();
+    expect(screen.queryByText('Starting the Kolequant engine.')).toBeNull();
+  });
+
+  it('keeps the latest finish callback without cancelling an active exit', async () => {
+    const firstFinish = vi.fn();
+    const latestFinish = vi.fn();
+    const view = render(<KolequantSplash duration={0} ready onFinish={firstFinish} />);
+
+    fireEvent.load(view.container.querySelector('.kq-splash__skyline img')!);
+    fireEvent.load(view.container.querySelector('.kq-splash__logo')!);
+    fireEvent.load(view.container.querySelector('.kq-splash__dna-glow')!);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    view.rerender(<KolequantSplash duration={0} ready onFinish={latestFinish} />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(firstFinish).not.toHaveBeenCalled();
+    expect(latestFinish).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/screens/HomeHub/HomeHub.tsx
+++ b/src/screens/HomeHub/HomeHub.tsx
@@ -287,7 +287,7 @@ export default function HomeHub() {
     progress: 0,
     status: 'Opening the house doors.',
   })
-  const splashDone = !isInitialAppSplash || (splashExitRequested && hubAssetState.ready)
+  const splashDone = splashExitRequested && hubAssetState.ready
   // Seed preloading from transient route state so "Start New Season" can
   // reuse the existing Play → preloader → /game flow without setting state in
   // an effect on mount.
@@ -624,9 +624,9 @@ export default function HomeHub() {
     })
   }, [])
 
-  function handleSplashFinish() {
+  const handleSplashFinish = useCallback(() => {
     setSplashExitRequested(true)
-  }
+  }, [])
 
   useEffect(() => {
     if (!splashDone) {

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -169,7 +169,7 @@ describe('HomeHub', () => {
     delete (window as Window & { game?: Record<string, unknown> }).game;
   });
 
-  it('shows the Kolequant splash only once per app session', async () => {
+  it('uses five seconds initially and no minimum on later in-app loads', async () => {
     const firstRender = renderHomeHub();
 
     expect(screen.getByTestId('kolequant-splash')).toBeInTheDocument();
@@ -185,13 +185,14 @@ describe('HomeHub', () => {
 
     renderHomeHub();
 
-    expect(screen.queryByTestId('kolequant-splash')).toBeNull();
+    expect(screen.getByTestId('kolequant-splash')).toHaveAttribute('data-duration', '0');
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
     });
   });
 
-  it('does not show the Kolequant splash again after a new season starts', async () => {
+  it('shows a zero-minimum readiness splash after a new season starts', async () => {
     const firstRender = renderHomeHub();
 
     fireEvent.click(screen.getByTestId('kolequant-splash'));
@@ -205,18 +206,20 @@ describe('HomeHub', () => {
 
     renderHomeHub();
 
-    expect(screen.queryByTestId('kolequant-splash')).toBeNull();
+    expect(screen.getByTestId('kolequant-splash')).toHaveAttribute('data-duration', '0');
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
     });
   });
 
-  it('shows the hub buttons immediately after quitting a run without saving', async () => {
+  it('uses a zero-minimum readiness splash after quitting a run without saving', async () => {
     sessionStorage.setItem('bb:homeHubSplashShownThisSession', 'true');
 
     renderHomeHub();
 
-    expect(screen.queryByTestId('kolequant-splash')).toBeNull();
+    expect(screen.getByTestId('kolequant-splash')).toHaveAttribute('data-duration', '0');
+    fireEvent.click(screen.getByTestId('kolequant-splash'));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
     });


### PR DESCRIPTION
## What changed
- preload the complete splash artwork before React initializes
- reveal the skyline, logo, DNA glow, status, and progress as one decoded composition
- start the five-second launch minimum only after artwork is ready
- keep later in-app splashes readiness-driven with no minimum delay
- make the exit callback resilient to parent re-renders

## Why
The skyline could arrive after the rest of the splash, creating a visibly piecemeal launch. The duration timer also started before the branded frame was actually visible.

## Validation
- `npm test -- --run src/components/KolequantSplash/__tests__/KolequantSplash.test.tsx src/screens/HomeHub/__tests__/HomeHub.test.tsx`
- `npm run typecheck`
- `git diff --check`