### PR TITLE
Fix splash timing lint

### DIFF
--- a/src/components/KolequantSplash/KolequantSplash.tsx
+++ b/src/components/KolequantSplash/KolequantSplash.tsx
@@ -71,7 +71,6 @@ export default function KolequantSplash({
 
   useEffect(() => {
     if (!artworkReady) return;
-    setMinimumElapsed(false);
     const timer = window.setTimeout(() => setMinimumElapsed(true), duration);
     return () => window.clearTimeout(timer);
   }, [artworkReady, duration]);
@@ -85,15 +84,14 @@ export default function KolequantSplash({
   }, [activeMessages.length, exiting, status]);
 
   useEffect(() => {
-    if (!ready || !artworkReady || !minimumElapsed || exiting) return;
-    setExiting(true);
-  }, [artworkReady, exiting, minimumElapsed, ready]);
-
-  useEffect(() => {
-    if (!exiting) return;
-    const timer = window.setTimeout(() => onFinishRef.current?.(), EXIT_MS);
-    return () => window.clearTimeout(timer);
-  }, [exiting]);
+    if (!ready || !artworkReady || !minimumElapsed) return;
+    const exitTimer = window.setTimeout(() => setExiting(true), 0);
+    const finishTimer = window.setTimeout(() => onFinishRef.current?.(), EXIT_MS);
+    return () => {
+      window.clearTimeout(exitTimer);
+      window.clearTimeout(finishTimer);
+    };
+  }, [artworkReady, minimumElapsed, ready]);
 
   const splashStyle = {
     '--kq-splash-min-duration': `${duration}ms`,


### PR DESCRIPTION
## What changed
- remove the synchronous minimum-timer reset from the artwork readiness effect
- schedule the splash fade and completion through asynchronous timer callbacks in one guarded effect
- preserve the decoded-artwork gate, five-second initial minimum, and latest-callback behavior

## Root cause
React's `react-hooks/set-state-in-effect` lint rule rejects synchronous `setState` calls inside effects. The splash used synchronous state transitions for both timer reset and fade entry.

## Validation
- `npm run lint:ci`
- `npm test -- --run src/components/KolequantSplash/__tests__/KolequantSplash.test.tsx src/screens/HomeHub/__tests__/HomeHub.test.tsx`
- `npm run typecheck`
- `git diff --check`