### PR TITLE
Broadcast Manager v2

### DIFF
--- a/src/broadcasting/broadcastTemplateCatalog.ts
+++ b/src/broadcasting/broadcastTemplateCatalog.ts
@@ -47,7 +47,18 @@ const feed = (
   note?: string,
   forceOnTv = true,
   campaign?: BroadcastCampaign
-): BroadcastTemplate => ({ id, phase, kind: 'feed', text, type, level, major, forceOnTv, campaign, note })
+): BroadcastTemplate => ({
+  id,
+  phase,
+  kind: 'feed',
+  text,
+  type,
+  level,
+  major,
+  forceOnTv,
+  campaign,
+  note,
+})
 
 const card = (
   id: string,
@@ -133,8 +144,28 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     'vox_populi',
     'Vox Populi seasons only'
   ),
-  feed('survival.opening', 'week_start', 'Surveyeval Mode online. Eight contestants enter; synthetic replacements keep the board full after every robo eviction.', 'game', 'major', 'surveyeval_opening', 'Surveyeval opening', true, 'survival'),
-  feed('survival.rules', 'week_start', '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON | Double Elimination: possible', 'game', 'minor', undefined, 'Surveyeval opening', true, 'survival'),
+  feed(
+    'survival.opening',
+    'week_start',
+    'Surveyeval Mode online. Eight contestants enter; synthetic replacements keep the board full after every robo eviction.',
+    'game',
+    'major',
+    'surveyeval_opening',
+    'Surveyeval opening',
+    true,
+    'survival'
+  ),
+  feed(
+    'survival.rules',
+    'week_start',
+    '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON | Double Elimination: possible',
+    'game',
+    'minor',
+    undefined,
+    'Surveyeval opening',
+    true,
+    'survival'
+  ),
   feed(
     'week.tribunal-start',
     'week_start',
@@ -209,7 +240,17 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     undefined,
     "Cupid's Arrow branch"
   ),
-  feed('cupid.activation', 'loh_comp_announcement', '🏹 The lights soften. A golden arrow crosses the house, splitting into eight trails of light. Cupid has chosen: {pairs}. From this moment, every victory, every danger, every vote, and every exit belongs to the pair. 💘', 'twist', 'critical', 'cupid_arrow', "Cupid's Arrow opening", true, 'cupid'),
+  feed(
+    'cupid.activation',
+    'loh_comp_announcement',
+    '🏹 The lights soften. A golden arrow crosses the house, splitting into eight trails of light. Cupid has chosen: {pairs}. From this moment, every victory, every danger, every vote, and every exit belongs to the pair. 💘',
+    'twist',
+    'critical',
+    'cupid_arrow',
+    "Cupid's Arrow opening",
+    true,
+    'cupid'
+  ),
   feed(
     'loh.vox-last-place',
     'loh_results',
@@ -460,13 +501,83 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     'eviction_results',
     '{evictee}, you have been eliminated from The Big Eye house. 🚪'
   ),
-  feed('cupid.spell-broken', 'eviction_results', '💔 Four pairs have fallen. Cracks race through Cupid\'s hearts, the final arrow dissolves into light, and Cupid takes flight from The Big Eye house. The rose glow fades: every survivor now plays alone. What the pairs felt—and what they did to each other—remains.', 'twist', 'critical', 'cupid_arrow_broken', "Cupid's Arrow ending", true, 'cupid'),
-  feed('cupid.pair-eviction', 'eviction_results', "{players}, Cupid's Arrow means you are eliminated together. 💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow eviction", true, 'cupid'),
-  feed('cupid.pair-tiebreak-eviction', 'eviction_results', "{leader} breaks the tie. {players}, Cupid's Arrow means you are eliminated together. 💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow tie-break eviction", true, 'cupid'),
-  feed('cupid.partner-eviction', 'eviction_results', "{partner} is bound to {evictee} by Cupid's Arrow and is eliminated too. 💔", 'game', 'major', 'cupid_partner_eviction', "Cupid's Arrow paired exit", true, 'cupid'),
-  feed('cupid.self-eviction-pair', 'eviction_results', "{player} has chosen to self-evict. Cupid's Arrow also eliminates {partner}. 🚪💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow paired exit", true, 'cupid'),
-  feed('cupid.pair-tiebreak-prompt', 'eviction_results', 'The nominated pairs are tied. {leader}, your LOH pair must decide which pair leaves. 🗳️', 'game', 'major', 'cupid_pair_tiebreak', "Cupid's Arrow tie-break", true, 'cupid'),
-  feed('survival.run-ended', 'eviction_results', 'Surveyeval run ended. You were eliminated on Day {day}.', 'game', 'major', 'surveyeval_ended', 'Surveyeval ending', true, 'survival'),
+  feed(
+    'cupid.spell-broken',
+    'eviction_results',
+    "💔 Four pairs have fallen. Cracks race through Cupid's hearts, the final arrow dissolves into light, and Cupid takes flight from The Big Eye house. The rose glow fades: every survivor now plays alone. What the pairs felt—and what they did to each other—remains.",
+    'twist',
+    'critical',
+    'cupid_arrow_broken',
+    "Cupid's Arrow ending",
+    true,
+    'cupid'
+  ),
+  feed(
+    'cupid.pair-eviction',
+    'eviction_results',
+    "{players}, Cupid's Arrow means you are eliminated together. 💔",
+    'game',
+    'major',
+    'cupid_pair_eviction',
+    "Cupid's Arrow eviction",
+    true,
+    'cupid'
+  ),
+  feed(
+    'cupid.pair-tiebreak-eviction',
+    'eviction_results',
+    "{leader} breaks the tie. {players}, Cupid's Arrow means you are eliminated together. 💔",
+    'game',
+    'major',
+    'cupid_pair_eviction',
+    "Cupid's Arrow tie-break eviction",
+    true,
+    'cupid'
+  ),
+  feed(
+    'cupid.partner-eviction',
+    'eviction_results',
+    "{partner} is bound to {evictee} by Cupid's Arrow and is eliminated too. 💔",
+    'game',
+    'major',
+    'cupid_partner_eviction',
+    "Cupid's Arrow paired exit",
+    true,
+    'cupid'
+  ),
+  feed(
+    'cupid.self-eviction-pair',
+    'eviction_results',
+    "{player} has chosen to self-evict. Cupid's Arrow also eliminates {partner}. 🚪💔",
+    'game',
+    'major',
+    'cupid_pair_eviction',
+    "Cupid's Arrow paired exit",
+    true,
+    'cupid'
+  ),
+  feed(
+    'cupid.pair-tiebreak-prompt',
+    'eviction_results',
+    'The nominated pairs are tied. {leader}, your LOH pair must decide which pair leaves. 🗳️',
+    'game',
+    'major',
+    'cupid_pair_tiebreak',
+    "Cupid's Arrow tie-break",
+    true,
+    'cupid'
+  ),
+  feed(
+    'survival.run-ended',
+    'eviction_results',
+    'Surveyeval run ended. You were eliminated on Day {day}.',
+    'game',
+    'major',
+    'surveyeval_ended',
+    'Surveyeval ending',
+    true,
+    'survival'
+  ),
   feed('week.day-end', 'week_end', 'Day {day} has come to an end. A new day begins soon… ✨'),
   card(
     'card.final4',

--- a/src/broadcasting/broadcastTemplateCatalog.ts
+++ b/src/broadcasting/broadcastTemplateCatalog.ts
@@ -1,4 +1,4 @@
-import type { BroadcastLevel, Phase, TvEvent } from '../types'
+import type { BroadcastCampaign, BroadcastLevel, Phase, TvEvent } from '../types'
 
 export type BroadcastTemplateKind = 'feed' | 'phase_card'
 
@@ -13,7 +13,23 @@ export interface BroadcastTemplate {
   major?: string
   /** Default faux-TV routing for a plain feed message. Cards are always routed. */
   forceOnTv?: boolean
+  /** Undefined templates are shared across all campaigns. */
+  campaign?: BroadcastCampaign
   note?: string
+}
+
+export const BROADCAST_CAMPAIGNS: readonly BroadcastCampaign[] = [
+  'classic',
+  'survival',
+  'cupid',
+  'vox_populi',
+]
+
+export const BROADCAST_CAMPAIGN_LABELS: Record<BroadcastCampaign, string> = {
+  classic: 'Classic',
+  survival: 'Surveyeval',
+  cupid: "Cupid's Arrow",
+  vox_populi: 'Vox Populi',
 }
 
 export interface BroadcastTemplateMatch {
@@ -29,8 +45,9 @@ const feed = (
   level: BroadcastLevel = 'minor', // i18n-ignore: Internal priority enum value, not player-facing copy
   major?: string,
   note?: string,
-  forceOnTv = true
-): BroadcastTemplate => ({ id, phase, kind: 'feed', text, type, level, major, forceOnTv, note })
+  forceOnTv = true,
+  campaign?: BroadcastCampaign
+): BroadcastTemplate => ({ id, phase, kind: 'feed', text, type, level, major, forceOnTv, campaign, note })
 
 const card = (
   id: string,
@@ -39,7 +56,8 @@ const card = (
   text: string,
   major: string,
   note?: string,
-  level: BroadcastLevel = 'major'
+  level: BroadcastLevel = 'major',
+  campaign?: BroadcastCampaign
 ): BroadcastTemplate => ({
   id,
   phase,
@@ -50,6 +68,7 @@ const card = (
   level,
   major,
   forceOnTv: true,
+  campaign,
   note,
 })
 
@@ -114,6 +133,8 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     'vox_populi',
     'Vox Populi seasons only'
   ),
+  feed('survival.opening', 'week_start', 'Surveyeval Mode online. Eight contestants enter; synthetic replacements keep the board full after every robo eviction.', 'game', 'major', 'surveyeval_opening', 'Surveyeval opening', true, 'survival'),
+  feed('survival.rules', 'week_start', '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON | Double Elimination: possible', 'game', 'minor', undefined, 'Surveyeval opening', true, 'survival'),
   feed(
     'week.tribunal-start',
     'week_start',
@@ -188,6 +209,7 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     undefined,
     "Cupid's Arrow branch"
   ),
+  feed('cupid.activation', 'loh_comp_announcement', '🏹 The lights soften. A golden arrow crosses the house, splitting into eight trails of light. Cupid has chosen: {pairs}. From this moment, every victory, every danger, every vote, and every exit belongs to the pair. 💘', 'twist', 'critical', 'cupid_arrow', "Cupid's Arrow opening", true, 'cupid'),
   feed(
     'loh.vox-last-place',
     'loh_results',
@@ -438,6 +460,13 @@ export const BROADCAST_TEMPLATE_CATALOG: readonly BroadcastTemplate[] = [
     'eviction_results',
     '{evictee}, you have been eliminated from The Big Eye house. 🚪'
   ),
+  feed('cupid.spell-broken', 'eviction_results', '💔 Four pairs have fallen. Cracks race through Cupid\'s hearts, the final arrow dissolves into light, and Cupid takes flight from The Big Eye house. The rose glow fades: every survivor now plays alone. What the pairs felt—and what they did to each other—remains.', 'twist', 'critical', 'cupid_arrow_broken', "Cupid's Arrow ending", true, 'cupid'),
+  feed('cupid.pair-eviction', 'eviction_results', "{players}, Cupid's Arrow means you are eliminated together. 💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow eviction", true, 'cupid'),
+  feed('cupid.pair-tiebreak-eviction', 'eviction_results', "{leader} breaks the tie. {players}, Cupid's Arrow means you are eliminated together. 💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow tie-break eviction", true, 'cupid'),
+  feed('cupid.partner-eviction', 'eviction_results', "{partner} is bound to {evictee} by Cupid's Arrow and is eliminated too. 💔", 'game', 'major', 'cupid_partner_eviction', "Cupid's Arrow paired exit", true, 'cupid'),
+  feed('cupid.self-eviction-pair', 'eviction_results', "{player} has chosen to self-evict. Cupid's Arrow also eliminates {partner}. 🚪💔", 'game', 'major', 'cupid_pair_eviction', "Cupid's Arrow paired exit", true, 'cupid'),
+  feed('cupid.pair-tiebreak-prompt', 'eviction_results', 'The nominated pairs are tied. {leader}, your LOH pair must decide which pair leaves. 🗳️', 'game', 'major', 'cupid_pair_tiebreak', "Cupid's Arrow tie-break", true, 'cupid'),
+  feed('survival.run-ended', 'eviction_results', 'Surveyeval run ended. You were eliminated on Day {day}.', 'game', 'major', 'surveyeval_ended', 'Surveyeval ending', true, 'survival'),
   feed('week.day-end', 'week_end', 'Day {day} has come to an end. A new day begins soon… ✨'),
   card(
     'card.final4',
@@ -567,6 +596,13 @@ export function getBroadcastTemplate(id: string): BroadcastTemplate | undefined 
 
 export function getBroadcastTemplatesForPhase(phase: Phase): readonly BroadcastTemplate[] {
   return BROADCAST_TEMPLATE_CATALOG.filter((template) => template.phase === phase)
+}
+
+export function matchesBroadcastCampaign(
+  template: Pick<BroadcastTemplate, 'campaign'>,
+  campaign: BroadcastCampaign | 'all'
+): boolean {
+  return campaign === 'all' || !template.campaign || template.campaign === campaign
 }
 
 export function getDefaultBroadcastOrder(template: BroadcastTemplate): number {

--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -782,34 +782,6 @@ export default function TvZone(props: TvZoneProps) {
   const [shockInfoSpotlightActive, setShockInfoSpotlightActive] = useState(false)
   // Ref forwarded to the TvAnnouncementOverlay info button for spotlight targeting.
   const announcementInfoButtonRef = useRef<HTMLButtonElement | null>(null)
-  // The end of Cupid's Arrow is a season climax, not an ordinary feed item.
-  // Keep an explicit broadcast alive so a Confessional prompt or phase card
-  // cannot bury the full-screen dissociation sequence.
-  const [cupidBreakAnnouncement, setCupidBreakAnnouncement] = useState<Announcement | null>(null)
-  const previousCupidStatusRef = useRef(gameState.cupidArrow?.status ?? 'inactive')
-
-  useEffect(() => {
-    const previousStatus = previousCupidStatusRef.current
-    const nextStatus = gameState.cupidArrow?.status ?? 'inactive'
-    previousCupidStatusRef.current = nextStatus
-
-    if (previousStatus === 'active' && nextStatus === 'broken') {
-      startTransition(() => {
-        setCupidBreakAnnouncement(
-          buildAnnouncement('cupid_arrow_broken', {
-            id: `cupid-arrow-break-${Date.now()}`,
-            text: "Cupid's Arrow has ended.",
-            type: 'twist',
-            timestamp: Date.now(),
-            meta: { major: 'cupid_arrow_broken' },
-          })
-        )
-      })
-    } else if (nextStatus !== 'broken') {
-      startTransition(() => setCupidBreakAnnouncement(null))
-    }
-  }, [gameState.cupidArrow?.status])
-
   // ── Phase-transition announcement detection ──────────────────────────────────
   // Fires whenever the game phase or alive-player count changes.
   // Also allows an in-place upgrade for nomination-phase overlays when
@@ -948,7 +920,6 @@ export default function TvZone(props: TvZoneProps) {
   // before a simultaneous phase card (for example the first LOH competition)
   // is allowed to take over the TV.
   const activeAnnouncement =
-    cupidBreakAnnouncement ??
     queuedShockAnnouncement?.announcement ??
     (eventAnnouncementHasShockPriority ? eventAnnouncement : null) ??
     priorityAnnouncement ??
@@ -1089,9 +1060,7 @@ export default function TvZone(props: TvZoneProps) {
       currentAnnouncement != null &&
       (CONTINUOUS_MAJOR_ANNOUNCEMENT_KEYS.has(currentAnnouncement.key) ||
         currentAnnouncement === managedEventAnnouncement)
-    if (cupidBreakAnnouncement) {
-      setCupidBreakAnnouncement(null)
-    } else if (queuedShockAnnouncement) {
+    if (queuedShockAnnouncement) {
       setDismissedEventId(queuedShockAnnouncement.eventId)
       setShockAnnouncementQueue((queue) => queue.slice(1))
     } else if (
@@ -1140,7 +1109,6 @@ export default function TvZone(props: TvZoneProps) {
   }, [
     activeAnnouncement,
     dispatch,
-    cupidBreakAnnouncement,
     queuedShockAnnouncement,
     managedEventAnnouncement,
     queuedBroadcastEvent,

--- a/src/modes/survivorRun.ts
+++ b/src/modes/survivorRun.ts
@@ -3,6 +3,7 @@ import type { SurvivorModeState } from './modeTypes';
 import { getDefaultCompetitionProfile, getDefaultCompetitionSeasonState } from '../ai/competition';
 import { createInitialGameState } from '../store/gameSlice';
 import { createInitialVoxPopuliState } from '../features/twists/voxPopuli';
+import { getBroadcastTemplate, getDefaultBroadcastOrder, renderBroadcastTemplate } from '../broadcasting/broadcastTemplateCatalog';
 
 const ROBO_NAMES = [
   'Lira', 'Kang', 'Sora', 'Mako', 'Venn', 'Rika', 'Nexo', 'Zari', 'Kiro', 'Tavi',
@@ -25,6 +26,13 @@ function robotAvatar(seed: string): string {
 
 function isPlayerExited(player: Player | undefined): boolean {
   return player?.status === 'evicted' || player?.status === 'jury';
+}
+
+function managedSurvivalEvent(id: string, templateId: string, variables: string[], timestamp: number, phase: GameState['phase']): TvEvent {
+  const template = getBroadcastTemplate(templateId);
+  if (!template) throw new Error(`Missing Broadcast Manager template: ${templateId}`);
+  const text = renderBroadcastTemplate(template.text, variables);
+  return { id, text, type: template.type, timestamp, ...(template.major ? { major: template.major } : {}), meta: { phase, week: 1, mode: 'survival', broadcastTemplateId: templateId, broadcastVariables: variables, broadcastOrder: getDefaultBroadcastOrder(template), broadcastLevel: template.level, broadcastManaged: true, ...(template.forceOnTv ? { forceOnTv: true } : {}), ...(template.major ? { major: template.major } : {}), ...(template.level === 'critical' ? { broadcastPriority: 'critical' } : {}), ...(template.level !== 'minor' ? { announcementSubtitle: text } : {}) } };
 }
 
 function getSurvivorModeState(state: GameState): SurvivorModeState {
@@ -56,13 +64,8 @@ export function terminalizeSurvivorRun(state: GameState): GameState {
   const currentDay = getSurvivorCurrentDay(state);
   const eventId = `survivor-failed-${state.runId ?? state.gameId}-${currentDay}`;
   const hasTerminalEvent = state.tvFeed.some((event) => event.id === eventId);
-  const gameOverEvent: TvEvent = {
-    id: eventId,
-    text: `Surveyeval run ended. You were eliminated on Day ${currentDay}.`,
-    type: 'game',
-    timestamp: Date.now(),
-    meta: { phase: state.phase, week: state.week, mode: 'survival' },
-  };
+  const gameOverEvent = managedSurvivalEvent(eventId, 'survival.run-ended', [String(currentDay)], Date.now(), state.phase);
+  gameOverEvent.meta = { ...gameOverEvent.meta, week: state.week };
 
   return {
     ...state,
@@ -179,20 +182,8 @@ export function createSurvivorRun(): GameState {
     competitionSeasonStateByPlayerId: buildCompetitionState(players),
     modeSpecific,
     tvFeed: [
-      {
-        id: 'survivor-e0',
-        text: 'Surveyeval Mode online. Eight contestants enter; synthetic replacements keep the board full after every robo eviction.',
-        type: 'game',
-        timestamp: now,
-        meta: { phase: 'week_start', week: 1, mode: 'survival' },
-      },
-      {
-        id: 'survivor-e1',
-        text: '[Rules] Public mode: OFF | Social mode: OFF | Endless days: ON | Double Elimination: possible',
-        type: 'game',
-        timestamp: now,
-        meta: { phase: 'week_start', week: 1, mode: 'survival' },
-      },
+      managedSurvivalEvent('survivor-e0', 'survival.opening', [], now, 'week_start'),
+      managedSurvivalEvent('survivor-e1', 'survival.rules', [], now + 1, 'week_start'),
     ],
   };
 }

--- a/src/screens/BroadcastManager/BroadcastManager.css
+++ b/src/screens/BroadcastManager/BroadcastManager.css
@@ -67,6 +67,22 @@
 .broadcast-manager__back {
   white-space: nowrap;
 }
+.broadcast-manager__campaign-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: 1rem;
+  color: #b7c2dd;
+  font-weight: 700;
+}
+.broadcast-manager__campaign-filter select {
+  min-width: 11rem;
+  border: 1px solid rgba(220, 230, 255, 0.24);
+  border-radius: 0.55rem;
+  color: inherit;
+  background: #111a34;
+  padding: 0.5rem 0.7rem;
+}
 
 .broadcast-manager__layout {
   display: grid;

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -11,13 +11,16 @@ import {
   updateTvEvent,
 } from '../../store/gameSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
-import type { BroadcastLevel, CustomBroadcastMessage, Phase, TvEvent } from '../../types'
+import type { BroadcastCampaign, BroadcastLevel, CustomBroadcastMessage, Phase, TvEvent } from '../../types'
 import { isDebugAccessGranted } from '../../utils/debugMode'
 import {
   ALL_BROADCAST_PHASES,
+  BROADCAST_CAMPAIGNS,
+  BROADCAST_CAMPAIGN_LABELS,
   getDefaultBroadcastOrder,
   getBroadcastTemplate,
   getBroadcastTemplatesForPhase,
+  matchesBroadcastCampaign,
   type BroadcastTemplate,
 } from '../../broadcasting/broadcastTemplateCatalog'
 import './BroadcastManager.css'
@@ -62,6 +65,7 @@ type EditorState = {
   isCard: boolean
   forceOnTv: boolean
   key: string
+  campaign: BroadcastCampaign | ''
 }
 
 function normalizeMessageKey(value: string): string {
@@ -103,6 +107,12 @@ function eventLevel(event: TvEvent): BroadcastLevel {
   return eventMajor(event) ? 'major' : 'minor'
 }
 
+function eventCampaign(event: TvEvent): BroadcastCampaign | null {
+  const templateId = event.meta?.broadcastTemplateId
+  if (typeof templateId === 'string') return getBroadcastTemplate(templateId)?.campaign ?? null
+  return event.meta?.mode === 'survival' ? 'survival' : null
+}
+
 export default function BroadcastManager() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -110,21 +120,30 @@ export default function BroadcastManager() {
   const game = useAppSelector((state) => state.game)
   const hasAccess = isDebugAccessGranted(searchParams, window.location.hostname)
   const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase)
+  const [selectedCampaign, setSelectedCampaign] = useState<BroadcastCampaign | 'all'>('all')
   const [editor, setEditor] = useState<EditorState | null>(null)
 
   const overrides = useMemo(() => game.broadcastOverrides ?? {}, [game.broadcastOverrides])
   const customMessages = useMemo(() => game.customBroadcasts ?? [], [game.customBroadcasts])
-  const templates = useMemo(() => getBroadcastTemplatesForPhase(selectedPhase), [selectedPhase])
+  const templates = useMemo(
+    () => getBroadcastTemplatesForPhase(selectedPhase).filter((template) => matchesBroadcastCampaign(template, selectedCampaign)),
+    [selectedCampaign, selectedPhase]
+  )
   const phaseCustom = useMemo(
     () =>
       customMessages
         .filter((message) => message.phase === selectedPhase)
+        .filter((message) => selectedCampaign === 'all' || !message.campaign || message.campaign === selectedCampaign)
         .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
-    [customMessages, selectedPhase]
+    [customMessages, selectedCampaign, selectedPhase]
   )
   const liveMessages = useMemo(
-    () => game.tvFeed.filter((event) => eventPhase(event) === selectedPhase),
-    [game.tvFeed, selectedPhase]
+    () => game.tvFeed.filter((event) => eventPhase(event) === selectedPhase && (selectedCampaign === 'all' || !eventCampaign(event) || eventCampaign(event) === selectedCampaign)),
+    [game.tvFeed, selectedCampaign, selectedPhase]
+  )
+  const visiblePhases = useMemo(
+    () => ALL_BROADCAST_PHASES.filter((phase) => selectedCampaign === 'all' || getBroadcastTemplatesForPhase(phase).some((template) => matchesBroadcastCampaign(template, selectedCampaign)) || customMessages.some((message) => message.phase === phase && (!message.campaign || message.campaign === selectedCampaign)) || game.tvFeed.some((event) => eventPhase(event) === phase && (!eventCampaign(event) || eventCampaign(event) === selectedCampaign))),
+    [customMessages, game.tvFeed, selectedCampaign]
   )
   const observedSources = useMemo(() => {
     const byId = new Map<string, TvEvent>()
@@ -219,6 +238,7 @@ export default function BroadcastManager() {
       isCard: template.kind === 'phase_card',
       forceOnTv: value.forceOnTv,
       key: template.id,
+      campaign: template.campaign ?? '',
     })
   }
 
@@ -235,6 +255,7 @@ export default function BroadcastManager() {
       isCard: false,
       forceOnTv: message.forceOnTv !== false,
       key: message.key ?? suggestMessageKey(message.text),
+      campaign: message.campaign ?? '',
     })
   }
 
@@ -252,6 +273,7 @@ export default function BroadcastManager() {
       forceOnTv: event.meta?.forceOnTv === true,
       key:
         typeof event.meta?.broadcastTemplateId === 'string' ? event.meta.broadcastTemplateId : '',
+      campaign: eventCampaign(event) ?? '',
     })
   }
 
@@ -274,6 +296,7 @@ export default function BroadcastManager() {
       isCard: false,
       forceOnTv: override?.forceOnTv === true || event.meta?.forceOnTv === true,
       key: id,
+      campaign: getBroadcastTemplate(id)?.campaign ?? '',
     })
   }
 
@@ -290,6 +313,7 @@ export default function BroadcastManager() {
       isCard: false,
       forceOnTv: true,
       key: '',
+      campaign: selectedCampaign === 'all' ? '' : selectedCampaign,
     })
   }
 
@@ -357,6 +381,7 @@ export default function BroadcastManager() {
           enabled: previous?.enabled ?? true,
           forceOnTv: editor.forceOnTv || editor.level === 'critical',
           order: previous?.order ?? 0,
+          campaign: editor.campaign || undefined,
         })
       )
     } else if (editor.mode === 'new') {
@@ -372,6 +397,7 @@ export default function BroadcastManager() {
           enabled: true,
           forceOnTv: editor.forceOnTv || editor.level === 'critical',
           order: Math.max(0, ...sequenceItems.map((item) => item.order)) + 100,
+          campaign: editor.campaign || undefined,
         })
       )
     } else if (editor.mode === 'live' && editor.id) {
@@ -414,13 +440,31 @@ export default function BroadcastManager() {
         </button>
       </header>
 
+      <label className="broadcast-manager__campaign-filter">
+        Campaign filter
+        <select
+          value={selectedCampaign}
+          onChange={(event) => {
+            const campaign = event.target.value as BroadcastCampaign | 'all'
+            setSelectedCampaign(campaign)
+            const nextPhase = ALL_BROADCAST_PHASES.find(
+              (phase) => campaign === 'all' || getBroadcastTemplatesForPhase(phase).some((template) => matchesBroadcastCampaign(template, campaign))
+            )
+            if (nextPhase) setSelectedPhase(nextPhase)
+          }}
+        >
+          <option value="all">All campaigns</option>
+          {BROADCAST_CAMPAIGNS.map((campaign) => <option key={campaign} value={campaign}>{BROADCAST_CAMPAIGN_LABELS[campaign]}</option>)}
+        </select>
+      </label>
+
       <div className="broadcast-manager__layout">
         {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
         <nav className="broadcast-manager__phases" aria-label="Broadcast phases">
-          {ALL_BROADCAST_PHASES.map((phase) => {
-            const builtInCount = getBroadcastTemplatesForPhase(phase).length
-            const customCount = customMessages.filter((message) => message.phase === phase).length
-            const liveCount = game.tvFeed.filter((event) => eventPhase(event) === phase).length
+          {visiblePhases.map((phase) => {
+            const builtInCount = getBroadcastTemplatesForPhase(phase).filter((template) => matchesBroadcastCampaign(template, selectedCampaign)).length
+            const customCount = customMessages.filter((message) => message.phase === phase && (selectedCampaign === 'all' || !message.campaign || message.campaign === selectedCampaign)).length
+            const liveCount = game.tvFeed.filter((event) => eventPhase(event) === phase && (selectedCampaign === 'all' || !eventCampaign(event) || eventCampaign(event) === selectedCampaign)).length
             return (
               <button
                 key={phase}
@@ -847,6 +891,15 @@ export default function BroadcastManager() {
               </select>
             </label>
             {(editor.mode === 'new' || editor.mode === 'custom') && (
+              <>
+              <label>
+                Campaign
+                <select value={editor.campaign} onChange={(event) => setEditor({ ...editor, campaign: event.target.value as BroadcastCampaign | '' })}>
+                  <option value="">All campaigns</option>
+                  {BROADCAST_CAMPAIGNS.map((campaign) => <option key={campaign} value={campaign}>{BROADCAST_CAMPAIGN_LABELS[campaign]}</option>)}
+                </select>
+                <small>This message emits only in the selected campaign. Choose All campaigns for shared copy.</small>
+              </label>
               <label>
                 {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
                 Message key / name
@@ -877,6 +930,7 @@ export default function BroadcastManager() {
                   </small>
                 )}
               </label>
+              </>
             )}
             {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && (
               <label>

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -11,7 +11,13 @@ import {
   updateTvEvent,
 } from '../../store/gameSlice'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
-import type { BroadcastCampaign, BroadcastLevel, CustomBroadcastMessage, Phase, TvEvent } from '../../types'
+import type {
+  BroadcastCampaign,
+  BroadcastLevel,
+  CustomBroadcastMessage,
+  Phase,
+  TvEvent,
+} from '../../types'
 import { isDebugAccessGranted } from '../../utils/debugMode'
 import {
   ALL_BROADCAST_PHASES,
@@ -126,23 +132,53 @@ export default function BroadcastManager() {
   const overrides = useMemo(() => game.broadcastOverrides ?? {}, [game.broadcastOverrides])
   const customMessages = useMemo(() => game.customBroadcasts ?? [], [game.customBroadcasts])
   const templates = useMemo(
-    () => getBroadcastTemplatesForPhase(selectedPhase).filter((template) => matchesBroadcastCampaign(template, selectedCampaign)),
+    () =>
+      getBroadcastTemplatesForPhase(selectedPhase).filter((template) =>
+        matchesBroadcastCampaign(template, selectedCampaign)
+      ),
     [selectedCampaign, selectedPhase]
   )
   const phaseCustom = useMemo(
     () =>
       customMessages
         .filter((message) => message.phase === selectedPhase)
-        .filter((message) => selectedCampaign === 'all' || !message.campaign || message.campaign === selectedCampaign)
+        .filter(
+          (message) =>
+            selectedCampaign === 'all' || !message.campaign || message.campaign === selectedCampaign
+        )
         .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
     [customMessages, selectedCampaign, selectedPhase]
   )
   const liveMessages = useMemo(
-    () => game.tvFeed.filter((event) => eventPhase(event) === selectedPhase && (selectedCampaign === 'all' || !eventCampaign(event) || eventCampaign(event) === selectedCampaign)),
+    () =>
+      game.tvFeed.filter(
+        (event) =>
+          eventPhase(event) === selectedPhase &&
+          (selectedCampaign === 'all' ||
+            !eventCampaign(event) ||
+            eventCampaign(event) === selectedCampaign)
+      ),
     [game.tvFeed, selectedCampaign, selectedPhase]
   )
   const visiblePhases = useMemo(
-    () => ALL_BROADCAST_PHASES.filter((phase) => selectedCampaign === 'all' || getBroadcastTemplatesForPhase(phase).some((template) => matchesBroadcastCampaign(template, selectedCampaign)) || customMessages.some((message) => message.phase === phase && (!message.campaign || message.campaign === selectedCampaign)) || game.tvFeed.some((event) => eventPhase(event) === phase && (!eventCampaign(event) || eventCampaign(event) === selectedCampaign))),
+    () =>
+      ALL_BROADCAST_PHASES.filter(
+        (phase) =>
+          selectedCampaign === 'all' ||
+          getBroadcastTemplatesForPhase(phase).some((template) =>
+            matchesBroadcastCampaign(template, selectedCampaign)
+          ) ||
+          customMessages.some(
+            (message) =>
+              message.phase === phase &&
+              (!message.campaign || message.campaign === selectedCampaign)
+          ) ||
+          game.tvFeed.some(
+            (event) =>
+              eventPhase(event) === phase &&
+              (!eventCampaign(event) || eventCampaign(event) === selectedCampaign)
+          )
+      ),
     [customMessages, game.tvFeed, selectedCampaign]
   )
   const observedSources = useMemo(() => {
@@ -448,13 +484,21 @@ export default function BroadcastManager() {
             const campaign = event.target.value as BroadcastCampaign | 'all'
             setSelectedCampaign(campaign)
             const nextPhase = ALL_BROADCAST_PHASES.find(
-              (phase) => campaign === 'all' || getBroadcastTemplatesForPhase(phase).some((template) => matchesBroadcastCampaign(template, campaign))
+              (phase) =>
+                campaign === 'all' ||
+                getBroadcastTemplatesForPhase(phase).some((template) =>
+                  matchesBroadcastCampaign(template, campaign)
+                )
             )
             if (nextPhase) setSelectedPhase(nextPhase)
           }}
         >
           <option value="all">All campaigns</option>
-          {BROADCAST_CAMPAIGNS.map((campaign) => <option key={campaign} value={campaign}>{BROADCAST_CAMPAIGN_LABELS[campaign]}</option>)}
+          {BROADCAST_CAMPAIGNS.map((campaign) => (
+            <option key={campaign} value={campaign}>
+              {BROADCAST_CAMPAIGN_LABELS[campaign]}
+            </option>
+          ))}
         </select>
       </label>
 
@@ -462,9 +506,23 @@ export default function BroadcastManager() {
         {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
         <nav className="broadcast-manager__phases" aria-label="Broadcast phases">
           {visiblePhases.map((phase) => {
-            const builtInCount = getBroadcastTemplatesForPhase(phase).filter((template) => matchesBroadcastCampaign(template, selectedCampaign)).length
-            const customCount = customMessages.filter((message) => message.phase === phase && (selectedCampaign === 'all' || !message.campaign || message.campaign === selectedCampaign)).length
-            const liveCount = game.tvFeed.filter((event) => eventPhase(event) === phase && (selectedCampaign === 'all' || !eventCampaign(event) || eventCampaign(event) === selectedCampaign)).length
+            const builtInCount = getBroadcastTemplatesForPhase(phase).filter((template) =>
+              matchesBroadcastCampaign(template, selectedCampaign)
+            ).length
+            const customCount = customMessages.filter(
+              (message) =>
+                message.phase === phase &&
+                (selectedCampaign === 'all' ||
+                  !message.campaign ||
+                  message.campaign === selectedCampaign)
+            ).length
+            const liveCount = game.tvFeed.filter(
+              (event) =>
+                eventPhase(event) === phase &&
+                (selectedCampaign === 'all' ||
+                  !eventCampaign(event) ||
+                  eventCampaign(event) === selectedCampaign)
+            ).length
             return (
               <button
                 key={phase}
@@ -892,44 +950,60 @@ export default function BroadcastManager() {
             </label>
             {(editor.mode === 'new' || editor.mode === 'custom') && (
               <>
-              <label>
-                Campaign
-                <select value={editor.campaign} onChange={(event) => setEditor({ ...editor, campaign: event.target.value as BroadcastCampaign | '' })}>
-                  <option value="">All campaigns</option>
-                  {BROADCAST_CAMPAIGNS.map((campaign) => <option key={campaign} value={campaign}>{BROADCAST_CAMPAIGN_LABELS[campaign]}</option>)}
-                </select>
-                <small>This message emits only in the selected campaign. Choose All campaigns for shared copy.</small>
-              </label>
-              <label>
-                {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
-                Message key / name
-                <input
-                  value={editor.key}
-                  placeholder={MESSAGE_KEY_PLACEHOLDER}
-                  onChange={(event) => setEditor({ ...editor, key: event.target.value })}
-                />
-                <small>
+                <label>
+                  Campaign
+                  <select
+                    value={editor.campaign}
+                    onChange={(event) =>
+                      setEditor({
+                        ...editor,
+                        campaign: event.target.value as BroadcastCampaign | '',
+                      })
+                    }
+                  >
+                    <option value="">All campaigns</option>
+                    {BROADCAST_CAMPAIGNS.map((campaign) => (
+                      <option key={campaign} value={campaign}>
+                        {BROADCAST_CAMPAIGN_LABELS[campaign]}
+                      </option>
+                    ))}
+                  </select>
+                  <small>
+                    This message emits only in the selected campaign. Choose All campaigns for
+                    shared copy.
+                  </small>
+                </label>
+                <label>
                   {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
-                  Use a readable stable key such as <code>social.alliance-warning</code>. Spaces are
-                  converted to dashes; a key without a prefix becomes <code>custom.your-key</code>.
-                </small>
-                {!normalizeMessageKey(editor.key) && (
-                  <small className="broadcast-manager__field-error">
+                  Message key / name
+                  <input
+                    value={editor.key}
+                    placeholder={MESSAGE_KEY_PLACEHOLDER}
+                    onChange={(event) => setEditor({ ...editor, key: event.target.value })}
+                  />
+                  <small>
                     {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
-                    A message key is required.
+                    Use a readable stable key such as <code>social.alliance-warning</code>. Spaces
+                    are converted to dashes; a key without a prefix becomes{' '}
+                    <code>custom.your-key</code>.
                   </small>
-                )}
-                {customMessages.some(
-                  (message) =>
-                    message.id !== editor.id &&
-                    (message.key ?? '') === normalizeMessageKey(editor.key)
-                ) && (
-                  <small className="broadcast-manager__field-error">
-                    {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
-                    That key is already in use.
-                  </small>
-                )}
-              </label>
+                  {!normalizeMessageKey(editor.key) && (
+                    <small className="broadcast-manager__field-error">
+                      {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                      A message key is required.
+                    </small>
+                  )}
+                  {customMessages.some(
+                    (message) =>
+                      message.id !== editor.id &&
+                      (message.key ?? '') === normalizeMessageKey(editor.key)
+                  ) && (
+                    <small className="broadcast-manager__field-error">
+                      {/* i18n-ignore: Debug-only authoring tool intentionally uses canonical English labels */}
+                      That key is already in use.
+                    </small>
+                  )}
+                </label>
               </>
             )}
             {(editor.isCard || editor.forceOnTv || editor.level !== 'minor') && (

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -494,7 +494,13 @@ export function createInitialGameState(options?: {
     ]
   })
   const seasonStartCustom = broadcastConfig.customMessages
-    .filter((message) => message.enabled && message.phase === 'season_start' && (!message.campaign || message.campaign === initialBroadcastCampaign) && message.text.trim())
+    .filter(
+      (message) =>
+        message.enabled &&
+        message.phase === 'season_start' &&
+        (!message.campaign || message.campaign === initialBroadcastCampaign) &&
+        message.text.trim()
+    )
     .map((message) => ({
       id: message.id,
       order: message.order ?? 10000,
@@ -686,8 +692,18 @@ function inferObservedBroadcastSource(state: GameState, phase: Phase, text: stri
 
 function currentBroadcastCampaign(state: GameState): BroadcastCampaign {
   if (state.mode === 'survival') return 'survival'
-  if (state.cupidArrow?.status === 'scheduled' || state.cupidArrow?.status === 'active' || state.expansionMode === 'cupidArrow') return 'cupid'
-  if (state.voxPopuli?.status === 'scheduled' || state.voxPopuli?.status === 'active' || state.expansionMode === 'voxPopuli') return 'vox_populi'
+  if (
+    state.cupidArrow?.status === 'scheduled' ||
+    state.cupidArrow?.status === 'active' ||
+    state.expansionMode === 'cupidArrow'
+  )
+    return 'cupid'
+  if (
+    state.voxPopuli?.status === 'scheduled' ||
+    state.voxPopuli?.status === 'active' ||
+    state.expansionMode === 'voxPopuli'
+  )
+    return 'vox_populi'
   return 'classic'
 }
 
@@ -1089,7 +1105,11 @@ function activateCupidArrowForSeason(state: GameState) {
     state,
     `🏹 The lights soften. A golden arrow crosses the house, splitting into eight trails of light. Cupid has chosen: ${pairNames}. From this moment, every victory, every danger, every vote, and every exit belongs to the pair. 💘`,
     'twist',
-    { major: 'cupid_arrow', broadcastTemplateId: 'cupid.activation', phase: 'loh_comp_announcement' }
+    {
+      major: 'cupid_arrow',
+      broadcastTemplateId: 'cupid.activation',
+      phase: 'loh_comp_announcement',
+    }
   )
 }
 
@@ -1137,7 +1157,11 @@ function breakCupidArrowSpell(state: GameState) {
     state,
     `💔 Four pairs have fallen. Cracks race through Cupid's hearts, the final arrow dissolves into light, and Cupid takes flight from The Big Eye house. The rose glow fades: every survivor now plays alone. What the pairs felt—and what they did to each other—remains.`,
     'twist',
-    { major: 'cupid_arrow_broken', broadcastTemplateId: 'cupid.spell-broken', phase: 'eviction_results' }
+    {
+      major: 'cupid_arrow_broken',
+      broadcastTemplateId: 'cupid.spell-broken',
+      phase: 'eviction_results',
+    }
   )
 }
 
@@ -1920,10 +1944,10 @@ function beginPhaseBroadcastSequence(state: GameState, phase: Phase) {
   _pendingPhaseCustoms = (state.customBroadcasts ?? [])
     .filter(
       (custom) =>
-      custom.enabled &&
-      custom.phase === phase &&
-      (!custom.campaign || custom.campaign === currentBroadcastCampaign(state)) &&
-      custom.text.trim() &&
+        custom.enabled &&
+        custom.phase === phase &&
+        (!custom.campaign || custom.campaign === currentBroadcastCampaign(state)) &&
+        custom.text.trim() &&
         !state.tvFeed.some(
           (event) => event.meta?.week === state.week && event.meta?.customBroadcastId === custom.id
         )
@@ -4511,10 +4535,23 @@ const gameSlice = createSlice({
       state.pendingEviction = null
       state.dayStartShock = null
 
-      const cupidEvictionTemplateId = msg.includes("Cupid's Arrow means you are eliminated together")
-        ? (msg.includes(' breaks the tie. ') ? 'cupid.pair-tiebreak-eviction' : 'cupid.pair-eviction')
-        : wasCupidPartnerFollowup ? 'cupid.partner-eviction' : undefined
-      pushEvent(state, msg, 'game', cupidEvictionTemplateId ? { broadcastTemplateId: cupidEvictionTemplateId, phase: 'eviction_results' } : undefined)
+      const cupidEvictionTemplateId = msg.includes(
+        "Cupid's Arrow means you are eliminated together"
+      )
+        ? msg.includes(' breaks the tie. ')
+          ? 'cupid.pair-tiebreak-eviction'
+          : 'cupid.pair-eviction'
+        : wasCupidPartnerFollowup
+          ? 'cupid.partner-eviction'
+          : undefined
+      pushEvent(
+        state,
+        msg,
+        'game',
+        cupidEvictionTemplateId
+          ? { broadcastTemplateId: cupidEvictionTemplateId, phase: 'eviction_results' }
+          : undefined
+      )
 
       if (
         cupidPartner &&
@@ -4660,7 +4697,9 @@ const gameSlice = createSlice({
           ? `${player.name} has chosen to self-evict. Cupid's Arrow also eliminates ${partner}. 🚪💔`
           : `${player.name} has chosen to self-evict from The Big Eye house. 🚪`,
         'game',
-        partner ? { broadcastTemplateId: 'cupid.self-eviction-pair', phase: 'eviction_results' } : undefined
+        partner
+          ? { broadcastTemplateId: 'cupid.self-eviction-pair', phase: 'eviction_results' }
+          : undefined
       )
     },
 

--- a/src/store/gameSlice.ts
+++ b/src/store/gameSlice.ts
@@ -16,6 +16,7 @@ import type {
   SpecialVetoType,
   ForcedShockType,
   BroadcastOverride,
+  BroadcastCampaign,
   BroadcastLevel,
   CustomBroadcastMessage,
 } from '../types'
@@ -448,6 +449,11 @@ export function createInitialGameState(options?: {
     isDev: import.meta.env.DEV,
     hasSpecialAccess: canAccessSpecialSettings(),
   })
+  const initialBroadcastCampaign: BroadcastCampaign = cupidArrowIsScheduled
+    ? 'cupid'
+    : voxPopuliIsScheduled
+      ? 'vox_populi'
+      : 'classic'
 
   // Season-opening broadcasts are built from the same persistent registry as
   // every later phase. This makes edits, disabling, and mixed built-in/custom
@@ -488,7 +494,7 @@ export function createInitialGameState(options?: {
     ]
   })
   const seasonStartCustom = broadcastConfig.customMessages
-    .filter((message) => message.enabled && message.phase === 'season_start' && message.text.trim())
+    .filter((message) => message.enabled && message.phase === 'season_start' && (!message.campaign || message.campaign === initialBroadcastCampaign) && message.text.trim())
     .map((message) => ({
       id: message.id,
       order: message.order ?? 10000,
@@ -676,6 +682,13 @@ function inferObservedBroadcastSource(state: GameState, phase: Phase, text: stri
   })
   const sourceHash = (hashString(`${phase}|${sourceText}`) >>> 0).toString(36)
   return { id: `observed.${phase}.${sourceHash}`, sourceText, variables }
+}
+
+function currentBroadcastCampaign(state: GameState): BroadcastCampaign {
+  if (state.mode === 'survival') return 'survival'
+  if (state.cupidArrow?.status === 'scheduled' || state.cupidArrow?.status === 'active' || state.expansionMode === 'cupidArrow') return 'cupid'
+  if (state.voxPopuli?.status === 'scheduled' || state.voxPopuli?.status === 'active' || state.expansionMode === 'voxPopuli') return 'vox_populi'
+  return 'classic'
 }
 
 function buildTvMeta(
@@ -1076,7 +1089,7 @@ function activateCupidArrowForSeason(state: GameState) {
     state,
     `🏹 The lights soften. A golden arrow crosses the house, splitting into eight trails of light. Cupid has chosen: ${pairNames}. From this moment, every victory, every danger, every vote, and every exit belongs to the pair. 💘`,
     'twist',
-    { major: 'cupid_arrow' }
+    { major: 'cupid_arrow', broadcastTemplateId: 'cupid.activation', phase: 'loh_comp_announcement' }
   )
 }
 
@@ -1124,7 +1137,7 @@ function breakCupidArrowSpell(state: GameState) {
     state,
     `💔 Four pairs have fallen. Cracks race through Cupid's hearts, the final arrow dissolves into light, and Cupid takes flight from The Big Eye house. The rose glow fades: every survivor now plays alone. What the pairs felt—and what they did to each other—remains.`,
     'twist',
-    { major: 'cupid_arrow_broken' }
+    { major: 'cupid_arrow_broken', broadcastTemplateId: 'cupid.spell-broken', phase: 'eviction_results' }
   )
 }
 
@@ -1214,7 +1227,8 @@ function resolveCupidPairEviction(state: GameState): boolean {
     pushEvent(
       state,
       `The nominated pairs are tied. ${tieBreaker.name}, your LOH pair must decide which pair leaves. 🗳️`,
-      'game'
+      'game',
+      { broadcastTemplateId: 'cupid.pair-tiebreak-prompt', phase: 'eviction_results' }
     )
     return true
   }
@@ -1906,9 +1920,10 @@ function beginPhaseBroadcastSequence(state: GameState, phase: Phase) {
   _pendingPhaseCustoms = (state.customBroadcasts ?? [])
     .filter(
       (custom) =>
-        custom.enabled &&
-        custom.phase === phase &&
-        custom.text.trim() &&
+      custom.enabled &&
+      custom.phase === phase &&
+      (!custom.campaign || custom.campaign === currentBroadcastCampaign(state)) &&
+      custom.text.trim() &&
         !state.tvFeed.some(
           (event) => event.meta?.week === state.week && event.meta?.customBroadcastId === custom.id
         )
@@ -4496,7 +4511,10 @@ const gameSlice = createSlice({
       state.pendingEviction = null
       state.dayStartShock = null
 
-      pushEvent(state, msg, 'game')
+      const cupidEvictionTemplateId = msg.includes("Cupid's Arrow means you are eliminated together")
+        ? (msg.includes(' breaks the tie. ') ? 'cupid.pair-tiebreak-eviction' : 'cupid.pair-eviction')
+        : wasCupidPartnerFollowup ? 'cupid.partner-eviction' : undefined
+      pushEvent(state, msg, 'game', cupidEvictionTemplateId ? { broadcastTemplateId: cupidEvictionTemplateId, phase: 'eviction_results' } : undefined)
 
       if (
         cupidPartner &&
@@ -4641,7 +4659,8 @@ const gameSlice = createSlice({
         partner
           ? `${player.name} has chosen to self-evict. Cupid's Arrow also eliminates ${partner}. 🚪💔`
           : `${player.name} has chosen to self-evict from The Big Eye house. 🚪`,
-        'game'
+        'game',
+        partner ? { broadcastTemplateId: 'cupid.self-eviction-pair', phase: 'eviction_results' } : undefined
       )
     },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,6 +237,9 @@ export interface TvEvent {
 
 export type BroadcastLevel = 'minor' | 'major' | 'critical'
 
+/** Campaign filter used by the Broadcast Manager. Undefined means shared by every campaign. */
+export type BroadcastCampaign = 'classic' | 'survival' | 'cupid' | 'vox_populi'
+
 /** Per-save changes to a built-in broadcast definition. */
 export interface BroadcastOverride {
   text?: string
@@ -257,6 +260,8 @@ export interface CustomBroadcastMessage {
   /** Human-readable authoring key shown in the manager and emitted metadata. */
   key?: string
   phase: Phase
+  /** Limit this authored message to one campaign. Omit it to use the message everywhere. */
+  campaign?: BroadcastCampaign
   text: string
   title?: string
   type: TvEvent['type']


### PR DESCRIPTION
## What changed
- Adds campaign filtering for Classic, Surveyeval, Cupid's Arrow, and Vox Populi.
- Lets custom broadcast messages be campaign-specific or shared.
- Registers Cupid and Surveyeval broadcasts as named, editable manager sources.
- Removes the duplicate hard-coded Cupid ending overlay so the manager controls it.

## Why
Broadcast Manager v1 did not fully cover Surveyeval or all Cupid branches, and managing campaign-specific copy was difficult in a mixed registry.

## Validation
- ESLint passes.
- Typecheck currently reaches an unrelated existing error in src/store/settingsSlice.ts involving SocialActionOverrides draft typing.