### PR TITLE
Synchronize eye-to-sun handoff and runtime credits

### DIFF
--- a/.github/workflows/cinematic-sun-preview.yml
+++ b/.github/workflows/cinematic-sun-preview.yml
@@ -1,0 +1,56 @@
+name: Cinematic sun handoff preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/cinematic/**'
+      - 'src/remotion/**'
+      - '.github/workflows/cinematic-sun-preview.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  render-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate cinematic timeline
+        run: npx vitest run src/cinematic/timeline/timeline.test.ts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Render transition preview
+        run: >-
+          npx remotion render src/remotion/index.ts BigEyeCinematicBackground
+          renders/sun-horizon-preview.mp4
+          --codec=h264
+          --pixel-format=yuv420p
+          --image-format=png
+          --color-space=bt709
+          --frames=1250-1540
+          --concurrency=2
+
+      - name: Upload preview video
+        uses: actions/upload-artifact@v4
+        with:
+          name: sun-horizon-preview
+          path: renders/sun-horizon-preview.mp4
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/cinematic-sun-preview.yml
+++ b/.github/workflows/cinematic-sun-preview.yml
@@ -46,7 +46,7 @@ jobs:
           --color-space=bt709
           --frames=1250-1540
           --concurrency=2
-          --gl=angle
+          --gl=swangle
 
       - name: Upload preview video
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cinematic-sun-preview.yml
+++ b/.github/workflows/cinematic-sun-preview.yml
@@ -46,6 +46,7 @@ jobs:
           --color-space=bt709
           --frames=1250-1540
           --concurrency=2
+          --gl=angle
 
       - name: Upload preview video
         uses: actions/upload-artifact@v4

--- a/public/config/credits.json
+++ b/public/config/credits.json
@@ -5,7 +5,7 @@
       "id": "thank-you",
       "fromSecond": 0,
       "toSecond": 3.15,
-      "lines": [{ "text": "Thank you for playing", "style": "title" }]
+      "lines": [{ "text": "THANK YOU FOR PLAYING", "style": "title" }]
     },
     {
       "id": "created-by",
@@ -22,7 +22,7 @@
       "toSecond": 9.45,
       "lines": [
         { "text": "Art Direction", "style": "label" },
-        { "text": "I.C.O LTD.", "style": "name", "gapBefore": true }
+        { "text": "I.C.O. LTD", "style": "name", "gapBefore": true }
       ]
     },
     {
@@ -39,7 +39,7 @@
       "fromSecond": 12.6,
       "toSecond": 17.1,
       "lines": [
-        { "text": "Music", "style": "label" },
+        { "text": "Main theme", "style": "label" },
         { "text": "“Move Into Me”", "style": "music-title", "gapBefore": true },
         { "text": "The Red Collective · Indigoe · JQ", "style": "body" }
       ]
@@ -47,7 +47,7 @@
     {
       "id": "album",
       "fromSecond": 17.1,
-      "toSecond": 24.3,
+      "toSecond": 21.3,
       "lines": [
         { "text": "From the album", "style": "small" },
         { "text": "Crushed Velvet", "style": "italic", "gapBefore": true },
@@ -56,8 +56,8 @@
     },
     {
       "id": "music-producers",
-      "fromSecond": 24.3,
-      "toSecond": 28.8,
+      "fromSecond": 22.5,
+      "toSecond": 27.8,
       "lines": [
         { "text": "Music producers", "style": "label" },
         { "text": "Joshua Ryan Collopy", "style": "name", "gapBefore": true },
@@ -65,45 +65,36 @@
       ]
     },
     {
-      "id": "thanks-rado",
+      "id": "thanks-jaysomeday",
       "fromSecond": 28.8,
       "toSecond": 31.5,
       "lines": [
-        { "text": "Special Thanks", "style": "label" },
-        { "text": "Ana-Luna Nieves", "style": "name", "gapBefore": true }
+        { "text": "Housemates theme by:", "style": "label" },
+        { "text": "Jay Someday - Midnight", "style": "name", "gapBefore": true }
       ]
     },
     {
-      "id": "thanks-candy",
+      "id": "thanks-newnote",
       "fromSecond": 31.5,
       "toSecond": 34.2,
       "lines": [
         { "text": "Special Thanks", "style": "label" },
-        { "text": "Candy Albert", "style": "name", "gapBefore": true }
+        { "text": "New Note Music", "style": "name", "gapBefore": true }
       ]
     },
     {
-      "id": "thanks-atiste",
+      "id": "thanks-mina",
       "fromSecond": 34.2,
       "toSecond": 36.9,
       "lines": [
         { "text": "Special Thanks", "style": "label" },
-        { "text": "Atiste House", "style": "name", "gapBefore": true }
-      ]
-    },
-    {
-      "id": "thanks-braun",
-      "fromSecond": 36.9,
-      "toSecond": 39.6,
-      "lines": [
-        { "text": "Special Thanks", "style": "label" },
-        { "text": "BBraun EMEA", "style": "name", "gapBefore": true }
+        { "text": "Dr. Mina T.K.", "style": "name", "gapBefore": true }
       ]
     },
     {
       "id": "disclaimer",
       "fromSecond": 39.6,
-      "toSecond": 43.2,
+      "toSecond": 45.2,
       "lines": [
         {
           "text": "Any resemblance to actual persons or events is purely coincidental.",
@@ -113,10 +104,10 @@
     },
     {
       "id": "closing",
-      "fromSecond": 43.2,
-      "toSecond": 48,
+      "fromSecond": 45.8,
+      "toSecond": 49.9,
       "lines": [
-        { "text": "The Big eye is still scanning...", "style": "closing-title" },
+        { "text": "THE BIG EYE IS STILL SCANNING...", "style": "closing-title" },
         { "text": "More is coming soon", "style": "closing-subtitle", "gapBefore": true }
       ]
     }

--- a/public/config/credits.json
+++ b/public/config/credits.json
@@ -5,15 +5,30 @@
       "id": "thank-you",
       "fromSecond": 0,
       "toSecond": 3.15,
-      "lines": [{ "text": "THANK YOU FOR PLAYING", "style": "title" }]
+      "lines": [
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "THANK YOU FOR PLAYING",
+          "style": "title"
+        }
+      ]
     },
     {
       "id": "created-by",
       "fromSecond": 3.15,
       "toSecond": 6.3,
       "lines": [
-        { "text": "Created by", "style": "label" },
-        { "text": "Georgi Cole", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Created by",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited proper names must remain unchanged in every locale",
+          "text": "Georgi Cole",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -21,8 +36,17 @@
       "fromSecond": 6.3,
       "toSecond": 9.45,
       "lines": [
-        { "text": "Art Direction", "style": "label" },
-        { "text": "I.C.O. LTD", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Art Direction",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited legal entity names must remain unchanged in every locale",
+          "text": "I.C.O. LTD",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -30,8 +54,17 @@
       "fromSecond": 9.45,
       "toSecond": 12.6,
       "lines": [
-        { "text": "Game Design", "style": "label" },
-        { "text": "Georgi Cole", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Game Design",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited proper names must remain unchanged in every locale",
+          "text": "Georgi Cole",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -39,9 +72,22 @@
       "fromSecond": 12.6,
       "toSecond": 17.1,
       "lines": [
-        { "text": "Main theme", "style": "label" },
-        { "text": "“Move Into Me”", "style": "music-title", "gapBefore": true },
-        { "text": "The Red Collective · Indigoe · JQ", "style": "body" }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Main theme",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Licensed music titles must remain unchanged in every locale",
+          "text": "“Move Into Me”",
+          "style": "music-title",
+          "gapBefore": true
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited artist names must remain unchanged in every locale",
+          "text": "The Red Collective · Indigoe · JQ",
+          "style": "body"
+        }
       ]
     },
     {
@@ -49,9 +95,23 @@
       "fromSecond": 17.1,
       "toSecond": 21.3,
       "lines": [
-        { "text": "From the album", "style": "small" },
-        { "text": "Crushed Velvet", "style": "italic", "gapBefore": true },
-        { "text": "Audiosocket Records", "style": "small", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "From the album",
+          "style": "small"
+        },
+        {
+          "i18nNote": "i18n-ignore: Licensed album titles must remain unchanged in every locale",
+          "text": "Crushed Velvet",
+          "style": "italic",
+          "gapBefore": true
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited record-label names must remain unchanged in every locale",
+          "text": "Audiosocket Records",
+          "style": "small",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -59,9 +119,22 @@
       "fromSecond": 22.5,
       "toSecond": 27.8,
       "lines": [
-        { "text": "Music producers", "style": "label" },
-        { "text": "Joshua Ryan Collopy", "style": "name", "gapBefore": true },
-        { "text": "James Andrew Quick", "style": "name" }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Music producers",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited proper names must remain unchanged in every locale",
+          "text": "Joshua Ryan Collopy",
+          "style": "name",
+          "gapBefore": true
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited proper names must remain unchanged in every locale",
+          "text": "James Andrew Quick",
+          "style": "name"
+        }
       ]
     },
     {
@@ -69,8 +142,17 @@
       "fromSecond": 28.8,
       "toSecond": 31.5,
       "lines": [
-        { "text": "Housemates theme by:", "style": "label" },
-        { "text": "Jay Someday - Midnight", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Housemates theme by:",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Licensed artist and track names must remain unchanged in every locale",
+          "text": "Jay Someday - Midnight",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -78,8 +160,17 @@
       "fromSecond": 31.5,
       "toSecond": 34.2,
       "lines": [
-        { "text": "Special Thanks", "style": "label" },
-        { "text": "New Note Music", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Special Thanks",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited organization names must remain unchanged in every locale",
+          "text": "New Note Music",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -87,8 +178,17 @@
       "fromSecond": 34.2,
       "toSecond": 36.9,
       "lines": [
-        { "text": "Special Thanks", "style": "label" },
-        { "text": "Dr. Mina T.K.", "style": "name", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "Special Thanks",
+          "style": "label"
+        },
+        {
+          "i18nNote": "i18n-ignore: Credited proper names must remain unchanged in every locale",
+          "text": "Dr. Mina T.K.",
+          "style": "name",
+          "gapBefore": true
+        }
       ]
     },
     {
@@ -97,6 +197,7 @@
       "toSecond": 45.2,
       "lines": [
         {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic legal copy is fixed in English for the 1.0 release",
           "text": "Any resemblance to actual persons or events is purely coincidental.",
           "style": "legal"
         }
@@ -107,8 +208,17 @@
       "fromSecond": 45.8,
       "toSecond": 49.9,
       "lines": [
-        { "text": "THE BIG EYE IS STILL SCANNING...", "style": "closing-title" },
-        { "text": "More is coming soon", "style": "closing-subtitle", "gapBefore": true }
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "THE BIG EYE IS STILL SCANNING...",
+          "style": "closing-title"
+        },
+        {
+          "i18nNote": "i18n-ignore: Owner-approved cinematic credits are fixed English copy for the 1.0 release",
+          "text": "More is coming soon",
+          "style": "closing-subtitle",
+          "gapBefore": true
+        }
       ]
     }
   ]

--- a/src/cinematic/celestial/celestialGeometry.ts
+++ b/src/cinematic/celestial/celestialGeometry.ts
@@ -4,6 +4,9 @@ import { lerp } from '../utils/math';
 export const CELESTIAL_DISC_RADIUS = 12;
 export const CELESTIAL_EYE_SCALE = 0.92;
 export const CELESTIAL_PUPIL_RADIUS = CELESTIAL_DISC_RADIUS / CELESTIAL_EYE_SCALE;
+export const CELESTIAL_SUN_X = 22;
+export const CELESTIAL_SUN_Y = 7.5;
+export const CELESTIAL_SUN_Z = -1135;
 
 export const getCelestialBreath = (frame: number): number =>
   1 + Math.sin(frame * 0.026) * 0.008;
@@ -13,5 +16,23 @@ export const getCelestialEyePosition = (state: TimelineState): readonly [number,
   return [
     lerp(moonY, 15, state.sunPositionProgress),
     lerp(-540, -760, state.sunPositionProgress),
+  ];
+};
+
+/**
+ * Shared world-space position for the iris/sun body and the surrounding eye
+ * geometry. Keeping this handoff in one function prevents the two visual
+ * layers from drifting apart while the eye becomes the coastal sun.
+ */
+export const getCelestialHandoffPosition = (
+  state: TimelineState,
+): readonly [number, number, number] => {
+  const [eyeY, eyeZ] = getCelestialEyePosition(state);
+  const handoff = state.sunHorizonProgress;
+
+  return [
+    lerp(0, CELESTIAL_SUN_X, handoff),
+    lerp(eyeY, CELESTIAL_SUN_Y, handoff) - state.sunsetProgress * 34,
+    lerp(eyeZ, CELESTIAL_SUN_Z, handoff),
   ];
 };

--- a/src/cinematic/effects/Atmosphere.tsx
+++ b/src/cinematic/effects/Atmosphere.tsx
@@ -16,7 +16,7 @@ import {
   CELESTIAL_EYE_SCALE,
   CELESTIAL_PUPIL_RADIUS,
   getCelestialBreath,
-  getCelestialEyePosition,
+  getCelestialHandoffPosition,
 } from '../celestial/celestialGeometry';
 import { easedRange } from '../utils/math';
 import { createSeededRandom, randomBetween } from '../utils/seededRandom';
@@ -323,7 +323,7 @@ const CelestialEye = ({ opacity, frame, state }: {
   const outline = useMemo(() => createEyeOutline(), []);
   if (opacity <= 0.001) return null;
 
-  const [y, z] = getCelestialEyePosition(state);
+  const [x, y, z] = getCelestialHandoffPosition(state);
   const revealOpen = Math.min(1, opacity * 1.25);
   const narrativeEyeOpen = 1 - easedRange(frame, 1545, 1588);
   const open = revealOpen * narrativeEyeOpen;
@@ -332,7 +332,7 @@ const CelestialEye = ({ opacity, frame, state }: {
 
   return (
     <group
-      position={[0, y, z]}
+      position={[x, y, z]}
       scale={[
         CELESTIAL_EYE_SCALE * breathe,
         CELESTIAL_EYE_SCALE * breathe * (0.035 + open * 0.965),

--- a/src/cinematic/lighting/CinematicLighting.tsx
+++ b/src/cinematic/lighting/CinematicLighting.tsx
@@ -1,8 +1,9 @@
 import { AdditiveBlending, Color } from 'three';
 import {
   CELESTIAL_DISC_RADIUS,
+  CELESTIAL_SUN_X,
   getCelestialBreath,
-  getCelestialEyePosition,
+  getCelestialHandoffPosition,
 } from '../celestial/celestialGeometry';
 import type { CinematicQuality } from '../config/cinematicQuality';
 import type { TimelineState } from '../timeline/timeline';
@@ -158,18 +159,15 @@ const CelestialAperture = ({ closure, quality }: { closure: number; quality: Cin
     </group>
   );
 };
-const CelestialBody = ({ state, sunX, quality }: { state: TimelineState; sunX: number; quality: CinematicQuality }) => {
+const CelestialBody = ({ state, quality }: { state: TimelineState; quality: CinematicQuality }) => {
   const sunsetOcclusion = 1 - smootherstep(clamp01((state.sunsetProgress - 0.72) / 0.28));
   const sunMorph = state.sunMorph;
   const lunarStrength = 1 - sunMorph;
   const moonVisibility = state.moonIntensity * lunarStrength;
   const sunVisibility = state.sunIntensity * state.sunRevealProgress;
   const celestialVisibility = Math.min(1, moonVisibility + sunVisibility) * sunsetOcclusion;
-  const x = lerp(0, sunX, state.sunHorizonProgress);
-  const [eyeY, eyeZ] = getCelestialEyePosition(state);
-  const y = lerp(eyeY, 7.5, state.sunHorizonProgress) - state.sunsetProgress * 34;
+  const [x, y, z] = getCelestialHandoffPosition(state);
   const breathe = getCelestialBreath(state.frame);
-  const z = lerp(eyeZ, -1135, state.sunHorizonProgress);
   const bodyScale = breathe;
   const sunVisualScale = lerp(1, 3.15, state.sunHorizonProgress);
   const haloScale = lerp(1, 2.25, state.sunHorizonProgress);
@@ -228,7 +226,6 @@ const CelestialBody = ({ state, sunX, quality }: { state: TimelineState; sunX: n
 };
 
 export const CinematicLighting = ({ state, quality }: { state: TimelineState; quality: CinematicQuality }) => {
-  const sunX = 22;
   const sunY = 15;
   const moonY = lerp(-42, 138, state.moonProgress);
   const sunColor = mixColor('#d8efff', '#ff8a48', state.sunWarmth);
@@ -243,14 +240,14 @@ export const CinematicLighting = ({ state, quality }: { state: TimelineState; qu
       <directionalLight
         color={sunColor}
         intensity={state.sunIntensity * 1.45}
-        position={[sunX, sunY, 100]}
+        position={[CELESTIAL_SUN_X, sunY, 100]}
       />
       <directionalLight
         color="#91b7ff"
         intensity={state.moonIntensity * 0.36}
         position={[-120, moonY, -310]}
       />
-      <CelestialBody state={state} sunX={sunX} quality={quality} />
+      <CelestialBody state={state} quality={quality} />
     </>
   );
 };

--- a/src/cinematic/timeline/timeline.test.ts
+++ b/src/cinematic/timeline/timeline.test.ts
@@ -15,6 +15,15 @@ describe('cinematic timeline handoffs', () => {
     expect(hiddenSun.sunIntensity).toBe(0);
   });
 
+  it('anchors the sun to the horizon before the yacht camera inspection', () => {
+    const revealEnd = getTimelineState(authoredToOutputFrame(1545));
+    const yachtFocusStart = getTimelineState(authoredToOutputFrame(1586));
+
+    expect(revealEnd.sunRevealProgress).toBeGreaterThan(0.99);
+    expect(revealEnd.sunHorizonProgress).toBeGreaterThan(0.99);
+    expect(yachtFocusStart.sunHorizonProgress).toBe(1);
+  });
+
   it('never leaves a gap between the city and the opaque coast', () => {
     for (let authoredFrame = 1540; authoredFrame <= 1600; authoredFrame += 2) {
       const state = getTimelineState(authoredToOutputFrame(authoredFrame));

--- a/src/cinematic/timeline/timeline.ts
+++ b/src/cinematic/timeline/timeline.ts
@@ -73,7 +73,10 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   // visibly opening; the sunrise illumination then follows the reveal.
   const sunRevealProgress = easedRange(frame, 1480, 1542);
   const sunPositionProgress = easedRange(frame, 1438, 1545);
-  const sunHorizonProgress = easedRange(frame, 1606, 1662);
+  // Complete the eye-to-horizon relocation as part of the same reveal. The
+  // yacht camera inspection begins later, so the sun is already anchored to
+  // the real horizon instead of correcting its position during the zoom.
+  const sunHorizonProgress = sunPositionProgress;
   // Establish a restrained pre-dawn before the shutter opens, then let full
   // daylight arrive with the revealed sun and coastline.
   const preDawn = easedRange(frame, 1328, 1438);

--- a/tests/unit/creditsContent.test.ts
+++ b/tests/unit/creditsContent.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CINEMATIC_CREDITS } from '../../src/cinematic/config/cinematicConfig'
 import {
@@ -21,6 +22,10 @@ const VALID_DOCUMENT = {
   ],
 }
 
+const BUNDLED_RUNTIME_CREDITS = JSON.parse(
+  readFileSync(new URL('../../public/config/credits.json', import.meta.url), 'utf8')
+) as unknown
+
 afterEach(() => {
   delete (window as Window & { __BIG_EYE_CREDITS_URL__?: string }).__BIG_EYE_CREDITS_URL__
   document.querySelector('meta[name="big-eye-credits-url"]')?.remove()
@@ -31,6 +36,10 @@ describe('runtime credits content', () => {
     const parsed = parseCreditsContent(VALID_DOCUMENT)
     expect(parsed).toHaveLength(1)
     expect(parsed?.[0]?.lines[1]?.text).toBe('New Producer')
+  })
+
+  it('keeps the bundled runtime document synchronized with the fallback copy', () => {
+    expect(parseCreditsContent(BUNDLED_RUNTIME_CREDITS)).toEqual(CINEMATIC_CREDITS)
   })
 
   it('rejects overlapping, duplicate, or out-of-range cards as a whole', () => {


### PR DESCRIPTION
Superseded after visual review. The shared-transform rewrite changed the original eye-to-sun choreography, reflection timing, and sea presentation beyond the requested scope. A clean replacement branch starts again from main and changes only the sun horizon timing while preserving the original animation components.