### PR TITLE
Fade the eye into a stable horizon sun

### DIFF
--- a/.github/workflows/cinematic-eye-fade-horizon-preview.yml
+++ b/.github/workflows/cinematic-eye-fade-horizon-preview.yml
@@ -41,7 +41,7 @@ jobs:
           --pixel-format=yuv420p
           --image-format=png
           --color-space=bt709
-          --frames=1410-1665
+          --frames=1370-1619
           --concurrency=2
           --gl=swangle
 

--- a/.github/workflows/cinematic-eye-fade-horizon-preview.yml
+++ b/.github/workflows/cinematic-eye-fade-horizon-preview.yml
@@ -1,0 +1,53 @@
+name: Cinematic eye fade horizon preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/cinematic/**'
+      - 'src/remotion/**'
+      - '.github/workflows/cinematic-eye-fade-horizon-preview.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  render-preview:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Render eye fade to horizon preview
+        run: >-
+          npx remotion render
+          src/remotion/index.ts
+          BigEyeCinematicBackground
+          renders/eye-fade-horizon-preview.mp4
+          --codec=h264
+          --pixel-format=yuv420p
+          --image-format=png
+          --color-space=bt709
+          --frames=1410-1665
+          --concurrency=2
+          --gl=swangle
+
+      - name: Upload preview video
+        uses: actions/upload-artifact@v4
+        with:
+          name: eye-fade-horizon-preview
+          path: renders/eye-fade-horizon-preview.mp4
+          retention-days: 7

--- a/src/cinematic/lighting/CinematicLighting.tsx
+++ b/src/cinematic/lighting/CinematicLighting.tsx
@@ -163,16 +163,20 @@ const CelestialBody = ({ state, sunX, quality }: { state: TimelineState; sunX: n
   const sunMorph = state.sunMorph;
   const lunarStrength = 1 - sunMorph;
   const moonVisibility = state.moonIntensity * lunarStrength;
-  const sunVisibility = state.sunIntensity * state.sunRevealProgress;
-  const celestialVisibility = Math.min(1, moonVisibility + sunVisibility) * sunsetOcclusion;
+  // The disc is allowed to appear before its environmental lighting, so the
+  // iris visibly becomes the sun before any reflection reaches the buildings.
+  const sunDiscVisibility = sunMorph * state.sunRevealProgress;
+  const celestialVisibility = Math.min(1, moonVisibility + sunDiscVisibility) * sunsetOcclusion;
   const x = lerp(0, sunX, state.sunHorizonProgress);
   const [eyeY, eyeZ] = getCelestialEyePosition(state);
   const y = lerp(eyeY, 7.5, state.sunHorizonProgress) - state.sunsetProgress * 34;
   const breathe = getCelestialBreath(state.frame);
   const z = lerp(eyeZ, -1135, state.sunHorizonProgress);
   const bodyScale = breathe;
-  const sunVisualScale = lerp(1, 3.15, state.sunHorizonProgress);
-  const haloScale = lerp(1, 2.25, state.sunHorizonProgress);
+  // Compensate only for the increased camera distance. The apparent disc size
+  // stays stable instead of visibly growing while crossing the waterline.
+  const sunVisualScale = lerp(1, 1.5, state.sunHorizonProgress);
+  const haloScale = lerp(1, 1.42, state.sunHorizonProgress);
   const glowColor = mixColor(
     mixColor('#afc9e3', '#ffc25f', sunMorph),
     '#ff5b24',
@@ -219,7 +223,7 @@ const CelestialBody = ({ state, sunX, quality }: { state: TimelineState; sunX: n
       </mesh>
       <pointLight
         color={glowColor}
-        intensity={(moonVisibility * 0.62 + sunVisibility * 1.3) * sunsetOcclusion}
+        intensity={(moonVisibility * 0.62 + state.sunIntensity * 1.3) * sunsetOcclusion}
         distance={390}
       />
       <CelestialAperture closure={state.apertureClosure} quality={quality} />

--- a/src/cinematic/timeline/timeline.ts
+++ b/src/cinematic/timeline/timeline.ts
@@ -69,11 +69,15 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
   const apertureClosure = Math.min(apertureClose, 1 - apertureOpen);
   // The celestial texture changes only while the aperture is fully closed.
   const sunMorph = easedRange(frame, 1344, 1374);
-  // Keep both the sun and its building reflections dark until the shutter is
-  // visibly opening; the sunrise illumination then follows the reveal.
+  // Reveal the transformed iris before its light begins affecting the city.
   const sunRevealProgress = easedRange(frame, 1480, 1542);
   const sunPositionProgress = easedRange(frame, 1438, 1545);
-  const sunHorizonProgress = easedRange(frame, 1606, 1662);
+  // As the eye outline fades, move the already-transformed iris directly to
+  // the final coastal horizon. There is no later secondary correction.
+  const sunHorizonProgress = easedRange(frame, 1545, 1588);
+  // Reflections and environmental sunlight begin only after the iris has
+  // completed its horizon handoff and clearly reads as the sun.
+  const sunIlluminationProgress = easedRange(frame, 1588, 1628);
   // Establish a restrained pre-dawn before the shutter opens, then let full
   // daylight arrive with the revealed sun and coastline.
   const preDawn = easedRange(frame, 1328, 1438);
@@ -154,7 +158,7 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
     ambientIntensity: (0.34 - stormShade * 0.08 + lightning * 0.72 + dawnProgress * 0.7)
       * (1 - sunsetProgress * 0.66),
     sunIntensity: sunMorph
-      * sunRevealProgress
+      * sunIlluminationProgress
       * (0.42 + dawnProgress * 0.95)
       * (1 - sunsetProgress * 0.38),
     sunWarmth: clamp01(0.48 + (1 - dawnProgress) * 0.44 + sunsetProgress * 0.46),
@@ -165,7 +169,7 @@ export const getTimelineState = (inputFrame: number): TimelineState => {
     vehicleLightIntensity: nightLightFade * (1.9 + stormShade * 0.82),
     lightning,
     lightningBolt,
-    eyeOpacity: easedRange(frame, 990, 1140) * (1 - easedRange(frame, 1578, 1622)),
+    eyeOpacity: easedRange(frame, 990, 1140) * (1 - easedRange(frame, 1545, 1588)),
     creditsOpacity: 1 - easedRange(frame, 1588, 1635),
     fadeToDark: finalDarkness,
   };


### PR DESCRIPTION
Starts from current `main`.

This implements the revised visual direction from the screenshot:
- the eye outline fades from frame 1545 to 1588
- the transformed iris moves directly from its original eye position to the final coastal horizon during that same fade
- the later secondary horizon correction is removed
- perspective compensation is reduced from 3.15x to 1.5x so the sun keeps a stable apparent size instead of growing inside the water
- the visible sun disc is decoupled from environmental light intensity
- building and scene reflections begin only after the iris has completed the handoff and reads as the sun

Unchanged:
- original aperture close/open choreography
- original iris-to-sun shader morph
- sea/coast geometry
- yacht zoom
- sunset progression
- main branch

Draft only. Do not merge before visual approval.