### PR TITLE
Land the existing eye-to-sun composite on the real horizon

### DIFF
--- a/.github/workflows/cinematic-composite-horizon-preview.yml
+++ b/.github/workflows/cinematic-composite-horizon-preview.yml
@@ -1,0 +1,53 @@
+name: Cinematic composite horizon preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/cinematic/celestial/celestialGeometry.ts'
+      - '.github/workflows/cinematic-composite-horizon-preview.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  render-preview:
+    if: github.event.pull_request.head.ref == 'agent/fix-composite-horizon-target'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Render current-main choreography with shared landing target fix
+        run: |
+          mkdir -p renders
+          npx remotion render src/remotion/index.ts BigEyeCinematicBackground renders/composite-horizon-preview.mp4 \
+            --codec=h264 \
+            --pixel-format=yuv420p \
+            --image-format=png \
+            --color-space=bt709 \
+            --frames=1250-1540 \
+            --concurrency=2 \
+            --gl=swangle
+
+      - name: Upload preview video
+        uses: actions/upload-artifact@v4
+        with:
+          name: composite-horizon-preview
+          path: renders/composite-horizon-preview.mp4
+          if-no-files-found: error
+          retention-days: 7

--- a/src/cinematic/celestial/celestialGeometry.ts
+++ b/src/cinematic/celestial/celestialGeometry.ts
@@ -11,7 +11,11 @@ export const getCelestialBreath = (frame: number): number =>
 export const getCelestialEyePosition = (state: TimelineState): readonly [number, number] => {
   const moonY = lerp(-42, 138, state.moonProgress);
   return [
-    lerp(moonY, 15, state.sunPositionProgress),
-    lerp(-540, -760, state.sunPositionProgress),
+    // Preserve the existing eye/iris movement, but make their shared authored
+    // landing point the real coastal horizon instead of the temporary
+    // in-water position. Both visual layers already consume this helper, so
+    // they remain coupled throughout the move and morph.
+    lerp(moonY, 7.5, state.sunPositionProgress),
+    lerp(-540, -1135, state.sunPositionProgress),
   ];
 };


### PR DESCRIPTION
Superseded after visual review. The replacement starts again from current main and uses a different handoff: the eye outline fades at the screenshot moment, the iris moves directly to the final horizon, apparent sun size stays stable, and environmental reflections begin only after the iris reads as the sun.