### PR TITLE
Broadcast Manager v1

### DIFF
--- a/e2e/playwright/core-player-journeys.spec.ts
+++ b/e2e/playwright/core-player-journeys.spec.ts
@@ -59,7 +59,7 @@ async function createProfileFromHome(page: Page, playerName: string): Promise<vo
 async function assertCampaignReady(page: Page, playerName: string): Promise<void> {
   const actionZone = page.getByRole('region', { name: 'Game action zone' })
   await expect(actionZone).toBeVisible({ timeout: SCREEN_TIMEOUT_MS })
-  await expect(actionZone.getByLabel('Day start', { exact: true })).toBeVisible()
+  await expect(actionZone.getByLabel('Season start', { exact: true })).toBeVisible()
   await expect(actionZone.getByLabel('Season 1, day 1', { exact: true })).toBeVisible()
   await expect(page.getByRole('toolbar', { name: 'Game actions' })).toBeVisible()
   await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible()

--- a/e2e/playwright/core-player-journeys.spec.ts
+++ b/e2e/playwright/core-player-journeys.spec.ts
@@ -282,6 +282,26 @@ async function advanceToFirstSocialPhase(page: Page): Promise<void> {
   throw new Error('The first social phase was not reachable through player controls.')
 }
 
+async function advanceToLohAnnouncement(page: Page): Promise<void> {
+  for (let step = 0; step < 12; step += 1) {
+    await closePhaseInformationIfPresent(page)
+    if ((await readAppState(page)).game.phase === 'loh_comp_announcement') return
+
+    const optionalContinue = page.getByRole('button', { name: 'Continue', exact: true })
+    if (await optionalContinue.isVisible()) {
+      await optionalContinue.click()
+      continue
+    }
+
+    const advance = page.getByRole('button', { name: 'Advance to next phase' })
+    await expect(advance).toBeVisible({ timeout: SCREEN_TIMEOUT_MS })
+    await expect(advance).toBeEnabled()
+    await advance.click()
+  }
+
+  throw new Error('The LOH competition announcement was not reachable through player controls.')
+}
+
 async function playOneCompleteWeek(page: Page): Promise<{
   endState: Awaited<ReturnType<typeof readAppState>>
   evidence: {
@@ -635,9 +655,7 @@ test.describe('Real player core journeys', () => {
     await startFreshCampaign(page, playerName)
 
     const actionZone = page.getByRole('region', { name: 'Game action zone' })
-    await page.getByRole('button', { name: 'Advance to next phase' }).click()
-    await expect(actionZone.getByLabel('Day start', { exact: true })).toBeVisible()
-    await page.getByRole('button', { name: 'Advance to next phase' }).click()
+    await advanceToLohAnnouncement(page)
     await expect(actionZone.getByLabel('LOH competition', { exact: true })).toBeVisible()
     await closePhaseInformationIfPresent(page)
 
@@ -723,7 +741,7 @@ test.describe('Real player core journeys', () => {
     await startFreshCampaign(page, playerName)
 
     const actionZone = page.getByRole('region', { name: 'Game action zone' })
-    await page.getByRole('button', { name: 'Advance to next phase' }).click()
+    await advanceToLohAnnouncement(page)
     await expect(actionZone.getByLabel('LOH competition', { exact: true })).toBeVisible()
     await closePhaseInformationIfPresent(page)
 

--- a/e2e/playwright/core-player-journeys.spec.ts
+++ b/e2e/playwright/core-player-journeys.spec.ts
@@ -546,7 +546,7 @@ test.describe('Real player core journeys', () => {
     const initialState = await readAppState(page)
     expect(initialState.game.seed).toBe(E2E_NEW_SEASON_FIXTURE.seasonSeed)
     expect(initialState.game.week).toBe(1)
-    expect(initialState.game.phase).toBe('week_start')
+    expect(initialState.game.phase).toBe('season_start')
     const initialActiveIds = initialState.game.players
       .filter((player) => player.status === 'active')
       .map((player) => player.id)
@@ -635,6 +635,8 @@ test.describe('Real player core journeys', () => {
     await startFreshCampaign(page, playerName)
 
     const actionZone = page.getByRole('region', { name: 'Game action zone' })
+    await page.getByRole('button', { name: 'Advance to next phase' }).click()
+    await expect(actionZone.getByLabel('Day start', { exact: true })).toBeVisible()
     await page.getByRole('button', { name: 'Advance to next phase' }).click()
     await expect(actionZone.getByLabel('LOH competition', { exact: true })).toBeVisible()
     await closePhaseInformationIfPresent(page)

--- a/e2e/playwright/reward-idempotency.spec.ts
+++ b/e2e/playwright/reward-idempotency.spec.ts
@@ -113,7 +113,7 @@ async function startCampaign(page: Page): Promise<void> {
 
   const actionZone = page.getByRole('region', { name: 'Game action zone' })
   await expect(actionZone).toBeVisible({ timeout: SCREEN_TIMEOUT_MS })
-  await expect(actionZone.getByLabel('Day start', { exact: true })).toBeVisible()
+  await expect(actionZone.getByLabel('Season start', { exact: true })).toBeVisible()
   await expect(page.getByRole('button', { name: PROFILE_NAME, exact: true })).toBeVisible()
 }
 

--- a/src/broadcasting/broadcastConfigPersistence.ts
+++ b/src/broadcasting/broadcastConfigPersistence.ts
@@ -1,0 +1,73 @@
+import type { BroadcastOverride, CustomBroadcastMessage } from '../types'
+
+export const BROADCAST_CONFIG_STORAGE_KEY = 'bbmobilenew:broadcast-manager:v2'
+
+export interface PersistedBroadcastConfig {
+  version: 2
+  overrides: Record<string, BroadcastOverride>
+  customMessages: CustomBroadcastMessage[]
+}
+
+function emptyConfig(): PersistedBroadcastConfig {
+  return { version: 2, overrides: {}, customMessages: [] }
+}
+
+function readableKeyFromText(text: string): string {
+  const slug = text
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .slice(0, 5)
+    .join('-')
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[.-]+|[.-]+$/g, '')
+  return `custom.${slug || 'message'}`
+}
+
+function migrateCustomKeys(messages: CustomBroadcastMessage[]): CustomBroadcastMessage[] {
+  const used = new Set<string>()
+  return messages.map((message) => {
+    const base = message.key?.trim() || readableKeyFromText(message.text)
+    let key = base
+    let suffix = 2
+    while (used.has(key)) key = `${base}-${suffix++}`
+    used.add(key)
+    return message.key === key ? message : { ...message, key }
+  })
+}
+
+export function loadBroadcastConfig(): PersistedBroadcastConfig {
+  if (typeof localStorage === 'undefined') return emptyConfig()
+  try {
+    const raw = localStorage.getItem(BROADCAST_CONFIG_STORAGE_KEY)
+    if (!raw) return emptyConfig()
+    const parsed = JSON.parse(raw) as Partial<PersistedBroadcastConfig>
+    if (parsed.version !== 2) return emptyConfig()
+    return {
+      version: 2,
+      overrides: parsed.overrides && typeof parsed.overrides === 'object' ? parsed.overrides : {},
+      customMessages: Array.isArray(parsed.customMessages)
+        ? migrateCustomKeys(parsed.customMessages)
+        : [],
+    }
+  } catch {
+    return emptyConfig()
+  }
+}
+
+export function saveBroadcastConfig(
+  overrides: Record<string, BroadcastOverride>,
+  customMessages: CustomBroadcastMessage[]
+): boolean {
+  if (typeof localStorage === 'undefined') return false
+  try {
+    localStorage.setItem(
+      BROADCAST_CONFIG_STORAGE_KEY,
+      JSON.stringify({ version: 2, overrides, customMessages } satisfies PersistedBroadcastConfig)
+    )
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/broadcasting/broadcastConfigPersistence.ts
+++ b/src/broadcasting/broadcastConfigPersistence.ts
@@ -22,7 +22,7 @@ function readableKeyFromText(text: string): string {
     .replace(/[^a-z0-9._-]+/g, '-')
     .replace(/-{2,}/g, '-')
     .replace(/^[.-]+|[.-]+$/g, '')
-  return `custom.${slug || 'message'}`
+  return `custom.${slug || 'message'}` // i18n-ignore: Internal storage key, never shown as player-facing copy
 }
 
 function migrateCustomKeys(messages: CustomBroadcastMessage[]): CustomBroadcastMessage[] {

--- a/src/broadcasting/broadcastTemplateCatalog.ts
+++ b/src/broadcasting/broadcastTemplateCatalog.ts
@@ -1,0 +1,252 @@
+import type { BroadcastLevel, Phase, TvEvent } from '../types'
+
+export type BroadcastTemplateKind = 'feed' | 'phase_card'
+
+export interface BroadcastTemplate {
+  id: string
+  phase: Phase
+  kind: BroadcastTemplateKind
+  text: string
+  title?: string
+  type: TvEvent['type']
+  level: BroadcastLevel
+  major?: string
+  /** Default faux-TV routing for a plain feed message. Cards are always routed. */
+  forceOnTv?: boolean
+  note?: string
+}
+
+export interface BroadcastTemplateMatch {
+  template: BroadcastTemplate
+  variables: string[]
+}
+
+const feed = (
+  id: string,
+  phase: Phase,
+  text: string,
+  type: TvEvent['type'] = 'game',
+  level: BroadcastLevel = 'minor',
+  major?: string,
+  note?: string,
+  forceOnTv = true
+): BroadcastTemplate => ({ id, phase, kind: 'feed', text, type, level, major, forceOnTv, note })
+
+const card = (
+  id: string,
+  phase: Phase,
+  title: string,
+  text: string,
+  major: string,
+  note?: string,
+  level: BroadcastLevel = 'major'
+): BroadcastTemplate => ({
+  id,
+  phase,
+  kind: 'phase_card',
+  title,
+  text,
+  type: 'game',
+  level,
+  major,
+  forceOnTv: true,
+  note,
+})
+
+/** Every phase value, including twist and interactive minigame sub-phases. */
+export const ALL_BROADCAST_PHASES: readonly Phase[] = [
+  'season_start',
+  'week_start',
+  'loh_comp_announcement',
+  'loh_comp',
+  'loh_results',
+  'democracia_vote',
+  'democracia_results',
+  'social_1',
+  'nominations',
+  'nomination_results',
+  'pre_veto_public_save',
+  'pos_comp_announcement',
+  'pos_comp',
+  'pos_results',
+  'pos_ceremony',
+  'pos_ceremony_results',
+  'social_2',
+  'live_vote',
+  'eviction_results',
+  'week_end',
+  'final4_eviction',
+  'final3',
+  'final3_comp1',
+  'final3_comp1_minigame',
+  'final3_comp2',
+  'final3_comp2_minigame',
+  'final3_comp3',
+  'final3_comp3_minigame',
+  'final3_decision',
+  'jury_announcement',
+  'jury_cinematic',
+  'jury',
+]
+
+/**
+ * Registry used by both the game emitter and Broadcast Manager. Braced values
+ * are capture slots: an edited template keeps the live player/day values.
+ */
+export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
+  feed('season.welcome', 'season_start', 'Welcome to The Big Eye house! 🏠 Season {season} is about to begin.', 'game', 'minor', undefined, undefined, true),
+  feed('season.public-mode-rule', 'season_start', '[Rules] Public mode: {status}'),
+  feed(
+    'season.vox-populi-intro',
+    'season_start',
+    'VOX POPULI is now in force. Housemates nominate in secret, the audience decides who leaves, and Public Mode reveals the pulse without changing the official result.',
+    'twist',
+    'critical',
+    'vox_populi',
+    'Vox Populi seasons only'
+  ),
+  feed(
+    'week.tribunal-start',
+    'week_start',
+    "Congrats all, you've just made it to tribunal. Your voices will crown the winner.",
+    'game',
+    'major',
+    'tribunal_phase',
+    'Only when the Tribunal stage begins'
+  ),
+  feed('week.day-start', 'week_start', 'Day {day} has begun. Get ready.', 'game', 'minor', undefined, undefined, true),
+  card('card.loh', 'loh_comp_announcement', 'LOH Competition', 'Power is up for grabs — who will become Leader of the House?', 'loh_comp_announcement'),
+  card('card.democracia', 'loh_comp_announcement', 'DEMOCRACIA!', 'The house will elect the new Leader of the House by secret vote.', 'democracia', 'Democracia branch', 'critical'),
+  card('card.vox-immunity', 'loh_comp_announcement', 'Immunity Competition', 'One housemate can earn safety from the public vote.', 'vox_immunity_comp', 'Vox Populi branch'),
+  card('card.vox-final4-competition', 'loh_comp_announcement', 'Final 4 Competition', 'No immunity is awarded today. Last place begins on the block; the other three each cast one secret vote.', 'vox_final4_immunity_comp', 'Vox Populi Final 4 branch'),
+  feed('loh.competition-start', 'loh_comp', 'The Leader of the House competition has begun! 🏆 Who will win power today?'),
+  feed('loh.democracia-vote-start', 'loh_comp', "🗳️ Today's Leader of the House will be chosen by popular vote! Cast your votes now.", 'game', 'major', 'democracia'),
+  feed('loh.winner', 'loh_results', '{winner} has won Leader of the House! 👑'),
+  feed('loh.cupid-winners', 'loh_results', "{winner} won Leader of the House, making {partner} co-LOH under Cupid's Arrow! 👑💘", 'game', 'minor', undefined, "Cupid's Arrow branch"),
+  feed('loh.vox-last-place', 'loh_results', '{player} finished last and is automatically nominated. 🎯', 'game', 'major', 'vox_last_place'),
+  card('card.democracia-vote', 'democracia_vote', 'DEMOCRACIA!', 'The house votes by secret ballot to elect the Leader of the House.', 'democracia', undefined, 'critical'),
+  feed('democracia.winner', 'democracia_vote', '🗳️ {winner} has been elected Leader of the House! 👑'),
+  feed('democracia.public-tiebreak', 'democracia_vote', '🗳️ Even after the ballotage, {players} are still tied! The public will decide by approval rating! 📊'),
+  feed('democracia.co-leaders', 'democracia_vote', '🗳️ The votes remain tied! {players} will BOTH serve as co-Leaders of the House! 👑👑'),
+  feed('democracia.no-voters', 'democracia_vote', '⚠️ No eligible voters available for ballotage. The winner is decided by chance!'),
+  feed('democracia.ballotage', 'democracia_vote', "🗳️ It's a tie between {players}! We go to BALLOTAGE! All other houseguests must revote between the tied candidates. 🗳️"),
+  feed('democracia.co-loh-social', 'democracia_results', '{players} are now co-Leaders of the House! 👑👑 Alliances are already forming…', 'social'),
+  feed('democracia.social', 'democracia_results', 'Housemates congratulate {winner}. Alliances are already forming… 💬', 'social'),
+  feed('democracia.vox-social', 'democracia_results', 'Housemates congratulate {winner} on winning immunity. The secret nomination conversations begin. 💬', 'social'),
+  feed('social.loh-congratulations', 'social_1', 'Housemates congratulate {winner}. Alliances are already forming… 💬', 'social'),
+  card('card.nominations', 'nominations', 'Nomination Ceremony', 'The Leader of the House will reveal who is in danger.', 'nomination_ceremony'),
+  card('card.double-eviction', 'nominations', 'Double Elimination!', 'Tonight, two housemates will leave the game.', 'double_eviction', 'Double Elimination branch'),
+  card('card.vox-nominations', 'nominations', 'Secret Nominations', 'Housemates nominate privately in the Confessional.', 'vox_nominations', 'Vox Populi branch'),
+  feed('nominations.preparing', 'nominations', '{leader} is preparing the nomination ceremony. 🎯'),
+  feed('nominations.vox-confessional', 'nominations', 'Housemates are being called to the Confessional one by one to nominate in secret. 🗳️'),
+  feed('nominations.human-prompt', 'nomination_results', "{leader}, it's time to make your nominations. Choose {count} players to nominate. 🎯"),
+  feed('nominations.co-loh-prompt', 'nomination_results', '{leader}, as co-Leader of the House, you must nominate one houseguest for elimination. 🎯'),
+  feed('nominations.co-loh-pick', 'nomination_results', '{leader} nominates {nominee}. 🎯'),
+  feed('nominations.vox-ballot', 'nomination_results', '{player}, cast {ballot} in the Confessional.', 'diary', 'major', 'vox_populi_ballot'),
+  feed('nominations.result', 'nomination_results', '{nominees} have been nominated for elimination. 🎯'),
+  feed('public-save.intro', 'pre_veto_public_save', "The final list of nominees today will be decided with the public's help."),
+  card('card.pos', 'pos_comp_announcement', 'Power of Safety', "It's time for the Power of Safety competition!", 'pos_comp_announcement'),
+  feed('pos.competition-start', 'pos_comp', 'The Power of Safety competition is underway! 🎭'),
+  feed('pos.winner', 'pos_results', '{winner} has won the Power of Safety! 🎭'),
+  card('card.safety', 'pos_ceremony', 'Safety Ceremony', 'The Power of Safety holder will reveal their decision.', 'veto_ceremony'),
+  card('card.final4-safety', 'pos_ceremony', 'Final 4 — Safety Ceremony', 'Only four players remain. The Power of Safety holder controls the sole vote.', 'final4', 'Final Four branch'),
+  card('card.vox-safety', 'pos_ceremony', 'Safety Ceremony', 'The safety decision can reshape the public vote.', 'vox_safety_ceremony', 'Vox Populi branch'),
+  feed('safety.holder', 'pos_ceremony', '{holder} is holding the Safety Ceremony. ⚡'),
+  feed('safety.secret-immunity', 'pos_ceremony_results', '{player} may use a secret {days}-day immunity right now to escape the block before the Safety Ceremony concludes. 🛡️'),
+  feed('safety.self-save', 'pos_ceremony_results', '{holder} used the Power of Safety and saved themselves! ⚡'),
+  feed('safety.save', 'pos_ceremony_results', '{holder} used the Power of Safety to save {nominee}! ⚡'),
+  feed('safety.hold', 'pos_ceremony_results', '{holder} chose not to use the Power of Safety. The nominations remain unchanged.'),
+  feed('safety.replacement-needed', 'pos_ceremony_results', '{leader} must now name a backup nominee. 🎯'),
+  feed('safety.replacement-selecting', 'pos_ceremony_results', '{leader} is selecting a backup nominee...'),
+  feed('safety.replacement', 'pos_ceremony_results', '{leader} named {nominee} as the backup nominee. 🎯'),
+  feed('safety.force-majeure', 'pos_ceremony_results', '{holder} used Force Majeure and saved themselves! ✨'),
+  feed('safety.halo', 'pos_ceremony_results', '{holder} used Halo Exchange and saved themselves! 😇'),
+  feed('safety.halo-prompt', 'pos_ceremony_results', '{holder}, will you use Halo Exchange? 😇'),
+  feed('safety.double-trouble', 'pos_ceremony_results', '{holder} used Double Trouble and saved themselves! 👑'),
+  feed('social.final-pitches', 'social_2', 'The nominees make their final pitches before the vote.', 'social'),
+  card('card.live-vote', 'live_vote', 'Live Elimination', 'The house will vote to eliminate.', 'live_eviction'),
+  card('card.vox-public-vote', 'live_vote', 'Public Vote', 'The audience decides who leaves.', 'vox_public_vote', 'Vox Populi branch'),
+  feed('vote.final-pitches', 'live_vote', 'Housemates give their last plea before voting begins.', 'social'),
+  feed('vote.tie-loh', 'eviction_results', "It's a tie between {nominees}! {leader}, as LOH you must break the tie. 🗳️"),
+  feed('vote.tie-pos', 'eviction_results', "It's a tie between {nominees}! {holder}, as POS holder, you must break the tie as a special exception. 🗳️"),
+  feed('vote.evicted', 'eviction_results', '{evictee}, you have been eliminated from The Big Eye house. 🚪'),
+  feed('week.day-end', 'week_end', 'Day {day} has come to an end. A new day begins soon… ✨'),
+  card('card.final4', 'final4_eviction', 'Final Four', 'The Power of Safety holder will cast the sole vote.', 'final4'),
+  feed('final4.pleas-start', 'final4_eviction', '{holder} asks nominees for their pleas. 🎤'),
+  feed('final4.plea', 'final4_eviction', '{nominee}: "{plea}"'),
+  card('card.final3', 'final3', 'The Finale', 'Three players remain — the three-part Final LOH begins.', 'final3_announcement'),
+  card('card.vox-final3', 'final3', 'Final 3', 'One housemate will win immunity. The audience will decide third place.', 'vox_final3', 'Vox Populi branch'),
+  feed('final3.part1-start', 'final3_comp1', 'Final 3 Part 1 is underway! All three players compete for the first leg of the Final LOH. 🏁'),
+  feed('final3.part1-result', 'final3_comp1', 'Final 3 Part 1 result: {winner} wins and advances directly to Part 3! The other two players will compete in Part 2. 🏆'),
+  feed('final3.part1-minigame', 'final3_comp1_minigame', 'Interactive Final 3 Part 1 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
+  feed('final3.part2-start', 'final3_comp2', 'Final 3 Part 2 is underway! The remaining two players battle to join the Part 1 winner in Part 3. 🏁'),
+  feed('final3.part2-result', 'final3_comp2', 'Final 3 Part 2 result: {winner} wins and advances to face the Part 1 winner in Part 3! 🏆'),
+  feed('final3.part2-minigame', 'final3_comp2_minigame', 'Interactive Final 3 Part 2 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
+  feed('final3.part3-start', 'final3_comp3', 'Final 3 Part 3 is underway! {first} (Part 1 winner) vs {second} (Part 2 winner) — the winner becomes the Final Leader of the House! 🏁'),
+  feed('final3.part3-result', 'final3_comp3', 'Final 3 Part 3: {winner} wins and is crowned the Final Leader of the House! 👑'),
+  feed('final3.part3-human-decision', 'final3_comp3', '{winner}, you must now eliminate either {nominees} to set the Final 2. 🎯'),
+  feed('final3.part3-minigame', 'final3_comp3_minigame', 'Interactive Final 3 Part 3 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
+  card('card.final-decision', 'final3_decision', 'Final LOH Decision', 'One finalist will be eliminated.', 'final_hoh'),
+  card('card.jury-announcement', 'jury_announcement', 'Tribunal Votes', 'The finalists will face the Tribunal.', 'jury'),
+  feed('jury.cinematic', 'jury_cinematic', 'The Tribunal prepares to crown a winner.', 'game', 'critical', 'jury'),
+  card('card.jury', 'jury', 'Tribunal Votes', 'The Tribunal decides the winner.', 'jury'),
+]
+
+const BY_ID = new Map(BROADCAST_TEMPLATE_CATALOG.map((template) => [template.id, template]))
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function compileTemplate(text: string): RegExp {
+  const parts = text.split(/\{[^}]+\}/g).map(escapeRegex)
+  return new RegExp(`^${parts.join('(.+?)')}$`, 'i')
+}
+
+export function getBroadcastTemplate(id: string): BroadcastTemplate | undefined {
+  return BY_ID.get(id)
+}
+
+export function getBroadcastTemplatesForPhase(phase: Phase): readonly BroadcastTemplate[] {
+  return BROADCAST_TEMPLATE_CATALOG.filter((template) => template.phase === phase)
+}
+
+export function getDefaultBroadcastOrder(template: BroadcastTemplate): number {
+  const phaseTemplates = getBroadcastTemplatesForPhase(template.phase)
+  const index = phaseTemplates.findIndex((candidate) => candidate.id === template.id)
+  return (Math.max(0, index) + 1) * 100
+}
+
+export function matchBroadcastTemplate(
+  text: string,
+  phase?: Phase,
+  explicitId?: unknown
+): BroadcastTemplateMatch | null {
+  if (typeof explicitId === 'string') {
+    const explicit = getBroadcastTemplate(explicitId)
+    if (explicit) {
+      const match = text.match(compileTemplate(explicit.text))
+      return { template: explicit, variables: match?.slice(1) ?? [] }
+    }
+  }
+  const candidates = BROADCAST_TEMPLATE_CATALOG.filter(
+    (template) => template.kind === 'feed' && (!phase || template.phase === phase)
+  )
+  for (const template of candidates) {
+    const match = text.match(compileTemplate(template.text))
+    if (match) return { template, variables: match.slice(1) }
+  }
+  if (phase) return matchBroadcastTemplate(text, undefined, explicitId)
+  return null
+}
+
+export function renderBroadcastTemplate(text: string, variables: readonly string[]): string {
+  let index = 0
+  return text.replace(/\{[^}]+\}/g, () => variables[index++] ?? '')
+}
+
+export function getPhaseCardTemplate(phase: Phase, major: string): BroadcastTemplate | undefined {
+  return BROADCAST_TEMPLATE_CATALOG.find(
+    (template) => template.kind === 'phase_card' && template.phase === phase && template.major === major
+  )
+}

--- a/src/broadcasting/broadcastTemplateCatalog.ts
+++ b/src/broadcasting/broadcastTemplateCatalog.ts
@@ -25,8 +25,8 @@ const feed = (
   id: string,
   phase: Phase,
   text: string,
-  type: TvEvent['type'] = 'game',
-  level: BroadcastLevel = 'minor',
+  type: TvEvent['type'] = 'game', // i18n-ignore: Internal event enum value, not player-facing copy
+  level: BroadcastLevel = 'minor', // i18n-ignore: Internal priority enum value, not player-facing copy
   major?: string,
   note?: string,
   forceOnTv = true
@@ -94,7 +94,16 @@ export const ALL_BROADCAST_PHASES: readonly Phase[] = [
  * are capture slots: an edited template keeps the live player/day values.
  */
 export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
-  feed('season.welcome', 'season_start', 'Welcome to The Big Eye house! 🏠 Season {season} is about to begin.', 'game', 'minor', undefined, undefined, true),
+  feed(
+    'season.welcome',
+    'season_start',
+    'Welcome to The Big Eye house! 🏠 Season {season} is about to begin.',
+    'game',
+    'minor',
+    undefined,
+    undefined,
+    true
+  ),
   feed('season.public-mode-rule', 'season_start', '[Rules] Public mode: {status}'),
   feed(
     'season.vox-populi-intro',
@@ -114,81 +123,430 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     'tribunal_phase',
     'Only when the Tribunal stage begins'
   ),
-  feed('week.day-start', 'week_start', 'Day {day} has begun. Get ready.', 'game', 'minor', undefined, undefined, true),
-  card('card.loh', 'loh_comp_announcement', 'LOH Competition', 'Power is up for grabs — who will become Leader of the House?', 'loh_comp_announcement'),
-  card('card.democracia', 'loh_comp_announcement', 'DEMOCRACIA!', 'The house will elect the new Leader of the House by secret vote.', 'democracia', 'Democracia branch', 'critical'),
-  card('card.vox-immunity', 'loh_comp_announcement', 'Immunity Competition', 'One housemate can earn safety from the public vote.', 'vox_immunity_comp', 'Vox Populi branch'),
-  card('card.vox-final4-competition', 'loh_comp_announcement', 'Final 4 Competition', 'No immunity is awarded today. Last place begins on the block; the other three each cast one secret vote.', 'vox_final4_immunity_comp', 'Vox Populi Final 4 branch'),
-  feed('loh.competition-start', 'loh_comp', 'The Leader of the House competition has begun! 🏆 Who will win power today?'),
-  feed('loh.democracia-vote-start', 'loh_comp', "🗳️ Today's Leader of the House will be chosen by popular vote! Cast your votes now.", 'game', 'major', 'democracia'),
+  feed(
+    'week.day-start',
+    'week_start',
+    'Day {day} has begun. Get ready.',
+    'game',
+    'minor',
+    undefined,
+    undefined,
+    true
+  ),
+  card(
+    'card.loh',
+    'loh_comp_announcement',
+    'LOH Competition',
+    'Power is up for grabs — who will become Leader of the House?',
+    'loh_comp_announcement'
+  ),
+  card(
+    'card.democracia',
+    'loh_comp_announcement',
+    'DEMOCRACIA!',
+    'The house will elect the new Leader of the House by secret vote.',
+    'democracia',
+    'Democracia branch',
+    'critical'
+  ),
+  card(
+    'card.vox-immunity',
+    'loh_comp_announcement',
+    'Immunity Competition',
+    'One housemate can earn safety from the public vote.',
+    'vox_immunity_comp',
+    'Vox Populi branch'
+  ),
+  card(
+    'card.vox-final4-competition',
+    'loh_comp_announcement',
+    'Final 4 Competition',
+    'No immunity is awarded today. Last place begins on the block; the other three each cast one secret vote.',
+    'vox_final4_immunity_comp',
+    'Vox Populi Final 4 branch'
+  ),
+  feed(
+    'loh.competition-start',
+    'loh_comp',
+    'The Leader of the House competition has begun! 🏆 Who will win power today?'
+  ),
+  feed(
+    'loh.democracia-vote-start',
+    'loh_comp',
+    "🗳️ Today's Leader of the House will be chosen by popular vote! Cast your votes now.",
+    'game',
+    'major',
+    'democracia'
+  ),
   feed('loh.winner', 'loh_results', '{winner} has won Leader of the House! 👑'),
-  feed('loh.cupid-winners', 'loh_results', "{winner} won Leader of the House, making {partner} co-LOH under Cupid's Arrow! 👑💘", 'game', 'minor', undefined, "Cupid's Arrow branch"),
-  feed('loh.vox-last-place', 'loh_results', '{player} finished last and is automatically nominated. 🎯', 'game', 'major', 'vox_last_place'),
-  card('card.democracia-vote', 'democracia_vote', 'DEMOCRACIA!', 'The house votes by secret ballot to elect the Leader of the House.', 'democracia', undefined, 'critical'),
-  feed('democracia.winner', 'democracia_vote', '🗳️ {winner} has been elected Leader of the House! 👑'),
-  feed('democracia.public-tiebreak', 'democracia_vote', '🗳️ Even after the ballotage, {players} are still tied! The public will decide by approval rating! 📊'),
-  feed('democracia.co-leaders', 'democracia_vote', '🗳️ The votes remain tied! {players} will BOTH serve as co-Leaders of the House! 👑👑'),
-  feed('democracia.no-voters', 'democracia_vote', '⚠️ No eligible voters available for ballotage. The winner is decided by chance!'),
-  feed('democracia.ballotage', 'democracia_vote', "🗳️ It's a tie between {players}! We go to BALLOTAGE! All other houseguests must revote between the tied candidates. 🗳️"),
-  feed('democracia.co-loh-social', 'democracia_results', '{players} are now co-Leaders of the House! 👑👑 Alliances are already forming…', 'social'),
-  feed('democracia.social', 'democracia_results', 'Housemates congratulate {winner}. Alliances are already forming… 💬', 'social'),
-  feed('democracia.vox-social', 'democracia_results', 'Housemates congratulate {winner} on winning immunity. The secret nomination conversations begin. 💬', 'social'),
-  feed('social.loh-congratulations', 'social_1', 'Housemates congratulate {winner}. Alliances are already forming… 💬', 'social'),
-  card('card.nominations', 'nominations', 'Nomination Ceremony', 'The Leader of the House will reveal who is in danger.', 'nomination_ceremony'),
-  card('card.double-eviction', 'nominations', 'Double Elimination!', 'Tonight, two housemates will leave the game.', 'double_eviction', 'Double Elimination branch'),
-  card('card.vox-nominations', 'nominations', 'Secret Nominations', 'Housemates nominate privately in the Confessional.', 'vox_nominations', 'Vox Populi branch'),
+  feed(
+    'loh.cupid-winners',
+    'loh_results',
+    "{winner} won Leader of the House, making {partner} co-LOH under Cupid's Arrow! 👑💘",
+    'game',
+    'minor',
+    undefined,
+    "Cupid's Arrow branch"
+  ),
+  feed(
+    'loh.vox-last-place',
+    'loh_results',
+    '{player} finished last and is automatically nominated. 🎯',
+    'game',
+    'major',
+    'vox_last_place'
+  ),
+  card(
+    'card.democracia-vote',
+    'democracia_vote',
+    'DEMOCRACIA!',
+    'The house votes by secret ballot to elect the Leader of the House.',
+    'democracia',
+    undefined,
+    'critical'
+  ),
+  feed(
+    'democracia.winner',
+    'democracia_vote',
+    '🗳️ {winner} has been elected Leader of the House! 👑'
+  ),
+  feed(
+    'democracia.public-tiebreak',
+    'democracia_vote',
+    '🗳️ Even after the ballotage, {players} are still tied! The public will decide by approval rating! 📊'
+  ),
+  feed(
+    'democracia.co-leaders',
+    'democracia_vote',
+    '🗳️ The votes remain tied! {players} will BOTH serve as co-Leaders of the House! 👑👑'
+  ),
+  feed(
+    'democracia.no-voters',
+    'democracia_vote',
+    '⚠️ No eligible voters available for ballotage. The winner is decided by chance!'
+  ),
+  feed(
+    'democracia.ballotage',
+    'democracia_vote',
+    "🗳️ It's a tie between {players}! We go to BALLOTAGE! All other houseguests must revote between the tied candidates. 🗳️"
+  ),
+  feed(
+    'democracia.co-loh-social',
+    'democracia_results',
+    '{players} are now co-Leaders of the House! 👑👑 Alliances are already forming…',
+    'social'
+  ),
+  feed(
+    'democracia.social',
+    'democracia_results',
+    'Housemates congratulate {winner}. Alliances are already forming… 💬',
+    'social'
+  ),
+  feed(
+    'democracia.vox-social',
+    'democracia_results',
+    'Housemates congratulate {winner} on winning immunity. The secret nomination conversations begin. 💬',
+    'social'
+  ),
+  feed(
+    'social.loh-congratulations',
+    'social_1',
+    'Housemates congratulate {winner}. Alliances are already forming… 💬',
+    'social'
+  ),
+  card(
+    'card.nominations',
+    'nominations',
+    'Nomination Ceremony',
+    'The Leader of the House will reveal who is in danger.',
+    'nomination_ceremony'
+  ),
+  card(
+    'card.double-eviction',
+    'nominations',
+    'Double Elimination!',
+    'Tonight, two housemates will leave the game.',
+    'double_eviction',
+    'Double Elimination branch'
+  ),
+  card(
+    'card.vox-nominations',
+    'nominations',
+    'Secret Nominations',
+    'Housemates nominate privately in the Confessional.',
+    'vox_nominations',
+    'Vox Populi branch'
+  ),
   feed('nominations.preparing', 'nominations', '{leader} is preparing the nomination ceremony. 🎯'),
-  feed('nominations.vox-confessional', 'nominations', 'Housemates are being called to the Confessional one by one to nominate in secret. 🗳️'),
-  feed('nominations.human-prompt', 'nomination_results', "{leader}, it's time to make your nominations. Choose {count} players to nominate. 🎯"),
-  feed('nominations.co-loh-prompt', 'nomination_results', '{leader}, as co-Leader of the House, you must nominate one houseguest for elimination. 🎯'),
+  feed(
+    'nominations.vox-confessional',
+    'nominations',
+    'Housemates are being called to the Confessional one by one to nominate in secret. 🗳️'
+  ),
+  feed(
+    'nominations.human-prompt',
+    'nomination_results',
+    "{leader}, it's time to make your nominations. Choose {count} players to nominate. 🎯"
+  ),
+  feed(
+    'nominations.co-loh-prompt',
+    'nomination_results',
+    '{leader}, as co-Leader of the House, you must nominate one houseguest for elimination. 🎯'
+  ),
   feed('nominations.co-loh-pick', 'nomination_results', '{leader} nominates {nominee}. 🎯'),
-  feed('nominations.vox-ballot', 'nomination_results', '{player}, cast {ballot} in the Confessional.', 'diary', 'major', 'vox_populi_ballot'),
-  feed('nominations.result', 'nomination_results', '{nominees} have been nominated for elimination. 🎯'),
-  feed('public-save.intro', 'pre_veto_public_save', "The final list of nominees today will be decided with the public's help."),
-  card('card.pos', 'pos_comp_announcement', 'Power of Safety', "It's time for the Power of Safety competition!", 'pos_comp_announcement'),
+  feed(
+    'nominations.vox-ballot',
+    'nomination_results',
+    '{player}, cast {ballot} in the Confessional.',
+    'diary',
+    'major',
+    'vox_populi_ballot'
+  ),
+  feed(
+    'nominations.result',
+    'nomination_results',
+    '{nominees} have been nominated for elimination. 🎯'
+  ),
+  feed(
+    'public-save.intro',
+    'pre_veto_public_save',
+    "The final list of nominees today will be decided with the public's help."
+  ),
+  card(
+    'card.pos',
+    'pos_comp_announcement',
+    'Power of Safety',
+    "It's time for the Power of Safety competition!",
+    'pos_comp_announcement'
+  ),
   feed('pos.competition-start', 'pos_comp', 'The Power of Safety competition is underway! 🎭'),
   feed('pos.winner', 'pos_results', '{winner} has won the Power of Safety! 🎭'),
-  card('card.safety', 'pos_ceremony', 'Safety Ceremony', 'The Power of Safety holder will reveal their decision.', 'veto_ceremony'),
-  card('card.final4-safety', 'pos_ceremony', 'Final 4 — Safety Ceremony', 'Only four players remain. The Power of Safety holder controls the sole vote.', 'final4', 'Final Four branch'),
-  card('card.vox-safety', 'pos_ceremony', 'Safety Ceremony', 'The safety decision can reshape the public vote.', 'vox_safety_ceremony', 'Vox Populi branch'),
+  card(
+    'card.safety',
+    'pos_ceremony',
+    'Safety Ceremony',
+    'The Power of Safety holder will reveal their decision.',
+    'veto_ceremony'
+  ),
+  card(
+    'card.final4-safety',
+    'pos_ceremony',
+    'Final 4 — Safety Ceremony',
+    'Only four players remain. The Power of Safety holder controls the sole vote.',
+    'final4',
+    'Final Four branch'
+  ),
+  card(
+    'card.vox-safety',
+    'pos_ceremony',
+    'Safety Ceremony',
+    'The safety decision can reshape the public vote.',
+    'vox_safety_ceremony',
+    'Vox Populi branch'
+  ),
   feed('safety.holder', 'pos_ceremony', '{holder} is holding the Safety Ceremony. ⚡'),
-  feed('safety.secret-immunity', 'pos_ceremony_results', '{player} may use a secret {days}-day immunity right now to escape the block before the Safety Ceremony concludes. 🛡️'),
-  feed('safety.self-save', 'pos_ceremony_results', '{holder} used the Power of Safety and saved themselves! ⚡'),
-  feed('safety.save', 'pos_ceremony_results', '{holder} used the Power of Safety to save {nominee}! ⚡'),
-  feed('safety.hold', 'pos_ceremony_results', '{holder} chose not to use the Power of Safety. The nominations remain unchanged.'),
-  feed('safety.replacement-needed', 'pos_ceremony_results', '{leader} must now name a backup nominee. 🎯'),
-  feed('safety.replacement-selecting', 'pos_ceremony_results', '{leader} is selecting a backup nominee...'),
-  feed('safety.replacement', 'pos_ceremony_results', '{leader} named {nominee} as the backup nominee. 🎯'),
-  feed('safety.force-majeure', 'pos_ceremony_results', '{holder} used Force Majeure and saved themselves! ✨'),
-  feed('safety.halo', 'pos_ceremony_results', '{holder} used Halo Exchange and saved themselves! 😇'),
+  feed(
+    'safety.secret-immunity',
+    'pos_ceremony_results',
+    '{player} may use a secret {days}-day immunity right now to escape the block before the Safety Ceremony concludes. 🛡️'
+  ),
+  feed(
+    'safety.self-save',
+    'pos_ceremony_results',
+    '{holder} used the Power of Safety and saved themselves! ⚡'
+  ),
+  feed(
+    'safety.save',
+    'pos_ceremony_results',
+    '{holder} used the Power of Safety to save {nominee}! ⚡'
+  ),
+  feed(
+    'safety.hold',
+    'pos_ceremony_results',
+    '{holder} chose not to use the Power of Safety. The nominations remain unchanged.'
+  ),
+  feed(
+    'safety.replacement-needed',
+    'pos_ceremony_results',
+    '{leader} must now name a backup nominee. 🎯'
+  ),
+  feed(
+    'safety.replacement-selecting',
+    'pos_ceremony_results',
+    '{leader} is selecting a backup nominee...'
+  ),
+  feed(
+    'safety.replacement',
+    'pos_ceremony_results',
+    '{leader} named {nominee} as the backup nominee. 🎯'
+  ),
+  feed(
+    'safety.force-majeure',
+    'pos_ceremony_results',
+    '{holder} used Force Majeure and saved themselves! ✨'
+  ),
+  feed(
+    'safety.halo',
+    'pos_ceremony_results',
+    '{holder} used Halo Exchange and saved themselves! 😇'
+  ),
   feed('safety.halo-prompt', 'pos_ceremony_results', '{holder}, will you use Halo Exchange? 😇'),
-  feed('safety.double-trouble', 'pos_ceremony_results', '{holder} used Double Trouble and saved themselves! 👑'),
-  feed('social.final-pitches', 'social_2', 'The nominees make their final pitches before the vote.', 'social'),
-  card('card.live-vote', 'live_vote', 'Live Elimination', 'The house will vote to eliminate.', 'live_eviction'),
-  card('card.vox-public-vote', 'live_vote', 'Public Vote', 'The audience decides who leaves.', 'vox_public_vote', 'Vox Populi branch'),
-  feed('vote.final-pitches', 'live_vote', 'Housemates give their last plea before voting begins.', 'social'),
-  feed('vote.tie-loh', 'eviction_results', "It's a tie between {nominees}! {leader}, as LOH you must break the tie. 🗳️"),
-  feed('vote.tie-pos', 'eviction_results', "It's a tie between {nominees}! {holder}, as POS holder, you must break the tie as a special exception. 🗳️"),
-  feed('vote.evicted', 'eviction_results', '{evictee}, you have been eliminated from The Big Eye house. 🚪'),
+  feed(
+    'safety.double-trouble',
+    'pos_ceremony_results',
+    '{holder} used Double Trouble and saved themselves! 👑'
+  ),
+  feed(
+    'social.final-pitches',
+    'social_2',
+    'The nominees make their final pitches before the vote.',
+    'social'
+  ),
+  card(
+    'card.live-vote',
+    'live_vote',
+    'Live Elimination',
+    'The house will vote to eliminate.',
+    'live_eviction'
+  ),
+  card(
+    'card.vox-public-vote',
+    'live_vote',
+    'Public Vote',
+    'The audience decides who leaves.',
+    'vox_public_vote',
+    'Vox Populi branch'
+  ),
+  feed(
+    'vote.final-pitches',
+    'live_vote',
+    'Housemates give their last plea before voting begins.',
+    'social'
+  ),
+  feed(
+    'vote.tie-loh',
+    'eviction_results',
+    "It's a tie between {nominees}! {leader}, as LOH you must break the tie. 🗳️"
+  ),
+  feed(
+    'vote.tie-pos',
+    'eviction_results',
+    "It's a tie between {nominees}! {holder}, as POS holder, you must break the tie as a special exception. 🗳️"
+  ),
+  feed(
+    'vote.evicted',
+    'eviction_results',
+    '{evictee}, you have been eliminated from The Big Eye house. 🚪'
+  ),
   feed('week.day-end', 'week_end', 'Day {day} has come to an end. A new day begins soon… ✨'),
-  card('card.final4', 'final4_eviction', 'Final Four', 'The Power of Safety holder will cast the sole vote.', 'final4'),
+  card(
+    'card.final4',
+    'final4_eviction',
+    'Final Four',
+    'The Power of Safety holder will cast the sole vote.',
+    'final4'
+  ),
   feed('final4.pleas-start', 'final4_eviction', '{holder} asks nominees for their pleas. 🎤'),
   feed('final4.plea', 'final4_eviction', '{nominee}: "{plea}"'),
-  card('card.final3', 'final3', 'The Finale', 'Three players remain — the three-part Final LOH begins.', 'final3_announcement'),
-  card('card.vox-final3', 'final3', 'Final 3', 'One housemate will win immunity. The audience will decide third place.', 'vox_final3', 'Vox Populi branch'),
-  feed('final3.part1-start', 'final3_comp1', 'Final 3 Part 1 is underway! All three players compete for the first leg of the Final LOH. 🏁'),
-  feed('final3.part1-result', 'final3_comp1', 'Final 3 Part 1 result: {winner} wins and advances directly to Part 3! The other two players will compete in Part 2. 🏆'),
-  feed('final3.part1-minigame', 'final3_comp1_minigame', 'Interactive Final 3 Part 1 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
-  feed('final3.part2-start', 'final3_comp2', 'Final 3 Part 2 is underway! The remaining two players battle to join the Part 1 winner in Part 3. 🏁'),
-  feed('final3.part2-result', 'final3_comp2', 'Final 3 Part 2 result: {winner} wins and advances to face the Part 1 winner in Part 3! 🏆'),
-  feed('final3.part2-minigame', 'final3_comp2_minigame', 'Interactive Final 3 Part 2 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
-  feed('final3.part3-start', 'final3_comp3', 'Final 3 Part 3 is underway! {first} (Part 1 winner) vs {second} (Part 2 winner) — the winner becomes the Final Leader of the House! 🏁'),
-  feed('final3.part3-result', 'final3_comp3', 'Final 3 Part 3: {winner} wins and is crowned the Final Leader of the House! 👑'),
-  feed('final3.part3-human-decision', 'final3_comp3', '{winner}, you must now eliminate either {nominees} to set the Final 2. 🎯'),
-  feed('final3.part3-minigame', 'final3_comp3_minigame', 'Interactive Final 3 Part 3 competition', 'game', 'minor', undefined, 'Gameplay screen; no feed line'),
-  card('card.final-decision', 'final3_decision', 'Final LOH Decision', 'One finalist will be eliminated.', 'final_hoh'),
-  card('card.jury-announcement', 'jury_announcement', 'Tribunal Votes', 'The finalists will face the Tribunal.', 'jury'),
-  feed('jury.cinematic', 'jury_cinematic', 'The Tribunal prepares to crown a winner.', 'game', 'critical', 'jury'),
+  card(
+    'card.final3',
+    'final3',
+    'The Finale',
+    'Three players remain — the three-part Final LOH begins.',
+    'final3_announcement'
+  ),
+  card(
+    'card.vox-final3',
+    'final3',
+    'Final 3',
+    'One housemate will win immunity. The audience will decide third place.',
+    'vox_final3',
+    'Vox Populi branch'
+  ),
+  feed(
+    'final3.part1-start',
+    'final3_comp1',
+    'Final 3 Part 1 is underway! All three players compete for the first leg of the Final LOH. 🏁'
+  ),
+  feed(
+    'final3.part1-result',
+    'final3_comp1',
+    'Final 3 Part 1 result: {winner} wins and advances directly to Part 3! The other two players will compete in Part 2. 🏆'
+  ),
+  feed(
+    'final3.part1-minigame',
+    'final3_comp1_minigame',
+    'Interactive Final 3 Part 1 competition',
+    'game',
+    'minor',
+    undefined,
+    'Gameplay screen; no feed line'
+  ),
+  feed(
+    'final3.part2-start',
+    'final3_comp2',
+    'Final 3 Part 2 is underway! The remaining two players battle to join the Part 1 winner in Part 3. 🏁'
+  ),
+  feed(
+    'final3.part2-result',
+    'final3_comp2',
+    'Final 3 Part 2 result: {winner} wins and advances to face the Part 1 winner in Part 3! 🏆'
+  ),
+  feed(
+    'final3.part2-minigame',
+    'final3_comp2_minigame',
+    'Interactive Final 3 Part 2 competition',
+    'game',
+    'minor',
+    undefined,
+    'Gameplay screen; no feed line'
+  ),
+  feed(
+    'final3.part3-start',
+    'final3_comp3',
+    'Final 3 Part 3 is underway! {first} (Part 1 winner) vs {second} (Part 2 winner) — the winner becomes the Final Leader of the House! 🏁'
+  ),
+  feed(
+    'final3.part3-result',
+    'final3_comp3',
+    'Final 3 Part 3: {winner} wins and is crowned the Final Leader of the House! 👑'
+  ),
+  feed(
+    'final3.part3-human-decision',
+    'final3_comp3',
+    '{winner}, you must now eliminate either {nominees} to set the Final 2. 🎯'
+  ),
+  feed(
+    'final3.part3-minigame',
+    'final3_comp3_minigame',
+    'Interactive Final 3 Part 3 competition',
+    'game',
+    'minor',
+    undefined,
+    'Gameplay screen; no feed line'
+  ),
+  card(
+    'card.final-decision',
+    'final3_decision',
+    'Final LOH Decision',
+    'One finalist will be eliminated.',
+    'final_hoh'
+  ),
+  card(
+    'card.jury-announcement',
+    'jury_announcement',
+    'Tribunal Votes',
+    'The finalists will face the Tribunal.',
+    'jury'
+  ),
+  feed(
+    'jury.cinematic',
+    'jury_cinematic',
+    'The Tribunal prepares to crown a winner.',
+    'game',
+    'critical',
+    'jury'
+  ),
   card('card.jury', 'jury', 'Tribunal Votes', 'The Tribunal decides the winner.', 'jury'),
 ]
 
@@ -247,6 +605,7 @@ export function renderBroadcastTemplate(text: string, variables: readonly string
 
 export function getPhaseCardTemplate(phase: Phase, major: string): BroadcastTemplate | undefined {
   return BROADCAST_TEMPLATE_CATALOG.find(
-    (template) => template.kind === 'phase_card' && template.phase === phase && template.major === major
+    (template) =>
+      template.kind === 'phase_card' && template.phase === phase && template.major === major
   )
 }

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -397,6 +397,7 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                 type="button"
                 onClick={() => navigate('/broadcast-manager?debug=1')}
               >
+                {/* i18n-ignore: Debug-only navigation control intentionally uses canonical English */}
                 Open Broadcast Manager
               </button>
 

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -54,6 +54,7 @@ import {
 import './DebugPanel.css';
 
 const PHASES: Phase[] = [
+  'season_start',
   'week_start',
   'loh_comp_announcement',
   'loh_comp',
@@ -391,6 +392,13 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                 <dt>Alive</dt> <dd>{alive.length}</dd>
                 <dt>Evicted</dt> <dd>{evicted.length}</dd>
               </dl>
+              <button
+                className="dbg-btn dbg-btn--wide"
+                type="button"
+                onClick={() => navigate('/broadcast-manager?debug=1')}
+              >
+                Open Broadcast Manager
+              </button>
 
               <details className="dbg-players">
                 <summary>Players ({game.players.length})</summary>

--- a/src/components/HousePulse/HousePulse.tsx
+++ b/src/components/HousePulse/HousePulse.tsx
@@ -29,6 +29,7 @@ const RUMOUR_LABEL: Record<string, string> = {
 }
 
 const PHASE_LABEL: Record<string, string> = {
+  // i18n-ignore: Legacy phase-label registry stores canonical English copy
   season_start: 'Season opening',
   week_start: 'Start of the day',
   loh_results: 'After the LOH competition',

--- a/src/components/HousePulse/HousePulse.tsx
+++ b/src/components/HousePulse/HousePulse.tsx
@@ -29,6 +29,7 @@ const RUMOUR_LABEL: Record<string, string> = {
 }
 
 const PHASE_LABEL: Record<string, string> = {
+  season_start: 'Season opening',
   week_start: 'Start of the day',
   loh_results: 'After the LOH competition',
   social_1: 'Before nominations',

--- a/src/components/ui/ShockIntroOverlay/ShockIntroOverlay.tsx
+++ b/src/components/ui/ShockIntroOverlay/ShockIntroOverlay.tsx
@@ -368,6 +368,7 @@ export default function ShockIntroOverlay({
             announcement={displayAnnouncement}
             paused
             showInfoButton={false}
+            playShockPrelude={false}
           />
         </div>
       )}

--- a/src/components/ui/TvAnnouncementModal/TvAnnouncementModal.tsx
+++ b/src/components/ui/TvAnnouncementModal/TvAnnouncementModal.tsx
@@ -16,6 +16,12 @@ interface PhaseCopy {
 }
 
 const PHASE_COPY: Record<string, PhaseCopy> = {
+  season_start: {
+    icon: '🏠',
+    label: 'SEASON START',
+    category: 'Game Event',
+    body: 'The house opens and the season rules are introduced before Day 1 begins.',
+  },
   week_start: {
     icon: '📅',
     label: 'NEW DAY',

--- a/src/components/ui/TvAnnouncementModal/TvAnnouncementModal.tsx
+++ b/src/components/ui/TvAnnouncementModal/TvAnnouncementModal.tsx
@@ -18,8 +18,10 @@ interface PhaseCopy {
 const PHASE_COPY: Record<string, PhaseCopy> = {
   season_start: {
     icon: '🏠',
+    // i18n-ignore: Legacy phase-copy registry stores canonical English copy
     label: 'SEASON START',
     category: 'Game Event',
+    // i18n-ignore: Legacy phase-copy registry stores canonical English copy
     body: 'The house opens and the season rules are introduced before Day 1 begins.',
   },
   week_start: {

--- a/src/components/ui/TvAnnouncementOverlay/TvAnnouncementOverlay.tsx
+++ b/src/components/ui/TvAnnouncementOverlay/TvAnnouncementOverlay.tsx
@@ -30,6 +30,8 @@ export interface TvAnnouncementOverlayProps {
   infoButtonRef?: RefObject<HTMLButtonElement | null>;
   /** When false, the info button is not rendered. */
   showInfoButton?: boolean;
+  /** Override legacy key-based shock detection when the runtime owns priority. */
+  playShockPrelude?: boolean;
 }
 
 const SHOCK_PRELUDE_DURATION_MS = 2320;
@@ -47,6 +49,7 @@ const FULLSCREEN_SHOCK_KEYS = new Set([
   'cupid_arrow_broken',
   'vox_populi',
   'twist',
+  'custom_critical',
 ]);
 
 function getAnnouncementThemeClass(key: string): string {
@@ -70,6 +73,8 @@ function getAnnouncementThemeClass(key: string): string {
     key === 'final3_announcement' ||
     key === 'final_hoh' ||
     key === 'jury' ||
+    key === 'custom_major' ||
+    key === 'custom_critical' ||
     key.startsWith('loh_tiebreak_')
   ) {
     return 'tv-announcement--theme-loh';
@@ -125,10 +130,12 @@ export default function TvAnnouncementOverlay({
   paused = false,
   infoButtonRef,
   showInfoButton = true,
+  playShockPrelude,
 }: TvAnnouncementOverlayProps) {
   const { t } = useI18n();
   const { title, subtitle, isLive, autoDismissMs } = announcement;
-  const shouldPlayShockPrelude = FULLSCREEN_SHOCK_KEYS.has(announcement.key);
+  const shouldPlayShockPrelude =
+    playShockPrelude ?? FULLSCREEN_SHOCK_KEYS.has(announcement.key);
   const [shockPreludeKey, setShockPreludeKey] = useState<string | null>(() =>
     shouldPlayShockPrelude ? announcement.key : null
   );

--- a/src/components/ui/TvZone.css
+++ b/src/components/ui/TvZone.css
@@ -381,6 +381,12 @@
   pointer-events: none;
 }
 
+/* Manager-driven plain messages keep the signal-lock blur, but resolve fast
+   enough that consecutive queue items never resemble an empty TV frame. */
+.tv-zone__now--quick-transition {
+  animation-duration: 120ms, 120ms;
+}
+
 .tv-zone__now--detox-stream {
   border: 1px solid rgba(255, 255, 255, 0.08);
   text-shadow:

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -111,18 +111,21 @@ const ANNOUNCEMENT_META: Record<
   { title: string; subtitle: string; isLive: boolean; autoDismissMs: number | null }
 > = {
   custom_broadcast: {
+    // i18n-ignore: Canonical in-world broadcast branding
     title: 'BIG EYE BROADCAST',
     subtitle: '',
     isLive: true,
     autoDismissMs: null,
   },
   custom_major: {
+    // i18n-ignore: Canonical in-world broadcast branding
     title: 'BIG EYE BROADCAST',
     subtitle: '',
     isLive: true,
     autoDismissMs: null,
   },
   custom_critical: {
+    // i18n-ignore: Canonical in-world broadcast branding
     title: 'SHOCK ANNOUNCEMENT',
     subtitle: '',
     isLive: true,
@@ -339,6 +342,11 @@ const ANNOUNCEMENT_META: Record<
     autoDismissMs: null,
   },
 }
+
+// i18n-ignore: Canonical in-world winner announcement copy
+const AUDIENCE_WINNER_SUBTITLE = 'The audience has spoken. The season champion is official.'
+// i18n-ignore: Canonical in-world winner announcement copy
+const TRIBUNAL_WINNER_SUBTITLE = 'The Tribunal has spoken. The season champion is official.'
 
 /**
  * Extract the major key from a TvEvent using explicit meta.major or ev.major
@@ -1600,11 +1608,12 @@ export default function TvZone(props: TvZoneProps) {
               <TvAnnouncementOverlay
                 announcement={{
                   key: 'season_winner',
+                  // i18n-ignore: Canonical in-world winner announcement title
                   title: `${winnerBroadcast.name} Wins The Big Eye`,
                   subtitle:
                     gameState.voxPopuli?.winnerId === winnerBroadcast.id
-                      ? 'The audience has spoken. The season champion is official.'
-                      : 'The Tribunal has spoken. The season champion is official.',
+                      ? AUDIENCE_WINNER_SUBTITLE
+                      : TRIBUNAL_WINNER_SUBTITLE,
                   isLive: true,
                   autoDismissMs: null,
                 }}

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -10,10 +10,14 @@ import {
   type CSSProperties,
 } from 'react'
 import { createPortal } from 'react-dom'
-import type { CupidArrowPair, Phase, Player } from '../../types'
+import type { BroadcastOverride, CupidArrowPair, Phase, Player } from '../../types'
 import { useStore } from 'react-redux'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
-import { selectAlivePlayers } from '../../store/gameSlice'
+import {
+  consumeBroadcastEvent,
+  selectAlivePlayers,
+  syncPhaseBroadcasts,
+} from '../../store/gameSlice'
 import { saveRunSnapshot } from '../../store/saveStatePersistence'
 import { DEFAULT_SETTINGS, setAudio } from '../../store/settingsSlice'
 import type { RootState } from '../../store/store'
@@ -34,6 +38,7 @@ import type { TvEvent } from '../../types'
 import TopUtilityButton from '../TopUtilityButton/TopUtilityButton'
 import { getViewportMessageKey } from './tvZoneKeys'
 import { LIVE_VOTE_PITCHES_EVENT_KEY } from '../../constants/tvEvents'
+import { getPhaseCardTemplate } from '../../broadcasting/broadcastTemplateCatalog'
 import {
   formatCycleAriaLabel,
   formatCycleLabel,
@@ -95,6 +100,9 @@ const MAJOR_KEYS = new Set([
   'twist',
   'loh_comp_announcement',
   'pos_comp_announcement',
+  'custom_broadcast',
+  'custom_major',
+  'custom_critical',
 ])
 
 /** Maps a major key to its announcement title and subtitle. */
@@ -102,6 +110,24 @@ const ANNOUNCEMENT_META: Record<
   string,
   { title: string; subtitle: string; isLive: boolean; autoDismissMs: number | null }
 > = {
+  custom_broadcast: {
+    title: 'BIG EYE BROADCAST',
+    subtitle: '',
+    isLive: true,
+    autoDismissMs: null,
+  },
+  custom_major: {
+    title: 'BIG EYE BROADCAST',
+    subtitle: '',
+    isLive: true,
+    autoDismissMs: null,
+  },
+  custom_critical: {
+    title: 'SHOCK ANNOUNCEMENT',
+    subtitle: '',
+    isLive: true,
+    autoDismissMs: null,
+  },
   nomination_ceremony: {
     title: 'Nomination Ceremony',
     subtitle: 'Two players are nominated for elimination.',
@@ -330,7 +356,12 @@ function extractMajorKey(ev: TvEvent): string | null {
 }
 
 /** Build an Announcement object for the given major key and event. */
-function buildAnnouncement(key: string, ev: TvEvent): Announcement {
+function buildAnnouncement(
+  key: string,
+  ev: TvEvent,
+  phase?: Phase,
+  overrides?: Record<string, BroadcastOverride>
+): Announcement {
   const meta = ANNOUNCEMENT_META[key] ?? {
     title: key.replace(/_/g, ' ').toUpperCase(),
     subtitle: ev.text,
@@ -349,17 +380,19 @@ function buildAnnouncement(key: string, ev: TvEvent): Announcement {
   const migratedFinalFourSubtitle = finalFourWinnerMatch
     ? 'There is no immunity today. Last place begins on the block, and the other three housemates will each cast one secret vote.'
     : null
+  const registryTemplate = phase ? getPhaseCardTemplate(phase, key) : undefined
+  const registryOverride = registryTemplate ? overrides?.[registryTemplate.id] : undefined
   return {
     key,
     ...meta,
     title:
       typeof eventTitle === 'string' && eventTitle.trim()
         ? eventTitle
-        : (migratedFinalFourTitle ?? meta.title),
+        : (registryOverride?.title ?? migratedFinalFourTitle ?? registryTemplate?.title ?? meta.title),
     subtitle:
       typeof eventSubtitle === 'string' && eventSubtitle.trim()
         ? eventSubtitle
-        : (migratedFinalFourSubtitle ?? meta.subtitle),
+        : (registryOverride?.text ?? migratedFinalFourSubtitle ?? registryTemplate?.text ?? meta.subtitle),
   }
 }
 
@@ -425,6 +458,19 @@ const PLAY_THROUGH_ANNOUNCEMENT_KEYS = new Set([
   'vox_populi_final_three_vote',
   'vox_populi_final_two',
 ])
+
+const LEGACY_DAY_END_EVENT = /^Day \d+ has come to an end\. A new day begins soon… ✨$/
+const LEGACY_DAY_START_EVENT = /^Day \d+ (?:has begun\. Get ready\.|begins! 🏠 It's time for the LOH competition\.)$/
+
+function getDailyTransitionPhase(event: TvEvent): Phase | null {
+  if (event.meta?.key === 'day_start') return 'week_start'
+  if (event.meta?.key === 'day_end') return 'week_end'
+  // Saved games created before the phase tags were introduced keep their
+  // original history, but should not replay a previous day's transition copy.
+  if (LEGACY_DAY_START_EVENT.test(event.text)) return 'week_start'
+  if (LEGACY_DAY_END_EVENT.test(event.text)) return 'week_end'
+  return null
+}
 
 // Major events now stay entirely inside the faux-TV presentation. Keeping this
 // set empty disables the former full-screen shock stinger without changing the
@@ -535,6 +581,27 @@ export default function TvZone(props: TvZoneProps) {
   const tvVisibleFeed = useMemo(() => gameState.tvFeed.filter(isVisibleOnTv), [gameState.tvFeed])
   // Filter entries for the main-screen log strip (excludes DR-only events).
   const mainLogFeed = useMemo(() => gameState.tvFeed.filter(isVisibleInMainLog), [gameState.tvFeed])
+  const queuedBroadcastEvent = useMemo(() => {
+    const queuedId = gameState.broadcastQueue?.[0]
+    return queuedId ? gameState.tvFeed.find((event) => event.id === queuedId) ?? null : null
+  }, [gameState.broadcastQueue, gameState.tvFeed])
+  const queuedBroadcastLevel = queuedBroadcastEvent?.meta?.broadcastLevel as
+    | 'minor'
+    | 'major'
+    | 'critical'
+    | undefined
+  const queuedBroadcastIsCard =
+    queuedBroadcastLevel === 'major' || queuedBroadcastLevel === 'critical'
+  const lastPlainBroadcastEvent = useMemo(() => {
+    const id = gameState.lastPlainBroadcastEventId
+    if (!id) return null
+    const event = gameState.tvFeed.find((candidate) => candidate.id === id)
+    if (
+      event?.meta?.phase !== gameState.phase ||
+      event?.meta?.week !== gameState.week
+    ) return null
+    return event
+  }, [gameState.lastPlainBroadcastEventId, gameState.phase, gameState.tvFeed, gameState.week])
   const mainLogMaxVisible = props.mainLogMaxVisible ?? 2
   const occupancyChip = props.occupancyChip ?? null
 
@@ -566,7 +633,7 @@ export default function TvZone(props: TvZoneProps) {
   // reappear for the same event after dismissal.
   const [dismissedEventId, setDismissedEventId] = useState<string | null>(null)
   // Track which phase was dismissed to avoid re-showing within the same phase.
-  const [dismissedPhase, setDismissedPhase] = useState<Phase | null>(null)
+  const [, setDismissedPhase] = useState<Phase | null>(null)
   // Phase-triggered announcement (set on phase transition, cleared on dismiss or non-popup phase).
   const [phaseAnnouncement, setPhaseAnnouncement] = useState<Announcement | null>(null)
   // Brief post-dismiss text fade (POST_DISMISS_FADE_MS) to avoid jarring text transitions.
@@ -596,7 +663,6 @@ export default function TvZone(props: TvZoneProps) {
   const shockSequenceLatestIdRef = useRef<string | null>(null)
   const seenShockEventIdsRef = useRef(new Set<string>())
   // Tracks the previous phase to detect phase transitions.
-  const previousPhaseRef = useRef<Phase | null>(null)
   // Stable ref so phase-transition effect always reads the latest latestEvent.
   const latestEventRef = useRef(latestEvent)
   // Update the ref after each render so the phase-transition effect always has
@@ -653,12 +719,17 @@ export default function TvZone(props: TvZoneProps) {
 
   const activeDetoxEvent = detoxMessageQueue[detoxMessageIndex]
   const isBroadcastRelevant = useCallback(
-    (event: TvEvent) =>
-      !(
-        extractMajorKey(event) === 'vox_populi_final_three_vote' &&
-        (alivePlayers.length !== 3 || gameState.voxPopuli?.publicVoteContext !== 'final3')
-      ),
-    [alivePlayers.length, gameState.voxPopuli?.publicVoteContext]
+    (event: TvEvent) => {
+      const transitionPhase = getDailyTransitionPhase(event)
+      return (
+        (transitionPhase === null || transitionPhase === gameState.phase) &&
+        !(
+          extractMajorKey(event) === 'vox_populi_final_three_vote' &&
+          (alivePlayers.length !== 3 || gameState.voxPopuli?.publicVoteContext !== 'final3')
+        )
+      )
+    },
+    [alivePlayers.length, gameState.phase, gameState.voxPopuli?.publicVoteContext]
   )
   // A critical broadcast is a single viewing experience: once the player has
   // dismissed its major card, do not immediately replay the identical copy as
@@ -668,10 +739,8 @@ export default function TvZone(props: TvZoneProps) {
       tvVisibleFeed.find(
         (event) =>
           isBroadcastRelevant(event) &&
-          !(
-            event.meta?.broadcastPriority === 'critical' &&
-            dismissedPriorityEventIds.has(event.id)
-          )
+          event.meta?.broadcastManaged !== true &&
+          !(event.meta?.broadcastPriority === 'critical' && dismissedPriorityEventIds.has(event.id))
       ) ?? null,
     [dismissedPriorityEventIds, isBroadcastRelevant, tvVisibleFeed]
   )
@@ -682,18 +751,19 @@ export default function TvZone(props: TvZoneProps) {
         .find(
           (event) =>
             event.meta?.broadcastPriority === 'critical' &&
+            event.meta?.broadcastManaged !== true &&
             event.meta?.week === gameState.week &&
             isBroadcastRelevant(event) &&
             !dismissedPriorityEventIds.has(event.id)
         ) ?? null,
-    [
-      dismissedPriorityEventIds,
-      gameState.week,
-      isBroadcastRelevant,
-      tvVisibleFeed,
-    ]
+    [dismissedPriorityEventIds, gameState.week, isBroadcastRelevant, tvVisibleFeed]
   )
-  const displayedEvent = activeDetoxEvent ?? priorityBroadcastEvent ?? latestRelevantEvent
+  const displayedEvent =
+    activeDetoxEvent ??
+    (!queuedBroadcastIsCard ? queuedBroadcastEvent : null) ??
+    priorityBroadcastEvent ??
+    latestRelevantEvent ??
+    lastPlainBroadcastEvent
   const detoxMessageActive = Boolean(activeDetoxEvent)
 
   // ── Shock announcement sequence state ────────────────────────────────────────
@@ -735,13 +805,11 @@ export default function TvZone(props: TvZoneProps) {
   // Fires whenever the game phase or alive-player count changes.
   // Also allows an in-place upgrade for nomination-phase overlays when
   // Double Eviction activates after the phase has already been entered.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const currentPhase = gameState.phase
-    const prevPhase = previousPhaseRef.current
-    previousPhaseRef.current = currentPhase
     const democraciaPreVoteActive =
       currentPhase === 'loh_comp_announcement' && gameState.democracia?.active === true
-    const key = democraciaPreVoteActive
+    const cardMajor = democraciaPreVoteActive
       ? 'democracia'
       : getPhaseAnnouncementKey(
           currentPhase,
@@ -749,53 +817,30 @@ export default function TvZone(props: TvZoneProps) {
           doubleEvictionActive,
           gameState.voxPopuli?.status === 'active'
         )
-    const keyChangedInPlace =
-      prevPhase === currentPhase &&
-      phaseAnnouncement?.key !== null &&
-      phaseAnnouncement?.key !== undefined &&
-      phaseAnnouncement?.key !== key
-
-    // Skip on initial mount (no previous phase) and when phase/key haven't changed.
-    if (prevPhase === null || (prevPhase === currentPhase && !keyChangedInPlace)) return
-    const ev = latestEventRef.current
-    // Batch all state updates as a non-urgent transition (satisfies react-hooks/set-state-in-effect
-    // by deferring setState calls into a callback rather than calling them synchronously).
+    dispatch(syncPhaseBroadcasts({ phase: currentPhase, cardMajor }))
     startTransition(() => {
-      if (key && (currentPhase !== dismissedPhase || keyChangedInPlace)) {
-        const stub: TvEvent = {
-          id: 'phase-transition-stub',
-          text: '',
-          type: 'game',
-          timestamp: Date.now(),
-        }
-        setPhaseAnnouncement(buildAnnouncement(key, ev ?? stub))
-        // Suppress any concurrent event-based popup with the same key to prevent duplication.
-        if (ev && extractMajorKey(ev) === key) {
-          setDismissedEventId(ev.id)
-        }
-      } else {
-        // Entering a non-popup phase: clear any stale phase announcement.
-        // Also clear the dismissed guard so the same phase can show its popup again in a later week.
-        if (dismissedPhase && currentPhase !== dismissedPhase) {
-          setDismissedPhase(null)
-        }
-        setPhaseAnnouncement(null)
-      }
+      setPhaseAnnouncement(null)
+      setDismissedPhase(null)
     })
   }, [
+    dispatch,
     gameState.phase,
+    gameState.week,
     gameState.democracia?.active,
     alivePlayers.length,
-    dismissedPhase,
     doubleEvictionActive,
     gameState.voxPopuli?.status,
-    phaseAnnouncement?.key,
+    gameState.broadcastOverrides,
+    gameState.customBroadcasts,
   ])
 
   // Event-based announcement: only explicit meta.major / ev.major (no text heuristics).
   const eventAnnouncement = useMemo<Announcement | null>(() => {
     const announcementEvent =
-      announcementPrerollEvent ?? priorityBroadcastEvent ?? latestRelevantEvent
+      (queuedBroadcastIsCard ? queuedBroadcastEvent : null) ??
+      announcementPrerollEvent ??
+      priorityBroadcastEvent ??
+      latestRelevantEvent
     if (!announcementEvent) return null
     // A phase card can dismiss its own event id while a newer critical Final 3
     // broadcast is waiting. Never let that incidental dismissal bury the
@@ -803,18 +848,27 @@ export default function TvZone(props: TvZoneProps) {
     const isUndismissedCriticalBroadcast =
       announcementEvent.meta?.broadcastPriority === 'critical' &&
       !dismissedPriorityEventIds.has(announcementEvent.id)
-    if (announcementEvent.id === dismissedEventId && !isUndismissedCriticalBroadcast) return null
+    if (
+      announcementEvent !== queuedBroadcastEvent &&
+      announcementEvent.id === dismissedEventId &&
+      !isUndismissedCriticalBroadcast
+    ) return null
     const majorKey = extractMajorKey(announcementEvent)
     return majorKey ? buildAnnouncement(majorKey, announcementEvent) : null
   }, [
     announcementPrerollEvent,
+    queuedBroadcastEvent,
+    queuedBroadcastIsCard,
     priorityBroadcastEvent,
     latestRelevantEvent,
     dismissedEventId,
     dismissedPriorityEventIds,
   ])
   const eventAnnouncementSource =
-    announcementPrerollEvent ?? priorityBroadcastEvent ?? latestRelevantEvent
+    (queuedBroadcastIsCard ? queuedBroadcastEvent : null) ??
+    announcementPrerollEvent ??
+    priorityBroadcastEvent ??
+    latestRelevantEvent
 
   // Capture shock events that are no longer the latest feed item by the time
   // React renders. This is common when a special veto immediately creates a
@@ -840,6 +894,10 @@ export default function TvZone(props: TvZoneProps) {
     const queued = [...newEvents].reverse().flatMap((event) => {
       const key = extractMajorKey(event)
       if (!key || !SHOCK_ANNOUNCEMENT_KEYS.has(key)) return []
+      // Phase-card branches used to emit a second legacy major event beside
+      // the card. The manager-controlled card is now the sole presentation
+      // source, so do not also enqueue that legacy event as another shock.
+      if (getPhaseCardTemplate(gameState.phase, key)) return []
       if (seenShockEventIdsRef.current.has(event.id)) return []
       seenShockEventIdsRef.current.add(event.id)
 
@@ -853,7 +911,7 @@ export default function TvZone(props: TvZoneProps) {
     startTransition(() => {
       setShockAnnouncementQueue((current) => [...current, ...queued])
     })
-  }, [tvVisibleFeed])
+  }, [gameState.phase, tvVisibleFeed])
 
   // The core game phase remains jury while the post-finale sequence plays.
   // Replace its stale Tribunal Votes card with the resolved winner on the
@@ -865,9 +923,16 @@ export default function TvZone(props: TvZoneProps) {
     return gameState.players.find((player) => player.id === finale.winnerId) ?? null
   }, [gameState.players, gameState.seasonFinale])
 
-  const eventAnnouncementHasShockPriority =
-    eventAnnouncement != null && SHOCK_ANNOUNCEMENT_KEYS.has(eventAnnouncement.key)
   const queuedShockAnnouncement = shockAnnouncementQueue[0] ?? null
+  const managedEventAnnouncement =
+    queuedBroadcastIsCard && eventAnnouncementSource?.id === queuedBroadcastEvent?.id
+      ? eventAnnouncement
+      : null
+  const eventAnnouncementHasShockPriority =
+    eventAnnouncement != null &&
+    (managedEventAnnouncement
+      ? queuedBroadcastLevel === 'critical'
+      : SHOCK_ANNOUNCEMENT_KEYS.has(eventAnnouncement.key))
 
   // A shock event must finish its fullscreen → Faux TV → info spotlight sequence
   // before a simultaneous phase card (for example the first LOH competition)
@@ -878,6 +943,7 @@ export default function TvZone(props: TvZoneProps) {
     (eventAnnouncementHasShockPriority ? eventAnnouncement : null) ??
     priorityAnnouncement ??
     externalAnnouncement ??
+    managedEventAnnouncement ??
     phaseAnnouncement ??
     eventAnnouncement
   const activeAnnouncementSequenceId =
@@ -886,7 +952,10 @@ export default function TvZone(props: TvZoneProps) {
     activeAnnouncement?.key ??
     ''
   const isShockAnnouncement =
-    activeAnnouncement != null && SHOCK_ANNOUNCEMENT_KEYS.has(activeAnnouncement.key)
+    activeAnnouncement != null &&
+    (activeAnnouncement === managedEventAnnouncement
+      ? queuedBroadcastLevel === 'critical'
+      : SHOCK_ANNOUNCEMENT_KEYS.has(activeAnnouncement.key))
   const audiencePreviewRevealActive = Boolean(props.audiencePreviewReveal)
   const showInlineAnnouncement =
     winnerBroadcast == null &&
@@ -896,11 +965,13 @@ export default function TvZone(props: TvZoneProps) {
     !voteResultsRevealActive &&
     !democraciaResultsRevealActive &&
     !audiencePreviewRevealActive
+
   const showOccupancyChip =
     occupancyChip != null && !showInlineAnnouncement && winnerBroadcast == null
   const suppressStaleLiveVotePitchMessage =
     displayedEvent?.meta?.key === LIVE_VOTE_PITCHES_EVENT_KEY && gameState.phase !== 'social_2'
-  const hasFallbackViewportMessage = Boolean(props.viewportFallbackMessage)
+  const viewportFallbackMessage = props.viewportFallbackMessage?.trim()
+  const hasFallbackViewportMessage = Boolean(viewportFallbackMessage)
   const hideViewportMessage =
     (postDismissBlocked && !hasFallbackViewportMessage) ||
     (suppressStaleLiveVotePitchMessage && !hasFallbackViewportMessage) ||
@@ -915,10 +986,8 @@ export default function TvZone(props: TvZoneProps) {
   // fallback instead of the suppressed event text so the viewport stays meaningful.
   const viewportDisplayText =
     suppressStaleLiveVotePitchMessage && hasFallbackViewportMessage
-      ? props.viewportFallbackMessage
-      : (displayedEvent?.text ??
-        props.viewportFallbackMessage ??
-        '')
+      ? viewportFallbackMessage
+      : (displayedEvent?.text ?? viewportFallbackMessage)
   const baseViewportMessageKey = getViewportMessageKey(displayedEvent)
   const viewportMessageKey = detoxMessageActive
     ? `${baseViewportMessageKey}-${detoxMessageIndex}`
@@ -929,7 +998,7 @@ export default function TvZone(props: TvZoneProps) {
   } else if (activeAnnouncement) {
     mainTvMessage = activeAnnouncement.title
   } else if (suppressStaleLiveVotePitchMessage) {
-    mainTvMessage = hasFallbackViewportMessage ? props.viewportFallbackMessage : undefined
+    mainTvMessage = viewportFallbackMessage
   } else {
     mainTvMessage = displayedEvent?.text
   }
@@ -995,12 +1064,23 @@ export default function TvZone(props: TvZoneProps) {
       })
     }
     const skipPostDismissFade =
-      currentAnnouncement != null && CONTINUOUS_MAJOR_ANNOUNCEMENT_KEYS.has(currentAnnouncement.key)
+      currentAnnouncement != null &&
+      (
+        CONTINUOUS_MAJOR_ANNOUNCEMENT_KEYS.has(currentAnnouncement.key) ||
+        currentAnnouncement === managedEventAnnouncement
+      )
     if (cupidBreakAnnouncement) {
       setCupidBreakAnnouncement(null)
     } else if (queuedShockAnnouncement) {
       setDismissedEventId(queuedShockAnnouncement.eventId)
       setShockAnnouncementQueue((queue) => queue.slice(1))
+    } else if (
+      managedEventAnnouncement &&
+      queuedBroadcastEvent &&
+      currentAnnouncement === managedEventAnnouncement
+    ) {
+      setDismissedEventId(queuedBroadcastEvent.id)
+      dispatch(consumeBroadcastEvent(queuedBroadcastEvent.id))
     } else if (priorityAnnouncement) {
       onPriorityAnnouncementDismiss?.()
     } else if (externalAnnouncement) {
@@ -1039,8 +1119,11 @@ export default function TvZone(props: TvZoneProps) {
     )
   }, [
     activeAnnouncement,
+    dispatch,
     cupidBreakAnnouncement,
     queuedShockAnnouncement,
+    managedEventAnnouncement,
+    queuedBroadcastEvent,
     priorityAnnouncement,
     externalAnnouncement,
     eventAnnouncementHasShockPriority,
@@ -1157,6 +1240,19 @@ export default function TvZone(props: TvZoneProps) {
   // card so the next Safety/shock announcement can take the screen.
   useEffect(() => {
     const handlePlay = (event: Event) => {
+      if (queuedBroadcastEvent && (!activeAnnouncement || managedEventAnnouncement)) {
+        if (managedEventAnnouncement) {
+          if ((gameState.broadcastQueue?.length ?? 0) > 1) event.preventDefault()
+          handleDismiss()
+        } else {
+          // A plain message needs to block Play only when another eligible TV
+          // item follows it. Acknowledging the final plain message and moving
+          // into the next phase should happen on the same button press.
+          if ((gameState.broadcastQueue?.length ?? 0) > 1) event.preventDefault()
+          dispatch(consumeBroadcastEvent(queuedBroadcastEvent.id))
+        }
+        return
+      }
       if (activeAnnouncement) {
         if (!PLAY_THROUGH_ANNOUNCEMENT_KEYS.has(activeAnnouncement.key)) {
           event.preventDefault()
@@ -1176,7 +1272,15 @@ export default function TvZone(props: TvZoneProps) {
     }
     window.addEventListener('ui:playPressed', handlePlay, { capture: true })
     return () => window.removeEventListener('ui:playPressed', handlePlay, { capture: true })
-  }, [activeAnnouncement, handleDismiss, priorityBroadcastEvent])
+  }, [
+    activeAnnouncement,
+    dispatch,
+    handleDismiss,
+    managedEventAnnouncement,
+    priorityBroadcastEvent,
+    queuedBroadcastEvent,
+    gameState.broadcastQueue?.length,
+  ])
 
   const handleModalClose = useCallback(() => setModalOpen(false), [])
 
@@ -1236,7 +1340,9 @@ export default function TvZone(props: TvZoneProps) {
       : gameState.voxPopuli?.status === 'active' && gameState.phase.startsWith('final3_comp')
         ? 'Final Immunity'
         : formatPhaseLabel(gameState.phase)
-  const isAtGameStart = gameState.week === 1 && gameState.phase === 'week_start'
+  const isAtGameStart =
+    gameState.week === 1 &&
+    (gameState.phase === 'season_start' || gameState.phase === 'week_start')
   const canSave = !isGuest && Boolean(activeProfileId) && !isAtGameStart && !hasPendingChallenge
   const saveChipAriaLabel = isGuest
     ? 'Save (unavailable in guest mode)'
@@ -1463,6 +1569,7 @@ export default function TvZone(props: TvZoneProps) {
               aria-hidden={hideViewportMessage}
               className={[
                 'tv-zone__now',
+                !detoxMessageActive && displayedEvent ? 'tv-zone__now--quick-transition' : '',
                 detoxMessageActive ? 'tv-zone__now--detox-stream' : '',
                 hideViewportMessage ? 'tv-zone__now--hidden' : '',
               ]
@@ -1514,6 +1621,11 @@ export default function TvZone(props: TvZoneProps) {
                 onDismiss={handleDismiss}
                 paused={modalOpen}
                 infoButtonRef={announcementInfoButtonRef}
+                playShockPrelude={
+                  activeAnnouncement === managedEventAnnouncement
+                    ? queuedBroadcastLevel === 'critical'
+                    : undefined
+                }
               />
             )}
 

--- a/src/components/ui/__tests__/TvZone.announcement.test.tsx
+++ b/src/components/ui/__tests__/TvZone.announcement.test.tsx
@@ -19,7 +19,7 @@
 
 import React, { type ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render as testingLibraryRender, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
@@ -28,6 +28,7 @@ import gameReducer, {
   activateDemocracia,
   activateDoubleEviction,
   addTvEvent,
+  consumeBroadcastEvent,
   setPhase,
   updatePlayer,
 } from '../../../store/gameSlice';
@@ -41,11 +42,26 @@ import TvZone from '../TvZone';
 import TvAnnouncementOverlay from '../TvAnnouncementOverlay/TvAnnouncementOverlay';
 import TvAnnouncementModal from '../TvAnnouncementModal/TvAnnouncementModal';
 import type { Player, TvEvent } from '../../../types';
+import { I18nContext, type I18nContextValue } from '../../../i18n/I18nContext';
+import { translate } from '../../../i18n/messages';
+
+const TEST_I18N: I18nContextValue = {
+  preference: 'en-US',
+  language: 'en-US',
+  systemLanguage: 'en-US',
+  t: (key, params) => translate('en-US', key, params),
+  formatNumber: (value) => String(value),
+  formatDate: (value) => String(value),
+};
+
+function render(ui: React.ReactNode) {
+  return testingLibraryRender(<I18nContext.Provider value={TEST_I18N}>{ui}</I18nContext.Provider>);
+}
 
 // ── Store helpers ─────────────────────────────────────────────────────────────
 
 function makeStore() {
-  return configureStore({
+  const store = configureStore({
     reducer: {
       game: gameReducer,
       social: socialReducer,
@@ -54,10 +70,16 @@ function makeStore() {
       finale: finaleReducer,
     },
   });
+  // These integration tests inject their own event/phase under test. Clear the
+  // real Season Start playback queue so it cannot mask that fixture.
+  for (const id of store.getState().game.broadcastQueue ?? []) {
+    store.dispatch(consumeBroadcastEvent(id));
+  }
+  return store;
 }
 
 function makeStoreWithSettings() {
-  return configureStore({
+  const store = configureStore({
     reducer: {
       game: gameReducer,
       social: socialReducer,
@@ -67,6 +89,10 @@ function makeStoreWithSettings() {
       settings: settingsReducer,
     },
   });
+  for (const id of store.getState().game.broadcastQueue ?? []) {
+    store.dispatch(consumeBroadcastEvent(id));
+  }
+  return store;
 }
 
 function renderTvZone(
@@ -610,20 +636,11 @@ describe('TvZone — announcement overlay', () => {
     );
   });
 
-  it('shows the POS announcement overlay and restores the public save result after dismissal', () => {
+  it('shows the POS announcement overlay without replaying the public save result', () => {
     const store = makeStore();
     renderTvZone(store);
 
     act(() => {
-      store.dispatch(
-        addTvEvent(
-          makeEvent({
-            id: 'ev-public-save-result',
-            text: 'Blue was saved with 50% of the public support. Kian and Georgi are still in danger.',
-            meta: { suppressPhaseAnnouncementKey: 'pos_comp_announcement' },
-          }),
-        ),
-      );
       store.dispatch(setPhase('pos_comp_announcement'));
     });
 
@@ -633,7 +650,7 @@ describe('TvZone — announcement overlay', () => {
     act(() => { window.dispatchEvent(new CustomEvent('tv:announcement-dismiss')); });
 
     expect(screen.queryByRole('dialog', { name: /Announcement: Power of Safety/i })).toBeNull();
-    expect(screen.getByText(/Blue was saved with 50% of the public support/i)).toBeTruthy();
+    expect(screen.queryByText(/Blue was saved with 50% of the public support/i)).toBeNull();
   });
 
   it('keeps the final pitches message hidden once live voting begins', () => {
@@ -789,6 +806,7 @@ describe('TvZone — announcement overlay', () => {
     renderTvZone(store);
 
     act(() => {
+      store.dispatch(setPhase('week_start'));
       store.dispatch(addTvEvent(makeEvent({
         id: 'tribunal-phase-preroll',
         text: `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`,
@@ -1106,6 +1124,52 @@ describe('TvZone — TVLog usage', () => {
   });
 });
 
+describe('TvZone day-transition broadcasts', () => {
+  it('shows each daily transition only in its own phase, including saved legacy events', () => {
+    const store = makeStore();
+    renderTvZone(store);
+
+    act(() => {
+      store.dispatch(
+        addTvEvent(
+          makeEvent({
+            id: 'legacy-day-end',
+            text: 'Day 1 has come to an end. A new day begins soon… ✨',
+          }),
+        ),
+      );
+      store.dispatch(setPhase('week_start'));
+    });
+
+    expect(document.querySelector('.tv-zone__now')?.textContent).not.toContain(
+      'Day 1 has come to an end.',
+    );
+
+    act(() => {
+      store.dispatch(
+        addTvEvent(
+          makeEvent({
+            id: 'day-start',
+            text: 'Day 2 has begun. Get ready.',
+            meta: { key: 'day_start' },
+          }),
+        ),
+      );
+    });
+
+    expect(document.querySelector('.tv-zone__now')).toHaveTextContent('Day 2 has begun. Get ready.');
+
+    act(() => {
+      store.dispatch(setPhase('loh_comp'));
+    });
+
+    expect(document.querySelector('.tv-zone__now')?.textContent).not.toContain('Day 2 has begun.');
+    expect(document.querySelector('.tv-zone__now')?.textContent).not.toContain(
+      'Day 1 has come to an end.',
+    );
+  });
+});
+
 // ── TvAnnouncementOverlay countdown unit tests ─────────────────────────────────
 
 describe('TvAnnouncementOverlay — countdown logic', () => {
@@ -1371,7 +1435,11 @@ describe('TvZone — phase-based announcement triggers', () => {
     act(() => { store.dispatch(activateDemocracia()); });
 
     expect(screen.queryByRole('dialog', { name: /Announcement: LOH Competition/i })).toBeNull();
-    expect(document.body.querySelector('[data-testid="shock-intro-overlay"]')).toBeNull();
+    expect(screen.getByTestId('tv-shock-prelude')).toHaveTextContent('DEMOCRACIA');
+
+    act(() => {
+      vi.advanceTimersByTime(SHOCK_INTRO_SETTLE_MS + 50);
+    });
 
     expect(screen.getByRole('dialog', { name: /Announcement: DEMOCRACIA!/i })).toBeDefined();
     expect(store.getState().game.phase).toBe('loh_comp_announcement');
@@ -1379,7 +1447,7 @@ describe('TvZone — phase-based announcement triggers', () => {
     vi.useRealTimers();
   });
 
-  it('keeps shock announcements inside the faux TV without a fullscreen interstitial', () => {
+  it('keeps a major Double Elimination announcement inside the faux TV', () => {
     vi.useFakeTimers();
     const store = makeStore();
     renderTvZone(store);
@@ -1387,8 +1455,9 @@ describe('TvZone — phase-based announcement triggers', () => {
     act(() => { store.dispatch(setPhase('nominations')); });
     act(() => { store.dispatch(activateDoubleEviction()); });
 
-    expect(document.body.querySelector('[data-testid="shock-intro-overlay"]')).toBeNull();
-    expect(document.body.querySelector('.tv-zone__viewport .tv-announcement')).not.toBeNull();
+    expect(screen.queryByTestId('shock-intro-overlay')).toBeNull();
+    expect(screen.queryByTestId('tv-shock-prelude')).toBeNull();
+    expect(screen.getByRole('dialog', { name: /Announcement: Double Elimination!/i })).toBeDefined();
     vi.useRealTimers();
   });
 

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -156,6 +156,8 @@ export function createSurvivorRun(): GameState {
     saveVersion: SAVE_VERSION,
     season: 1,
     week: 1,
+    // Surveyeval has its own opening feed and begins directly on Day 1.
+    phase: 'week_start',
     publicModeEnabled: false,
     cupidArrow: {
       scheduledSeason: null,

--- a/src/publicOpinion/DramaPublicSaveIntegration.ts
+++ b/src/publicOpinion/DramaPublicSaveIntegration.ts
@@ -213,7 +213,6 @@ export function completeDramaPublicSave(
     store.dispatch(
       commitPublicSave({
         savedId: outcome.savedId,
-        supportPercent: outcome.winningShare,
       })
     )
   }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -48,6 +48,7 @@ const load = (element: ReactNode) => (
 // Keep the QA lab in release bundles. Access remains gated inside the route,
 // while production testers can audit every minigame through the central panel.
 const GameDebug = lazy(() => import('./screens/GameDebug/GameDebug'))
+const BroadcastManager = lazy(() => import('./screens/BroadcastManager/BroadcastManager'))
 
 // Manual QA page. Normal release builds omit it; local production previews can
 // opt in with VITE_ENABLE_QA_ROUTES=true.
@@ -349,6 +350,14 @@ export const router = createHashRouter([
         element: (
           <Suspense fallback={null}>
             <GameDebug />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'broadcast-manager',
+        element: (
+          <Suspense fallback={null}>
+            <BroadcastManager />
           </Suspense>
         ),
       },

--- a/src/screens/BroadcastManager/BroadcastManager.css
+++ b/src/screens/BroadcastManager/BroadcastManager.css
@@ -19,95 +19,395 @@
 
 .broadcast-manager h1,
 .broadcast-manager h2,
-.broadcast-manager p { margin: 0; }
-.broadcast-manager h1 { font-size: clamp(1.6rem, 3vw, 2.4rem); }
-.broadcast-manager__header > div > p:last-child { margin-top: .45rem; color: #b7c2dd; }
-.broadcast-manager__eyebrow { color: #91abff; font-size: .72rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.broadcast-manager p {
+  margin: 0;
+}
+.broadcast-manager h1 {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+}
+.broadcast-manager__header > div > p:last-child {
+  margin-top: 0.45rem;
+  color: #b7c2dd;
+}
+.broadcast-manager__eyebrow {
+  color: #91abff;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
 
 .broadcast-manager button,
 .broadcast-manager input,
 .broadcast-manager textarea,
-.broadcast-manager select { font: inherit; }
-.broadcast-manager button { border: 1px solid rgba(220, 230, 255, .24); border-radius: .55rem; color: inherit; background: #1a2648; cursor: pointer; padding: .56rem .78rem; }
-.broadcast-manager button:hover { background: #283a6b; }
-.broadcast-manager__primary { border-color: #9fb6ff !important; background: #5374d8 !important; color: #fff; font-weight: 800; }
-.broadcast-manager__primary:disabled { cursor: not-allowed; opacity: .5; }
-.broadcast-manager__back { white-space: nowrap; }
+.broadcast-manager select {
+  font: inherit;
+}
+.broadcast-manager button {
+  border: 1px solid rgba(220, 230, 255, 0.24);
+  border-radius: 0.55rem;
+  color: inherit;
+  background: #1a2648;
+  cursor: pointer;
+  padding: 0.56rem 0.78rem;
+}
+.broadcast-manager button:hover {
+  background: #283a6b;
+}
+.broadcast-manager__primary {
+  border-color: #9fb6ff !important;
+  background: #5374d8 !important;
+  color: #fff;
+  font-weight: 800;
+}
+.broadcast-manager__primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.broadcast-manager__back {
+  white-space: nowrap;
+}
 
-.broadcast-manager__layout { display: grid; grid-template-columns: minmax(12rem, 17rem) minmax(0, 1fr); gap: 1rem; margin-top: 1.5rem; }
+.broadcast-manager__layout {
+  display: grid;
+  grid-template-columns: minmax(12rem, 17rem) minmax(0, 1fr);
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
 .broadcast-manager__phases,
-.broadcast-manager__messages { border: 1px solid rgba(220, 230, 255, .14); border-radius: .9rem; background: rgba(8, 14, 31, .78); }
-.broadcast-manager__phases { max-height: calc(100vh - 12rem); overflow: auto; padding: .5rem; }
-.broadcast-manager__phases button { display: flex; align-items: center; justify-content: space-between; width: 100%; border: 0; background: transparent; text-align: left; text-transform: capitalize; }
-.broadcast-manager__phases button.is-selected { background: #3853a2; }
-.broadcast-manager__phases small { color: #b9c8ff; }
-.broadcast-manager__messages { min-height: 28rem; padding: clamp(1rem, 2vw, 1.5rem); }
+.broadcast-manager__messages {
+  border: 1px solid rgba(220, 230, 255, 0.14);
+  border-radius: 0.9rem;
+  background: rgba(8, 14, 31, 0.78);
+}
+.broadcast-manager__phases {
+  max-height: calc(100vh - 12rem);
+  overflow: auto;
+  padding: 0.5rem;
+}
+.broadcast-manager__phases button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  text-transform: capitalize;
+}
+.broadcast-manager__phases button.is-selected {
+  background: #3853a2;
+}
+.broadcast-manager__phases small {
+  color: #b9c8ff;
+}
+.broadcast-manager__messages {
+  min-height: 28rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+}
 .broadcast-manager__template-section,
-.broadcast-manager__live-section { margin-top: 1.25rem; }
+.broadcast-manager__live-section {
+  margin-top: 1.25rem;
+}
 .broadcast-manager__template-section h3,
-.broadcast-manager__live-section h3 { margin: 0; font-size: 1rem; }
+.broadcast-manager__live-section h3 {
+  margin: 0;
+  font-size: 1rem;
+}
 .broadcast-manager__template-section > div > p,
-.broadcast-manager__live-section > div > p { margin-top: .35rem; color: #aebbd5; font-size: .84rem; }
-.broadcast-manager__message-card--template { background: rgba(52, 76, 137, .32); border-color: rgba(140, 171, 255, .32); }
-.broadcast-manager__template-note { color: #9eb3e9; font-style: italic; }
-.broadcast-manager__count-help { margin-top: .45rem !important; color: #8998b7; font-size: .78rem; }
-.broadcast-manager__sequence { margin-top: 1.2rem; border: 1px solid rgba(145, 171, 255, .28); border-radius: .8rem; padding: 1rem; background: rgba(31, 48, 91, .34); }
-.broadcast-manager__sequence h3 { margin: 0; font-size: 1rem; }
-.broadcast-manager__sequence > div > p { margin-top: .3rem; color: #aebbd5; font-size: .84rem; }
-.broadcast-manager__sequence-list { display: grid; gap: .45rem; margin: .8rem 0 0; padding: 0; list-style: none; }
-.broadcast-manager__sequence-list li { display: grid; grid-template-columns: auto auto minmax(8rem, 1fr) auto auto auto; align-items: center; gap: .45rem; border-radius: .55rem; padding: .45rem; background: rgba(10, 18, 39, .7); }
-.broadcast-manager__sequence-position { display: grid; place-items: center; width: 1.6rem; height: 1.6rem; border-radius: 999px; background: #5875d2; font-weight: 900; }
-.broadcast-manager__sequence-kind { color: #9eb3e9; font-size: .7rem; font-weight: 800; text-transform: uppercase; }
-.broadcast-manager__sequence-copy { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.broadcast-manager__sequence-list button { padding: .38rem .55rem; font-size: .76rem; }
-.broadcast-manager__message-card h4 { margin: .65rem 0 0; font-size: 1.05rem; }
-.broadcast-manager__message-card.is-disabled { opacity: .56; border-style: dashed; }
-.broadcast-manager__edited { color: #8ee7ba; font-weight: 800; }
-.broadcast-manager__disabled { color: #ffaaa5; font-weight: 800; text-transform: uppercase; }
-.broadcast-manager__empty { margin-top: 2rem; color: #a9b6d2; }
-.broadcast-manager__message-list { display: grid; gap: .75rem; padding: 0; margin: 1rem 0 0; list-style: none; }
-.broadcast-manager__message-card { border: 1px solid rgba(220, 230, 255, .14); border-radius: .75rem; padding: 1rem; background: rgba(33, 48, 87, .48); }
-.broadcast-manager__message-card > p { margin-top: .55rem; line-height: 1.45; white-space: pre-wrap; }
-.broadcast-manager__message-meta { display: flex; flex-wrap: wrap; align-items: center; gap: .45rem; color: #b9c8df; font-size: .78rem; }
-.broadcast-manager__message-meta code { border-radius: .3rem; padding: .15rem .35rem; background: #111a32; color: #d3e0ff; }
-.broadcast-manager__badge { border-radius: 999px; padding: .18rem .45rem; color: #091020; font-weight: 900; text-transform: uppercase; }
-.broadcast-manager__badge--minor { background: #aab9d7; }
-.broadcast-manager__badge--major { background: #ffc76d; }
-.broadcast-manager__badge--critical { background: #ff817b; }
-.broadcast-manager__message-actions { margin-top: .85rem; justify-content: flex-end; }
-.broadcast-manager__danger { border-color: #a84854 !important; color: #ffd8dc !important; }
-.broadcast-manager__unassigned { margin-top: 1.25rem; color: #c7d2ea; }
-.broadcast-manager__history { margin-top: 1.4rem; border-top: 1px solid rgba(220, 230, 255, .14); padding-top: 1rem; color: #c7d2ea; }
-.broadcast-manager__history summary { cursor: pointer; font-weight: 800; }
-.broadcast-manager__history > p { margin-top: .45rem; color: #9facc5; font-size: .84rem; }
-.broadcast-manager__unassigned summary { cursor: pointer; }
-.broadcast-manager__unassigned p { margin: .7rem 0; font-size: .85rem; }
-.broadcast-manager__unassigned button { display: block; width: 100%; margin-top: .4rem; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.broadcast-manager__live-section > div > p {
+  margin-top: 0.35rem;
+  color: #aebbd5;
+  font-size: 0.84rem;
+}
+.broadcast-manager__message-card--template {
+  background: rgba(52, 76, 137, 0.32);
+  border-color: rgba(140, 171, 255, 0.32);
+}
+.broadcast-manager__template-note {
+  color: #9eb3e9;
+  font-style: italic;
+}
+.broadcast-manager__count-help {
+  margin-top: 0.45rem !important;
+  color: #8998b7;
+  font-size: 0.78rem;
+}
+.broadcast-manager__sequence {
+  margin-top: 1.2rem;
+  border: 1px solid rgba(145, 171, 255, 0.28);
+  border-radius: 0.8rem;
+  padding: 1rem;
+  background: rgba(31, 48, 91, 0.34);
+}
+.broadcast-manager__sequence h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+.broadcast-manager__sequence > div > p {
+  margin-top: 0.3rem;
+  color: #aebbd5;
+  font-size: 0.84rem;
+}
+.broadcast-manager__sequence-list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0.8rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+.broadcast-manager__sequence-list li {
+  display: grid;
+  grid-template-columns: auto auto minmax(8rem, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 0.55rem;
+  padding: 0.45rem;
+  background: rgba(10, 18, 39, 0.7);
+}
+.broadcast-manager__sequence-position {
+  display: grid;
+  place-items: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  background: #5875d2;
+  font-weight: 900;
+}
+.broadcast-manager__sequence-kind {
+  color: #9eb3e9;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.broadcast-manager__sequence-copy {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.broadcast-manager__sequence-list button {
+  padding: 0.38rem 0.55rem;
+  font-size: 0.76rem;
+}
+.broadcast-manager__message-card h4 {
+  margin: 0.65rem 0 0;
+  font-size: 1.05rem;
+}
+.broadcast-manager__message-card.is-disabled {
+  opacity: 0.56;
+  border-style: dashed;
+}
+.broadcast-manager__edited {
+  color: #8ee7ba;
+  font-weight: 800;
+}
+.broadcast-manager__disabled {
+  color: #ffaaa5;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.broadcast-manager__empty {
+  margin-top: 2rem;
+  color: #a9b6d2;
+}
+.broadcast-manager__message-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 1rem 0 0;
+  list-style: none;
+}
+.broadcast-manager__message-card {
+  border: 1px solid rgba(220, 230, 255, 0.14);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: rgba(33, 48, 87, 0.48);
+}
+.broadcast-manager__message-card > p {
+  margin-top: 0.55rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+.broadcast-manager__message-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  color: #b9c8df;
+  font-size: 0.78rem;
+}
+.broadcast-manager__message-meta code {
+  border-radius: 0.3rem;
+  padding: 0.15rem 0.35rem;
+  background: #111a32;
+  color: #d3e0ff;
+}
+.broadcast-manager__badge {
+  border-radius: 999px;
+  padding: 0.18rem 0.45rem;
+  color: #091020;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+.broadcast-manager__badge--minor {
+  background: #aab9d7;
+}
+.broadcast-manager__badge--major {
+  background: #ffc76d;
+}
+.broadcast-manager__badge--critical {
+  background: #ff817b;
+}
+.broadcast-manager__message-actions {
+  margin-top: 0.85rem;
+  justify-content: flex-end;
+}
+.broadcast-manager__danger {
+  border-color: #a84854 !important;
+  color: #ffd8dc !important;
+}
+.broadcast-manager__unassigned {
+  margin-top: 1.25rem;
+  color: #c7d2ea;
+}
+.broadcast-manager__history {
+  margin-top: 1.4rem;
+  border-top: 1px solid rgba(220, 230, 255, 0.14);
+  padding-top: 1rem;
+  color: #c7d2ea;
+}
+.broadcast-manager__history summary {
+  cursor: pointer;
+  font-weight: 800;
+}
+.broadcast-manager__history > p {
+  margin-top: 0.45rem;
+  color: #9facc5;
+  font-size: 0.84rem;
+}
+.broadcast-manager__unassigned summary {
+  cursor: pointer;
+}
+.broadcast-manager__unassigned p {
+  margin: 0.7rem 0;
+  font-size: 0.85rem;
+}
+.broadcast-manager__unassigned button {
+  display: block;
+  width: 100%;
+  margin-top: 0.4rem;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-.broadcast-manager__editor-backdrop { position: fixed; z-index: 13000; inset: 0; display: grid; place-items: center; padding: 1rem; background: rgba(0, 0, 0, .68); }
-.broadcast-manager__editor { width: min(42rem, 100%); display: grid; gap: .9rem; border: 1px solid rgba(220, 230, 255, .25); border-radius: 1rem; padding: 1.25rem; background: #111a31; box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, .5); }
-.broadcast-manager__editor header { align-items: start; }
-.broadcast-manager__editor header button { padding: .2rem .55rem; font-size: 1.35rem; }
-.broadcast-manager__editor label { display: grid; gap: .38rem; color: #c5d0e7; font-size: .84rem; }
+.broadcast-manager__editor-backdrop {
+  position: fixed;
+  z-index: 13000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.68);
+}
+.broadcast-manager__editor {
+  width: min(42rem, 100%);
+  display: grid;
+  gap: 0.9rem;
+  border: 1px solid rgba(220, 230, 255, 0.25);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: #111a31;
+  box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.5);
+}
+.broadcast-manager__editor header {
+  align-items: start;
+}
+.broadcast-manager__editor header button {
+  padding: 0.2rem 0.55rem;
+  font-size: 1.35rem;
+}
+.broadcast-manager__editor label {
+  display: grid;
+  gap: 0.38rem;
+  color: #c5d0e7;
+  font-size: 0.84rem;
+}
 .broadcast-manager__editor input,
 .broadcast-manager__editor textarea,
-.broadcast-manager__editor select { box-sizing: border-box; width: 100%; border: 1px solid #40537e; border-radius: .5rem; padding: .62rem; color: #f4f7ff; background: #0b1224; }
-.broadcast-manager__editor textarea { resize: vertical; }
-.broadcast-manager__editor small { color: #9daeca; line-height: 1.35; }
-.broadcast-manager__editor small code { color: #d8e2ff; }
-.broadcast-manager__editor .broadcast-manager__field-error { color: #ff9e9e; font-weight: 700; }
-.broadcast-manager__editor .broadcast-manager__check { grid-template-columns: auto 1fr; align-items: center; border: 1px solid #40537e; border-radius: .6rem; padding: .7rem; }
-.broadcast-manager__editor .broadcast-manager__check input { width: 1.1rem; height: 1.1rem; margin: 0; }
-.broadcast-manager__editor .broadcast-manager__check small { grid-column: 2; }
-.broadcast-manager__editor-grid { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; }
-.broadcast-manager__editor footer { justify-content: flex-end; }
+.broadcast-manager__editor select {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid #40537e;
+  border-radius: 0.5rem;
+  padding: 0.62rem;
+  color: #f4f7ff;
+  background: #0b1224;
+}
+.broadcast-manager__editor textarea {
+  resize: vertical;
+}
+.broadcast-manager__editor small {
+  color: #9daeca;
+  line-height: 1.35;
+}
+.broadcast-manager__editor small code {
+  color: #d8e2ff;
+}
+.broadcast-manager__editor .broadcast-manager__field-error {
+  color: #ff9e9e;
+  font-weight: 700;
+}
+.broadcast-manager__editor .broadcast-manager__check {
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  border: 1px solid #40537e;
+  border-radius: 0.6rem;
+  padding: 0.7rem;
+}
+.broadcast-manager__editor .broadcast-manager__check input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: 0;
+}
+.broadcast-manager__editor .broadcast-manager__check small {
+  grid-column: 2;
+}
+.broadcast-manager__editor-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+.broadcast-manager__editor footer {
+  justify-content: flex-end;
+}
 
 @media (max-width: 720px) {
-  .broadcast-manager__header { align-items: start; flex-direction: column; }
-  .broadcast-manager__layout { grid-template-columns: 1fr; }
-  .broadcast-manager__phases { display: flex; max-height: none; overflow-x: auto; padding: .45rem; }
-  .broadcast-manager__phases button { min-width: max-content; width: auto; }
-  .broadcast-manager__editor-grid { grid-template-columns: 1fr; }
-  .broadcast-manager__sequence-list li { grid-template-columns: auto auto 1fr; }
-  .broadcast-manager__sequence-copy { grid-column: 1 / -1; }
+  .broadcast-manager__header {
+    align-items: start;
+    flex-direction: column;
+  }
+  .broadcast-manager__layout {
+    grid-template-columns: 1fr;
+  }
+  .broadcast-manager__phases {
+    display: flex;
+    max-height: none;
+    overflow-x: auto;
+    padding: 0.45rem;
+  }
+  .broadcast-manager__phases button {
+    min-width: max-content;
+    width: auto;
+  }
+  .broadcast-manager__editor-grid {
+    grid-template-columns: 1fr;
+  }
+  .broadcast-manager__sequence-list li {
+    grid-template-columns: auto auto 1fr;
+  }
+  .broadcast-manager__sequence-copy {
+    grid-column: 1 / -1;
+  }
 }

--- a/src/screens/BroadcastManager/BroadcastManager.css
+++ b/src/screens/BroadcastManager/BroadcastManager.css
@@ -1,0 +1,113 @@
+.broadcast-manager {
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: clamp(1rem, 3vw, 2.25rem);
+  color: #edf2ff;
+  background: radial-gradient(circle at top, #202b51, #0b1020 55%);
+}
+
+.broadcast-manager__header,
+.broadcast-manager__section-heading,
+.broadcast-manager__message-actions,
+.broadcast-manager__editor header,
+.broadcast-manager__editor footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.broadcast-manager h1,
+.broadcast-manager h2,
+.broadcast-manager p { margin: 0; }
+.broadcast-manager h1 { font-size: clamp(1.6rem, 3vw, 2.4rem); }
+.broadcast-manager__header > div > p:last-child { margin-top: .45rem; color: #b7c2dd; }
+.broadcast-manager__eyebrow { color: #91abff; font-size: .72rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+
+.broadcast-manager button,
+.broadcast-manager input,
+.broadcast-manager textarea,
+.broadcast-manager select { font: inherit; }
+.broadcast-manager button { border: 1px solid rgba(220, 230, 255, .24); border-radius: .55rem; color: inherit; background: #1a2648; cursor: pointer; padding: .56rem .78rem; }
+.broadcast-manager button:hover { background: #283a6b; }
+.broadcast-manager__primary { border-color: #9fb6ff !important; background: #5374d8 !important; color: #fff; font-weight: 800; }
+.broadcast-manager__primary:disabled { cursor: not-allowed; opacity: .5; }
+.broadcast-manager__back { white-space: nowrap; }
+
+.broadcast-manager__layout { display: grid; grid-template-columns: minmax(12rem, 17rem) minmax(0, 1fr); gap: 1rem; margin-top: 1.5rem; }
+.broadcast-manager__phases,
+.broadcast-manager__messages { border: 1px solid rgba(220, 230, 255, .14); border-radius: .9rem; background: rgba(8, 14, 31, .78); }
+.broadcast-manager__phases { max-height: calc(100vh - 12rem); overflow: auto; padding: .5rem; }
+.broadcast-manager__phases button { display: flex; align-items: center; justify-content: space-between; width: 100%; border: 0; background: transparent; text-align: left; text-transform: capitalize; }
+.broadcast-manager__phases button.is-selected { background: #3853a2; }
+.broadcast-manager__phases small { color: #b9c8ff; }
+.broadcast-manager__messages { min-height: 28rem; padding: clamp(1rem, 2vw, 1.5rem); }
+.broadcast-manager__template-section,
+.broadcast-manager__live-section { margin-top: 1.25rem; }
+.broadcast-manager__template-section h3,
+.broadcast-manager__live-section h3 { margin: 0; font-size: 1rem; }
+.broadcast-manager__template-section > div > p,
+.broadcast-manager__live-section > div > p { margin-top: .35rem; color: #aebbd5; font-size: .84rem; }
+.broadcast-manager__message-card--template { background: rgba(52, 76, 137, .32); border-color: rgba(140, 171, 255, .32); }
+.broadcast-manager__template-note { color: #9eb3e9; font-style: italic; }
+.broadcast-manager__count-help { margin-top: .45rem !important; color: #8998b7; font-size: .78rem; }
+.broadcast-manager__sequence { margin-top: 1.2rem; border: 1px solid rgba(145, 171, 255, .28); border-radius: .8rem; padding: 1rem; background: rgba(31, 48, 91, .34); }
+.broadcast-manager__sequence h3 { margin: 0; font-size: 1rem; }
+.broadcast-manager__sequence > div > p { margin-top: .3rem; color: #aebbd5; font-size: .84rem; }
+.broadcast-manager__sequence-list { display: grid; gap: .45rem; margin: .8rem 0 0; padding: 0; list-style: none; }
+.broadcast-manager__sequence-list li { display: grid; grid-template-columns: auto auto minmax(8rem, 1fr) auto auto auto; align-items: center; gap: .45rem; border-radius: .55rem; padding: .45rem; background: rgba(10, 18, 39, .7); }
+.broadcast-manager__sequence-position { display: grid; place-items: center; width: 1.6rem; height: 1.6rem; border-radius: 999px; background: #5875d2; font-weight: 900; }
+.broadcast-manager__sequence-kind { color: #9eb3e9; font-size: .7rem; font-weight: 800; text-transform: uppercase; }
+.broadcast-manager__sequence-copy { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.broadcast-manager__sequence-list button { padding: .38rem .55rem; font-size: .76rem; }
+.broadcast-manager__message-card h4 { margin: .65rem 0 0; font-size: 1.05rem; }
+.broadcast-manager__message-card.is-disabled { opacity: .56; border-style: dashed; }
+.broadcast-manager__edited { color: #8ee7ba; font-weight: 800; }
+.broadcast-manager__disabled { color: #ffaaa5; font-weight: 800; text-transform: uppercase; }
+.broadcast-manager__empty { margin-top: 2rem; color: #a9b6d2; }
+.broadcast-manager__message-list { display: grid; gap: .75rem; padding: 0; margin: 1rem 0 0; list-style: none; }
+.broadcast-manager__message-card { border: 1px solid rgba(220, 230, 255, .14); border-radius: .75rem; padding: 1rem; background: rgba(33, 48, 87, .48); }
+.broadcast-manager__message-card > p { margin-top: .55rem; line-height: 1.45; white-space: pre-wrap; }
+.broadcast-manager__message-meta { display: flex; flex-wrap: wrap; align-items: center; gap: .45rem; color: #b9c8df; font-size: .78rem; }
+.broadcast-manager__message-meta code { border-radius: .3rem; padding: .15rem .35rem; background: #111a32; color: #d3e0ff; }
+.broadcast-manager__badge { border-radius: 999px; padding: .18rem .45rem; color: #091020; font-weight: 900; text-transform: uppercase; }
+.broadcast-manager__badge--minor { background: #aab9d7; }
+.broadcast-manager__badge--major { background: #ffc76d; }
+.broadcast-manager__badge--critical { background: #ff817b; }
+.broadcast-manager__message-actions { margin-top: .85rem; justify-content: flex-end; }
+.broadcast-manager__danger { border-color: #a84854 !important; color: #ffd8dc !important; }
+.broadcast-manager__unassigned { margin-top: 1.25rem; color: #c7d2ea; }
+.broadcast-manager__history { margin-top: 1.4rem; border-top: 1px solid rgba(220, 230, 255, .14); padding-top: 1rem; color: #c7d2ea; }
+.broadcast-manager__history summary { cursor: pointer; font-weight: 800; }
+.broadcast-manager__history > p { margin-top: .45rem; color: #9facc5; font-size: .84rem; }
+.broadcast-manager__unassigned summary { cursor: pointer; }
+.broadcast-manager__unassigned p { margin: .7rem 0; font-size: .85rem; }
+.broadcast-manager__unassigned button { display: block; width: 100%; margin-top: .4rem; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.broadcast-manager__editor-backdrop { position: fixed; z-index: 13000; inset: 0; display: grid; place-items: center; padding: 1rem; background: rgba(0, 0, 0, .68); }
+.broadcast-manager__editor { width: min(42rem, 100%); display: grid; gap: .9rem; border: 1px solid rgba(220, 230, 255, .25); border-radius: 1rem; padding: 1.25rem; background: #111a31; box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, .5); }
+.broadcast-manager__editor header { align-items: start; }
+.broadcast-manager__editor header button { padding: .2rem .55rem; font-size: 1.35rem; }
+.broadcast-manager__editor label { display: grid; gap: .38rem; color: #c5d0e7; font-size: .84rem; }
+.broadcast-manager__editor input,
+.broadcast-manager__editor textarea,
+.broadcast-manager__editor select { box-sizing: border-box; width: 100%; border: 1px solid #40537e; border-radius: .5rem; padding: .62rem; color: #f4f7ff; background: #0b1224; }
+.broadcast-manager__editor textarea { resize: vertical; }
+.broadcast-manager__editor small { color: #9daeca; line-height: 1.35; }
+.broadcast-manager__editor small code { color: #d8e2ff; }
+.broadcast-manager__editor .broadcast-manager__field-error { color: #ff9e9e; font-weight: 700; }
+.broadcast-manager__editor .broadcast-manager__check { grid-template-columns: auto 1fr; align-items: center; border: 1px solid #40537e; border-radius: .6rem; padding: .7rem; }
+.broadcast-manager__editor .broadcast-manager__check input { width: 1.1rem; height: 1.1rem; margin: 0; }
+.broadcast-manager__editor .broadcast-manager__check small { grid-column: 2; }
+.broadcast-manager__editor-grid { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; }
+.broadcast-manager__editor footer { justify-content: flex-end; }
+
+@media (max-width: 720px) {
+  .broadcast-manager__header { align-items: start; flex-direction: column; }
+  .broadcast-manager__layout { grid-template-columns: 1fr; }
+  .broadcast-manager__phases { display: flex; max-height: none; overflow-x: auto; padding: .45rem; }
+  .broadcast-manager__phases button { min-width: max-content; width: auto; }
+  .broadcast-manager__editor-grid { grid-template-columns: 1fr; }
+  .broadcast-manager__sequence-list li { grid-template-columns: auto auto 1fr; }
+  .broadcast-manager__sequence-copy { grid-column: 1 / -1; }
+}

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -1,0 +1,527 @@
+import { useMemo, useState } from 'react'
+import { Navigate, useNavigate, useSearchParams } from 'react-router'
+import {
+  addCustomBroadcast,
+  removeCustomBroadcast,
+  removeTvEvent,
+  reorderPhaseBroadcasts,
+  resetBroadcastOverride,
+  setBroadcastOverride,
+  updateCustomBroadcast,
+  updateTvEvent,
+} from '../../store/gameSlice'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import type {
+  BroadcastLevel,
+  CustomBroadcastMessage,
+  Phase,
+  TvEvent,
+} from '../../types'
+import { isDebugAccessGranted } from '../../utils/debugMode'
+import {
+  ALL_BROADCAST_PHASES,
+  getDefaultBroadcastOrder,
+  getBroadcastTemplate,
+  getBroadcastTemplatesForPhase,
+  type BroadcastTemplate,
+} from '../../broadcasting/broadcastTemplateCatalog'
+import './BroadcastManager.css'
+
+const EVENT_TYPES: TvEvent['type'][] = ['game', 'social', 'vote', 'twist', 'diary']
+
+type EditorState = {
+  mode: 'builtin' | 'custom' | 'new' | 'live'
+  id: string | null
+  phase: Phase
+  text: string
+  title: string
+  type: TvEvent['type']
+  level: BroadcastLevel
+  major: string
+  isCard: boolean
+  forceOnTv: boolean
+  key: string
+}
+
+function normalizeMessageKey(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[.-]+|[.-]+$/g, '')
+  if (!normalized) return ''
+  return normalized.includes('.') ? normalized : `custom.${normalized}`
+}
+
+function suggestMessageKey(text: string): string {
+  return normalizeMessageKey(text.split(/\s+/).slice(0, 5).join('-'))
+}
+
+function phaseLabel(phase: Phase): string {
+  return phase.replace(/_/g, ' ')
+}
+
+function eventPhase(event: TvEvent): Phase | null {
+  const phase = event.meta?.phase
+  return typeof phase === 'string' && ALL_BROADCAST_PHASES.includes(phase as Phase)
+    ? (phase as Phase)
+    : null
+}
+
+function eventMajor(event: TvEvent): string {
+  const major = event.meta?.major ?? event.major
+  return typeof major === 'string' ? major : ''
+}
+
+function eventLevel(event: TvEvent): BroadcastLevel {
+  const level = event.meta?.broadcastLevel
+  if (level === 'minor' || level === 'major' || level === 'critical') return level
+  if (event.meta?.broadcastPriority === 'critical') return 'critical'
+  return eventMajor(event) ? 'major' : 'minor'
+}
+
+export default function BroadcastManager() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const game = useAppSelector((state) => state.game)
+  const hasAccess = isDebugAccessGranted(searchParams, window.location.hostname)
+  const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase)
+  const [editor, setEditor] = useState<EditorState | null>(null)
+
+  const overrides = game.broadcastOverrides ?? {}
+  const customMessages = game.customBroadcasts ?? []
+  const templates = useMemo(() => getBroadcastTemplatesForPhase(selectedPhase), [selectedPhase])
+  const phaseCustom = useMemo(
+    () => customMessages
+      .filter((message) => message.phase === selectedPhase)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    [customMessages, selectedPhase]
+  )
+  const liveMessages = useMemo(
+    () => game.tvFeed.filter((event) => eventPhase(event) === selectedPhase),
+    [game.tvFeed, selectedPhase]
+  )
+  const observedSources = useMemo(() => {
+    const byId = new Map<string, TvEvent>()
+    for (const event of liveMessages) {
+      const id = event.meta?.broadcastTemplateId
+      if (
+        typeof id === 'string' &&
+        !getBroadcastTemplate(id) &&
+        typeof event.meta?.customBroadcastId !== 'string' &&
+        !byId.has(id)
+      ) byId.set(id, event)
+    }
+    return [...byId.values()]
+  }, [liveMessages])
+  const sequenceItems = useMemo(() => {
+    const sourceItems = templates.map((template) => ({
+      id: template.id,
+      kind: 'source' as const,
+      order: overrides[template.id]?.order ?? getDefaultBroadcastOrder(template),
+      label: overrides[template.id]?.title ?? template.title ?? overrides[template.id]?.text ?? template.text,
+      template,
+    }))
+    const knownIds = new Set(sourceItems.map((item) => item.id))
+    const observedItems = observedSources.flatMap((event) => {
+      const id = typeof event.meta?.broadcastTemplateId === 'string'
+        ? event.meta.broadcastTemplateId
+        : null
+      if (!id || knownIds.has(id)) return []
+      return [{
+        id,
+        kind: 'source' as const,
+        order: overrides[id]?.order ??
+          (typeof event.meta?.broadcastOrder === 'number' ? event.meta.broadcastOrder : 10000),
+        label: overrides[id]?.text ??
+          (typeof event.meta?.broadcastSourceText === 'string' ? event.meta.broadcastSourceText : event.text),
+        event,
+      }]
+    })
+    const customItems = phaseCustom.map((message, index) => ({
+      id: message.id,
+      kind: 'custom' as const,
+      order: message.order ?? (templates.length + index + 1) * 100,
+      label: message.text,
+      message,
+    }))
+    return [...sourceItems, ...observedItems, ...customItems].sort(
+      (a, b) => a.order - b.order || a.id.localeCompare(b.id)
+    )
+  }, [observedSources, overrides, phaseCustom, templates])
+  const unassignedMessages = useMemo(
+    () => game.tvFeed.filter((event) => eventPhase(event) === null),
+    [game.tvFeed]
+  )
+
+  if (!hasAccess) return <Navigate to="/" replace />
+
+  function effectiveTemplate(template: BroadcastTemplate) {
+    const override = overrides[template.id]
+    return {
+      text: override?.text ?? template.text,
+      title: override?.title ?? template.title ?? '',
+      type: override?.type ?? template.type,
+      level: override?.level ?? template.level,
+      major: override?.major === null ? '' : (override?.major ?? template.major ?? ''),
+      disabled: override?.disabled === true,
+      edited: override != null,
+      forceOnTv:
+        override?.forceOnTv ?? template.forceOnTv ?? template.kind === 'phase_card',
+    }
+  }
+
+  function editTemplate(template: BroadcastTemplate) {
+    const value = effectiveTemplate(template)
+    setEditor({
+      mode: 'builtin',
+      id: template.id,
+      phase: template.phase,
+      text: value.text,
+      title: value.title,
+      type: value.type,
+      level: value.level,
+      major: value.major,
+      isCard: template.kind === 'phase_card',
+      forceOnTv: value.forceOnTv,
+      key: template.id,
+    })
+  }
+
+  function editCustom(message: CustomBroadcastMessage) {
+    setEditor({
+      mode: 'custom',
+      id: message.id,
+      phase: message.phase,
+      text: message.text,
+      title: message.title ?? '',
+      type: message.type,
+      level: message.level,
+      major: message.major ?? '',
+      isCard: false,
+      forceOnTv: message.forceOnTv !== false,
+      key: message.key ?? suggestMessageKey(message.text),
+    })
+  }
+
+  function editLive(event: TvEvent) {
+    setEditor({
+      mode: 'live',
+      id: event.id,
+      phase: eventPhase(event) ?? selectedPhase,
+      text: event.text,
+      title: typeof event.meta?.announcementTitle === 'string' ? event.meta.announcementTitle : '',
+      type: event.type,
+      level: eventLevel(event),
+      major: eventMajor(event),
+      isCard: false,
+      forceOnTv: event.meta?.forceOnTv === true,
+      key: typeof event.meta?.broadcastTemplateId === 'string' ? event.meta.broadcastTemplateId : '',
+    })
+  }
+
+  function editObservedSource(event: TvEvent) {
+    const id = String(event.meta?.broadcastTemplateId ?? '')
+    const override = overrides[id]
+    const sourceText = typeof event.meta?.broadcastSourceText === 'string'
+      ? event.meta.broadcastSourceText
+      : event.text
+    setEditor({
+      mode: 'builtin',
+      id,
+      phase: eventPhase(event) ?? selectedPhase,
+      text: override?.text ?? sourceText,
+      title: override?.title ?? '',
+      type: override?.type ?? event.type,
+      level: override?.level ?? eventLevel(event),
+      major: override?.major === null ? '' : (override?.major ?? eventMajor(event)),
+      isCard: false,
+      forceOnTv: override?.forceOnTv === true || event.meta?.forceOnTv === true,
+      key: id,
+    })
+  }
+
+  function addMessage() {
+    setEditor({
+      mode: 'new',
+      id: null,
+      phase: selectedPhase,
+      text: '',
+      title: '',
+      type: 'game',
+      level: 'minor',
+      major: '',
+      isCard: false,
+      forceOnTv: true,
+      key: '',
+    })
+  }
+
+  function moveSequenceItem(id: string, direction: -1 | 1) {
+    const currentIndex = sequenceItems.findIndex((item) => item.id === id)
+    const targetIndex = currentIndex + direction
+    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= sequenceItems.length) return
+    const reordered = [...sequenceItems]
+    ;[reordered[currentIndex], reordered[targetIndex]] = [reordered[targetIndex], reordered[currentIndex]]
+    dispatch(reorderPhaseBroadcasts({
+      phase: selectedPhase,
+      items: reordered.map((item) => ({ id: item.id, kind: item.kind })),
+    }))
+  }
+
+  function editSequenceItem(item: (typeof sequenceItems)[number]) {
+    if ('message' in item && item.message) editCustom(item.message)
+    else if ('template' in item && item.template) editTemplate(item.template)
+    else if ('event' in item && item.event) editObservedSource(item.event)
+  }
+
+  function saveEditor() {
+    if (!editor || !editor.text.trim()) return
+    const customKey = normalizeMessageKey(editor.key)
+    if ((editor.mode === 'new' || editor.mode === 'custom') && !customKey) return
+    const duplicateKey = customMessages.some(
+      (message) => message.id !== editor.id && (message.key ?? '') === customKey
+    )
+    if (duplicateKey) return
+    const major = editor.level === 'minor' ? undefined : editor.major.trim() || undefined
+    if (editor.mode === 'builtin' && editor.id) {
+      dispatch(setBroadcastOverride({
+        id: editor.id,
+        changes: {
+          text: editor.text.trim(),
+          title:
+            editor.isCard || editor.forceOnTv || editor.level !== 'minor'
+              ? editor.title.trim()
+              : undefined,
+          type: editor.type,
+          level: editor.level,
+          major: major ?? null,
+          forceOnTv: editor.forceOnTv || editor.level === 'critical',
+        },
+      }))
+    } else if (editor.mode === 'custom' && editor.id) {
+      const previous = customMessages.find((message) => message.id === editor.id)
+      dispatch(updateCustomBroadcast({
+        id: editor.id,
+        key: customKey,
+        phase: editor.phase,
+        text: editor.text.trim(),
+        title: editor.title.trim() || undefined,
+        type: editor.type,
+        level: editor.level,
+        major,
+        enabled: previous?.enabled ?? true,
+        forceOnTv: editor.forceOnTv || editor.level === 'critical',
+        order: previous?.order ?? 0,
+      }))
+    } else if (editor.mode === 'new') {
+      dispatch(addCustomBroadcast({
+        key: customKey,
+        phase: editor.phase,
+        text: editor.text.trim(),
+        title: editor.title.trim() || undefined,
+        type: editor.type,
+        level: editor.level,
+        major,
+        enabled: true,
+        forceOnTv: editor.forceOnTv || editor.level === 'critical',
+        order: Math.max(0, ...sequenceItems.map((item) => item.order)) + 100,
+      }))
+    } else if (editor.mode === 'live' && editor.id) {
+      dispatch(updateTvEvent({
+        id: editor.id,
+        text: editor.text.trim(),
+        type: editor.type,
+        phase: editor.phase,
+        major: major ?? null,
+        broadcastPriority: editor.level === 'critical' ? 'critical' : null,
+        forceOnTv: editor.forceOnTv || editor.level === 'critical',
+        announcementTitle: editor.title.trim() || undefined,
+      }))
+    }
+    setEditor(null)
+  }
+
+  return (
+    <main className="broadcast-manager">
+      <header className="broadcast-manager__header">
+        <div>
+          <p className="broadcast-manager__eyebrow">QA tools · Day {game.week}</p>
+          <h1>Broadcast Manager</h1>
+          <p>Permanent broadcast authoring. Changes survive navigation, reloads, and new campaigns.</p>
+        </div>
+        <button type="button" className="broadcast-manager__back" onClick={() => navigate('/game?debug=1')}>
+          Back to game
+        </button>
+      </header>
+
+      <div className="broadcast-manager__layout">
+        <nav className="broadcast-manager__phases" aria-label="Broadcast phases">
+          {ALL_BROADCAST_PHASES.map((phase) => {
+            const builtInCount = getBroadcastTemplatesForPhase(phase).length
+            const customCount = customMessages.filter((message) => message.phase === phase).length
+            const liveCount = game.tvFeed.filter((event) => eventPhase(event) === phase).length
+            return (
+              <button key={phase} type="button" className={phase === selectedPhase ? 'is-selected' : ''} onClick={() => setSelectedPhase(phase)}>
+                <span>{phaseLabel(phase)}</span>
+                <small>{builtInCount} + {customCount} / {liveCount}</small>
+              </button>
+            )
+          })}
+        </nav>
+
+        <section className="broadcast-manager__messages" aria-labelledby="broadcast-manager-phase-title">
+          <div className="broadcast-manager__section-heading">
+            <div>
+              <p className="broadcast-manager__eyebrow">{selectedPhase === game.phase ? 'Current phase' : 'Phase registry'}</p>
+              <h2 id="broadcast-manager-phase-title">{phaseLabel(selectedPhase)}</h2>
+            </div>
+            <button type="button" className="broadcast-manager__primary" onClick={addMessage}>Add phase message</button>
+          </div>
+          <p className="broadcast-manager__count-help">Counts are built-in + custom / already emitted.</p>
+
+          <section className="broadcast-manager__sequence" aria-label="Full phase broadcast sequence">
+            <div><h3>Full phase sequence</h3><p>Every built-in, observed, and custom item shares this order. Position 1 is processed first.</p></div>
+            <ol className="broadcast-manager__sequence-list">
+              {sequenceItems.map((item, index) => (
+                <li key={`${item.kind}:${item.id}`}>
+                  <span className="broadcast-manager__sequence-position">{index + 1}</span>
+                  <span className="broadcast-manager__sequence-kind">{item.kind === 'custom' ? 'custom' : 'built-in'}</span>
+                  <span className="broadcast-manager__sequence-copy">{item.label}</span>
+                  <button type="button" disabled={index === 0} onClick={() => moveSequenceItem(item.id, -1)}>Move up</button>
+                  <button type="button" disabled={index === sequenceItems.length - 1} onClick={() => moveSequenceItem(item.id, 1)}>Move down</button>
+                  <button type="button" onClick={() => editSequenceItem(item)}>Edit</button>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="broadcast-manager__template-section" aria-label="Built-in flow messages">
+            <div><h3>Built-in Play flow</h3><p>These are registry entries used by the game. Disable removes the message, not the ceremony or phase.</p></div>
+            {templates.length === 0 ? <p className="broadcast-manager__empty">This interactive phase has no separate broadcast line.</p> : (
+              <ol className="broadcast-manager__message-list">
+                {templates.map((template) => {
+                  const value = effectiveTemplate(template)
+                  return (
+                    <li key={template.id} className={`broadcast-manager__message-card broadcast-manager__message-card--template${value.disabled ? ' is-disabled' : ''}`}>
+                      <div className="broadcast-manager__message-meta">
+                        <span className={`broadcast-manager__badge broadcast-manager__badge--${value.level}`}>{value.level}</span>
+                        <span>{template.kind === 'phase_card' ? 'phase card' : value.type}</span>
+                        <code>{template.id}</code>
+                        {value.edited && <span className="broadcast-manager__edited">edited</span>}
+                        {value.disabled && <span className="broadcast-manager__disabled">disabled</span>}
+                        {template.note && <span className="broadcast-manager__template-note">{template.note}</span>}
+                      </div>
+                      {value.title && <h4>{value.title}</h4>}
+                      <p>{value.text}</p>
+                      <div className="broadcast-manager__message-actions">
+                        <button type="button" onClick={() => editTemplate(template)}>Edit source</button>
+                        <button type="button" onClick={() => dispatch(setBroadcastOverride({ id: template.id, changes: { disabled: !value.disabled } }))}>
+                          {value.disabled ? 'Enable' : 'Disable'}
+                        </button>
+                        {value.edited && <button type="button" onClick={() => dispatch(resetBroadcastOverride(template.id))}>Restore default</button>}
+                      </div>
+                    </li>
+                  )
+                })}
+              </ol>
+            )}
+          </section>
+
+          {observedSources.length > 0 && (
+            <section className="broadcast-manager__live-section" aria-label="Observed Play sources">
+              <div><h3>Observed Play sources</h3><p>Branch messages discovered in this run. Editing one changes the same source on future Play presses.</p></div>
+              <ol className="broadcast-manager__message-list">
+                {observedSources.map((event) => {
+                  const id = String(event.meta?.broadcastTemplateId)
+                  const override = overrides[id]
+                  const sourceText = typeof event.meta?.broadcastSourceText === 'string' ? event.meta.broadcastSourceText : event.text
+                  return (
+                    <li key={id} className={`broadcast-manager__message-card broadcast-manager__message-card--template${override?.disabled ? ' is-disabled' : ''}`}>
+                      <div className="broadcast-manager__message-meta"><span className={`broadcast-manager__badge broadcast-manager__badge--${override?.level ?? eventLevel(event)}`}>{override?.level ?? eventLevel(event)}</span><span>{override?.type ?? event.type}</span><code>{id}</code>{override && <span className="broadcast-manager__edited">edited</span>}</div>
+                      <p>{override?.text ?? sourceText}</p>
+                      <div className="broadcast-manager__message-actions">
+                        <button type="button" onClick={() => editObservedSource(event)}>Edit source</button>
+                        <button type="button" onClick={() => dispatch(setBroadcastOverride({ id, changes: { disabled: !override?.disabled } }))}>{override?.disabled ? 'Enable' : 'Disable'}</button>
+                        {override && <button type="button" onClick={() => dispatch(resetBroadcastOverride(id))}>Restore default</button>}
+                      </div>
+                    </li>
+                  )
+                })}
+              </ol>
+            </section>
+          )}
+
+          <section className="broadcast-manager__live-section" aria-label="Custom phase messages">
+            <div><h3>Custom phase messages</h3><p>These automatically emit once per day when Play processes this phase.</p></div>
+            {phaseCustom.length === 0 ? <p className="broadcast-manager__empty">No custom messages for this phase.</p> : (
+              <ol className="broadcast-manager__message-list">
+                {phaseCustom.map((message) => (
+                  <li key={message.id} className={`broadcast-manager__message-card${message.enabled ? '' : ' is-disabled'}`}>
+                    <div className="broadcast-manager__message-meta">
+                      <span className={`broadcast-manager__badge broadcast-manager__badge--${message.level}`}>{message.level}</span>
+                      <span>type: {message.type}</span><code>{message.key ?? suggestMessageKey(message.text)}</code>
+                      <span>position {phaseCustom.findIndex((item) => item.id === message.id) + 1}</span>
+                      {message.forceOnTv && <span className="broadcast-manager__edited">faux TV</span>}
+                      {!message.enabled && <span className="broadcast-manager__disabled">disabled</span>}
+                    </div>
+                    <p>{message.text}</p>
+                    <div className="broadcast-manager__message-actions">
+                      <button type="button" onClick={() => editCustom(message)}>Edit</button>
+                      <button type="button" onClick={() => dispatch(updateCustomBroadcast({ ...message, enabled: !message.enabled }))}>{message.enabled ? 'Disable' : 'Enable'}</button>
+                      <button type="button" className="broadcast-manager__danger" onClick={() => window.confirm('Delete this custom phase message?') && dispatch(removeCustomBroadcast(message.id))}>Delete</button>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+
+          <details className="broadcast-manager__history">
+            <summary>Live history ({liveMessages.length})</summary>
+            <p>Already-emitted rows can still be corrected or removed without changing the source definition.</p>
+            <ol className="broadcast-manager__message-list">
+              {liveMessages.map((event) => (
+                <li key={event.id} className="broadcast-manager__message-card">
+                  <div className="broadcast-manager__message-meta"><span>{event.type}</span>{typeof event.meta?.broadcastTemplateId === 'string' && <code>{event.meta.broadcastTemplateId}</code>}</div>
+                  <p>{event.text}</p>
+                  <div className="broadcast-manager__message-actions">
+                    <button type="button" onClick={() => editLive(event)}>Edit emitted row</button>
+                    <button type="button" className="broadcast-manager__danger" onClick={() => window.confirm('Remove this emitted row from the current run?') && dispatch(removeTvEvent(event.id))}>Remove row</button>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </details>
+
+          {unassignedMessages.length > 0 && (
+            <details className="broadcast-manager__unassigned">
+              <summary>{unassignedMessages.length} legacy row{unassignedMessages.length === 1 ? '' : 's'} without a phase</summary>
+              {unassignedMessages.map((event) => <button key={event.id} type="button" onClick={() => editLive(event)}>{event.text}</button>)}
+            </details>
+          )}
+        </section>
+      </div>
+
+      {editor && (
+        <div className="broadcast-manager__editor-backdrop" role="presentation">
+          <section className="broadcast-manager__editor" role="dialog" aria-modal="true" aria-label="Edit broadcast message">
+            <header><h2>{editor.mode === 'new' ? 'Add phase message' : editor.mode === 'builtin' ? 'Edit built-in source' : 'Edit broadcast message'}</h2><button type="button" aria-label="Close editor" onClick={() => setEditor(null)}>×</button></header>
+            <label>Ceremony phase<select disabled={editor.mode === 'builtin'} value={editor.phase} onChange={(event) => setEditor({ ...editor, phase: event.target.value as Phase })}>{ALL_BROADCAST_PHASES.map((phase) => <option key={phase} value={phase}>{phaseLabel(phase)}</option>)}</select></label>
+            {(editor.mode === 'new' || editor.mode === 'custom') && <label>Message key / name<input value={editor.key} placeholder="social.alliance-warning" onChange={(event) => setEditor({ ...editor, key: event.target.value })} /><small>Use a readable stable key such as <code>social.alliance-warning</code>. Spaces are converted to dashes; a key without a prefix becomes <code>custom.your-key</code>.</small>{!normalizeMessageKey(editor.key) && <small className="broadcast-manager__field-error">A message key is required.</small>}{customMessages.some((message) => message.id !== editor.id && (message.key ?? '') === normalizeMessageKey(editor.key)) && <small className="broadcast-manager__field-error">That key is already in use.</small>}</label>}
+            {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && <label>{editor.isCard || editor.level !== 'minor' ? 'Card title' : 'Faux-TV title (optional)'}<input value={editor.title} placeholder="BIG EYE BROADCAST" onChange={(event) => setEditor({ ...editor, title: event.target.value })} /></label>}
+            <label>{editor.isCard ? 'Card subtitle' : 'Message'}<textarea value={editor.text} rows={5} onChange={(event) => setEditor({ ...editor, text: event.target.value })} /><small>Keep placeholders such as {'{winner}'} if the live player value should remain dynamic.</small></label>
+            <div className="broadcast-manager__editor-grid">
+              <label>Event type<select value={editor.type} onChange={(event) => setEditor({ ...editor, type: event.target.value as TvEvent['type'] })}>{EVENT_TYPES.map((type) => <option key={type} value={type}>{type}</option>)}</select></label>
+              <label>Broadcast level<select value={editor.level} onChange={(event) => { const level = event.target.value as BroadcastLevel; setEditor({ ...editor, level, forceOnTv: level === 'critical' ? true : editor.forceOnTv }) }}><option value="minor">Minor · normal log line</option><option value="major">Major · faux-TV card</option><option value="critical">Critical · fullscreen shock + card</option></select></label>
+            </div>
+            <label className="broadcast-manager__check"><input type="checkbox" checked={editor.forceOnTv} onChange={(event) => setEditor({ ...editor, forceOnTv: event.target.checked })} /><span>Force this message onto the faux TV</span><small>No announcement key is needed. If unchecked, minor messages stay in the log; major and critical messages always use the faux TV.</small></label>
+            <footer><button type="button" onClick={() => setEditor(null)}>Cancel</button><button type="button" className="broadcast-manager__primary" disabled={!editor.text.trim() || ((editor.mode === 'new' || editor.mode === 'custom') && (!normalizeMessageKey(editor.key) || customMessages.some((message) => message.id !== editor.id && (message.key ?? '') === normalizeMessageKey(editor.key))))} onClick={saveEditor}>Save</button></footer>
+          </section>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -11,12 +11,7 @@ import {
   updateTvEvent,
 } from '../../store/gameSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
-import type {
-  BroadcastLevel,
-  CustomBroadcastMessage,
-  Phase,
-  TvEvent,
-} from '../../types'
+import type { BroadcastLevel, CustomBroadcastMessage, Phase, TvEvent } from '../../types'
 import { isDebugAccessGranted } from '../../utils/debugMode'
 import {
   ALL_BROADCAST_PHASES,
@@ -28,6 +23,10 @@ import {
 import './BroadcastManager.css'
 
 const EVENT_TYPES: TvEvent['type'][] = ['game', 'social', 'vote', 'twist', 'diary']
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const FULL_PHASE_SEQUENCE_LABEL = 'Full phase broadcast sequence'
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const BUILT_IN_FLOW_LABEL = 'Built-in flow messages'
 
 type EditorState = {
   mode: 'builtin' | 'custom' | 'new' | 'live'
@@ -51,6 +50,7 @@ function normalizeMessageKey(value: string): string {
     .replace(/-{2,}/g, '-')
     .replace(/^[.-]+|[.-]+$/g, '')
   if (!normalized) return ''
+  // i18n-ignore: Internal message key prefix, never rendered as player-facing copy
   return normalized.includes('.') ? normalized : `custom.${normalized}`
 }
 
@@ -90,13 +90,14 @@ export default function BroadcastManager() {
   const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase)
   const [editor, setEditor] = useState<EditorState | null>(null)
 
-  const overrides = game.broadcastOverrides ?? {}
-  const customMessages = game.customBroadcasts ?? []
+  const overrides = useMemo(() => game.broadcastOverrides ?? {}, [game.broadcastOverrides])
+  const customMessages = useMemo(() => game.customBroadcasts ?? [], [game.customBroadcasts])
   const templates = useMemo(() => getBroadcastTemplatesForPhase(selectedPhase), [selectedPhase])
   const phaseCustom = useMemo(
-    () => customMessages
-      .filter((message) => message.phase === selectedPhase)
-      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    () =>
+      customMessages
+        .filter((message) => message.phase === selectedPhase)
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
     [customMessages, selectedPhase]
   )
   const liveMessages = useMemo(
@@ -112,7 +113,8 @@ export default function BroadcastManager() {
         !getBroadcastTemplate(id) &&
         typeof event.meta?.customBroadcastId !== 'string' &&
         !byId.has(id)
-      ) byId.set(id, event)
+      )
+        byId.set(id, event)
     }
     return [...byId.values()]
   }, [liveMessages])
@@ -121,24 +123,33 @@ export default function BroadcastManager() {
       id: template.id,
       kind: 'source' as const,
       order: overrides[template.id]?.order ?? getDefaultBroadcastOrder(template),
-      label: overrides[template.id]?.title ?? template.title ?? overrides[template.id]?.text ?? template.text,
+      label:
+        overrides[template.id]?.title ??
+        template.title ??
+        overrides[template.id]?.text ??
+        template.text,
       template,
     }))
     const knownIds = new Set(sourceItems.map((item) => item.id))
     const observedItems = observedSources.flatMap((event) => {
-      const id = typeof event.meta?.broadcastTemplateId === 'string'
-        ? event.meta.broadcastTemplateId
-        : null
+      const id =
+        typeof event.meta?.broadcastTemplateId === 'string' ? event.meta.broadcastTemplateId : null
       if (!id || knownIds.has(id)) return []
-      return [{
-        id,
-        kind: 'source' as const,
-        order: overrides[id]?.order ??
-          (typeof event.meta?.broadcastOrder === 'number' ? event.meta.broadcastOrder : 10000),
-        label: overrides[id]?.text ??
-          (typeof event.meta?.broadcastSourceText === 'string' ? event.meta.broadcastSourceText : event.text),
-        event,
-      }]
+      return [
+        {
+          id,
+          kind: 'source' as const,
+          order:
+            overrides[id]?.order ??
+            (typeof event.meta?.broadcastOrder === 'number' ? event.meta.broadcastOrder : 10000),
+          label:
+            overrides[id]?.text ??
+            (typeof event.meta?.broadcastSourceText === 'string'
+              ? event.meta.broadcastSourceText
+              : event.text),
+          event,
+        },
+      ]
     })
     const customItems = phaseCustom.map((message, index) => ({
       id: message.id,
@@ -168,8 +179,7 @@ export default function BroadcastManager() {
       major: override?.major === null ? '' : (override?.major ?? template.major ?? ''),
       disabled: override?.disabled === true,
       edited: override != null,
-      forceOnTv:
-        override?.forceOnTv ?? template.forceOnTv ?? template.kind === 'phase_card',
+      forceOnTv: override?.forceOnTv ?? template.forceOnTv ?? template.kind === 'phase_card',
     }
   }
 
@@ -218,16 +228,18 @@ export default function BroadcastManager() {
       major: eventMajor(event),
       isCard: false,
       forceOnTv: event.meta?.forceOnTv === true,
-      key: typeof event.meta?.broadcastTemplateId === 'string' ? event.meta.broadcastTemplateId : '',
+      key:
+        typeof event.meta?.broadcastTemplateId === 'string' ? event.meta.broadcastTemplateId : '',
     })
   }
 
   function editObservedSource(event: TvEvent) {
     const id = String(event.meta?.broadcastTemplateId ?? '')
     const override = overrides[id]
-    const sourceText = typeof event.meta?.broadcastSourceText === 'string'
-      ? event.meta.broadcastSourceText
-      : event.text
+    const sourceText =
+      typeof event.meta?.broadcastSourceText === 'string'
+        ? event.meta.broadcastSourceText
+        : event.text
     setEditor({
       mode: 'builtin',
       id,
@@ -264,11 +276,16 @@ export default function BroadcastManager() {
     const targetIndex = currentIndex + direction
     if (currentIndex < 0 || targetIndex < 0 || targetIndex >= sequenceItems.length) return
     const reordered = [...sequenceItems]
-    ;[reordered[currentIndex], reordered[targetIndex]] = [reordered[targetIndex], reordered[currentIndex]]
-    dispatch(reorderPhaseBroadcasts({
-      phase: selectedPhase,
-      items: reordered.map((item) => ({ id: item.id, kind: item.kind })),
-    }))
+    ;[reordered[currentIndex], reordered[targetIndex]] = [
+      reordered[targetIndex],
+      reordered[currentIndex],
+    ]
+    dispatch(
+      reorderPhaseBroadcasts({
+        phase: selectedPhase,
+        items: reordered.map((item) => ({ id: item.id, kind: item.kind })),
+      })
+    )
   }
 
   function editSequenceItem(item: (typeof sequenceItems)[number]) {
@@ -287,59 +304,67 @@ export default function BroadcastManager() {
     if (duplicateKey) return
     const major = editor.level === 'minor' ? undefined : editor.major.trim() || undefined
     if (editor.mode === 'builtin' && editor.id) {
-      dispatch(setBroadcastOverride({
-        id: editor.id,
-        changes: {
-          text: editor.text.trim(),
-          title:
-            editor.isCard || editor.forceOnTv || editor.level !== 'minor'
-              ? editor.title.trim()
-              : undefined,
-          type: editor.type,
-          level: editor.level,
-          major: major ?? null,
-          forceOnTv: editor.forceOnTv || editor.level === 'critical',
-        },
-      }))
+      dispatch(
+        setBroadcastOverride({
+          id: editor.id,
+          changes: {
+            text: editor.text.trim(),
+            title:
+              editor.isCard || editor.forceOnTv || editor.level !== 'minor'
+                ? editor.title.trim()
+                : undefined,
+            type: editor.type,
+            level: editor.level,
+            major: major ?? null,
+            forceOnTv: editor.forceOnTv || editor.level === 'critical',
+          },
+        })
+      )
     } else if (editor.mode === 'custom' && editor.id) {
       const previous = customMessages.find((message) => message.id === editor.id)
-      dispatch(updateCustomBroadcast({
-        id: editor.id,
-        key: customKey,
-        phase: editor.phase,
-        text: editor.text.trim(),
-        title: editor.title.trim() || undefined,
-        type: editor.type,
-        level: editor.level,
-        major,
-        enabled: previous?.enabled ?? true,
-        forceOnTv: editor.forceOnTv || editor.level === 'critical',
-        order: previous?.order ?? 0,
-      }))
+      dispatch(
+        updateCustomBroadcast({
+          id: editor.id,
+          key: customKey,
+          phase: editor.phase,
+          text: editor.text.trim(),
+          title: editor.title.trim() || undefined,
+          type: editor.type,
+          level: editor.level,
+          major,
+          enabled: previous?.enabled ?? true,
+          forceOnTv: editor.forceOnTv || editor.level === 'critical',
+          order: previous?.order ?? 0,
+        })
+      )
     } else if (editor.mode === 'new') {
-      dispatch(addCustomBroadcast({
-        key: customKey,
-        phase: editor.phase,
-        text: editor.text.trim(),
-        title: editor.title.trim() || undefined,
-        type: editor.type,
-        level: editor.level,
-        major,
-        enabled: true,
-        forceOnTv: editor.forceOnTv || editor.level === 'critical',
-        order: Math.max(0, ...sequenceItems.map((item) => item.order)) + 100,
-      }))
+      dispatch(
+        addCustomBroadcast({
+          key: customKey,
+          phase: editor.phase,
+          text: editor.text.trim(),
+          title: editor.title.trim() || undefined,
+          type: editor.type,
+          level: editor.level,
+          major,
+          enabled: true,
+          forceOnTv: editor.forceOnTv || editor.level === 'critical',
+          order: Math.max(0, ...sequenceItems.map((item) => item.order)) + 100,
+        })
+      )
     } else if (editor.mode === 'live' && editor.id) {
-      dispatch(updateTvEvent({
-        id: editor.id,
-        text: editor.text.trim(),
-        type: editor.type,
-        phase: editor.phase,
-        major: major ?? null,
-        broadcastPriority: editor.level === 'critical' ? 'critical' : null,
-        forceOnTv: editor.forceOnTv || editor.level === 'critical',
-        announcementTitle: editor.title.trim() || undefined,
-      }))
+      dispatch(
+        updateTvEvent({
+          id: editor.id,
+          text: editor.text.trim(),
+          type: editor.type,
+          phase: editor.phase,
+          major: major ?? null,
+          broadcastPriority: editor.level === 'critical' ? 'critical' : null,
+          forceOnTv: editor.forceOnTv || editor.level === 'critical',
+          announcementTitle: editor.title.trim() || undefined,
+        })
+      )
     }
     setEditor(null)
   }
@@ -348,80 +373,188 @@ export default function BroadcastManager() {
     <main className="broadcast-manager">
       <header className="broadcast-manager__header">
         <div>
+          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
           <p className="broadcast-manager__eyebrow">QA tools · Day {game.week}</p>
+          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
           <h1>Broadcast Manager</h1>
-          <p>Permanent broadcast authoring. Changes survive navigation, reloads, and new campaigns.</p>
+          <p>
+            {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+            Permanent broadcast authoring. Changes survive navigation, reloads, and new campaigns.
+          </p>
         </div>
-        <button type="button" className="broadcast-manager__back" onClick={() => navigate('/game?debug=1')}>
+        <button
+          type="button"
+          className="broadcast-manager__back"
+          onClick={() => navigate('/game?debug=1')}
+        >
+          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
           Back to game
         </button>
       </header>
 
       <div className="broadcast-manager__layout">
+        {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
         <nav className="broadcast-manager__phases" aria-label="Broadcast phases">
           {ALL_BROADCAST_PHASES.map((phase) => {
             const builtInCount = getBroadcastTemplatesForPhase(phase).length
             const customCount = customMessages.filter((message) => message.phase === phase).length
             const liveCount = game.tvFeed.filter((event) => eventPhase(event) === phase).length
             return (
-              <button key={phase} type="button" className={phase === selectedPhase ? 'is-selected' : ''} onClick={() => setSelectedPhase(phase)}>
+              <button
+                key={phase}
+                type="button"
+                className={phase === selectedPhase ? 'is-selected' : ''}
+                onClick={() => setSelectedPhase(phase)}
+              >
                 <span>{phaseLabel(phase)}</span>
-                <small>{builtInCount} + {customCount} / {liveCount}</small>
+                <small>
+                  {builtInCount} + {customCount} / {liveCount}
+                </small>
               </button>
             )
           })}
         </nav>
 
-        <section className="broadcast-manager__messages" aria-labelledby="broadcast-manager-phase-title">
+        <section
+          className="broadcast-manager__messages"
+          aria-labelledby="broadcast-manager-phase-title"
+        >
           <div className="broadcast-manager__section-heading">
             <div>
-              <p className="broadcast-manager__eyebrow">{selectedPhase === game.phase ? 'Current phase' : 'Phase registry'}</p>
+              <p className="broadcast-manager__eyebrow">
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                {selectedPhase === game.phase ? 'Current phase' : 'Phase registry'}
+              </p>
               <h2 id="broadcast-manager-phase-title">{phaseLabel(selectedPhase)}</h2>
             </div>
-            <button type="button" className="broadcast-manager__primary" onClick={addMessage}>Add phase message</button>
+            <button type="button" className="broadcast-manager__primary" onClick={addMessage}>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+              Add phase message
+            </button>
           </div>
-          <p className="broadcast-manager__count-help">Counts are built-in + custom / already emitted.</p>
+          <p className="broadcast-manager__count-help">
+            {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+            Counts are built-in + custom / already emitted.
+          </p>
 
-          <section className="broadcast-manager__sequence" aria-label="Full phase broadcast sequence">
-            <div><h3>Full phase sequence</h3><p>Every built-in, observed, and custom item shares this order. Position 1 is processed first.</p></div>
+          <section className="broadcast-manager__sequence" aria-label={FULL_PHASE_SEQUENCE_LABEL}>
+            <div>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+              <h3>Full phase sequence</h3>
+              <p>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                Every built-in, observed, and custom item shares this order. Position 1 is processed
+                first.
+              </p>
+            </div>
             <ol className="broadcast-manager__sequence-list">
               {sequenceItems.map((item, index) => (
                 <li key={`${item.kind}:${item.id}`}>
                   <span className="broadcast-manager__sequence-position">{index + 1}</span>
-                  <span className="broadcast-manager__sequence-kind">{item.kind === 'custom' ? 'custom' : 'built-in'}</span>
+                  <span className="broadcast-manager__sequence-kind">
+                    {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                    {item.kind === 'custom' ? 'custom' : 'built-in'}
+                  </span>
                   <span className="broadcast-manager__sequence-copy">{item.label}</span>
-                  <button type="button" disabled={index === 0} onClick={() => moveSequenceItem(item.id, -1)}>Move up</button>
-                  <button type="button" disabled={index === sequenceItems.length - 1} onClick={() => moveSequenceItem(item.id, 1)}>Move down</button>
-                  <button type="button" onClick={() => editSequenceItem(item)}>Edit</button>
+                  <button
+                    type="button"
+                    disabled={index === 0}
+                    onClick={() => moveSequenceItem(item.id, -1)}
+                  >
+                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                    Move up
+                  </button>
+                  <button
+                    type="button"
+                    disabled={index === sequenceItems.length - 1}
+                    onClick={() => moveSequenceItem(item.id, 1)}
+                  >
+                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                    Move down
+                  </button>
+                  <button type="button" onClick={() => editSequenceItem(item)}>
+                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                    Edit
+                  </button>
                 </li>
               ))}
             </ol>
           </section>
 
-          <section className="broadcast-manager__template-section" aria-label="Built-in flow messages">
-            <div><h3>Built-in Play flow</h3><p>These are registry entries used by the game. Disable removes the message, not the ceremony or phase.</p></div>
-            {templates.length === 0 ? <p className="broadcast-manager__empty">This interactive phase has no separate broadcast line.</p> : (
+          <section className="broadcast-manager__template-section" aria-label={BUILT_IN_FLOW_LABEL}>
+            <div>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+              <h3>Built-in Play flow</h3>
+              <p>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                These are registry entries used by the game. Disable removes the message, not the
+                ceremony or phase.
+              </p>
+            </div>
+            {templates.length === 0 ? (
+              <p className="broadcast-manager__empty">
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                This interactive phase has no separate broadcast line.
+              </p>
+            ) : (
               <ol className="broadcast-manager__message-list">
                 {templates.map((template) => {
                   const value = effectiveTemplate(template)
                   return (
-                    <li key={template.id} className={`broadcast-manager__message-card broadcast-manager__message-card--template${value.disabled ? ' is-disabled' : ''}`}>
+                    <li
+                      key={template.id}
+                      className={`broadcast-manager__message-card broadcast-manager__message-card--template${value.disabled ? ' is-disabled' : ''}`}
+                    >
                       <div className="broadcast-manager__message-meta">
-                        <span className={`broadcast-manager__badge broadcast-manager__badge--${value.level}`}>{value.level}</span>
+                        <span
+                          className={`broadcast-manager__badge broadcast-manager__badge--${value.level}`}
+                        >
+                          {value.level}
+                        </span>
+                        {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
                         <span>{template.kind === 'phase_card' ? 'phase card' : value.type}</span>
                         <code>{template.id}</code>
+                        {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
                         {value.edited && <span className="broadcast-manager__edited">edited</span>}
-                        {value.disabled && <span className="broadcast-manager__disabled">disabled</span>}
-                        {template.note && <span className="broadcast-manager__template-note">{template.note}</span>}
+                        {value.disabled && (
+                          <span className="broadcast-manager__disabled">
+                            {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                            disabled
+                          </span>
+                        )}
+                        {template.note && (
+                          <span className="broadcast-manager__template-note">{template.note}</span>
+                        )}
                       </div>
                       {value.title && <h4>{value.title}</h4>}
                       <p>{value.text}</p>
                       <div className="broadcast-manager__message-actions">
-                        <button type="button" onClick={() => editTemplate(template)}>Edit source</button>
-                        <button type="button" onClick={() => dispatch(setBroadcastOverride({ id: template.id, changes: { disabled: !value.disabled } }))}>
+                        <button type="button" onClick={() => editTemplate(template)}>
+                          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                          Edit source
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            dispatch(
+                              setBroadcastOverride({
+                                id: template.id,
+                                changes: { disabled: !value.disabled },
+                              })
+                            )
+                          }
+                        >
+                          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                           {value.disabled ? 'Enable' : 'Disable'}
                         </button>
-                        {value.edited && <button type="button" onClick={() => dispatch(resetBroadcastOverride(template.id))}>Restore default</button>}
+                        {value.edited && (
+                          <button
+                            type="button"
+                            onClick={() => dispatch(resetBroadcastOverride(template.id))}
+                          >
+                            Restore default
+                          </button>
+                        )}
                       </div>
                     </li>
                   )
@@ -432,20 +565,62 @@ export default function BroadcastManager() {
 
           {observedSources.length > 0 && (
             <section className="broadcast-manager__live-section" aria-label="Observed Play sources">
-              <div><h3>Observed Play sources</h3><p>Branch messages discovered in this run. Editing one changes the same source on future Play presses.</p></div>
+              <div>
+                <h3>Observed Play sources</h3>
+                <p>
+                  Branch messages discovered in this run. Editing one changes the same source on
+                  future Play presses.
+                </p>
+              </div>
               <ol className="broadcast-manager__message-list">
                 {observedSources.map((event) => {
                   const id = String(event.meta?.broadcastTemplateId)
                   const override = overrides[id]
-                  const sourceText = typeof event.meta?.broadcastSourceText === 'string' ? event.meta.broadcastSourceText : event.text
+                  const sourceText =
+                    typeof event.meta?.broadcastSourceText === 'string'
+                      ? event.meta.broadcastSourceText
+                      : event.text
                   return (
-                    <li key={id} className={`broadcast-manager__message-card broadcast-manager__message-card--template${override?.disabled ? ' is-disabled' : ''}`}>
-                      <div className="broadcast-manager__message-meta"><span className={`broadcast-manager__badge broadcast-manager__badge--${override?.level ?? eventLevel(event)}`}>{override?.level ?? eventLevel(event)}</span><span>{override?.type ?? event.type}</span><code>{id}</code>{override && <span className="broadcast-manager__edited">edited</span>}</div>
+                    <li
+                      key={id}
+                      className={`broadcast-manager__message-card broadcast-manager__message-card--template${override?.disabled ? ' is-disabled' : ''}`}
+                    >
+                      <div className="broadcast-manager__message-meta">
+                        <span
+                          className={`broadcast-manager__badge broadcast-manager__badge--${override?.level ?? eventLevel(event)}`}
+                        >
+                          {override?.level ?? eventLevel(event)}
+                        </span>
+                        <span>{override?.type ?? event.type}</span>
+                        <code>{id}</code>
+                        {override && <span className="broadcast-manager__edited">edited</span>}
+                      </div>
                       <p>{override?.text ?? sourceText}</p>
                       <div className="broadcast-manager__message-actions">
-                        <button type="button" onClick={() => editObservedSource(event)}>Edit source</button>
-                        <button type="button" onClick={() => dispatch(setBroadcastOverride({ id, changes: { disabled: !override?.disabled } }))}>{override?.disabled ? 'Enable' : 'Disable'}</button>
-                        {override && <button type="button" onClick={() => dispatch(resetBroadcastOverride(id))}>Restore default</button>}
+                        <button type="button" onClick={() => editObservedSource(event)}>
+                          Edit source
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            dispatch(
+                              setBroadcastOverride({
+                                id,
+                                changes: { disabled: !override?.disabled },
+                              })
+                            )
+                          }
+                        >
+                          {override?.disabled ? 'Enable' : 'Disable'}
+                        </button>
+                        {override && (
+                          <button
+                            type="button"
+                            onClick={() => dispatch(resetBroadcastOverride(id))}
+                          >
+                            Restore default
+                          </button>
+                        )}
                       </div>
                     </li>
                   )
@@ -455,23 +630,60 @@ export default function BroadcastManager() {
           )}
 
           <section className="broadcast-manager__live-section" aria-label="Custom phase messages">
-            <div><h3>Custom phase messages</h3><p>These automatically emit once per day when Play processes this phase.</p></div>
-            {phaseCustom.length === 0 ? <p className="broadcast-manager__empty">No custom messages for this phase.</p> : (
+            <div>
+              <h3>Custom phase messages</h3>
+              <p>These automatically emit once per day when Play processes this phase.</p>
+            </div>
+            {phaseCustom.length === 0 ? (
+              <p className="broadcast-manager__empty">No custom messages for this phase.</p>
+            ) : (
               <ol className="broadcast-manager__message-list">
                 {phaseCustom.map((message) => (
-                  <li key={message.id} className={`broadcast-manager__message-card${message.enabled ? '' : ' is-disabled'}`}>
+                  <li
+                    key={message.id}
+                    className={`broadcast-manager__message-card${message.enabled ? '' : ' is-disabled'}`}
+                  >
                     <div className="broadcast-manager__message-meta">
-                      <span className={`broadcast-manager__badge broadcast-manager__badge--${message.level}`}>{message.level}</span>
-                      <span>type: {message.type}</span><code>{message.key ?? suggestMessageKey(message.text)}</code>
-                      <span>position {phaseCustom.findIndex((item) => item.id === message.id) + 1}</span>
-                      {message.forceOnTv && <span className="broadcast-manager__edited">faux TV</span>}
-                      {!message.enabled && <span className="broadcast-manager__disabled">disabled</span>}
+                      <span
+                        className={`broadcast-manager__badge broadcast-manager__badge--${message.level}`}
+                      >
+                        {message.level}
+                      </span>
+                      <span>type: {message.type}</span>
+                      <code>{message.key ?? suggestMessageKey(message.text)}</code>
+                      <span>
+                        position {phaseCustom.findIndex((item) => item.id === message.id) + 1}
+                      </span>
+                      {message.forceOnTv && (
+                        <span className="broadcast-manager__edited">faux TV</span>
+                      )}
+                      {!message.enabled && (
+                        <span className="broadcast-manager__disabled">disabled</span>
+                      )}
                     </div>
                     <p>{message.text}</p>
                     <div className="broadcast-manager__message-actions">
-                      <button type="button" onClick={() => editCustom(message)}>Edit</button>
-                      <button type="button" onClick={() => dispatch(updateCustomBroadcast({ ...message, enabled: !message.enabled }))}>{message.enabled ? 'Disable' : 'Enable'}</button>
-                      <button type="button" className="broadcast-manager__danger" onClick={() => window.confirm('Delete this custom phase message?') && dispatch(removeCustomBroadcast(message.id))}>Delete</button>
+                      <button type="button" onClick={() => editCustom(message)}>
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          dispatch(updateCustomBroadcast({ ...message, enabled: !message.enabled }))
+                        }
+                      >
+                        {message.enabled ? 'Disable' : 'Enable'}
+                      </button>
+                      <button
+                        type="button"
+                        className="broadcast-manager__danger"
+                        onClick={() =>
+                          window.confirm('Delete this custom phase message?') &&
+                          dispatch(removeCustomBroadcast(message.id))
+                        }
+                      >
+                        Delete
+                      </button>
                     </div>
                   </li>
                 ))}
@@ -481,15 +693,34 @@ export default function BroadcastManager() {
 
           <details className="broadcast-manager__history">
             <summary>Live history ({liveMessages.length})</summary>
-            <p>Already-emitted rows can still be corrected or removed without changing the source definition.</p>
+            <p>
+              Already-emitted rows can still be corrected or removed without changing the source
+              definition.
+            </p>
             <ol className="broadcast-manager__message-list">
               {liveMessages.map((event) => (
                 <li key={event.id} className="broadcast-manager__message-card">
-                  <div className="broadcast-manager__message-meta"><span>{event.type}</span>{typeof event.meta?.broadcastTemplateId === 'string' && <code>{event.meta.broadcastTemplateId}</code>}</div>
+                  <div className="broadcast-manager__message-meta">
+                    <span>{event.type}</span>
+                    {typeof event.meta?.broadcastTemplateId === 'string' && (
+                      <code>{event.meta.broadcastTemplateId}</code>
+                    )}
+                  </div>
                   <p>{event.text}</p>
                   <div className="broadcast-manager__message-actions">
-                    <button type="button" onClick={() => editLive(event)}>Edit emitted row</button>
-                    <button type="button" className="broadcast-manager__danger" onClick={() => window.confirm('Remove this emitted row from the current run?') && dispatch(removeTvEvent(event.id))}>Remove row</button>
+                    <button type="button" onClick={() => editLive(event)}>
+                      Edit emitted row
+                    </button>
+                    <button
+                      type="button"
+                      className="broadcast-manager__danger"
+                      onClick={() =>
+                        window.confirm('Remove this emitted row from the current run?') &&
+                        dispatch(removeTvEvent(event.id))
+                      }
+                    >
+                      Remove row
+                    </button>
                   </div>
                 </li>
               ))}
@@ -498,8 +729,15 @@ export default function BroadcastManager() {
 
           {unassignedMessages.length > 0 && (
             <details className="broadcast-manager__unassigned">
-              <summary>{unassignedMessages.length} legacy row{unassignedMessages.length === 1 ? '' : 's'} without a phase</summary>
-              {unassignedMessages.map((event) => <button key={event.id} type="button" onClick={() => editLive(event)}>{event.text}</button>)}
+              <summary>
+                {unassignedMessages.length} legacy row{unassignedMessages.length === 1 ? '' : 's'}{' '}
+                without a phase
+              </summary>
+              {unassignedMessages.map((event) => (
+                <button key={event.id} type="button" onClick={() => editLive(event)}>
+                  {event.text}
+                </button>
+              ))}
             </details>
           )}
         </section>
@@ -507,18 +745,159 @@ export default function BroadcastManager() {
 
       {editor && (
         <div className="broadcast-manager__editor-backdrop" role="presentation">
-          <section className="broadcast-manager__editor" role="dialog" aria-modal="true" aria-label="Edit broadcast message">
-            <header><h2>{editor.mode === 'new' ? 'Add phase message' : editor.mode === 'builtin' ? 'Edit built-in source' : 'Edit broadcast message'}</h2><button type="button" aria-label="Close editor" onClick={() => setEditor(null)}>×</button></header>
-            <label>Ceremony phase<select disabled={editor.mode === 'builtin'} value={editor.phase} onChange={(event) => setEditor({ ...editor, phase: event.target.value as Phase })}>{ALL_BROADCAST_PHASES.map((phase) => <option key={phase} value={phase}>{phaseLabel(phase)}</option>)}</select></label>
-            {(editor.mode === 'new' || editor.mode === 'custom') && <label>Message key / name<input value={editor.key} placeholder="social.alliance-warning" onChange={(event) => setEditor({ ...editor, key: event.target.value })} /><small>Use a readable stable key such as <code>social.alliance-warning</code>. Spaces are converted to dashes; a key without a prefix becomes <code>custom.your-key</code>.</small>{!normalizeMessageKey(editor.key) && <small className="broadcast-manager__field-error">A message key is required.</small>}{customMessages.some((message) => message.id !== editor.id && (message.key ?? '') === normalizeMessageKey(editor.key)) && <small className="broadcast-manager__field-error">That key is already in use.</small>}</label>}
-            {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && <label>{editor.isCard || editor.level !== 'minor' ? 'Card title' : 'Faux-TV title (optional)'}<input value={editor.title} placeholder="BIG EYE BROADCAST" onChange={(event) => setEditor({ ...editor, title: event.target.value })} /></label>}
-            <label>{editor.isCard ? 'Card subtitle' : 'Message'}<textarea value={editor.text} rows={5} onChange={(event) => setEditor({ ...editor, text: event.target.value })} /><small>Keep placeholders such as {'{winner}'} if the live player value should remain dynamic.</small></label>
+          <section
+            className="broadcast-manager__editor"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Edit broadcast message"
+          >
+            <header>
+              <h2>
+                {editor.mode === 'new'
+                  ? 'Add phase message'
+                  : editor.mode === 'builtin'
+                    ? 'Edit built-in source'
+                    : 'Edit broadcast message'}
+              </h2>
+              <button type="button" aria-label="Close editor" onClick={() => setEditor(null)}>
+                ×
+              </button>
+            </header>
+            <label>
+              Ceremony phase
+              <select
+                disabled={editor.mode === 'builtin'}
+                value={editor.phase}
+                onChange={(event) => setEditor({ ...editor, phase: event.target.value as Phase })}
+              >
+                {ALL_BROADCAST_PHASES.map((phase) => (
+                  <option key={phase} value={phase}>
+                    {phaseLabel(phase)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {(editor.mode === 'new' || editor.mode === 'custom') && (
+              <label>
+                Message key / name
+                <input
+                  value={editor.key}
+                  placeholder="social.alliance-warning"
+                  onChange={(event) => setEditor({ ...editor, key: event.target.value })}
+                />
+                <small>
+                  Use a readable stable key such as <code>social.alliance-warning</code>. Spaces are
+                  converted to dashes; a key without a prefix becomes <code>custom.your-key</code>.
+                </small>
+                {!normalizeMessageKey(editor.key) && (
+                  <small className="broadcast-manager__field-error">
+                    A message key is required.
+                  </small>
+                )}
+                {customMessages.some(
+                  (message) =>
+                    message.id !== editor.id &&
+                    (message.key ?? '') === normalizeMessageKey(editor.key)
+                ) && (
+                  <small className="broadcast-manager__field-error">
+                    That key is already in use.
+                  </small>
+                )}
+              </label>
+            )}
+            {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && (
+              <label>
+                {editor.isCard || editor.level !== 'minor'
+                  ? 'Card title'
+                  : 'Faux-TV title (optional)'}
+                <input
+                  value={editor.title}
+                  placeholder="BIG EYE BROADCAST"
+                  onChange={(event) => setEditor({ ...editor, title: event.target.value })}
+                />
+              </label>
+            )}
+            <label>
+              {editor.isCard ? 'Card subtitle' : 'Message'}
+              <textarea
+                value={editor.text}
+                rows={5}
+                onChange={(event) => setEditor({ ...editor, text: event.target.value })}
+              />
+              <small>
+                Keep placeholders such as {'{winner}'} if the live player value should remain
+                dynamic.
+              </small>
+            </label>
             <div className="broadcast-manager__editor-grid">
-              <label>Event type<select value={editor.type} onChange={(event) => setEditor({ ...editor, type: event.target.value as TvEvent['type'] })}>{EVENT_TYPES.map((type) => <option key={type} value={type}>{type}</option>)}</select></label>
-              <label>Broadcast level<select value={editor.level} onChange={(event) => { const level = event.target.value as BroadcastLevel; setEditor({ ...editor, level, forceOnTv: level === 'critical' ? true : editor.forceOnTv }) }}><option value="minor">Minor · normal log line</option><option value="major">Major · faux-TV card</option><option value="critical">Critical · fullscreen shock + card</option></select></label>
+              <label>
+                Event type
+                <select
+                  value={editor.type}
+                  onChange={(event) =>
+                    setEditor({ ...editor, type: event.target.value as TvEvent['type'] })
+                  }
+                >
+                  {EVENT_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Broadcast level
+                <select
+                  value={editor.level}
+                  onChange={(event) => {
+                    const level = event.target.value as BroadcastLevel
+                    setEditor({
+                      ...editor,
+                      level,
+                      forceOnTv: level === 'critical' ? true : editor.forceOnTv,
+                    })
+                  }}
+                >
+                  <option value="minor">Minor · normal log line</option>
+                  <option value="major">Major · faux-TV card</option>
+                  <option value="critical">Critical · fullscreen shock + card</option>
+                </select>
+              </label>
             </div>
-            <label className="broadcast-manager__check"><input type="checkbox" checked={editor.forceOnTv} onChange={(event) => setEditor({ ...editor, forceOnTv: event.target.checked })} /><span>Force this message onto the faux TV</span><small>No announcement key is needed. If unchecked, minor messages stay in the log; major and critical messages always use the faux TV.</small></label>
-            <footer><button type="button" onClick={() => setEditor(null)}>Cancel</button><button type="button" className="broadcast-manager__primary" disabled={!editor.text.trim() || ((editor.mode === 'new' || editor.mode === 'custom') && (!normalizeMessageKey(editor.key) || customMessages.some((message) => message.id !== editor.id && (message.key ?? '') === normalizeMessageKey(editor.key))))} onClick={saveEditor}>Save</button></footer>
+            <label className="broadcast-manager__check">
+              <input
+                type="checkbox"
+                checked={editor.forceOnTv}
+                onChange={(event) => setEditor({ ...editor, forceOnTv: event.target.checked })}
+              />
+              <span>Force this message onto the faux TV</span>
+              <small>
+                No announcement key is needed. If unchecked, minor messages stay in the log; major
+                and critical messages always use the faux TV.
+              </small>
+            </label>
+            <footer>
+              <button type="button" onClick={() => setEditor(null)}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="broadcast-manager__primary"
+                disabled={
+                  !editor.text.trim() ||
+                  ((editor.mode === 'new' || editor.mode === 'custom') &&
+                    (!normalizeMessageKey(editor.key) ||
+                      customMessages.some(
+                        (message) =>
+                          message.id !== editor.id &&
+                          (message.key ?? '') === normalizeMessageKey(editor.key)
+                      )))
+                }
+                onClick={saveEditor}
+              >
+                Save
+              </button>
+            </footer>
           </section>
         </div>
       )}

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -27,6 +27,28 @@ const EVENT_TYPES: TvEvent['type'][] = ['game', 'social', 'vote', 'twist', 'diar
 const FULL_PHASE_SEQUENCE_LABEL = 'Full phase broadcast sequence'
 // i18n-ignore: Debug-only accessibility label intentionally uses canonical English
 const BUILT_IN_FLOW_LABEL = 'Built-in flow messages'
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const OBSERVED_PLAY_SOURCES_LABEL = 'Observed Play sources'
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const CUSTOM_PHASE_MESSAGES_LABEL = 'Custom phase messages'
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const EDIT_BROADCAST_MESSAGE_LABEL = 'Edit broadcast message'
+// i18n-ignore: Debug-only accessibility label intentionally uses canonical English
+const CLOSE_EDITOR_LABEL = 'Close editor'
+// i18n-ignore: Debug-only editor heading intentionally uses canonical English
+const ADD_PHASE_MESSAGE_LABEL = 'Add phase message'
+// i18n-ignore: Debug-only editor heading intentionally uses canonical English
+const EDIT_BUILT_IN_SOURCE_LABEL = 'Edit built-in source'
+// i18n-ignore: Debug-only editor heading intentionally uses canonical English
+const EDIT_MESSAGE_LABEL = 'Edit broadcast message'
+// i18n-ignore: Debug-only form label intentionally uses canonical English
+const CARD_TITLE_LABEL = 'Card title'
+// i18n-ignore: Debug-only form label intentionally uses canonical English
+const OPTIONAL_FAUX_TV_TITLE_LABEL = 'Faux-TV title (optional)'
+// i18n-ignore: Debug-only authoring placeholder intentionally uses canonical key syntax
+const MESSAGE_KEY_PLACEHOLDER = 'social.alliance-warning'
+// i18n-ignore: Canonical in-world broadcast branding
+const DEFAULT_CARD_TITLE_PLACEHOLDER = 'BIG EYE BROADCAST'
 
 type EditorState = {
   mode: 'builtin' | 'custom' | 'new' | 'live'
@@ -552,6 +574,7 @@ export default function BroadcastManager() {
                             type="button"
                             onClick={() => dispatch(resetBroadcastOverride(template.id))}
                           >
+                            {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                             Restore default
                           </button>
                         )}
@@ -564,10 +587,15 @@ export default function BroadcastManager() {
           </section>
 
           {observedSources.length > 0 && (
-            <section className="broadcast-manager__live-section" aria-label="Observed Play sources">
+            <section
+              className="broadcast-manager__live-section"
+              aria-label={OBSERVED_PLAY_SOURCES_LABEL}
+            >
               <div>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 <h3>Observed Play sources</h3>
                 <p>
+                  {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                   Branch messages discovered in this run. Editing one changes the same source on
                   future Play presses.
                 </p>
@@ -593,11 +621,17 @@ export default function BroadcastManager() {
                         </span>
                         <span>{override?.type ?? event.type}</span>
                         <code>{id}</code>
-                        {override && <span className="broadcast-manager__edited">edited</span>}
+                        {override && (
+                          <span className="broadcast-manager__edited">
+                            {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                            edited
+                          </span>
+                        )}
                       </div>
                       <p>{override?.text ?? sourceText}</p>
                       <div className="broadcast-manager__message-actions">
                         <button type="button" onClick={() => editObservedSource(event)}>
+                          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                           Edit source
                         </button>
                         <button
@@ -611,6 +645,7 @@ export default function BroadcastManager() {
                             )
                           }
                         >
+                          {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                           {override?.disabled ? 'Enable' : 'Disable'}
                         </button>
                         {override && (
@@ -618,6 +653,7 @@ export default function BroadcastManager() {
                             type="button"
                             onClick={() => dispatch(resetBroadcastOverride(id))}
                           >
+                            {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                             Restore default
                           </button>
                         )}
@@ -629,13 +665,23 @@ export default function BroadcastManager() {
             </section>
           )}
 
-          <section className="broadcast-manager__live-section" aria-label="Custom phase messages">
+          <section
+            className="broadcast-manager__live-section"
+            aria-label={CUSTOM_PHASE_MESSAGES_LABEL}
+          >
             <div>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
               <h3>Custom phase messages</h3>
-              <p>These automatically emit once per day when Play processes this phase.</p>
+              <p>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                These automatically emit once per day when Play processes this phase.
+              </p>
             </div>
             {phaseCustom.length === 0 ? (
-              <p className="broadcast-manager__empty">No custom messages for this phase.</p>
+              <p className="broadcast-manager__empty">
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                No custom messages for this phase.
+              </p>
             ) : (
               <ol className="broadcast-manager__message-list">
                 {phaseCustom.map((message) => (
@@ -649,21 +695,32 @@ export default function BroadcastManager() {
                       >
                         {message.level}
                       </span>
-                      <span>type: {message.type}</span>
+                      <span>
+                        {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                        type: {message.type}
+                      </span>
                       <code>{message.key ?? suggestMessageKey(message.text)}</code>
                       <span>
+                        {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
                         position {phaseCustom.findIndex((item) => item.id === message.id) + 1}
                       </span>
                       {message.forceOnTv && (
-                        <span className="broadcast-manager__edited">faux TV</span>
+                        <span className="broadcast-manager__edited">
+                          {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                          faux TV
+                        </span>
                       )}
                       {!message.enabled && (
-                        <span className="broadcast-manager__disabled">disabled</span>
+                        <span className="broadcast-manager__disabled">
+                          {/* i18n-ignore: Debug-only authoring metadata intentionally uses canonical English labels */}
+                          disabled
+                        </span>
                       )}
                     </div>
                     <p>{message.text}</p>
                     <div className="broadcast-manager__message-actions">
                       <button type="button" onClick={() => editCustom(message)}>
+                        {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                         Edit
                       </button>
                       <button
@@ -672,6 +729,7 @@ export default function BroadcastManager() {
                           dispatch(updateCustomBroadcast({ ...message, enabled: !message.enabled }))
                         }
                       >
+                        {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                         {message.enabled ? 'Disable' : 'Enable'}
                       </button>
                       <button
@@ -682,6 +740,7 @@ export default function BroadcastManager() {
                           dispatch(removeCustomBroadcast(message.id))
                         }
                       >
+                        {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                         Delete
                       </button>
                     </div>
@@ -692,8 +751,12 @@ export default function BroadcastManager() {
           </section>
 
           <details className="broadcast-manager__history">
-            <summary>Live history ({liveMessages.length})</summary>
+            <summary>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+              Live history ({liveMessages.length})
+            </summary>
             <p>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
               Already-emitted rows can still be corrected or removed without changing the source
               definition.
             </p>
@@ -709,6 +772,7 @@ export default function BroadcastManager() {
                   <p>{event.text}</p>
                   <div className="broadcast-manager__message-actions">
                     <button type="button" onClick={() => editLive(event)}>
+                      {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                       Edit emitted row
                     </button>
                     <button
@@ -719,6 +783,7 @@ export default function BroadcastManager() {
                         dispatch(removeTvEvent(event.id))
                       }
                     >
+                      {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                       Remove row
                     </button>
                   </div>
@@ -730,7 +795,9 @@ export default function BroadcastManager() {
           {unassignedMessages.length > 0 && (
             <details className="broadcast-manager__unassigned">
               <summary>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 {unassignedMessages.length} legacy row{unassignedMessages.length === 1 ? '' : 's'}{' '}
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 without a phase
               </summary>
               {unassignedMessages.map((event) => (
@@ -749,21 +816,23 @@ export default function BroadcastManager() {
             className="broadcast-manager__editor"
             role="dialog"
             aria-modal="true"
-            aria-label="Edit broadcast message"
+            aria-label={EDIT_BROADCAST_MESSAGE_LABEL}
           >
             <header>
               <h2>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 {editor.mode === 'new'
-                  ? 'Add phase message'
+                  ? ADD_PHASE_MESSAGE_LABEL
                   : editor.mode === 'builtin'
-                    ? 'Edit built-in source'
-                    : 'Edit broadcast message'}
+                    ? EDIT_BUILT_IN_SOURCE_LABEL
+                    : EDIT_MESSAGE_LABEL}
               </h2>
-              <button type="button" aria-label="Close editor" onClick={() => setEditor(null)}>
+              <button type="button" aria-label={CLOSE_EDITOR_LABEL} onClick={() => setEditor(null)}>
                 ×
               </button>
             </header>
             <label>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
               Ceremony phase
               <select
                 disabled={editor.mode === 'builtin'}
@@ -779,18 +848,21 @@ export default function BroadcastManager() {
             </label>
             {(editor.mode === 'new' || editor.mode === 'custom') && (
               <label>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Message key / name
                 <input
                   value={editor.key}
-                  placeholder="social.alliance-warning"
+                  placeholder={MESSAGE_KEY_PLACEHOLDER}
                   onChange={(event) => setEditor({ ...editor, key: event.target.value })}
                 />
                 <small>
+                  {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                   Use a readable stable key such as <code>social.alliance-warning</code>. Spaces are
                   converted to dashes; a key without a prefix becomes <code>custom.your-key</code>.
                 </small>
                 {!normalizeMessageKey(editor.key) && (
                   <small className="broadcast-manager__field-error">
+                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                     A message key is required.
                   </small>
                 )}
@@ -800,6 +872,7 @@ export default function BroadcastManager() {
                     (message.key ?? '') === normalizeMessageKey(editor.key)
                 ) && (
                   <small className="broadcast-manager__field-error">
+                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                     That key is already in use.
                   </small>
                 )}
@@ -807,17 +880,19 @@ export default function BroadcastManager() {
             )}
             {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && (
               <label>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 {editor.isCard || editor.level !== 'minor'
-                  ? 'Card title'
-                  : 'Faux-TV title (optional)'}
+                  ? CARD_TITLE_LABEL
+                  : OPTIONAL_FAUX_TV_TITLE_LABEL}
                 <input
                   value={editor.title}
-                  placeholder="BIG EYE BROADCAST"
+                  placeholder={DEFAULT_CARD_TITLE_PLACEHOLDER}
                   onChange={(event) => setEditor({ ...editor, title: event.target.value })}
                 />
               </label>
             )}
             <label>
+              {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
               {editor.isCard ? 'Card subtitle' : 'Message'}
               <textarea
                 value={editor.text}
@@ -825,12 +900,14 @@ export default function BroadcastManager() {
                 onChange={(event) => setEditor({ ...editor, text: event.target.value })}
               />
               <small>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Keep placeholders such as {'{winner}'} if the live player value should remain
                 dynamic.
               </small>
             </label>
             <div className="broadcast-manager__editor-grid">
               <label>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Event type
                 <select
                   value={editor.type}
@@ -846,6 +923,7 @@ export default function BroadcastManager() {
                 </select>
               </label>
               <label>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Broadcast level
                 <select
                   value={editor.level}
@@ -858,8 +936,11 @@ export default function BroadcastManager() {
                     })
                   }}
                 >
+                  {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                   <option value="minor">Minor · normal log line</option>
+                  {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                   <option value="major">Major · faux-TV card</option>
+                  {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                   <option value="critical">Critical · fullscreen shock + card</option>
                 </select>
               </label>
@@ -870,14 +951,19 @@ export default function BroadcastManager() {
                 checked={editor.forceOnTv}
                 onChange={(event) => setEditor({ ...editor, forceOnTv: event.target.checked })}
               />
-              <span>Force this message onto the faux TV</span>
+              <span>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                Force this message onto the faux TV
+              </span>
               <small>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 No announcement key is needed. If unchecked, minor messages stay in the log; major
                 and critical messages always use the faux TV.
               </small>
             </label>
             <footer>
               <button type="button" onClick={() => setEditor(null)}>
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Cancel
               </button>
               <button
@@ -895,6 +981,7 @@ export default function BroadcastManager() {
                 }
                 onClick={saveEditor}
               >
+                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Save
               </button>
             </footer>

--- a/src/screens/GameScreen/flows/useTwistFlow.ts
+++ b/src/screens/GameScreen/flows/useTwistFlow.ts
@@ -328,7 +328,7 @@ export function useTwistFlow({
 
   const handlePublicSaveResultDismiss = useCallback(() => {
     if (!pendingPublicSaveResult) return
-    dispatch(commitPublicSave(pendingPublicSaveResult))
+    dispatch(commitPublicSave({ savedId: pendingPublicSaveResult.savedId }))
     setPendingPublicSaveResult(null)
   }, [dispatch, pendingPublicSaveResult])
 

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -19,6 +19,7 @@ import './Profile.css';
 const HOLD_REVEAL_DELAY_MS = 360;
 
 const PHASE_SHORT_LABELS: Partial<Record<Phase, string>> = {
+  // i18n-ignore: Legacy compact phase-label registry stores canonical English copy
   season_start: 'Season',
   week_start: 'Start',
   loh_comp_announcement: 'LOH',

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -19,6 +19,7 @@ import './Profile.css';
 const HOLD_REVEAL_DELAY_MS = 360;
 
 const PHASE_SHORT_LABELS: Partial<Record<Phase, string>> = {
+  season_start: 'Season',
   week_start: 'Start',
   loh_comp_announcement: 'LOH',
   loh_comp: 'LOH',
@@ -499,7 +500,7 @@ export default function Profile() {
   const survivorUnlockedCount = Object.keys(survivorUnlocks).length;
   const survivorAchievementCards = buildUnlockedSurvivorAchievementDisplayModels(survivorUnlocks);
 
-  const gameInProgress = isGameActive || week > 1 || phase !== 'week_start';
+  const gameInProgress = isGameActive || week > 1 || (phase !== 'season_start' && phase !== 'week_start');
   const returnTo = ((location.state as { from?: string } | null)?.from === '/'
     ? '/'
     : '/game');

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -45,31 +45,13 @@ export function isBattleBackReturnResultEvent(ev: ActivityVisibilityEvent): bool
 }
 
 /**
- * Legacy phase-prelude events duplicate dedicated major announcement overlays
- * and add no new result, rule, or decision. Hide them from both broadcast
- * surfaces so each transition is announced once.
- */
-export function isRedundantCompetitionPreludeEvent(ev: ActivityVisibilityEvent): boolean {
-  if (typeof ev.text !== 'string') return false
-  const text = ev.text.replace(/\s+/g, ' ').trim()
-  return (
-    /the leader of the house comp(?:etition)? is about to begin/i.test(text) ||
-    /(?:it is|it's) time for the power of safety competition/i.test(text) ||
-    /^final 3!?\s*three players remain\b/i.test(text) ||
-    /^final 3\s*[—-]\s*day \d+!?\s*the three-part loh competition begins\b/i.test(text)
-  )
-}
-
-/**
  * Returns true when the event should appear in the main-screen TVLog strip.
  *
  * Rules:
- *  - Redundant competition/finale preludes: false.
  *  - No channels (legacy event): visible everywhere → true.
  *  - Has channels: visible only if 'mainLog' or 'tv' is included.
  */
 export function isVisibleInMainLog(ev: ActivityVisibilityEvent): boolean {
-  if (isRedundantCompetitionPreludeEvent(ev)) return false
   if (!ev.channels) return true
   return ev.channels.includes('mainLog') || ev.channels.includes('tv')
 }
@@ -79,13 +61,11 @@ export function isVisibleInMainLog(ev: ActivityVisibilityEvent): boolean {
  *
  * Rules:
  *  - Back 2 the Game winner/result event: false; it remains available to mainLog.
- *  - Redundant competition/finale preludes: false.
  *  - No channels (legacy event): visible everywhere → true.
  *  - Has channels: visible only if 'tv' or 'mainLog' is included.
  */
 export function isVisibleOnTv(ev: ActivityVisibilityEvent): boolean {
   if (isBattleBackReturnResultEvent(ev)) return false
-  if (isRedundantCompetitionPreludeEvent(ev)) return false
   if (ev.meta?.suppressTv === true) return false
   if (!ev.channels) return true
   return ev.channels.includes('tv') || ev.channels.includes('mainLog')

--- a/src/services/sound/musicConfig.ts
+++ b/src/services/sound/musicConfig.ts
@@ -181,6 +181,7 @@ const VETO_MUSIC = musicTrack('veto')
  * Phase now produces a TypeScript error until its music behavior is declared.
  */
 export const DEFAULT_PHASE_MUSIC_POLICY: Readonly<Record<Phase, MusicSelection>> = {
+  season_start: SILENT_MUSIC,
   week_start: SILENT_MUSIC,
   loh_comp_announcement: SILENT_MUSIC,
   loh_comp: COMPETITION_MUSIC,

--- a/src/social/incomingInteractions.ts
+++ b/src/social/incomingInteractions.ts
@@ -1,4 +1,3 @@
-import { addTvEvent } from '../store/gameSlice'
 import { getIncomingInteractionTone } from './incomingInteractionPresentation'
 import {
   getIncomingResponseLogCopy,
@@ -57,35 +56,6 @@ const RESPONSE_VERBS: Record<IncomingInteractionResponseType, string> = {
   ignore: 'ignored',
 }
 
-const IGNORED_INTERACTION_SUMMARY_LABELS: Record<
-  IncomingInteractionType,
-  { singular: string; plural: string }
-> = {
-  compliment: { singular: 'compliment', plural: 'compliments' },
-  gossip: { singular: 'gossip drop', plural: 'gossip drops' },
-  warning: { singular: 'warning', plural: 'warnings' },
-  alliance_proposal: { singular: 'alliance proposal', plural: 'alliance proposals' },
-  deal_offer: { singular: 'deal offer', plural: 'deal offers' },
-  nomination_plea: { singular: 'nomination plea', plural: 'nomination pleas' },
-  check_in: { singular: 'check-in', plural: 'check-ins' },
-  snide_remark: { singular: 'snide remark', plural: 'snide remarks' },
-  other: { singular: 'message', plural: 'messages' },
-}
-
-const IGNORED_INTERACTION_TYPE_PRIORITY: Record<IncomingInteractionType, number> = {
-  deal_offer: 0,
-  nomination_plea: 1,
-  alliance_proposal: 2,
-  warning: 3,
-  check_in: 4,
-  gossip: 5,
-  compliment: 6,
-  snide_remark: 7,
-  other: 8,
-}
-
-const DEFAULT_IGNORED_INTERACTION_LABEL = 'messages'
-
 type ResolutionSource = 'player' | 'expiry'
 
 function resolveRealityIncomingInteraction(
@@ -122,36 +92,6 @@ function resolveRealityIncomingInteraction(
 
 export function getIncomingInteractionTypeLabel(type: IncomingInteractionType): string {
   return TYPE_LABELS[type]
-}
-
-function formatList(items: string[]): string {
-  if (items.length === 0) return DEFAULT_IGNORED_INTERACTION_LABEL
-  if (items.length === 1) return items[0]
-  if (items.length === 2) return `${items[0]} and ${items[1]}`
-  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`
-}
-
-function buildIgnoredIncomingInteractionsSummary(interactions: IncomingInteraction[]): string {
-  const counts = new Map<IncomingInteractionType, number>()
-  interactions.forEach((interaction) => {
-    counts.set(interaction.type, (counts.get(interaction.type) ?? 0) + 1)
-  })
-  const uniqueSenderCount = new Set(interactions.map((interaction) => interaction.fromId)).size
-  const typeFragments = Array.from(counts.entries())
-    .sort(
-      ([leftType], [rightType]) =>
-        IGNORED_INTERACTION_TYPE_PRIORITY[leftType] - IGNORED_INTERACTION_TYPE_PRIORITY[rightType]
-    )
-    .map(([type, count]) => {
-      const labels = IGNORED_INTERACTION_SUMMARY_LABELS[type]
-      return count === 1 ? labels.singular : labels.plural
-    })
-
-  if (uniqueSenderCount === 1) {
-    return `One player's ${formatList(typeFragments)} required an answer and passed its deadline.`
-  }
-
-  return `Several players' ${formatList(typeFragments)} required answers and passed their deadlines.`
 }
 
 function getResponseDelta(
@@ -646,17 +586,6 @@ export function autoResolveExpiredIncomingInteractionsForClock(day: number, phas
         day,
         phase,
         realityBeforeResponse
-      )
-    }
-
-    if (required.length > 0) {
-      dispatch(
-        addTvEvent({
-          text: buildIgnoredIncomingInteractionsSummary(required),
-          type: 'social',
-          source: 'system',
-          channels: ['tv', 'mainLog'],
-        })
       )
     }
 

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -15,6 +15,9 @@ import type {
   SeasonFinaleState,
   SpecialVetoType,
   ForcedShockType,
+  BroadcastOverride,
+  BroadcastLevel,
+  CustomBroadcastMessage,
 } from '../types'
 import type { IncomingInteraction, SocialActionLogEntry } from '../social/types'
 import { mulberry32, seededPick, seededPickN } from './rng'
@@ -107,6 +110,14 @@ import {
   resolveVoxReplacementNominees,
   shouldScheduleVoxPopuliSeason,
 } from '../features/twists/voxPopuli'
+import {
+  getDefaultBroadcastOrder,
+  getBroadcastTemplate,
+  getPhaseCardTemplate,
+  matchBroadcastTemplate,
+  renderBroadcastTemplate,
+} from '../broadcasting/broadcastTemplateCatalog'
+import { loadBroadcastConfig } from '../broadcasting/broadcastConfigPersistence'
 
 // ─── Canonical phase order ────────────────────────────────────────────────────
 const PHASE_ORDER: Phase[] = [
@@ -387,6 +398,7 @@ export function createInitialGameState(options?: {
   const seed = options?.seed ?? 42
   const freshPlayers = buildInitialPlayers(twinShockConsumed)
   const freshSettings = loadSettings()
+  const broadcastConfig = loadBroadcastConfig()
   // Guest mode never persists archives — treat as an empty history so guest
   // sessions always start at Season 1 regardless of any logged-in user data.
   const isGuest = loadProfilesState().isGuest
@@ -395,6 +407,7 @@ export function createInitialGameState(options?: {
     : (loadSeasonArchives(archiveKeyForActiveProfile()) ?? [])
   const season = nextSeasonNumber(seasonArchives)
   const expansionDebugAccess = import.meta.env.DEV || canAccessSpecialSettings()
+  const forceClassicLocal = import.meta.env.DEV && import.meta.env.VITE_FORCE_CLASSIC === 'true'
   const cupidScheduleOptions = {
       season,
       seasonArchives,
@@ -404,13 +417,15 @@ export function createInitialGameState(options?: {
   // Cupid may organically enter a Classic season only for an owner. An explicit
   // debug season override remains available for testing, but DEV alone is not ownership.
   const cupidArrowIsScheduled =
-    (hasCachedStoreAccess('cupidArrow') && shouldScheduleCupidArrowSeason(cupidScheduleOptions)) ||
-    (expansionDebugAccess &&
-      freshSettings.sim.cupidArrowSeasonOverride === season &&
-      shouldScheduleCupidArrowSeason(cupidScheduleOptions))
+    !forceClassicLocal &&
+    ((hasCachedStoreAccess('cupidArrow') && shouldScheduleCupidArrowSeason(cupidScheduleOptions)) ||
+      (expansionDebugAccess &&
+        freshSettings.sim.cupidArrowSeasonOverride === season &&
+        shouldScheduleCupidArrowSeason(cupidScheduleOptions)))
   // Vox Populi is a separately launched expansion. It never enters Classic just
   // because the product is owned; only the explicit debug override can pre-schedule it.
   const voxPopuliIsScheduled =
+    !forceClassicLocal &&
     expansionDebugAccess &&
     freshSettings.sim.voxPopuliSeasonOverride === season &&
     shouldScheduleVoxPopuliSeason({
@@ -426,39 +441,103 @@ export function createInitialGameState(options?: {
     initialVoxPopuli.activatedSeason = season
     initialVoxPopuli.activatedWeek = 1
   }
-  const initialTvFeed: TvEvent[] = [
-    ...(voxPopuliIsScheduled
-      ? [
-          {
-            id: 'vox-populi-season-intro',
-            text: 'VOX POPULI is now in force. Housemates nominate in secret, the audience decides who leaves, and Public Mode reveals the pulse without changing the official result.',
-            type: 'twist' as const,
-            timestamp: Date.now(),
-            meta: { phase: 'week_start', week: 1, major: 'vox_populi', broadcastPriority: 'critical' },
-          },
-        ]
-      : []),
-    {
-      id: 'e0',
-      text: `Welcome to The Big Eye house! 🏠 Season ${season} is about to begin.`,
-      type: 'game' as const,
-      timestamp: Date.now(),
-      meta: { phase: 'week_start', week: 1 },
-    },
-    {
-      id: 'e1',
-      text: `[Rules] Public mode: ${freshSettings.sim.publicMode === true ? 'ON' : 'OFF'}`,
-      type: 'game' as const,
-      timestamp: Date.now(),
-      meta: { phase: 'week_start', week: 1 },
-    },
-  ]
+  const publicModeEnabled = resolvePublicModeRuntimeEnabled(freshSettings.sim.publicMode === true, {
+    hasStoreAccess: hasCachedStoreAccess('publicMode'),
+    adminOverride: freshSettings.sim.publicModeAdminOverride === true,
+    isDev: import.meta.env.DEV,
+    hasSpecialAccess: canAccessSpecialSettings(),
+  })
+
+  // Season-opening broadcasts are built from the same persistent registry as
+  // every later phase. This makes edits, disabling, and mixed built-in/custom
+  // ordering effective before the first Play press as well.
+  const seasonStartBuiltIns = [
+    { id: 'season.welcome', variables: [String(season)], include: true },
+    { id: 'season.public-mode-rule', variables: [publicModeEnabled ? 'ON' : 'OFF'], include: true },
+    { id: 'season.vox-populi-intro', variables: [], include: voxPopuliIsScheduled },
+  ].flatMap(({ id, variables, include }) => {
+    const template = getBroadcastTemplate(id)
+    if (!include || !template) return []
+    const override = broadcastConfig.overrides[id]
+    if (override?.disabled) return []
+    const level = override?.level ?? template.level
+    const forceOnTv = override?.forceOnTv ?? template.forceOnTv ?? false
+    const defaultMajor = template.major
+    const selectedMajor = override?.major === null ? undefined : (override?.major ?? defaultMajor)
+    const major = level === 'critical'
+      ? selectedMajor ?? 'custom_critical'
+      : level === 'major'
+        ? selectedMajor ?? 'custom_major'
+        : undefined
+    return [{
+      id,
+      order: override?.order ?? getDefaultBroadcastOrder(template),
+      text: renderBroadcastTemplate(override?.text ?? template.text, variables),
+      type: override?.type ?? template.type,
+      level,
+      major,
+      forceOnTv,
+      title: override?.title,
+      customId: undefined as string | undefined,
+      templateId: id,
+      variables,
+    }]
+  })
+  const seasonStartCustom = broadcastConfig.customMessages
+    .filter((message) => message.enabled && message.phase === 'season_start' && message.text.trim())
+    .map((message) => ({
+      id: message.id,
+      order: message.order ?? 10000,
+      text: message.text,
+      type: message.type,
+      level: message.level,
+      major: message.level === 'critical'
+        ? message.major ?? 'custom_critical'
+        : message.level === 'major'
+          ? message.major ?? 'custom_major'
+          : undefined,
+      forceOnTv: message.forceOnTv !== false,
+      title: message.title,
+      customId: message.id,
+      templateId: message.key ?? message.id,
+      variables: [] as string[],
+    }))
+  const seasonStartTime = Date.now()
+  const seasonStartItems = [...seasonStartBuiltIns, ...seasonStartCustom]
+    .sort((left, right) => left.order - right.order)
+  const initialTvFeed: TvEvent[] = seasonStartItems.map((item, index) => ({
+      id: `season-start-${item.id}-${index}`,
+      text: item.text,
+      type: item.type,
+      timestamp: seasonStartTime + index,
+      ...(item.major ? { major: item.major } : {}),
+      meta: {
+        phase: 'season_start',
+        week: 1,
+        broadcastTemplateId: item.templateId,
+        broadcastOrder: item.order,
+        broadcastLevel: item.level,
+        broadcastManaged: true,
+        broadcastVariables: item.variables,
+        ...(item.customId ? { customBroadcastId: item.customId } : {}),
+        ...(item.major ? { major: item.major } : {}),
+        ...(item.level === 'critical' ? { broadcastPriority: 'critical' } : {}),
+        ...(item.forceOnTv ? { forceOnTv: true } : {}),
+        ...(item.level !== 'minor' ? { announcementSubtitle: item.text } : {}),
+        ...(item.level !== 'minor' && item.title ? { announcementTitle: item.title } : {}),
+      },
+    }))
+  const initialBroadcastQueue = initialTvFeed
+    .filter((event) =>
+      event.meta?.forceOnTv === true || event.meta?.broadcastLevel === 'major' || event.meta?.broadcastLevel === 'critical'
+    )
+    .map((event) => event.id)
   return {
     gameId: crypto.randomUUID(),
     expansionMode: null,
     season,
     week: 1,
-    phase: 'week_start',
+    phase: 'season_start',
     seed,
     lohId: null,
     lohSocialPlan: null,
@@ -467,12 +546,7 @@ export function createInitialGameState(options?: {
     lohSafetyAdvice: null,
     prevHohId: null,
     nomineeIds: [],
-    publicModeEnabled: resolvePublicModeRuntimeEnabled(freshSettings.sim.publicMode === true, {
-      hasStoreAccess: hasCachedStoreAccess('publicMode'),
-      adminOverride: freshSettings.sim.publicModeAdminOverride === true,
-      isDev: import.meta.env.DEV,
-      hasSpecialAccess: canAccessSpecialSettings(),
-    }),
+    publicModeEnabled,
     posWinnerId: null,
     replacementNeeded: false,
     povSavedId: null,
@@ -507,6 +581,10 @@ export function createInitialGameState(options?: {
     players: freshPlayers,
     competitionSeasonStateByPlayerId: buildInitialCompetitionSeasonState(freshPlayers),
     tvFeed: initialTvFeed,
+    broadcastQueue: initialBroadcastQueue,
+    lastPlainBroadcastEventId: null,
+    broadcastOverrides: broadcastConfig.overrides,
+    customBroadcasts: broadcastConfig.customMessages,
     isLive: false,
     hasSeenConfessionalSpotlight: false,
     seasonArchives,
@@ -571,7 +649,26 @@ const initialState: GameState = createInitialGameState()
 // ─── Helper ──────────────────────────────────────────────────────────────────
 /** Monotonic counter to guarantee unique event IDs within the same millisecond. */
 let _pushEventCounter = 0
+let _activeBroadcastPhase: Phase | null = null
+let _pendingPhaseCustoms: CustomBroadcastMessage[] | null = null
+let _flushingPhaseCustom = false
 const MAX_GAME_HISTORY_EVENTS = 1000
+
+function inferObservedBroadcastSource(state: GameState, phase: Phase, text: string) {
+  const playerNames = [...new Set(state.players.map((player) => player.name).filter(Boolean))]
+    .sort((a, b) => b.length - a.length)
+    .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const tokenPattern = playerNames.length > 0
+    ? new RegExp(`${playerNames.join('|')}|\\b\\d+\\b`, 'g')
+    : /\b\d+\b/g
+  const variables: string[] = []
+  const sourceText = text.replace(tokenPattern, (value) => {
+    variables.push(value)
+    return '{value}'
+  })
+  const sourceHash = (hashString(`${phase}|${sourceText}`) >>> 0).toString(36)
+  return { id: `observed.${phase}.${sourceHash}`, sourceText, variables }
+}
 
 function buildTvMeta(
   state: Pick<GameState, 'phase' | 'week'>,
@@ -584,21 +681,222 @@ function buildTvMeta(
   }
 }
 
+/**
+ * A reducer transition can occasionally be resumed after an overlay or an
+ * automatic callback. Do not add the same broadcast line twice on the same
+ * in-game day; distinct wording and every other event remain intact.
+ */
+function findDuplicateDayBroadcast(state: GameState, text: string): TvEvent | undefined {
+  const normalizedText = text.replace(/\s+/g, ' ').trim()
+  return state.tvFeed.find(
+    (event) =>
+      event.meta?.week === state.week && event.text.replace(/\s+/g, ' ').trim() === normalizedText
+  )
+}
+
+function managedBroadcastOrder(state: GameState, event: TvEvent): number {
+  const templateId = event.meta?.broadcastTemplateId
+  if (typeof templateId === 'string') {
+    const overrideOrder = state.broadcastOverrides?.[templateId]?.order
+    if (typeof overrideOrder === 'number') return overrideOrder
+  }
+  const customId = event.meta?.customBroadcastId
+  if (typeof customId === 'string') {
+    const customOrder = state.customBroadcasts?.find((message) => message.id === customId)?.order
+    if (typeof customOrder === 'number') return customOrder
+  }
+  return typeof event.meta?.broadcastOrder === 'number' ? event.meta.broadcastOrder : 10000
+}
+
+function enqueueManagedBroadcast(state: GameState, event: TvEvent) {
+  const level = event.meta?.broadcastLevel as BroadcastLevel | undefined
+  const shouldShow = event.meta?.forceOnTv === true || level === 'major' || level === 'critical'
+  if (!shouldShow || event.meta?.broadcastConsumed === true) return
+  const queue = [...(state.broadcastQueue ?? [])].filter((id) =>
+    state.tvFeed.some((candidate) => candidate.id === id && candidate.meta?.broadcastConsumed !== true)
+  )
+  if (!queue.includes(event.id)) queue.push(event.id)
+  const orderFor = (id: string) => {
+    const candidate = state.tvFeed.find((item) => item.id === id)
+    return candidate ? managedBroadcastOrder(state, candidate) : 10000
+  }
+  queue.sort((left, right) => orderFor(left) - orderFor(right))
+  state.broadcastQueue = queue
+}
+
+function rebuildManagedBroadcastQueue(state: GameState, phase: Phase) {
+  const retainedPlainEvent = state.lastPlainBroadcastEventId
+    ? state.tvFeed.find((event) => event.id === state.lastPlainBroadcastEventId)
+    : undefined
+  if (
+    state.lastPlainBroadcastEventId &&
+    (
+      retainedPlainEvent?.meta?.phase !== phase ||
+      retainedPlainEvent?.meta?.week !== state.week
+    )
+  ) {
+    state.lastPlainBroadcastEventId = null
+  }
+
+  const eligible = state.tvFeed.filter((event) => {
+    if (event.meta?.phase !== phase || event.meta?.week !== state.week) return false
+    if (event.meta?.broadcastManaged !== true || event.meta?.broadcastConsumed === true) return false
+    const level = event.meta?.broadcastLevel as BroadcastLevel | undefined
+    if (event.meta?.forceOnTv !== true && level !== 'major' && level !== 'critical') return false
+    const templateId = event.meta?.broadcastTemplateId
+    if (typeof templateId === 'string' && state.broadcastOverrides?.[templateId]?.disabled) return false
+    const customId = event.meta?.customBroadcastId
+    if (typeof customId === 'string') {
+      const custom = state.customBroadcasts?.find((message) => message.id === customId)
+      if (!custom?.enabled) return false
+    }
+    return true
+  })
+  eligible.sort(
+    (left, right) =>
+      managedBroadcastOrder(state, left) - managedBroadcastOrder(state, right) ||
+      left.timestamp - right.timestamp ||
+      left.id.localeCompare(right.id)
+  )
+  state.broadcastQueue = eligible.map((event) => event.id)
+}
+
+function refreshManagedBroadcastDefinition(state: GameState, event: TvEvent) {
+  if (event.meta?.broadcastManaged !== true || event.meta?.broadcastConsumed === true) return
+  const customId = event.meta?.customBroadcastId
+  const custom = typeof customId === 'string'
+    ? state.customBroadcasts?.find((message) => message.id === customId)
+    : undefined
+  const templateId = event.meta?.broadcastTemplateId
+  const template = typeof templateId === 'string' ? getBroadcastTemplate(templateId) : undefined
+  const override = typeof templateId === 'string' ? state.broadcastOverrides?.[templateId] : undefined
+  const variables = Array.isArray(event.meta?.broadcastVariables)
+    ? event.meta.broadcastVariables.filter((value): value is string => typeof value === 'string')
+    : []
+  const level = custom?.level ?? override?.level ?? template?.level ??
+    (event.meta?.broadcastLevel as BroadcastLevel | undefined) ?? 'minor'
+  const forceOnTv = custom
+    ? custom.forceOnTv !== false
+    : override?.forceOnTv ?? template?.forceOnTv ?? (event.meta?.forceOnTv === true)
+  const configuredMajor = custom?.major ??
+    (override?.major === null ? undefined : (override?.major ?? template?.major))
+  const major = level === 'critical'
+    ? configuredMajor ?? 'custom_critical'
+    : level === 'major'
+      ? configuredMajor ?? 'custom_major'
+      : undefined
+
+  if (custom) {
+    event.text = custom.text
+    event.type = custom.type
+  } else if (template) {
+    event.text = renderBroadcastTemplate(override?.text ?? template.text, variables)
+    event.type = override?.type ?? template.type
+  }
+  event.major = major
+  const meta: NonNullable<TvEvent['meta']> = {
+    ...(event.meta ?? {}),
+    broadcastLevel: level,
+  }
+  if (major) meta.major = major
+  else delete meta.major
+  if (forceOnTv) meta.forceOnTv = true
+  else delete meta.forceOnTv
+  if (level === 'critical') meta.broadcastPriority = 'critical'
+  else delete meta.broadcastPriority
+  if (level !== 'minor') {
+    meta.announcementTitle = custom?.title ?? override?.title ?? template?.title
+    meta.announcementSubtitle = event.text
+  } else {
+    delete meta.announcementTitle
+    delete meta.announcementSubtitle
+  }
+  event.meta = meta
+}
+
 function pushEvent(
   state: GameState,
   text: string,
   type: TvEvent['type'],
   meta?: TvEvent['meta']
-): TvEvent {
+): TvEvent | undefined {
+  const explicitTemplateId = meta?.broadcastTemplateId ?? meta?.templateId
+  const hintedPhase = typeof meta?.phase === 'string'
+    ? (meta.phase as Phase)
+    : (_activeBroadcastPhase ?? state.phase)
+  const matched = matchBroadcastTemplate(text, hintedPhase, explicitTemplateId)
+  const template = matched?.template
+  const authoredTemplateId = typeof explicitTemplateId === 'string' ? explicitTemplateId : null
+  const observed = template || authoredTemplateId
+    ? null
+    : inferObservedBroadcastSource(state, hintedPhase, text)
+  const templateId = template?.id ?? authoredTemplateId ?? observed?.id
+  const variables = matched?.variables ?? observed?.variables ?? []
+  const override = templateId ? state.broadcastOverrides?.[templateId] : undefined
+  if (override?.disabled) return undefined
+
+  const finalText = override?.text
+    ? renderBroadcastTemplate(override.text, variables)
+    : text
+  const finalType = override?.type ?? type
+  const authoredLevel = meta?.broadcastLevel as BroadcastLevel | undefined
+  const defaultMajor = template?.major ?? (typeof meta?.major === 'string' ? meta.major : undefined)
+  const finalLevel = override?.level ?? template?.level ?? authoredLevel ??
+    (meta?.broadcastPriority === 'critical' ? 'critical' : defaultMajor ? 'major' : 'minor')
+  const selectedMajor = override?.major === null ? undefined : (override?.major ?? defaultMajor)
+  const forceOnTv = override?.forceOnTv ??
+    (typeof meta?.forceOnTv === 'boolean' ? meta.forceOnTv : undefined) ??
+    template?.forceOnTv ??
+    true
+  const finalMajor = finalLevel === 'critical'
+    ? selectedMajor ?? 'custom_critical'
+    : finalLevel === 'major'
+      ? selectedMajor ?? 'custom_major'
+      : undefined
+  const intendedPhase = template?.phase ?? hintedPhase
+  const broadcastOrder = override?.order ??
+    (template ? getDefaultBroadcastOrder(template) :
+      typeof meta?.broadcastOrder === 'number' ? meta.broadcastOrder : 10000)
+  if (
+    !_flushingPhaseCustom &&
+    !meta?.customBroadcastId &&
+    _pendingPhaseCustoms &&
+    intendedPhase === _activeBroadcastPhase
+  ) {
+    flushPhaseCustomsBefore(state, broadcastOrder)
+  }
+  const finalMeta: TvEvent['meta'] = {
+    ...meta,
+    phase: intendedPhase,
+    ...(templateId ? { broadcastTemplateId: templateId } : {}),
+    ...(observed ? { broadcastSourceText: observed.sourceText } : {}),
+    broadcastVariables: variables,
+    broadcastOrder,
+    broadcastLevel: finalLevel,
+    broadcastManaged: true,
+    ...(forceOnTv ? { forceOnTv: true } : {}),
+    ...(finalLevel !== 'minor' && override?.title ? { announcementTitle: override.title } : {}),
+    ...(finalLevel !== 'minor' ? { announcementSubtitle: finalText } : {}),
+  }
+  if (finalLevel === 'minor' || !finalMajor) delete finalMeta.major
+  else finalMeta.major = finalMajor
+  if (finalLevel === 'critical') finalMeta.broadcastPriority = 'critical'
+  else if (override?.level) delete finalMeta.broadcastPriority
+
+  const duplicate = findDuplicateDayBroadcast(state, finalText)
+  if (duplicate) return duplicate
+
   const ts = Date.now()
   const event: TvEvent = {
     id: `${state.phase}-w${state.week}-${ts}-${++_pushEventCounter}`,
-    text,
-    type,
+    text: finalText,
+    type: finalType,
     timestamp: ts,
-    meta: buildTvMeta(state, meta),
+    major: finalMajor,
+    meta: buildTvMeta(state, finalMeta),
   }
   state.tvFeed = [event, ...state.tvFeed].slice(0, MAX_GAME_HISTORY_EVENTS)
+  enqueueManagedBroadcast(state, event)
   return event
 }
 
@@ -1572,19 +1870,54 @@ function pushVoxPostEvictionReaction(state: GameState, evictee: Player): void {
   })
 }
 
-function pushPovCompetitionAnnouncement(state: GameState) {
-  pushEvent(
-    state,
-    `It is time for the Power of Safety competition! 🎭 Housemates will battle for the most powerful item in the game.`,
-    'game'
-  )
+function emitCustomBroadcast(state: GameState, custom: CustomBroadcastMessage, phase: Phase) {
+  _flushingPhaseCustom = true
+  pushEvent(state, custom.text, custom.type, {
+    phase,
+    customBroadcastId: custom.id,
+    broadcastTemplateId: custom.key ?? custom.id,
+    broadcastOrder: custom.order ?? 10000,
+    broadcastLevel: custom.level,
+    forceOnTv: custom.forceOnTv !== false,
+    ...(custom.level !== 'minor' && custom.major ? { major: custom.major } : {}),
+    ...(custom.level === 'critical' ? { broadcastPriority: 'critical' } : {}),
+    ...(custom.title ? { announcementTitle: custom.title } : {}),
+    ...(custom.level !== 'minor' ? { announcementSubtitle: custom.text } : {}),
+  })
+  _flushingPhaseCustom = false
+}
+
+function beginPhaseBroadcastSequence(state: GameState, phase: Phase) {
+  _activeBroadcastPhase = phase
+  _pendingPhaseCustoms = (state.customBroadcasts ?? [])
+    .filter((custom) =>
+      custom.enabled &&
+      custom.phase === phase &&
+      custom.text.trim() &&
+      !state.tvFeed.some(
+        (event) => event.meta?.week === state.week && event.meta?.customBroadcastId === custom.id
+      )
+    )
+    .sort((a, b) => (a.order ?? 10000) - (b.order ?? 10000))
+}
+
+function flushPhaseCustomsBefore(state: GameState, order: number) {
+  while (_pendingPhaseCustoms?.length && (_pendingPhaseCustoms[0].order ?? 10000) < order) {
+    const custom = _pendingPhaseCustoms.shift()!
+    emitCustomBroadcast(state, custom, _activeBroadcastPhase ?? custom.phase)
+  }
+}
+
+function finishPhaseBroadcastSequence(state: GameState) {
+  flushPhaseCustomsBefore(state, Number.POSITIVE_INFINITY)
+  _pendingPhaseCustoms = null
+  _activeBroadcastPhase = null
 }
 
 type CommitPublicSavePayload =
   | string
   | {
       savedId: string
-      supportPercent?: number
     }
 
 /**
@@ -2235,7 +2568,11 @@ function applyLohWinner(state: GameState, winnerId: string, source?: string) {
     partner
       ? `${winner?.name ?? winnerId} won Leader of the House, making ${partner.name} co-LOH under Cupid's Arrow! 👑💘`
       : `${winner?.name ?? winnerId} has won Leader of the House! 👑`,
-    'game'
+    'game',
+    {
+      phase: 'loh_results',
+      broadcastTemplateId: partner ? 'loh.cupid-winners' : 'loh.winner',
+    }
   )
 }
 
@@ -2534,6 +2871,230 @@ const gameSlice = createSlice({
         meta: buildTvMeta(state, action.payload.meta),
       }
       state.tvFeed = [event, ...state.tvFeed].slice(0, MAX_GAME_HISTORY_EVENTS)
+    },
+    /** Update one existing broadcast without replacing its identity or position in the timeline. */
+    updateTvEvent(
+      state,
+      action: PayloadAction<{
+        id: string
+        text: string
+        type: TvEvent['type']
+        major?: string | null
+        broadcastPriority?: 'critical' | null
+        phase?: Phase
+        forceOnTv?: boolean
+        announcementTitle?: string
+      }>
+    ) {
+      const event = state.tvFeed.find((entry) => entry.id === action.payload.id)
+      if (!event) return
+
+      event.text = action.payload.text
+      event.type = action.payload.type
+      const meta = { ...(event.meta ?? {}) }
+      if (action.payload.phase) meta.phase = action.payload.phase
+
+      if (action.payload.major) {
+        event.major = action.payload.major
+        meta.major = action.payload.major
+      } else {
+        delete event.major
+        delete meta.major
+      }
+
+      if (action.payload.broadcastPriority === 'critical') {
+        meta.broadcastPriority = 'critical'
+      } else {
+        delete meta.broadcastPriority
+      }
+      meta.broadcastLevel = action.payload.broadcastPriority === 'critical'
+        ? 'critical'
+        : action.payload.major
+          ? 'major'
+          : 'minor'
+      meta.broadcastManaged = true
+      if (action.payload.forceOnTv) {
+        meta.forceOnTv = true
+      } else {
+        delete meta.forceOnTv
+      }
+      if (meta.broadcastLevel !== 'minor') {
+        meta.announcementSubtitle = action.payload.text
+        if (action.payload.announcementTitle) meta.announcementTitle = action.payload.announcementTitle
+      } else {
+        delete meta.announcementTitle
+        delete meta.announcementSubtitle
+      }
+      event.meta = meta
+      enqueueManagedBroadcast(state, event)
+    },
+    /** Remove one broadcast event from the current run. */
+    removeTvEvent(state, action: PayloadAction<string>) {
+      state.tvFeed = state.tvFeed.filter((event) => event.id !== action.payload)
+      state.broadcastQueue = (state.broadcastQueue ?? []).filter((id) => id !== action.payload)
+      if (state.lastPlainBroadcastEventId === action.payload) {
+        state.lastPlainBroadcastEventId = null
+      }
+    },
+    /** Change the source definition used by future Play-driven broadcasts. */
+    setBroadcastOverride(
+      state,
+      action: PayloadAction<{ id: string; changes: BroadcastOverride }>
+    ) {
+      state.broadcastOverrides ??= {}
+      state.broadcastOverrides[action.payload.id] = {
+        ...(state.broadcastOverrides[action.payload.id] ?? {}),
+        ...action.payload.changes,
+      }
+    },
+    /** Restore a built-in message to its source copy and classification. */
+    resetBroadcastOverride(state, action: PayloadAction<string>) {
+      if (!state.broadcastOverrides) return
+      delete state.broadcastOverrides[action.payload]
+    },
+    /**
+     * Apply authoring changes saved by another browser tab. The storage event
+     * is the bridge between a manager tab and a running game tab; rebuilding
+     * here makes those changes effective without restarting the season.
+     */
+    replaceBroadcastConfig(
+      state,
+      action: PayloadAction<{
+        overrides: Record<string, BroadcastOverride>
+        customMessages: CustomBroadcastMessage[]
+      }>
+    ) {
+      state.broadcastOverrides = action.payload.overrides
+      state.customBroadcasts = action.payload.customMessages
+      beginPhaseBroadcastSequence(state, state.phase)
+      finishPhaseBroadcastSequence(state)
+      for (const event of state.tvFeed) {
+        if (event.meta?.phase === state.phase && event.meta?.week === state.week) {
+          refreshManagedBroadcastDefinition(state, event)
+        }
+      }
+      rebuildManagedBroadcastQueue(state, state.phase)
+    },
+    /**
+     * Materialize and order every manager-controlled broadcast for the active
+     * phase. TvZone calls this on mount/phase entry so special phases and
+     * messages authored while the manager was open use the same runtime queue.
+     */
+    syncPhaseBroadcasts(
+      state,
+      action: PayloadAction<{ phase: Phase; cardMajor?: string | null }>
+    ) {
+      if (state.phase !== action.payload.phase) return
+      beginPhaseBroadcastSequence(state, action.payload.phase)
+      const cardMajor = action.payload.cardMajor ?? null
+      const activeCardTemplate = cardMajor
+        ? getPhaseCardTemplate(action.payload.phase, cardMajor)
+        : undefined
+
+      // A phase can change its branch without changing the phase name (for
+      // example, the ordinary LOH card becoming Democracia). Keep the old
+      // card in history, but never leave it eligible in the live queue beside
+      // the newly selected card.
+      for (const event of state.tvFeed) {
+        if (event.meta?.phase !== action.payload.phase || event.meta?.week !== state.week) continue
+        const templateId = event.meta?.broadcastTemplateId
+        const template = typeof templateId === 'string' ? getBroadcastTemplate(templateId) : undefined
+        if (
+          template?.kind === 'phase_card' &&
+          template.id !== activeCardTemplate?.id
+        ) {
+          event.meta = { ...(event.meta ?? {}), broadcastConsumed: true }
+        }
+      }
+
+      if (cardMajor) {
+        const template = activeCardTemplate
+        if (template) {
+          pushEvent(state, template.text, template.type, {
+            phase: action.payload.phase,
+            broadcastTemplateId: template.id,
+            broadcastLevel: 'major',
+            forceOnTv: true,
+            major: template.major,
+            announcementTitle: template.title,
+            announcementSubtitle: template.text,
+          })
+        }
+      }
+      finishPhaseBroadcastSequence(state)
+
+      for (const event of state.tvFeed) {
+        if (event.meta?.phase === action.payload.phase && event.meta?.week === state.week) {
+          refreshManagedBroadcastDefinition(state, event)
+        }
+      }
+
+      rebuildManagedBroadcastQueue(state, action.payload.phase)
+    },
+    /** Consume exactly one faux-TV item; Play cannot advance while another remains. */
+    consumeBroadcastEvent(state, action: PayloadAction<string>) {
+      const event = state.tvFeed.find((candidate) => candidate.id === action.payload)
+      if (event) {
+        event.meta = { ...(event.meta ?? {}), broadcastConsumed: true }
+        if (event.meta.broadcastLevel === 'minor') {
+          state.lastPlainBroadcastEventId = event.id
+        }
+      }
+      state.broadcastQueue = (state.broadcastQueue ?? []).filter((id) => id !== action.payload)
+    },
+    addCustomBroadcast(
+      state,
+      action: PayloadAction<Omit<CustomBroadcastMessage, 'id'> & { id?: string }>
+    ) {
+      state.customBroadcasts ??= []
+      state.customBroadcasts.push({
+        ...action.payload,
+        id: action.payload.id ?? crypto.randomUUID(),
+      })
+    },
+    updateCustomBroadcast(state, action: PayloadAction<CustomBroadcastMessage>) {
+      state.customBroadcasts ??= []
+      const index = state.customBroadcasts.findIndex((message) => message.id === action.payload.id)
+      if (index !== -1) state.customBroadcasts[index] = action.payload
+    },
+    reorderCustomBroadcasts(
+      state,
+      action: PayloadAction<{ phase: Phase; orderedIds: string[] }>
+    ) {
+      const orderById = new Map(action.payload.orderedIds.map((id, index) => [id, (index + 1) * 10]))
+      for (const message of state.customBroadcasts ?? []) {
+        if (message.phase !== action.payload.phase) continue
+        const order = orderById.get(message.id)
+        if (order != null) message.order = order
+      }
+    },
+    reorderPhaseBroadcasts(
+      state,
+      action: PayloadAction<{
+        phase: Phase
+        items: Array<{ id: string; kind: 'source' | 'custom' }>
+      }>
+    ) {
+      state.broadcastOverrides ??= {}
+      action.payload.items.forEach((item, index) => {
+        const order = (index + 1) * 100
+        if (item.kind === 'custom') {
+          const message = (state.customBroadcasts ?? []).find(
+            (candidate) => candidate.id === item.id && candidate.phase === action.payload.phase
+          )
+          if (message) message.order = order
+        } else {
+          state.broadcastOverrides![item.id] = {
+            ...(state.broadcastOverrides![item.id] ?? {}),
+            order,
+          }
+        }
+      })
+    },
+    removeCustomBroadcast(state, action: PayloadAction<string>) {
+      state.customBroadcasts = (state.customBroadcasts ?? []).filter(
+        (message) => message.id !== action.payload
+      )
     },
     /** Persist a social phase summary to the Diary Room log (not the TV feed). */
     addSocialSummary(state, action: PayloadAction<{ summary: string; week: number }>) {
@@ -3263,8 +3824,6 @@ const gameSlice = createSlice({
       const expectedAfter = cupidActive ? 4 : 2
       if (state.nomineeIds.length !== expectedBefore) return
       const savedId = typeof action.payload === 'string' ? action.payload : action.payload.savedId
-      const supportPercent =
-        typeof action.payload === 'string' ? null : (action.payload.supportPercent ?? null)
       if (!state.nomineeIds.includes(savedId)) return
 
       const savedPlayer = state.players.find((p) => p.id === savedId)
@@ -3275,9 +3834,6 @@ const gameSlice = createSlice({
       )
       const remainingNomineeIds = state.nomineeIds.filter((id) => !savedUnitIds.includes(id))
       if (remainingNomineeIds.length !== expectedAfter) return
-      const remainingNomineeNames = remainingNomineeIds
-        .map((id) => state.players.find((p) => p.id === id)?.name)
-        .filter((name): name is string => Boolean(name))
 
       // Remove from active nominee block
       state.nomineeIds = remainingNomineeIds
@@ -3296,20 +3852,6 @@ const gameSlice = createSlice({
       state.awaitingPublicSave = false
       // Advance directly to pos_comp_announcement so veto starts with 2 nominees
       state.phase = 'pos_comp_announcement'
-
-      pushPovCompetitionAnnouncement(state)
-      pushEvent(
-        state,
-        `${formatNameList(
-          savedUnitIds.map((id) => state.players.find((player) => player.id === id)?.name ?? id)
-        )} ${savedUnitIds.length > 1 ? 'were' : 'was'} saved${
-          supportPercent !== null
-            ? ` with ${Math.round(supportPercent)}% of the public support`
-            : ' by the public'
-        }. ${formatNameList(remainingNomineeNames)} are still in danger.`,
-        'game',
-        { suppressPhaseAnnouncementKey: 'pos_comp_announcement' }
-      )
     },
 
     /**
@@ -3972,7 +4514,6 @@ const gameSlice = createSlice({
         )
       } else if (isFinal4) {
         state.phase = 'final3'
-        pushEvent(state, `Final 3! Three players remain. 🏆`, 'game')
       } else if (state.doubleEviction?.pendingSecondEviction) {
         // Double Eviction: promote the second eviction to the main pending slot.
         state.pendingEviction = state.doubleEviction.pendingSecondEviction
@@ -5241,6 +5782,8 @@ const gameSlice = createSlice({
         seasonArchives,
         season,
         status: 'active' as const,
+        broadcastOverrides: state.broadcastOverrides ?? {},
+        customBroadcasts: state.customBroadcasts ?? [],
       }
       fresh.twinShockConsumed = twinShockConsumed
       fresh.twinShockActivatedSeason = state.twinShockActivatedSeason ?? null
@@ -5256,24 +5799,25 @@ const gameSlice = createSlice({
         fresh.voxPopuli.status =
           fresh.voxPopuli.scheduledSeason === season ? 'scheduled' : 'inactive'
       }
-      // Update the welcome message to reflect the actual season number.
-      // publicModeEnabled is already derived from settings inside createInitialGameState().
-      fresh.tvFeed = [
-        {
-          id: 'e0',
-          text: `Welcome to The Big Eye house! 🏠 Season ${season} is about to begin.`,
-          type: 'game' as const,
-          timestamp: Date.now(),
-          meta: { phase: fresh.phase, week: fresh.week },
-        },
-        {
-          id: 'e1',
-          text: `[Rules] Public mode: ${fresh.publicModeEnabled === true ? 'ON' : 'OFF'}`,
-          type: 'game' as const,
-          timestamp: Date.now(),
-          meta: { phase: fresh.phase, week: fresh.week },
-        },
-      ]
+      // Preserve the manager-built Season Start sequence. Only refresh the
+      // dynamic season placeholder after the archive-derived season is known.
+      fresh.tvFeed = fresh.tvFeed.map((event) =>
+        event.meta?.broadcastTemplateId === 'season.welcome'
+          ? {
+              ...event,
+              text: renderBroadcastTemplate(
+                fresh.broadcastOverrides?.['season.welcome']?.text ??
+                  getBroadcastTemplate('season.welcome')?.text ??
+                  event.text,
+                [String(season)]
+              ),
+            }
+          : event
+      )
+      beginPhaseBroadcastSequence(fresh, 'season_start')
+      finishPhaseBroadcastSequence(fresh)
+      fresh.tvFeed.forEach((event) => refreshManagedBroadcastDefinition(fresh, event))
+      rebuildManagedBroadcastQueue(fresh, 'season_start')
       return fresh
     },
     /**
@@ -5281,12 +5825,18 @@ const gameSlice = createSlice({
      * Replaces the entire game slice with the snapshot.
      * seasonFinale field is always preserved as-is from the snapshot.
      */
-    hydrateGame(_state, action: PayloadAction<GameState>) {
-      return {
+    hydrateGame(state, action: PayloadAction<GameState>) {
+      const hydrated: GameState = {
         ...action.payload,
         gameId: action.payload.gameId ?? crypto.randomUUID(),
         hasSeenConfessionalSpotlight: action.payload.hasSeenConfessionalSpotlight ?? false,
         status: action.payload.status ?? 'active',
+        // Broadcast Manager configuration is permanent authoring data, not a
+        // campaign snapshot. Never let an older saved run overwrite it.
+        broadcastOverrides: state.broadcastOverrides ?? {},
+        customBroadcasts: state.customBroadcasts ?? [],
+        broadcastQueue: action.payload.broadcastQueue ?? [],
+        lastPlainBroadcastEventId: action.payload.lastPlainBroadcastEventId ?? null,
         twinShock: action.payload.twinShock ?? createInitialTwinShockState(),
         lohSafetyAdvice: action.payload.lohSafetyAdvice ?? null,
         currentWeekNominationRecord: action.payload.currentWeekNominationRecord ?? null,
@@ -5309,6 +5859,35 @@ const gameSlice = createSlice({
           action.payload.liaForcedUntilTwinShockResolved ??
           !(action.payload.twinShockConsumed ?? false),
       }
+      if (import.meta.env.DEV && import.meta.env.VITE_FORCE_CLASSIC === 'true') {
+        hydrated.expansionMode = null
+        hydrated.twistActive = false
+        if (hydrated.cupidArrow) {
+          hydrated.cupidArrow = {
+            ...hydrated.cupidArrow,
+            scheduledSeason: null,
+            status: 'inactive',
+            activatedSeason: null,
+            activatedWeek: null,
+            pairs: [],
+            eliminatedPairCount: 0,
+            pendingPartnerEvictionId: null,
+          }
+        }
+        if (hydrated.voxPopuli) {
+          hydrated.voxPopuli = {
+            ...hydrated.voxPopuli,
+            scheduledSeason: null,
+            status: 'inactive',
+            activatedSeason: null,
+            activatedWeek: null,
+            awaitingPublicVote: false,
+            publicVoteContext: null,
+            finaleStage: null,
+          }
+        }
+      }
+      return hydrated
     },
 
     clearSurvivorReplacementTransition(state) {
@@ -5386,6 +5965,18 @@ const gameSlice = createSlice({
         return
       }
 
+      // Emit any current-phase message that was authored after the phase had
+      // already been entered. Normally these were emitted during entry and the
+      // ID/day guard makes this a no-op.
+      if (PHASE_ORDER.includes(state.phase)) {
+        beginPhaseBroadcastSequence(state, state.phase)
+        finishPhaseBroadcastSequence(state)
+      } else {
+        // Finale-only phases do not use the weekly destination switch below.
+        beginPhaseBroadcastSequence(state, state.phase)
+        finishPhaseBroadcastSequence(state)
+      }
+
       // ── Special-phase handling (Final4 / Final3 are outside PHASE_ORDER) ──
       if (state.phase === 'final4_eviction') {
         // Guard: Final 4 eviction requires a valid POS holder
@@ -5460,13 +6051,6 @@ const gameSlice = createSlice({
           )
           state.phase = 'final3_comp2'
           return
-        }
-        if (!isVoxPopuliActive(state)) {
-          pushEvent(
-            state,
-            `Final 3 — Day ${state.week}! The three-part LOH competition begins. 🏆`,
-            'game'
-          )
         }
         state.phase = 'final3_comp1'
         return
@@ -5833,6 +6417,7 @@ const gameSlice = createSlice({
         state.aiReplacementStep = 2
         return
       }
+
       if (state.aiReplacementStep === 2) {
         // Guard: wait until the UI has acknowledged the step-1 announcement.
         if (state.aiReplacementWaiting) return
@@ -6131,7 +6716,7 @@ const gameSlice = createSlice({
 
       const currentIdx = PHASE_ORDER.indexOf(state.phase)
       const nextIdx = (currentIdx + 1) % PHASE_ORDER.length
-      let nextPhase: Phase = PHASE_ORDER[nextIdx]
+      let nextPhase: Phase = state.phase === 'season_start' ? 'week_start' : PHASE_ORDER[nextIdx]
 
       if (state.phase === 'eviction_results' && nextPhase === 'week_end') {
         if (shouldQueueTwinShockBeforeDayEnd(state)) return
@@ -6144,15 +6729,19 @@ const gameSlice = createSlice({
 
       const alive = state.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury')
 
+      beginPhaseBroadcastSequence(state, nextPhase)
       switch (nextPhase) {
         case 'week_start': {
+          const enteringDayOne = state.phase === 'season_start'
           activateVoxPopuliForSeason(state)
           // week_end → week_start: increment week and reset week-level fields.
           // Save the outgoing LOH so they can be excluded from this week's LOH comp.
-          state.prevHohId = state.lohId ?? null
-          state.lastWeekNominationRecord = state.currentWeekNominationRecord ?? null
+          if (!enteringDayOne) {
+            state.prevHohId = state.lohId ?? null
+            state.lastWeekNominationRecord = state.currentWeekNominationRecord ?? null
+            state.week += 1
+          }
           state.currentWeekNominationRecord = null
-          state.week += 1
           state.lohId = null
           state.lohSocialPlan = null
           state.nomineeIds = []
@@ -6233,37 +6822,25 @@ const gameSlice = createSlice({
             !isVoxPopuliActive(state) &&
             state.tribunalPhaseAnnounced !== true &&
             state.players.some((player) => player.status === 'jury')
-          const tribunalAnnouncement = tribunalPhaseBegins
+          const tribunalEvent = tribunalPhaseBegins
             ? pushEvent(
-                state,
-                `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`,
-                'game',
-                { major: 'tribunal_phase' }
-              )
+              state,
+              `Congrats all, you've just made it to tribunal. Your voices will crown the winner.`,
+              'game',
+              { major: 'tribunal_phase', phase: 'week_start' }
+            )
             : null
-          if (tribunalPhaseBegins) {
+          if (tribunalEvent) {
             state.tribunalPhaseAnnounced = true
           }
-          pushEvent(
-            state,
-            isVoxPopuliActive(state)
-              ? `Day ${state.week} begins! 🏠 It's time for the immunity competition.`
-              : `Day ${state.week} begins! 🏠 It's time for the LOH competition.`,
-            'game',
-            tribunalAnnouncement
-              ? { announcementPrerollEventId: tribunalAnnouncement.id }
-              : undefined
-          )
+          pushEvent(state, `Day ${state.week} has begun. Get ready.`, 'game', {
+            key: 'day_start',
+            phase: 'week_start',
+            ...(tribunalEvent ? { announcementPrerollEventId: tribunalEvent.id } : {}),
+          })
           break
         }
         case 'loh_comp_announcement': {
-          pushEvent(
-            state,
-            isVoxPopuliActive(state)
-              ? `Today's immunity competition is about to begin. The winner will be safe; the last-place finisher will go onto the block.`
-              : `The Leader of the House comp is about to begin! All eligible players will now battle for the title.`,
-            'game'
-          )
           activateCupidArrowForSeason(state)
           break
         }
@@ -6342,12 +6919,16 @@ const gameSlice = createSlice({
         }
         case 'social_1': {
           maybePushTwinShockClue(state)
-          const hohName = state.players.find((p) => p.id === state.lohId)?.name ?? 'The new LOH'
-          pushEvent(
-            state,
-            `Housemates congratulate ${hohName}. Alliances are already forming… 💬`,
-            'social'
-          )
+          const democraciaSocialBeatAlreadyShown =
+            state.democracia?.activatedDay === state.week && state.democracia.active === false
+          if (!democraciaSocialBeatAlreadyShown) {
+            const hohName = state.players.find((p) => p.id === state.lohId)?.name ?? 'The new LOH'
+            pushEvent(
+              state,
+              `Housemates congratulate ${hohName}. Alliances are already forming… 💬`,
+              'social'
+            )
+          }
           break
         }
         case 'nominations': {
@@ -6563,7 +7144,6 @@ const gameSlice = createSlice({
               )
             }
             nextPhase = 'pos_comp_announcement'
-            pushPovCompetitionAnnouncement(state)
             break
           }
           // Normal weeks: block advance() and let the UI resolve which nominee is saved.
@@ -6575,10 +7155,8 @@ const gameSlice = createSlice({
           )
           break
         }
-        case 'pos_comp_announcement': {
-          pushPovCompetitionAnnouncement(state)
+        case 'pos_comp_announcement':
           break
-        }
         case 'pos_comp': {
           pushEvent(state, `The Power of Safety competition is underway! 🎭`, 'game')
           break
@@ -7355,12 +7933,14 @@ const gameSlice = createSlice({
           pushEvent(
             state,
             `Day ${state.week} has come to an end. A new day begins soon… ✨`,
-            'game'
+            'game',
+            { key: 'day_end', phase: 'week_end' }
           )
           break
         }
       }
 
+      finishPhaseBroadcastSequence(state)
       state.phase = nextPhase
     },
 
@@ -7803,6 +8383,18 @@ export const {
   syncStrategicRelationships,
   setLohSocialPlan,
   addTvEvent,
+  updateTvEvent,
+  removeTvEvent,
+  setBroadcastOverride,
+  resetBroadcastOverride,
+  replaceBroadcastConfig,
+  syncPhaseBroadcasts,
+  consumeBroadcastEvent,
+  addCustomBroadcast,
+  updateCustomBroadcast,
+  reorderCustomBroadcasts,
+  reorderPhaseBroadcasts,
+  removeCustomBroadcast,
   setDramaSocialMode,
   setLohSafetyAdvice,
   addSocialSummary,
@@ -8344,14 +8936,9 @@ function resolveDebugBlockers(
   ) {
     const publicSaveResult = resolvePairAwarePublicSave(rootState)
     const savedId = publicSaveResult.savedId || game.nomineeIds[0]
-    const supportPercent = expandCupidIds(game, [savedId]).reduce(
-      (sum, id) => sum + (publicSaveResult.voteShareByPlayerId[id] ?? 0),
-      0
-    )
     dispatch(
       commitPublicSave({
         savedId,
-        supportPercent,
       })
     )
     return true
@@ -8545,15 +9132,10 @@ export const fastForwardToEviction = () => (dispatch: AppDispatch, getState: () 
     ) {
       const publicSaveResult = resolvePairAwarePublicSave(rootState)
       const savedId = publicSaveResult.savedId || state.nomineeIds[0]
-      const supportPercent = expandCupidIds(state, [savedId]).reduce(
-        (sum, id) => sum + (publicSaveResult.voteShareByPlayerId[id] ?? 0),
-        0
-      )
       dispatch(
-        commitPublicSave({
-          savedId,
-          supportPercent,
-        })
+      commitPublicSave({
+        savedId,
+      })
       )
     } else {
       dispatch(advance())

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -162,10 +162,7 @@ store.subscribe(() => {
   ) {
     prevBroadcastOverrides = current.game.broadcastOverrides
     prevCustomBroadcasts = current.game.customBroadcasts
-    saveBroadcastConfig(
-      current.game.broadcastOverrides ?? {},
-      current.game.customBroadcasts ?? []
-    )
+    saveBroadcastConfig(current.game.broadcastOverrides ?? {}, current.game.customBroadcasts ?? [])
   }
   if (current.settings !== prevSettings) {
     prevSettings = current.settings

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import gameReducer from './gameSlice'
+import gameReducer, { replaceBroadcastConfig } from './gameSlice'
 import finaleReducer from './finaleSlice'
 import challengeReducer from './challengeSlice'
 import settingsReducer, { loadSettings, saveSettings } from './settingsSlice'
@@ -49,6 +49,11 @@ import { secretMissionMiddleware } from './secretMissionMiddleware'
 import { gameDiagnosticsMiddleware } from '../services/diagnostics/gameDiagnostics'
 import vipReducer, { loadVipState } from './vipSlice'
 import { saveCachedVipEntitlement } from '../vip/vipStorage'
+import {
+  BROADCAST_CONFIG_STORAGE_KEY,
+  loadBroadcastConfig,
+  saveBroadcastConfig,
+} from '../broadcasting/broadcastConfigPersistence'
 
 export const store = configureStore({
   reducer: {
@@ -101,11 +106,22 @@ export const store = configureStore({
     ),
 })
 
+// The Broadcast Manager is commonly kept open beside the game. localStorage
+// persists its authoring data; this listener makes a save in that manager tab
+// immediately update the live game tab and its ordered presentation queue.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== BROADCAST_CONFIG_STORAGE_KEY) return
+    const config = loadBroadcastConfig()
+    store.dispatch(replaceBroadcastConfig(config))
+  })
+}
+
 function hasMeaningfulGameProgress(game: ReturnType<typeof store.getState>['game']): boolean {
   return (
     game.mode === 'survival' ||
     game.week > 1 ||
-    game.phase !== 'week_start' ||
+    (game.phase !== 'season_start' && game.phase !== 'week_start') ||
     Boolean(game.runId) ||
     Boolean(game.pendingEviction) ||
     Boolean(game.seasonFinale)
@@ -124,6 +140,8 @@ let prevAds = store.getState().ads
 let prevVip = store.getState().vip
 // Persist active mode runs whenever the game slice changes.
 let prevGame = store.getState().game
+let prevBroadcastOverrides = store.getState().game.broadcastOverrides
+let prevCustomBroadcasts = store.getState().game.customBroadcasts
 let prevFinale = store.getState().finale
 let prevSocial = store.getState().social
 let prevPublicOpinion = store.getState().publicOpinion
@@ -138,6 +156,17 @@ let prevSeasonArchivesLength = prevSeasonArchives?.length ?? 0
 let prevArchiveProfileId: string | null = store.getState().profiles?.activeProfileId ?? null
 store.subscribe(() => {
   const current = store.getState()
+  if (
+    current.game.broadcastOverrides !== prevBroadcastOverrides ||
+    current.game.customBroadcasts !== prevCustomBroadcasts
+  ) {
+    prevBroadcastOverrides = current.game.broadcastOverrides
+    prevCustomBroadcasts = current.game.customBroadcasts
+    saveBroadcastConfig(
+      current.game.broadcastOverrides ?? {},
+      current.game.customBroadcasts ?? []
+    )
+  }
   if (current.settings !== prevSettings) {
     prevSettings = current.settings
     saveSettings(current.settings)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,6 +149,8 @@ export interface MinigameContext {
 
 // Canonical weekly-game phase list (in execution order)
 export type Phase =
+  /** One-time opening phase before Day 1 begins. */
+  | 'season_start'
   | 'week_start'
   /** Pre-competition TV announcement before the LOH competition begins. */
   | 'loh_comp_announcement'
@@ -231,6 +233,38 @@ export interface TvEvent {
    * background / AI-driven events. Required when channels includes 'dr'.
    */
   source?: ActivitySource
+}
+
+export type BroadcastLevel = 'minor' | 'major' | 'critical'
+
+/** Per-save changes to a built-in broadcast definition. */
+export interface BroadcastOverride {
+  text?: string
+  title?: string
+  type?: TvEvent['type']
+  level?: BroadcastLevel
+  major?: string | null
+  disabled?: boolean
+  /** Put this message on the faux TV. This does not change its visual level. */
+  forceOnTv?: boolean
+  /** Author-defined position within its phase. Lower values appear first. */
+  order?: number
+}
+
+/** A user-authored line that is emitted whenever its assigned phase is entered. */
+export interface CustomBroadcastMessage {
+  id: string
+  /** Human-readable authoring key shown in the manager and emitted metadata. */
+  key?: string
+  phase: Phase
+  text: string
+  title?: string
+  type: TvEvent['type']
+  level: BroadcastLevel
+  major?: string
+  enabled: boolean
+  forceOnTv?: boolean
+  order?: number
 }
 
 // ─── Spectator overlay ────────────────────────────────────────────────────────
@@ -608,6 +642,14 @@ export interface GameState {
    */
   competitionSeasonStateByPlayerId?: Record<string, CompetitionSeasonState>
   tvFeed: TvEvent[]
+  /** Ordered event IDs waiting to be presented by the faux-TV player. */
+  broadcastQueue?: string[]
+  /** Last consumed plain faux-TV message, retained until another message replaces it. */
+  lastPlainBroadcastEventId?: string | null
+  /** Editable built-in broadcast copy, keyed by the stable registry ID. */
+  broadcastOverrides?: Record<string, BroadcastOverride>
+  /** Additional phase messages authored in the Broadcast Manager. */
+  customBroadcasts?: CustomBroadcastMessage[]
   isLive: boolean
   /** One-time per-season tutorial flag for the confessional FAB spotlight. */
   hasSeenConfessionalSpotlight?: boolean

--- a/src/utils/gameStatusLanguage.ts
+++ b/src/utils/gameStatusLanguage.ts
@@ -1,6 +1,7 @@
 import type { Phase } from '../types';
 
 const PHASE_LABELS: Partial<Record<Phase, string>> = {
+  season_start: 'Season start',
   week_start: 'Day start',
   loh_comp_announcement: 'LOH competition',
   loh_comp: 'LOH competition',

--- a/src/utils/gameStatusLanguage.ts
+++ b/src/utils/gameStatusLanguage.ts
@@ -1,6 +1,7 @@
 import type { Phase } from '../types';
 
 const PHASE_LABELS: Partial<Record<Phase, string>> = {
+  // i18n-ignore: Legacy status-label registry stores canonical English copy
   season_start: 'Season start',
   week_start: 'Day start',
   loh_comp_announcement: 'LOH competition',

--- a/tests/activityService.test.ts
+++ b/tests/activityService.test.ts
@@ -38,7 +38,6 @@ describe('isVisibleInMainLog', () => {
   it('returns false when channels is ["recentActivity"] only', () => {
     expect(isVisibleInMainLog({ channels: ['recentActivity'] })).toBe(false)
   })
-
 })
 
 // ── isVisibleOnTv ─────────────────────────────────────────────────────────────
@@ -80,7 +79,6 @@ describe('isVisibleOnTv', () => {
     expect(isBattleBackReturnResultEvent(activationEvent)).toBe(false)
     expect(isVisibleOnTv(activationEvent)).toBe(true)
   })
-
 })
 
 // ── isVisibleInDr ─────────────────────────────────────────────────────────────

--- a/tests/activityService.test.ts
+++ b/tests/activityService.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect } from 'vitest'
 import {
   isBattleBackReturnResultEvent,
-  isRedundantCompetitionPreludeEvent,
   isVisibleInMainLog,
   isVisibleOnTv,
   isVisibleInDr,
@@ -40,41 +39,6 @@ describe('isVisibleInMainLog', () => {
     expect(isVisibleInMainLog({ channels: ['recentActivity'] })).toBe(false)
   })
 
-  it('removes redundant LOH and POS prelude messages from the log', () => {
-    const lohPrelude = {
-      type: 'game',
-      text: 'The Leader of the House comp is about to begin! All eligible players will now battle for the title.',
-      channels: ['tv', 'mainLog'] as ActivityChannel[],
-    }
-    const posPrelude = {
-      type: 'game',
-      text: 'It is time for the Power of Safety competition! Housemates, get ready.',
-      channels: ['tv', 'mainLog'] as ActivityChannel[],
-    }
-
-    expect(isRedundantCompetitionPreludeEvent(lohPrelude)).toBe(true)
-    expect(isRedundantCompetitionPreludeEvent(posPrelude)).toBe(true)
-    expect(isVisibleInMainLog(lohPrelude)).toBe(false)
-    expect(isVisibleInMainLog(posPrelude)).toBe(false)
-  })
-
-  it('removes both redundant Final 3 follow-up messages after the major card', () => {
-    const remaining = {
-      type: 'game',
-      text: 'Final 3! Three players remain. 🏆',
-      channels: ['tv', 'mainLog'] as ActivityChannel[],
-    }
-    const competition = {
-      type: 'game',
-      text: 'Final 3 — Day 14! The three-part LOH competition begins. 🏆',
-      channels: ['tv', 'mainLog'] as ActivityChannel[],
-    }
-
-    expect(isRedundantCompetitionPreludeEvent(remaining)).toBe(true)
-    expect(isRedundantCompetitionPreludeEvent(competition)).toBe(true)
-    expect(isVisibleInMainLog(remaining)).toBe(false)
-    expect(isVisibleInMainLog(competition)).toBe(false)
-  })
 })
 
 // ── isVisibleOnTv ─────────────────────────────────────────────────────────────
@@ -117,23 +81,6 @@ describe('isVisibleOnTv', () => {
     expect(isVisibleOnTv(activationEvent)).toBe(true)
   })
 
-  it('removes redundant LOH and POS prelude messages from the TV viewport', () => {
-    expect(
-      isVisibleOnTv({
-        text: 'The Leader of the House competition is about to begin! All eligible players will now battle for the title.',
-      })
-    ).toBe(false)
-    expect(isVisibleOnTv({ text: "It's time for the Power of Safety competition!" })).toBe(false)
-  })
-
-  it('removes redundant Final 3 messages from the TV viewport', () => {
-    expect(isVisibleOnTv({ text: 'Final 3! Three players remain. 🏆' })).toBe(false)
-    expect(
-      isVisibleOnTv({
-        text: 'Final 3 — Day 14! The three-part LOH competition begins. 🏆',
-      })
-    ).toBe(false)
-  })
 })
 
 // ── isVisibleInDr ─────────────────────────────────────────────────────────────

--- a/tests/broadcastConfigPersistence.test.ts
+++ b/tests/broadcastConfigPersistence.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  BROADCAST_CONFIG_STORAGE_KEY,
+  loadBroadcastConfig,
+  saveBroadcastConfig,
+} from '../src/broadcasting/broadcastConfigPersistence'
+
+describe('broadcast manager permanent configuration', () => {
+  beforeEach(() => localStorage.removeItem(BROADCAST_CONFIG_STORAGE_KEY))
+
+  it('round-trips overrides and custom messages independently from a campaign save', () => {
+    expect(saveBroadcastConfig(
+      { 'week.day-start': { text: 'A permanent day start.', disabled: false } },
+      [{
+        id: 'custom-1',
+        key: 'social.permanent-message',
+        phase: 'week_start',
+        text: 'Permanent custom message',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      }]
+    )).toBe(true)
+
+    expect(loadBroadcastConfig()).toMatchObject({
+      overrides: { 'week.day-start': { text: 'A permanent day start.' } },
+      customMessages: [{ id: 'custom-1', forceOnTv: true, order: 10 }],
+    })
+  })
+
+  it('migrates old UUID-only messages to readable unique authoring keys', () => {
+    localStorage.setItem(BROADCAST_CONFIG_STORAGE_KEY, JSON.stringify({
+      version: 2,
+      overrides: {},
+      customMessages: [
+        { id: 'uuid-1', phase: 'social_1', text: 'Alliance warning arrives', type: 'game', level: 'minor', enabled: true },
+        { id: 'uuid-2', phase: 'social_1', text: 'Alliance warning arrives', type: 'game', level: 'minor', enabled: true },
+      ],
+    }))
+
+    expect(loadBroadcastConfig().customMessages.map((message) => message.key)).toEqual([
+      'custom.alliance-warning-arrives',
+      'custom.alliance-warning-arrives-2',
+    ])
+  })
+})

--- a/tests/broadcastConfigPersistence.test.ts
+++ b/tests/broadcastConfigPersistence.test.ts
@@ -9,20 +9,24 @@ describe('broadcast manager permanent configuration', () => {
   beforeEach(() => localStorage.removeItem(BROADCAST_CONFIG_STORAGE_KEY))
 
   it('round-trips overrides and custom messages independently from a campaign save', () => {
-    expect(saveBroadcastConfig(
-      { 'week.day-start': { text: 'A permanent day start.', disabled: false } },
-      [{
-        id: 'custom-1',
-        key: 'social.permanent-message',
-        phase: 'week_start',
-        text: 'Permanent custom message',
-        type: 'game',
-        level: 'minor',
-        enabled: true,
-        forceOnTv: true,
-        order: 10,
-      }]
-    )).toBe(true)
+    expect(
+      saveBroadcastConfig(
+        { 'week.day-start': { text: 'A permanent day start.', disabled: false } },
+        [
+          {
+            id: 'custom-1',
+            key: 'social.permanent-message',
+            phase: 'week_start',
+            text: 'Permanent custom message',
+            type: 'game',
+            level: 'minor',
+            enabled: true,
+            forceOnTv: true,
+            order: 10,
+          },
+        ]
+      )
+    ).toBe(true)
 
     expect(loadBroadcastConfig()).toMatchObject({
       overrides: { 'week.day-start': { text: 'A permanent day start.' } },
@@ -31,14 +35,31 @@ describe('broadcast manager permanent configuration', () => {
   })
 
   it('migrates old UUID-only messages to readable unique authoring keys', () => {
-    localStorage.setItem(BROADCAST_CONFIG_STORAGE_KEY, JSON.stringify({
-      version: 2,
-      overrides: {},
-      customMessages: [
-        { id: 'uuid-1', phase: 'social_1', text: 'Alliance warning arrives', type: 'game', level: 'minor', enabled: true },
-        { id: 'uuid-2', phase: 'social_1', text: 'Alliance warning arrives', type: 'game', level: 'minor', enabled: true },
-      ],
-    }))
+    localStorage.setItem(
+      BROADCAST_CONFIG_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        overrides: {},
+        customMessages: [
+          {
+            id: 'uuid-1',
+            phase: 'social_1',
+            text: 'Alliance warning arrives',
+            type: 'game',
+            level: 'minor',
+            enabled: true,
+          },
+          {
+            id: 'uuid-2',
+            phase: 'social_1',
+            text: 'Alliance warning arrives',
+            type: 'game',
+            level: 'minor',
+            enabled: true,
+          },
+        ],
+      })
+    )
 
     expect(loadBroadcastConfig().customMessages.map((message) => message.key)).toEqual([
       'custom.alliance-warning-arrives',

--- a/tests/broadcastManager.reducer.test.ts
+++ b/tests/broadcastManager.reducer.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from 'vitest'
+import gameReducer, {
+  addCustomBroadcast,
+  addTvEvent,
+  advance,
+  consumeBroadcastEvent,
+  hydrateGame,
+  replaceBroadcastConfig,
+  removeTvEvent,
+  reorderCustomBroadcasts,
+  reorderPhaseBroadcasts,
+  resetGame,
+  setBroadcastOverride,
+  syncPhaseBroadcasts,
+  updateTvEvent,
+} from '../src/store/gameSlice'
+
+describe('broadcast manager reducers', () => {
+  it('registers and queues the LOH winner as an LOH Results faux-TV message', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = { ...state, phase: 'loh_comp', seed: 42 }
+
+    state = gameReducer(state, advance())
+
+    const winnerEvent = state.tvFeed.find(
+      (event) => event.meta?.broadcastTemplateId === 'loh.winner'
+    )
+    expect(winnerEvent).toMatchObject({
+      meta: {
+        phase: 'loh_results',
+        broadcastLevel: 'minor',
+        forceOnTv: true,
+      },
+    })
+    expect(state.broadcastQueue).toContain(winnerEvent?.id)
+  })
+
+  it('edits an existing message while preserving its identity and chronology', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addTvEvent({ text: 'Original copy', type: 'game' }))
+    const event = state.tvFeed[0]
+
+    state = gameReducer(
+      state,
+      updateTvEvent({
+        id: event.id,
+        text: 'Edited copy',
+        type: 'twist',
+        phase: 'nominations',
+        major: 'nomination_ceremony',
+        broadcastPriority: 'critical',
+      })
+    )
+
+    expect(state.tvFeed[0]).toMatchObject({
+      id: event.id,
+      timestamp: event.timestamp,
+      text: 'Edited copy',
+      type: 'twist',
+      major: 'nomination_ceremony',
+      meta: {
+        phase: 'nominations',
+        major: 'nomination_ceremony',
+        broadcastPriority: 'critical',
+      },
+    })
+  })
+
+  it('removes only the requested message', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addTvEvent({ text: 'Keep me', type: 'game' }))
+    state = gameReducer(state, addTvEvent({ text: 'Remove me', type: 'game' }))
+    const removeId = state.tvFeed[0].id
+    const retainedId = state.tvFeed[1].id
+
+    state = gameReducer(state, removeTvEvent(removeId))
+
+    expect(state.tvFeed.map((event) => event.id)).toContain(retainedId)
+    expect(state.tvFeed.map((event) => event.id)).not.toContain(removeId)
+  })
+
+  it('uses edited built-in copy in the real Play flow and tags the destination phase', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(
+      state,
+      setBroadcastOverride({
+        id: 'loh.competition-start',
+        changes: { text: 'The edited LOH competition message.' },
+      })
+    )
+
+    state = gameReducer(state, advance()) // season_start -> week_start
+    state = gameReducer(state, advance()) // week_start -> announcement
+    state = gameReducer(state, advance()) // announcement -> loh_comp
+
+    expect(state.tvFeed[0]).toMatchObject({
+      text: 'The edited LOH competition message.',
+      meta: { phase: 'loh_comp', broadcastTemplateId: 'loh.competition-start' },
+    })
+  })
+
+  it('disables only the duplicate broadcast definition, not the phase', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(
+      state,
+      setBroadcastOverride({ id: 'loh.competition-start', changes: { disabled: true } })
+    )
+
+    state = gameReducer(state, advance())
+    state = gameReducer(state, advance())
+    state = gameReducer(state, advance())
+
+    expect(state.phase).toBe('loh_comp')
+    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'loh.competition-start')).toBe(false)
+  })
+
+  it('emits a custom message once when Play processes its phase', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'qa-custom',
+        phase: 'week_start',
+        text: 'Custom day-opening line.',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+      })
+    )
+
+    state = gameReducer(state, advance())
+
+    expect(state.tvFeed.filter((event) => event.meta?.customBroadcastId === 'qa-custom')).toHaveLength(1)
+  })
+
+  it('starts a fresh season separately and enters Day 1 without incrementing the day', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+
+    expect(state.phase).toBe('season_start')
+    expect(state.week).toBe(1)
+    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.welcome')).toBe(true)
+    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.public-mode-rule')).toBe(true)
+
+    state = gameReducer(state, advance())
+
+    expect(state.phase).toBe('week_start')
+    expect(state.week).toBe(1)
+    expect(state.tvFeed.filter((event) => event.meta?.broadcastTemplateId === 'season.welcome')).toHaveLength(1)
+    expect(state.tvFeed[0]).toMatchObject({
+      text: 'Day 1 has begun. Get ready.',
+      meta: { phase: 'week_start', broadcastTemplateId: 'week.day-start' },
+    })
+  })
+
+  it('keeps permanent manager configuration when an older campaign is hydrated', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'permanent-message',
+        phase: 'week_start',
+        text: 'Keep across campaigns.',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+      })
+    )
+    const oldSnapshot = { ...state, customBroadcasts: [], broadcastOverrides: {} }
+
+    state = gameReducer(state, hydrateGame(oldSnapshot))
+
+    expect(state.customBroadcasts?.map((message) => message.id)).toContain('permanent-message')
+  })
+
+  it('applies manager changes from another tab to the active phase queue', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, replaceBroadcastConfig({
+      overrides: state.broadcastOverrides ?? {},
+      customMessages: [{
+        id: 'cross-tab-message',
+        key: 'custom.cross-tab-message',
+        phase: 'season_start',
+        text: 'Saved in the manager tab.',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      }],
+    }))
+
+    const event = state.tvFeed.find(
+      (candidate) => candidate.meta?.customBroadcastId === 'cross-tab-message'
+    )
+    expect(event?.text).toBe('Saved in the manager tab.')
+    expect(state.broadcastQueue?.[0]).toBe(event?.id)
+  })
+
+  it('honors custom sequence order and can force a minor line onto the faux TV', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'second', key: 'custom.second', phase: 'week_start', text: 'Second line', type: 'game', level: 'minor',
+      enabled: true, order: 20,
+    }))
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'first', key: 'custom.first', phase: 'week_start', text: 'First line', type: 'game', level: 'minor',
+      enabled: true, order: 10, forceOnTv: true,
+    }))
+
+    state = gameReducer(state, advance())
+
+    const customEvents = state.tvFeed.filter((event) => event.meta?.customBroadcastId)
+    expect(
+      [...customEvents]
+        .sort((a, b) => Number(a.meta?.broadcastOrder) - Number(b.meta?.broadcastOrder))
+        .map((event) => event.meta?.customBroadcastId)
+    ).toEqual(['first', 'second'])
+    expect(customEvents.find((event) => event.meta?.customBroadcastId === 'first')).toMatchObject({
+      meta: {
+        broadcastLevel: 'minor',
+        forceOnTv: true,
+        broadcastTemplateId: 'custom.first',
+      },
+    })
+    const forcedMinor = customEvents.find((event) => event.meta?.customBroadcastId === 'first')
+    expect(forcedMinor?.major).toBeUndefined()
+    expect(state.broadcastQueue).toContain(forcedMinor?.id)
+  })
+
+  it('reorders a phase atomically', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'one', key: 'custom.one', phase: 'social_1', text: 'One', type: 'game',
+      level: 'minor', enabled: true, order: 10,
+    }))
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'two', key: 'custom.two', phase: 'social_1', text: 'Two', type: 'game',
+      level: 'minor', enabled: true, order: 20,
+    }))
+
+    state = gameReducer(state, reorderCustomBroadcasts({
+      phase: 'social_1', orderedIds: ['two', 'one'],
+    }))
+
+    expect(
+      [...(state.customBroadcasts ?? [])]
+        .filter((message) => message.phase === 'social_1')
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map((message) => message.id)
+    ).toEqual(['two', 'one'])
+  })
+
+  it('uses level and force as independent presentation controls', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    const messages = [
+      { id: 'plain-log', level: 'minor' as const, forceOnTv: false, order: 10 },
+      { id: 'plain-tv', level: 'minor' as const, forceOnTv: true, order: 20 },
+      { id: 'major-card', level: 'major' as const, forceOnTv: false, order: 30 },
+      { id: 'critical-card', level: 'critical' as const, forceOnTv: true, order: 40 },
+    ]
+    for (const message of messages) {
+      state = gameReducer(state, addCustomBroadcast({
+        ...message,
+        key: `custom.${message.id}`,
+        phase: 'season_start',
+        text: message.id,
+        type: 'game',
+        enabled: true,
+      }))
+    }
+
+    state = gameReducer(state, syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    const byCustomId = (id: string) =>
+      state.tvFeed.find((event) => event.meta?.customBroadcastId === id)
+    expect(byCustomId('plain-log')?.major).toBeUndefined()
+    expect(byCustomId('plain-tv')).toMatchObject({
+      major: undefined,
+      meta: { broadcastLevel: 'minor', forceOnTv: true },
+    })
+    expect(byCustomId('major-card')).toMatchObject({
+      major: 'custom_major',
+      meta: { broadcastLevel: 'major', major: 'custom_major' },
+    })
+    expect(byCustomId('critical-card')).toMatchObject({
+      major: 'custom_critical',
+      meta: {
+        broadcastLevel: 'critical',
+        major: 'custom_critical',
+        broadcastPriority: 'critical',
+      },
+    })
+    expect(state.broadcastQueue).not.toContain(byCustomId('plain-log')?.id)
+    expect(state.broadcastQueue).toEqual(expect.arrayContaining([
+      byCustomId('plain-tv')?.id,
+      byCustomId('major-card')?.id,
+      byCustomId('critical-card')?.id,
+    ]))
+  })
+
+  it('lets a built-in phase card be reclassified by the manager', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = { ...state, phase: 'loh_comp_announcement' }
+    state = gameReducer(state, setBroadcastOverride({
+      id: 'card.loh',
+      changes: { level: 'minor', forceOnTv: false },
+    }))
+    state = gameReducer(state, syncPhaseBroadcasts({
+      phase: 'loh_comp_announcement',
+      cardMajor: 'loh_comp_announcement',
+    }))
+
+    const card = state.tvFeed.find((event) => event.meta?.broadcastTemplateId === 'card.loh')
+    expect(card).toMatchObject({
+      major: undefined,
+      meta: { broadcastLevel: 'minor', broadcastManaged: true },
+    })
+    expect(card?.meta?.forceOnTv).toBeUndefined()
+    expect(state.broadcastQueue).not.toContain(card?.id)
+
+    state = gameReducer(state, setBroadcastOverride({
+      id: 'card.loh',
+      changes: { level: 'critical', forceOnTv: true },
+    }))
+    state = gameReducer(state, syncPhaseBroadcasts({
+      phase: 'loh_comp_announcement',
+      cardMajor: 'loh_comp_announcement',
+    }))
+
+    expect(state.tvFeed.find((event) => event.id === card?.id)).toMatchObject({
+      meta: { broadcastLevel: 'critical', broadcastPriority: 'critical' },
+    })
+    expect(state.broadcastQueue).toContain(card?.id)
+  })
+
+  it('preserves a manager-authored Season Start item before the welcome after reset', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'opening-first',
+      key: 'custom.opening-first',
+      phase: 'season_start',
+      text: 'Opening first.',
+      type: 'game',
+      level: 'minor',
+      enabled: true,
+      forceOnTv: true,
+      order: 10,
+    }))
+
+    state = gameReducer(state, resetGame())
+
+    const queueCopy = state.broadcastQueue ?? []
+    const queuedTexts = queueCopy.map((id) => state.tvFeed.find((event) => event.id === id)?.text)
+    expect(queuedTexts[0]).toBe('Opening first.')
+    expect(queuedTexts.some((text) => text?.startsWith('Welcome to The Big Eye house!'))).toBe(true)
+
+    const firstId = queueCopy[0]
+    state = gameReducer(state, consumeBroadcastEvent(firstId))
+    expect(state.tvFeed.find((event) => event.id === firstId)?.meta?.broadcastConsumed).toBe(true)
+    expect(state.broadcastQueue).not.toContain(firstId)
+  })
+
+  it('places a custom message before the built-in day-start line in the full phase sequence', () => {
+    let state = gameReducer(undefined, { type: 'init' })
+    state = gameReducer(state, addCustomBroadcast({
+      id: 'before-day-start',
+      key: 'week.before-day-start',
+      phase: 'week_start',
+      text: 'This runs before the day starts.',
+      type: 'game',
+      level: 'minor',
+      enabled: true,
+      order: 100,
+    }))
+    state = gameReducer(state, reorderPhaseBroadcasts({
+      phase: 'week_start',
+      items: [
+        { id: 'before-day-start', kind: 'custom' },
+        { id: 'week.tribunal-start', kind: 'source' },
+        { id: 'week.day-start', kind: 'source' },
+      ],
+    }))
+    state = { ...state, phase: 'week_end' }
+
+    state = gameReducer(state, advance())
+
+    const custom = state.tvFeed.find((event) => event.meta?.customBroadcastId === 'before-day-start')
+    const dayStart = state.tvFeed.find((event) => event.meta?.broadcastTemplateId === 'week.day-start')
+    expect(custom?.meta?.broadcastOrder).toBeLessThan(Number(dayStart?.meta?.broadcastOrder))
+  })
+})

--- a/tests/broadcastManager.reducer.test.ts
+++ b/tests/broadcastManager.reducer.test.ts
@@ -111,7 +111,9 @@ describe('broadcast manager reducers', () => {
     state = gameReducer(state, advance())
 
     expect(state.phase).toBe('loh_comp')
-    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'loh.competition-start')).toBe(false)
+    expect(
+      state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'loh.competition-start')
+    ).toBe(false)
   })
 
   it('emits a custom message once when Play processes its phase', () => {
@@ -130,7 +132,9 @@ describe('broadcast manager reducers', () => {
 
     state = gameReducer(state, advance())
 
-    expect(state.tvFeed.filter((event) => event.meta?.customBroadcastId === 'qa-custom')).toHaveLength(1)
+    expect(
+      state.tvFeed.filter((event) => event.meta?.customBroadcastId === 'qa-custom')
+    ).toHaveLength(1)
   })
 
   it('starts a fresh season separately and enters Day 1 without incrementing the day', () => {
@@ -138,14 +142,20 @@ describe('broadcast manager reducers', () => {
 
     expect(state.phase).toBe('season_start')
     expect(state.week).toBe(1)
-    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.welcome')).toBe(true)
-    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.public-mode-rule')).toBe(true)
+    expect(state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.welcome')).toBe(
+      true
+    )
+    expect(
+      state.tvFeed.some((event) => event.meta?.broadcastTemplateId === 'season.public-mode-rule')
+    ).toBe(true)
 
     state = gameReducer(state, advance())
 
     expect(state.phase).toBe('week_start')
     expect(state.week).toBe(1)
-    expect(state.tvFeed.filter((event) => event.meta?.broadcastTemplateId === 'season.welcome')).toHaveLength(1)
+    expect(
+      state.tvFeed.filter((event) => event.meta?.broadcastTemplateId === 'season.welcome')
+    ).toHaveLength(1)
     expect(state.tvFeed[0]).toMatchObject({
       text: 'Day 1 has begun. Get ready.',
       meta: { phase: 'week_start', broadcastTemplateId: 'week.day-start' },
@@ -174,20 +184,25 @@ describe('broadcast manager reducers', () => {
 
   it('applies manager changes from another tab to the active phase queue', () => {
     let state = gameReducer(undefined, { type: 'init' })
-    state = gameReducer(state, replaceBroadcastConfig({
-      overrides: state.broadcastOverrides ?? {},
-      customMessages: [{
-        id: 'cross-tab-message',
-        key: 'custom.cross-tab-message',
-        phase: 'season_start',
-        text: 'Saved in the manager tab.',
-        type: 'game',
-        level: 'minor',
-        enabled: true,
-        forceOnTv: true,
-        order: 10,
-      }],
-    }))
+    state = gameReducer(
+      state,
+      replaceBroadcastConfig({
+        overrides: state.broadcastOverrides ?? {},
+        customMessages: [
+          {
+            id: 'cross-tab-message',
+            key: 'custom.cross-tab-message',
+            phase: 'season_start',
+            text: 'Saved in the manager tab.',
+            type: 'game',
+            level: 'minor',
+            enabled: true,
+            forceOnTv: true,
+            order: 10,
+          },
+        ],
+      })
+    )
 
     const event = state.tvFeed.find(
       (candidate) => candidate.meta?.customBroadcastId === 'cross-tab-message'
@@ -198,14 +213,33 @@ describe('broadcast manager reducers', () => {
 
   it('honors custom sequence order and can force a minor line onto the faux TV', () => {
     let state = gameReducer(undefined, { type: 'init' })
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'second', key: 'custom.second', phase: 'week_start', text: 'Second line', type: 'game', level: 'minor',
-      enabled: true, order: 20,
-    }))
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'first', key: 'custom.first', phase: 'week_start', text: 'First line', type: 'game', level: 'minor',
-      enabled: true, order: 10, forceOnTv: true,
-    }))
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'second',
+        key: 'custom.second',
+        phase: 'week_start',
+        text: 'Second line',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        order: 20,
+      })
+    )
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'first',
+        key: 'custom.first',
+        phase: 'week_start',
+        text: 'First line',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        order: 10,
+        forceOnTv: true,
+      })
+    )
 
     state = gameReducer(state, advance())
 
@@ -229,18 +263,40 @@ describe('broadcast manager reducers', () => {
 
   it('reorders a phase atomically', () => {
     let state = gameReducer(undefined, { type: 'init' })
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'one', key: 'custom.one', phase: 'social_1', text: 'One', type: 'game',
-      level: 'minor', enabled: true, order: 10,
-    }))
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'two', key: 'custom.two', phase: 'social_1', text: 'Two', type: 'game',
-      level: 'minor', enabled: true, order: 20,
-    }))
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'one',
+        key: 'custom.one',
+        phase: 'social_1',
+        text: 'One',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        order: 10,
+      })
+    )
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'two',
+        key: 'custom.two',
+        phase: 'social_1',
+        text: 'Two',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        order: 20,
+      })
+    )
 
-    state = gameReducer(state, reorderCustomBroadcasts({
-      phase: 'social_1', orderedIds: ['two', 'one'],
-    }))
+    state = gameReducer(
+      state,
+      reorderCustomBroadcasts({
+        phase: 'social_1',
+        orderedIds: ['two', 'one'],
+      })
+    )
 
     expect(
       [...(state.customBroadcasts ?? [])]
@@ -259,14 +315,17 @@ describe('broadcast manager reducers', () => {
       { id: 'critical-card', level: 'critical' as const, forceOnTv: true, order: 40 },
     ]
     for (const message of messages) {
-      state = gameReducer(state, addCustomBroadcast({
-        ...message,
-        key: `custom.${message.id}`,
-        phase: 'season_start',
-        text: message.id,
-        type: 'game',
-        enabled: true,
-      }))
+      state = gameReducer(
+        state,
+        addCustomBroadcast({
+          ...message,
+          key: `custom.${message.id}`,
+          phase: 'season_start',
+          text: message.id,
+          type: 'game',
+          enabled: true,
+        })
+      )
     }
 
     state = gameReducer(state, syncPhaseBroadcasts({ phase: 'season_start' }))
@@ -291,24 +350,32 @@ describe('broadcast manager reducers', () => {
       },
     })
     expect(state.broadcastQueue).not.toContain(byCustomId('plain-log')?.id)
-    expect(state.broadcastQueue).toEqual(expect.arrayContaining([
-      byCustomId('plain-tv')?.id,
-      byCustomId('major-card')?.id,
-      byCustomId('critical-card')?.id,
-    ]))
+    expect(state.broadcastQueue).toEqual(
+      expect.arrayContaining([
+        byCustomId('plain-tv')?.id,
+        byCustomId('major-card')?.id,
+        byCustomId('critical-card')?.id,
+      ])
+    )
   })
 
   it('lets a built-in phase card be reclassified by the manager', () => {
     let state = gameReducer(undefined, { type: 'init' })
     state = { ...state, phase: 'loh_comp_announcement' }
-    state = gameReducer(state, setBroadcastOverride({
-      id: 'card.loh',
-      changes: { level: 'minor', forceOnTv: false },
-    }))
-    state = gameReducer(state, syncPhaseBroadcasts({
-      phase: 'loh_comp_announcement',
-      cardMajor: 'loh_comp_announcement',
-    }))
+    state = gameReducer(
+      state,
+      setBroadcastOverride({
+        id: 'card.loh',
+        changes: { level: 'minor', forceOnTv: false },
+      })
+    )
+    state = gameReducer(
+      state,
+      syncPhaseBroadcasts({
+        phase: 'loh_comp_announcement',
+        cardMajor: 'loh_comp_announcement',
+      })
+    )
 
     const card = state.tvFeed.find((event) => event.meta?.broadcastTemplateId === 'card.loh')
     expect(card).toMatchObject({
@@ -318,14 +385,20 @@ describe('broadcast manager reducers', () => {
     expect(card?.meta?.forceOnTv).toBeUndefined()
     expect(state.broadcastQueue).not.toContain(card?.id)
 
-    state = gameReducer(state, setBroadcastOverride({
-      id: 'card.loh',
-      changes: { level: 'critical', forceOnTv: true },
-    }))
-    state = gameReducer(state, syncPhaseBroadcasts({
-      phase: 'loh_comp_announcement',
-      cardMajor: 'loh_comp_announcement',
-    }))
+    state = gameReducer(
+      state,
+      setBroadcastOverride({
+        id: 'card.loh',
+        changes: { level: 'critical', forceOnTv: true },
+      })
+    )
+    state = gameReducer(
+      state,
+      syncPhaseBroadcasts({
+        phase: 'loh_comp_announcement',
+        cardMajor: 'loh_comp_announcement',
+      })
+    )
 
     expect(state.tvFeed.find((event) => event.id === card?.id)).toMatchObject({
       meta: { broadcastLevel: 'critical', broadcastPriority: 'critical' },
@@ -335,17 +408,20 @@ describe('broadcast manager reducers', () => {
 
   it('preserves a manager-authored Season Start item before the welcome after reset', () => {
     let state = gameReducer(undefined, { type: 'init' })
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'opening-first',
-      key: 'custom.opening-first',
-      phase: 'season_start',
-      text: 'Opening first.',
-      type: 'game',
-      level: 'minor',
-      enabled: true,
-      forceOnTv: true,
-      order: 10,
-    }))
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'opening-first',
+        key: 'custom.opening-first',
+        phase: 'season_start',
+        text: 'Opening first.',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
 
     state = gameReducer(state, resetGame())
 
@@ -362,30 +438,40 @@ describe('broadcast manager reducers', () => {
 
   it('places a custom message before the built-in day-start line in the full phase sequence', () => {
     let state = gameReducer(undefined, { type: 'init' })
-    state = gameReducer(state, addCustomBroadcast({
-      id: 'before-day-start',
-      key: 'week.before-day-start',
-      phase: 'week_start',
-      text: 'This runs before the day starts.',
-      type: 'game',
-      level: 'minor',
-      enabled: true,
-      order: 100,
-    }))
-    state = gameReducer(state, reorderPhaseBroadcasts({
-      phase: 'week_start',
-      items: [
-        { id: 'before-day-start', kind: 'custom' },
-        { id: 'week.tribunal-start', kind: 'source' },
-        { id: 'week.day-start', kind: 'source' },
-      ],
-    }))
+    state = gameReducer(
+      state,
+      addCustomBroadcast({
+        id: 'before-day-start',
+        key: 'week.before-day-start',
+        phase: 'week_start',
+        text: 'This runs before the day starts.',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        order: 100,
+      })
+    )
+    state = gameReducer(
+      state,
+      reorderPhaseBroadcasts({
+        phase: 'week_start',
+        items: [
+          { id: 'before-day-start', kind: 'custom' },
+          { id: 'week.tribunal-start', kind: 'source' },
+          { id: 'week.day-start', kind: 'source' },
+        ],
+      })
+    )
     state = { ...state, phase: 'week_end' }
 
     state = gameReducer(state, advance())
 
-    const custom = state.tvFeed.find((event) => event.meta?.customBroadcastId === 'before-day-start')
-    const dayStart = state.tvFeed.find((event) => event.meta?.broadcastTemplateId === 'week.day-start')
+    const custom = state.tvFeed.find(
+      (event) => event.meta?.customBroadcastId === 'before-day-start'
+    )
+    const dayStart = state.tvFeed.find(
+      (event) => event.meta?.broadcastTemplateId === 'week.day-start'
+    )
     expect(custom?.meta?.broadcastOrder).toBeLessThan(Number(dayStart?.meta?.broadcastOrder))
   })
 })

--- a/tests/broadcastQueue.presentation.test.tsx
+++ b/tests/broadcastQueue.presentation.test.tsx
@@ -47,11 +47,19 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'phase-scoped-plain', key: 'custom.phase-scoped-plain', phase: 'season_start',
-      text: 'Only visible during season start', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 10,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'phase-scoped-plain',
+        key: 'custom.phase-scoped-plain',
+        phase: 'season_start',
+        text: 'Only visible during season start',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
     const eventId = store.getState().game.broadcastQueue?.[0]
     expect(eventId).toBeTruthy()
@@ -60,21 +68,25 @@ describe('manager-driven faux-TV queue', () => {
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
 
-    expect(screen.getByRole('region', { name: 'Live game events display' }))
-      .toHaveTextContent('Only visible during season start')
+    expect(screen.getByRole('region', { name: 'Live game events display' })).toHaveTextContent(
+      'Only visible during season start'
+    )
 
     act(() => {
       store.dispatch(setPhase('week_start'))
     })
 
     await waitFor(() => {
-      expect(screen.getByRole('region', { name: 'Live game events display' }))
-        .not.toHaveTextContent('Only visible during season start')
+      expect(
+        screen.getByRole('region', { name: 'Live game events display' })
+      ).not.toHaveTextContent('Only visible during season start')
     })
     expect(store.getState().game.lastPlainBroadcastEventId).toBeNull()
   })
@@ -84,23 +96,41 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'unchecked-only', key: 'custom.unchecked-only', phase: 'democracia_results',
-      text: 'This belongs only in the log', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: false, order: 10,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'eligible-next', key: 'custom.eligible-next', phase: 'democracia_results',
-      text: 'This is the next eligible message', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 20,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'unchecked-only',
+        key: 'custom.unchecked-only',
+        phase: 'democracia_results',
+        text: 'This belongs only in the log',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: false,
+        order: 10,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'eligible-next',
+        key: 'custom.eligible-next',
+        phase: 'democracia_results',
+        text: 'This is the next eligible message',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 20,
+      })
+    )
     store.dispatch(setPhase('democracia_results'))
     store.dispatch(syncPhaseBroadcasts({ phase: 'democracia_results' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
@@ -117,17 +147,27 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'final-plain', key: 'custom.final-plain', phase: 'season_start',
-      text: 'Final plain message', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 10,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'final-plain',
+        key: 'custom.final-plain',
+        phase: 'season_start',
+        text: 'Final plain message',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
@@ -146,22 +186,40 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'plain-one', key: 'custom.plain-one', phase: 'season_start',
-      text: 'First consecutive message', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 10,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'plain-two', key: 'custom.plain-two', phase: 'season_start',
-      text: 'Second consecutive message', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 20,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'plain-one',
+        key: 'custom.plain-one',
+        phase: 'season_start',
+        text: 'First consecutive message',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'plain-two',
+        key: 'custom.plain-two',
+        phase: 'season_start',
+        text: 'Second consecutive message',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 20,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
@@ -186,23 +244,35 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'final-major', key: 'custom.final-major', phase: 'season_start',
-      text: 'Final major card', title: 'Final major title', type: 'game',
-      level: 'major', enabled: true, forceOnTv: true, order: 10,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'final-major',
+        key: 'custom.final-major',
+        phase: 'season_start',
+        text: 'Final major card',
+        title: 'Final major title',
+        type: 'game',
+        level: 'major',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
     await waitFor(() => {
-      expect(screen.getByRole('dialog', { name: /Announcement: Final major title/i }))
-        .toBeInTheDocument()
+      expect(
+        screen.getByRole('dialog', { name: /Announcement: Final major title/i })
+      ).toBeInTheDocument()
     })
 
     let accepted = false
@@ -219,28 +289,48 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'major-before-plain', key: 'custom.major-before-plain', phase: 'season_start',
-      text: 'Ceremony card copy', title: 'Ceremony card title', type: 'game',
-      level: 'major', enabled: true, forceOnTv: true, order: 10,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'plain-after-major', key: 'custom.plain-after-major', phase: 'season_start',
-      text: 'Immediate message after ceremony', type: 'game', level: 'minor',
-      enabled: true, forceOnTv: true, order: 20,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'major-before-plain',
+        key: 'custom.major-before-plain',
+        phase: 'season_start',
+        text: 'Ceremony card copy',
+        title: 'Ceremony card title',
+        type: 'game',
+        level: 'major',
+        enabled: true,
+        forceOnTv: true,
+        order: 10,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'plain-after-major',
+        key: 'custom.plain-after-major',
+        phase: 'season_start',
+        text: 'Immediate message after ceremony',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 20,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
     await waitFor(() => {
-      expect(screen.getByRole('dialog', { name: /Announcement: Ceremony card title/i }))
-        .toBeInTheDocument()
+      expect(
+        screen.getByRole('dialog', { name: /Announcement: Ceremony card title/i })
+      ).toBeInTheDocument()
     })
 
     let accepted = true
@@ -259,33 +349,73 @@ describe('manager-driven faux-TV queue', () => {
     for (const id of store.getState().game.broadcastQueue ?? []) {
       store.dispatch(consumeBroadcastEvent(id))
     }
-    store.dispatch(addCustomBroadcast({
-      id: 'minor-log', key: 'custom.minor-log', phase: 'season_start', text: 'Log only',
-      type: 'game', level: 'minor', enabled: true, forceOnTv: false, order: 10,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'minor-tv', key: 'custom.minor-tv', phase: 'season_start', text: 'Plain faux TV',
-      type: 'game', level: 'minor', enabled: true, forceOnTv: true, order: 20,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'major-tv', key: 'custom.major-tv', phase: 'season_start', text: 'Major copy',
-      title: 'Major title', type: 'game', level: 'major', enabled: true, order: 30,
-    }))
-    store.dispatch(addCustomBroadcast({
-      id: 'critical-tv', key: 'custom.critical-tv', phase: 'season_start', text: 'Critical copy',
-      title: 'Critical title', type: 'game', level: 'critical', enabled: true, order: 40,
-    }))
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'minor-log',
+        key: 'custom.minor-log',
+        phase: 'season_start',
+        text: 'Log only',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: false,
+        order: 10,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'minor-tv',
+        key: 'custom.minor-tv',
+        phase: 'season_start',
+        text: 'Plain faux TV',
+        type: 'game',
+        level: 'minor',
+        enabled: true,
+        forceOnTv: true,
+        order: 20,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'major-tv',
+        key: 'custom.major-tv',
+        phase: 'season_start',
+        text: 'Major copy',
+        title: 'Major title',
+        type: 'game',
+        level: 'major',
+        enabled: true,
+        order: 30,
+      })
+    )
+    store.dispatch(
+      addCustomBroadcast({
+        id: 'critical-tv',
+        key: 'custom.critical-tv',
+        phase: 'season_start',
+        text: 'Critical copy',
+        title: 'Critical title',
+        type: 'game',
+        level: 'critical',
+        enabled: true,
+        order: 40,
+      })
+    )
     store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
 
     render(
       <I18nContext.Provider value={TEST_I18N}>
         <Provider store={store}>
-          <MemoryRouter><TvZone /></MemoryRouter>
+          <MemoryRouter>
+            <TvZone />
+          </MemoryRouter>
         </Provider>
       </I18nContext.Provider>
     )
 
-    expect(screen.getByRole('region', { name: 'Live game events display' })).toHaveTextContent('Plain faux TV')
+    expect(screen.getByRole('region', { name: 'Live game events display' })).toHaveTextContent(
+      'Plain faux TV'
+    )
     expect(screen.queryByText('Log only')).not.toBeNull()
 
     let accepted = true

--- a/tests/broadcastQueue.presentation.test.tsx
+++ b/tests/broadcastQueue.presentation.test.tsx
@@ -1,0 +1,309 @@
+import React from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import TvZone from '../src/components/ui/TvZone'
+import gameReducer, {
+  addCustomBroadcast,
+  consumeBroadcastEvent,
+  setPhase,
+  syncPhaseBroadcasts,
+} from '../src/store/gameSlice'
+import settingsReducer from '../src/store/settingsSlice'
+import profilesReducer from '../src/store/profilesSlice'
+import challengeReducer from '../src/store/challengeSlice'
+import finaleReducer from '../src/store/finaleSlice'
+import socialReducer from '../src/social/socialSlice'
+import { I18nContext, type I18nContextValue } from '../src/i18n/I18nContext'
+import { translate } from '../src/i18n/messages'
+
+const TEST_I18N: I18nContextValue = {
+  preference: 'en-US',
+  language: 'en-US',
+  systemLanguage: 'en-US',
+  t: (key, params) => translate('en-US', key, params),
+  formatNumber: (value) => String(value),
+  formatDate: (value) => String(value),
+}
+
+function makeStore() {
+  return configureStore({
+    reducer: {
+      game: gameReducer,
+      settings: settingsReducer,
+      profiles: profilesReducer,
+      challenge: challengeReducer,
+      finale: finaleReducer,
+      social: socialReducer,
+    },
+  })
+}
+
+describe('manager-driven faux-TV queue', () => {
+  it('does not retain a consumed forced-minor message after its phase ends', async () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'phase-scoped-plain', key: 'custom.phase-scoped-plain', phase: 'season_start',
+      text: 'Only visible during season start', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 10,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+    const eventId = store.getState().game.broadcastQueue?.[0]
+    expect(eventId).toBeTruthy()
+    store.dispatch(consumeBroadcastEvent(eventId!))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+
+    expect(screen.getByRole('region', { name: 'Live game events display' }))
+      .toHaveTextContent('Only visible during season start')
+
+    act(() => {
+      store.dispatch(setPhase('week_start'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: 'Live game events display' }))
+        .not.toHaveTextContent('Only visible during season start')
+    })
+    expect(store.getState().game.lastPlainBroadcastEventId).toBeNull()
+  })
+
+  it('skips unchecked messages directly to the next eligible item', () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'unchecked-only', key: 'custom.unchecked-only', phase: 'democracia_results',
+      text: 'This belongs only in the log', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: false, order: 10,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'eligible-next', key: 'custom.eligible-next', phase: 'democracia_results',
+      text: 'This is the next eligible message', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 20,
+    }))
+    store.dispatch(setPhase('democracia_results'))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'democracia_results' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+
+    expect(store.getState().game.broadcastQueue).toHaveLength(1)
+    const viewport = screen.getByRole('region', { name: 'Live game events display' })
+    expect(viewport).not.toHaveTextContent('This belongs only in the log')
+    expect(viewport).toHaveTextContent('This is the next eligible message')
+    expect(viewport.querySelector('.tv-zone__now')).not.toHaveStyle({ opacity: '0' })
+  })
+
+  it('allows one Play press to acknowledge the final plain message and continue', () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'final-plain', key: 'custom.final-plain', phase: 'season_start',
+      text: 'Final plain message', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 10,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+
+    let accepted = false
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+
+    expect(accepted).toBe(true)
+    expect(store.getState().game.broadcastQueue).toEqual([])
+  })
+
+  it('uses the quick reveal when moving between consecutive plain messages', () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'plain-one', key: 'custom.plain-one', phase: 'season_start',
+      text: 'First consecutive message', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 10,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'plain-two', key: 'custom.plain-two', phase: 'season_start',
+      text: 'Second consecutive message', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 20,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+
+    const originalTextNode = document.querySelector('.tv-zone__now')
+    expect(originalTextNode).toHaveTextContent('First consecutive message')
+
+    let accepted = true
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+
+    expect(accepted).toBe(false)
+    const updatedTextNode = document.querySelector('.tv-zone__now')
+    expect(updatedTextNode).not.toBe(originalTextNode)
+    expect(updatedTextNode).toHaveClass('tv-zone__now--quick-transition')
+    expect(updatedTextNode).toHaveTextContent('Second consecutive message')
+  })
+
+  it('allows one Play press to acknowledge the final major card and continue', async () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'final-major', key: 'custom.final-major', phase: 'season_start',
+      text: 'Final major card', title: 'Final major title', type: 'game',
+      level: 'major', enabled: true, forceOnTv: true, order: 10,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /Announcement: Final major title/i }))
+        .toBeInTheDocument()
+    })
+
+    let accepted = false
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+
+    expect(accepted).toBe(true)
+    expect(store.getState().game.broadcastQueue).toEqual([])
+  })
+
+  it('shows the next managed message immediately after a major card dismissal', async () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'major-before-plain', key: 'custom.major-before-plain', phase: 'season_start',
+      text: 'Ceremony card copy', title: 'Ceremony card title', type: 'game',
+      level: 'major', enabled: true, forceOnTv: true, order: 10,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'plain-after-major', key: 'custom.plain-after-major', phase: 'season_start',
+      text: 'Immediate message after ceremony', type: 'game', level: 'minor',
+      enabled: true, forceOnTv: true, order: 20,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /Announcement: Ceremony card title/i }))
+        .toBeInTheDocument()
+    })
+
+    let accepted = true
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+
+    expect(accepted).toBe(false)
+    const viewport = screen.getByRole('region', { name: 'Live game events display' })
+    expect(viewport).toHaveTextContent('Immediate message after ceremony')
+    expect(viewport.querySelector('.tv-zone__now')).not.toHaveStyle({ opacity: '0' })
+  })
+
+  it('plays forced minor, major, and critical messages in manager order before phase advance', async () => {
+    const store = makeStore()
+    for (const id of store.getState().game.broadcastQueue ?? []) {
+      store.dispatch(consumeBroadcastEvent(id))
+    }
+    store.dispatch(addCustomBroadcast({
+      id: 'minor-log', key: 'custom.minor-log', phase: 'season_start', text: 'Log only',
+      type: 'game', level: 'minor', enabled: true, forceOnTv: false, order: 10,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'minor-tv', key: 'custom.minor-tv', phase: 'season_start', text: 'Plain faux TV',
+      type: 'game', level: 'minor', enabled: true, forceOnTv: true, order: 20,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'major-tv', key: 'custom.major-tv', phase: 'season_start', text: 'Major copy',
+      title: 'Major title', type: 'game', level: 'major', enabled: true, order: 30,
+    }))
+    store.dispatch(addCustomBroadcast({
+      id: 'critical-tv', key: 'custom.critical-tv', phase: 'season_start', text: 'Critical copy',
+      title: 'Critical title', type: 'game', level: 'critical', enabled: true, order: 40,
+    }))
+    store.dispatch(syncPhaseBroadcasts({ phase: 'season_start' }))
+
+    render(
+      <I18nContext.Provider value={TEST_I18N}>
+        <Provider store={store}>
+          <MemoryRouter><TvZone /></MemoryRouter>
+        </Provider>
+      </I18nContext.Provider>
+    )
+
+    expect(screen.getByRole('region', { name: 'Live game events display' })).toHaveTextContent('Plain faux TV')
+    expect(screen.queryByText('Log only')).not.toBeNull()
+
+    let accepted = true
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+    expect(accepted).toBe(false)
+    expect(store.getState().game.phase).toBe('season_start')
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: /Announcement: Major title/i })).toBeInTheDocument()
+    })
+
+    act(() => {
+      accepted = window.dispatchEvent(new CustomEvent('ui:playPressed', { cancelable: true }))
+    })
+    expect(accepted).toBe(false)
+    await waitFor(() => {
+      expect(screen.getByTestId('tv-shock-prelude')).toHaveTextContent('Critical title')
+    })
+  })
+})

--- a/tests/broadcastTemplateCatalog.test.ts
+++ b/tests/broadcastTemplateCatalog.test.ts
@@ -19,9 +19,9 @@ describe('broadcast template catalog', () => {
       'social_1'
     )
     expect(match?.template.id).toBe('social.loh-congratulations')
-    expect(renderBroadcastTemplate('The house congratulates {winner}.', match?.variables ?? [])).toBe(
-      'The house congratulates Rune.'
-    )
+    expect(
+      renderBroadcastTemplate('The house congratulates {winner}.', match?.variables ?? [])
+    ).toBe('The house congratulates Rune.')
   })
 
   it('routes every built-in feed message onto the faux TV by default', () => {

--- a/tests/broadcastTemplateCatalog.test.ts
+++ b/tests/broadcastTemplateCatalog.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ALL_BROADCAST_PHASES,
+  BROADCAST_TEMPLATE_CATALOG,
+  matchBroadcastTemplate,
+  renderBroadcastTemplate,
+} from '../src/broadcasting/broadcastTemplateCatalog'
+
+describe('broadcast template catalog', () => {
+  it('has at least one visible source template for every manager phase', () => {
+    for (const phase of ALL_BROADCAST_PHASES) {
+      expect(BROADCAST_TEMPLATE_CATALOG.some((template) => template.phase === phase)).toBe(true)
+    }
+  })
+
+  it('captures dynamic values so edited copy can preserve them', () => {
+    const match = matchBroadcastTemplate(
+      'Housemates congratulate Rune. Alliances are already forming… 💬',
+      'social_1'
+    )
+    expect(match?.template.id).toBe('social.loh-congratulations')
+    expect(renderBroadcastTemplate('The house congratulates {winner}.', match?.variables ?? [])).toBe(
+      'The house congratulates Rune.'
+    )
+  })
+
+  it('routes every built-in feed message onto the faux TV by default', () => {
+    const feeds = BROADCAST_TEMPLATE_CATALOG.filter((template) => template.kind === 'feed')
+    expect(feeds.length).toBeGreaterThan(0)
+    expect(feeds.every((template) => template.forceOnTv === true)).toBe(true)
+  })
+
+  it('captures variables when a runtime event supplies an explicit template id', () => {
+    const match = matchBroadcastTemplate(
+      'Ash has won Leader of the House! 👑',
+      'loh_results',
+      'loh.winner'
+    )
+    expect(match?.variables).toEqual(['Ash'])
+  })
+})

--- a/tests/democracia.flow.test.ts
+++ b/tests/democracia.flow.test.ts
@@ -376,6 +376,17 @@ describe('Democracia twist', () => {
       // Advance from democracia_results → social_1
       store.dispatch(advance())
       expect(store.getState().game.phase).toBe('social_1')
+
+      // The Democracia result already announced the social beat. Leaving the
+      // normal social phase must not broadcast the same congratulations again.
+      store.dispatch(advance())
+      const congratulations = store
+        .getState()
+        .game.tvFeed.filter(
+          (event) =>
+            event.text === 'Housemates congratulate Player 1. Alliances are already forming… 💬'
+        )
+      expect(congratulations).toHaveLength(1)
     })
   })
 

--- a/tests/gameOver.screen.test.tsx
+++ b/tests/gameOver.screen.test.tsx
@@ -88,7 +88,7 @@ describe('GameOver screen', () => {
     expect(archives).toHaveLength(1);
     expect(archives[0].seasonIndex).toBe(3);
     expect(archives[0].playerSummaries.some((summary) => summary.playerId === 'user')).toBe(true);
-    expect(store.getState().game.phase).toBe('week_start');
+    expect(store.getState().game.phase).toBe('season_start');
     expect(store.getState().game.seasonFinale).toBeNull();
   });
 
@@ -116,7 +116,7 @@ describe('GameOver screen', () => {
     });
 
     expect(store.getState().game.week).toBe(1);
-    expect(store.getState().game.phase).toBe('week_start');
+    expect(store.getState().game.phase).toBe('season_start');
 
     const archives = store.getState().game.seasonArchives ?? [];
     expect(archives).toHaveLength(1);

--- a/tests/integration/social.memory.test.ts
+++ b/tests/integration/social.memory.test.ts
@@ -76,7 +76,7 @@ describe('social memory integration for incoming interactions', () => {
     expect(entry.recentEvents[0].type).toBe('ignored_compliment')
   })
 
-  it('adds one cheerful TV summary when multiple incoming interactions expire together', () => {
+  it('keeps expired messages in the social inbox history without adding a TV reminder', () => {
     const store = makeStore()
     const { players, week } = store.getState().game
     const aiPlayers = players.filter((p) => !p.isUser)
@@ -106,18 +106,26 @@ describe('social memory integration for incoming interactions', () => {
 
     store.dispatch(autoResolveExpiredIncomingInteractionsForWeek(week + 1) as never)
 
-    const socialEvents = store
-      .getState()
-      .game.tvFeed.filter((event) => event.type === 'social' && event.source === 'system')
-
-    expect(socialEvents).toHaveLength(1)
-    expect(socialEvents[0].channels).toEqual(['tv', 'mainLog'])
-    expect(socialEvents[0].text).toBe(
+    expect(store.getState().game.tvFeed.map((event) => event.text)).not.toContain(
       "Several players' deal offer and nomination plea required answers and passed their deadlines."
     )
+    expect(
+      store
+        .getState()
+        .social.incomingInteractions.filter((interaction) => interaction.resolved)
+        .map((interaction) => interaction.id)
+        .sort()
+    ).toEqual(['i-expired-deal', 'i-expired-plea'])
+    expect(
+      store
+        .getState()
+        .social.incomingInteractionLogs.filter(
+          (entry) => entry.reason === 'auto_resolved_ignored' && entry.stage === 'auto_resolution'
+        )
+    ).toHaveLength(2)
   })
 
-  it('uses singular player wording when multiple expired interactions came from one sender', () => {
+  it('records every expired required message even when they came from one sender', () => {
     const store = makeStore()
     const { players, week } = store.getState().game
     const ai = players.find((p) => !p.isUser)!
@@ -147,13 +155,15 @@ describe('social memory integration for incoming interactions', () => {
 
     store.dispatch(autoResolveExpiredIncomingInteractionsForWeek(week + 1) as never)
 
-    const socialEvents = store
-      .getState()
-      .game.tvFeed.filter((event) => event.type === 'social' && event.source === 'system')
-
-    expect(socialEvents).toHaveLength(1)
-    expect(socialEvents[0].text).toBe(
+    expect(store.getState().game.tvFeed.map((event) => event.text)).not.toContain(
       "One player's deal offer and nomination plea required an answer and passed its deadline."
     )
+    expect(
+      store
+        .getState()
+        .social.incomingInteractionLogs.filter(
+          (entry) => entry.reason === 'auto_resolved_ignored' && entry.actorId === ai.id
+        )
+    ).toHaveLength(2)
   })
 })

--- a/tests/logsReducer.test.ts
+++ b/tests/logsReducer.test.ts
@@ -15,6 +15,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import gameReducer, {
   advance,
   addTvEvent,
+  setPhase,
   setReplacementNominee,
   submitPovSaveTarget,
   aiReplacementRendered,
@@ -82,6 +83,45 @@ describe('tvFeed — event ID uniqueness', () => {
     const uniqueIds = new Set(ids)
 
     expect(uniqueIds.size).toBe(ids.length)
+  })
+
+  it('does not repeat an exact broadcast line if a phase is resumed', () => {
+    const store = makeStore({
+      phase: 'loh_results',
+      week: 2,
+      lohId: 'p1',
+      players: makePlayers(6).map((player) =>
+        player.id === 'p1' ? { ...player, status: 'loh' as const } : player
+      ),
+    })
+
+    store.dispatch(advance())
+    store.dispatch(setPhase('loh_results'))
+    store.dispatch(advance())
+
+    expect(
+      store
+        .getState()
+        .game.tvFeed.filter(
+          (event) => event.text === 'Housemates congratulate Player 1. Alliances are already forming… 💬'
+        )
+    ).toHaveLength(1)
+  })
+
+  it('adds exactly one fresh day-start line after day end', () => {
+    const store = makeStore({ phase: 'week_end', week: 1, tvFeed: [] })
+
+    store.dispatch(advance())
+
+    const dayStarts = store
+      .getState()
+      .game.tvFeed.filter((event) => event.meta?.key === 'day_start')
+
+    expect(dayStarts).toHaveLength(1)
+    expect(dayStarts[0]).toMatchObject({
+      text: 'Day 2 has begun. Get ready.',
+      meta: { phase: 'week_start', week: 2 },
+    })
   })
 
   it('addTvEvent produces unique IDs for rapid-fire dispatches', () => {

--- a/tests/logsReducer.test.ts
+++ b/tests/logsReducer.test.ts
@@ -103,7 +103,8 @@ describe('tvFeed — event ID uniqueness', () => {
       store
         .getState()
         .game.tvFeed.filter(
-          (event) => event.text === 'Housemates congratulate Player 1. Alliances are already forming… 💬'
+          (event) =>
+            event.text === 'Housemates congratulate Player 1. Alliances are already forming… 💬'
         )
     ).toHaveLength(1)
   })

--- a/tests/thirdNominee.flow.test.ts
+++ b/tests/thirdNominee.flow.test.ts
@@ -368,7 +368,7 @@ describe('pre_veto_public_save phase', () => {
 
     expect(state.phase).toBe('pos_comp_announcement');
     expect(state.awaitingPublicSave).toBeFalsy();
-    expect(state.tvFeed[0]?.text).toContain('It is time for the Power of Safety competition');
+    expect(state.tvFeed).toHaveLength(0);
   });
 
   it('skips pre_veto_public_save and still announces POS when public mode is off', () => {
@@ -385,7 +385,7 @@ describe('pre_veto_public_save phase', () => {
 
     expect(state.phase).toBe('pos_comp_announcement');
     expect(state.awaitingPublicSave).toBeFalsy();
-    expect(state.tvFeed[0]?.text).toContain('It is time for the Power of Safety competition');
+    expect(state.tvFeed).toHaveLength(0);
   });
 
   it('skips pre_veto_public_save when the block is not exactly 3 nominees', () => {
@@ -402,7 +402,7 @@ describe('pre_veto_public_save phase', () => {
 
     expect(state.phase).toBe('pos_comp_announcement');
     expect(state.awaitingPublicSave).toBeFalsy();
-    expect(state.tvFeed[0]?.text).toContain('It is time for the Power of Safety competition');
+    expect(state.tvFeed).toHaveLength(0);
   });
 
   it('commitPublicSave removes saved nominee, records publicSavedNomineeId, and advances phase', () => {
@@ -419,7 +419,7 @@ describe('pre_veto_public_save phase', () => {
       players,
     });
 
-    store.dispatch(commitPublicSave({ savedId: 'p1', supportPercent: 52 }));
+    store.dispatch(commitPublicSave({ savedId: 'p1' }));
     const state = store.getState().game;
 
     expect(state.phase).toBe('pos_comp_announcement');
@@ -431,15 +431,9 @@ describe('pre_veto_public_save phase', () => {
     expect(state.nomineeIds).toContain('p5');
     // Saved player reverts to active
     expect(state.players.find((p) => p.id === 'p1')?.status).toBe('active');
-    expect(state.tvFeed[0]?.text).toBe(
-      'Player 1 was saved with 52% of the public support. Player 2 and Player 5 are still in danger.',
-    );
-    expect(state.tvFeed[0]?.meta?.suppressPhaseAnnouncementKey).toBe('pos_comp_announcement');
-    expect(
-      state.tvFeed.some((event) =>
-        event.text.includes('It is time for the Power of Safety competition'),
-      ),
-    ).toBe(true);
+    // The result has already played in the Public Save reveal; committing it
+    // updates gameplay only and does not repeat that reveal in the TV feed.
+    expect(state.tvFeed).toHaveLength(0);
   });
 
   it('commitPublicSave is a no-op when phase is not pre_veto_public_save', () => {

--- a/tests/unit/settings.restart.test.ts
+++ b/tests/unit/settings.restart.test.ts
@@ -246,14 +246,14 @@ describe('resetGame() uses fresh settings', () => {
     expect(players).toHaveLength(16);
   });
 
-  it('resets to week 1, phase week_start', () => {
+  it('resets to week 1, phase season_start', () => {
     const store = makeStore();
     persistSettings(DEFAULT_SETTINGS);
     store.dispatch(resetGame());
 
     const { week, phase } = store.getState().game;
     expect(week).toBe(1);
-    expect(phase).toBe('week_start');
+    expect(phase).toBe('season_start');
   });
 
   it('preserves existing seasonArchives when no payload is provided', () => {
@@ -285,11 +285,11 @@ describe('createInitialGameState() factory', () => {
     expect(state2.players).toHaveLength(10);
   });
 
-  it('always starts at week 1, phase week_start', () => {
+  it('always starts at week 1, phase season_start', () => {
     persistSettings(DEFAULT_SETTINGS);
     const state = createInitialGameState();
     expect(state.week).toBe(1);
-    expect(state.phase).toBe('week_start');
+    expect(state.phase).toBe('season_start');
   });
 
   it('reads publicMode from persisted settings', () => {


### PR DESCRIPTION
## Summary

- add a permanent Broadcast Manager covering every ceremony phase, built-in source, observed Play source, and custom message
- support editing, disabling, deleting, reordering, readable keys, broadcast levels, and explicit faux-TV routing
- drive the live faux-TV from one manager-ordered queue with cross-tab persistence and synchronization
- introduce a dedicated Season Start phase and preserve Classic campaign startup behavior
- remove repeated public-save, ceremony-prelude, social-congratulations, and expired-interaction broadcasts
- smooth message handoffs, eliminate stale/empty TV states, and preserve a faster blur transition for ordinary messages

## Why

Broadcast copy previously came from several independent paths: reducer events, synthesized phase cards, legacy TV selectors, and social reminders. Those paths could repeat the same information, ignore manager ordering, retain stale messages across phases, or leave transient empty states between cards.

This change gives every displayed broadcast a single ordered runtime path controlled by the Broadcast Manager. Disabled and unchecked messages are skipped, while eligible messages advance without intermediate empty frames.

## Validation

- `npm run typecheck`
- 9 targeted test files
- 218 tests passed covering persistence, reducer ordering, queue presentation, ceremony overlays, duplicate prevention, public-save flow, social reminders, and phase transitions

## Notes

This PR intentionally excludes unrelated local Tetris and broader audio-system work.