### PR TITLE
Add central remote manager and GitHub Pages live config

### DIFF
--- a/docs/remote-manager-guide.md
+++ b/docs/remote-manager-guide.md
@@ -1,0 +1,69 @@
+# Remote Manager operator guide
+
+The game reads its live configuration from:
+
+`https://georgi-cole.github.io/bbmobilenew/config/live-config.json`
+
+Released clients check at startup and refresh every five minutes. If the file is temporarily unavailable, the last valid cached configuration is used; bundled defaults remain the final fallback.
+
+## Open the control panel
+
+1. Open the deployed game with `#/remote-manager?debug=1&qa=1` at the end of its URL.
+2. The first successful QA visit remembers access on that browser. You can also open **Remote Manager** from the QA Control Center afterward.
+3. The panel loads the currently published JSON. Changes made in the form are only a local draft until you publish them.
+
+## One-time GitHub setup
+
+Create a fine-grained personal access token in GitHub, restricted to the `georgi-cole/bbmobilenew` repository.
+
+- Repository permission **Contents: Read and write** is required to update the JSON file.
+- Repository permission **Pull requests: Read and write** is required for the recommended review-PR flow.
+- Give the token a short expiration and revoke it if it is ever shared.
+
+Paste the token into the Publish tab when needed. The panel keeps it only in the current browser tab and never saves it in the repository, JSON, or local storage.
+
+## Common operations
+
+### Send a message to everyone
+
+1. Open **Broadcast**.
+2. Enable “Show this message to all players.”
+3. Enter a title and message; choose Critical only for urgent notices.
+4. Optionally schedule start and end times.
+5. Open **Publish** and choose **Create review PR**.
+6. Review and merge the PR on GitHub. GitHub Pages deploys the new file, and active clients pick it up within about five minutes.
+7. To remove the message, disable it and publish again.
+
+### Replace a music track
+
+1. Host the audio at a public HTTPS URL that permits browser playback.
+2. Open **Music**, choose **Add track override**, select the semantic game track, and paste the URL.
+3. Set volume between 0 and 1 and publish.
+4. Remove the override and publish again to return to the bundled track.
+
+### Schedule a competition
+
+1. Open **Game**, enable remote competition rules, and add a rule.
+2. Choose whether it matches a day or remaining-player count, and whether it applies to LOH, POS, or either.
+3. Choose a random game, category, or exact game.
+4. Leave the winner on “Play normally,” choose a random winner, or enter an exact player ID.
+5. Use priority when multiple rules can match; higher numbers win.
+6. Publish. Protected twist rules and participant eligibility still take precedence.
+
+### Tune Social/Drama energy
+
+1. Open **Social**.
+2. Change weekly energy or caps for normal and drama modes.
+3. Update the revision note so the change is easy to identify.
+4. Publish. Existing games use the refreshed settings when the runtime reads the social configuration.
+
+## Publishing choices
+
+- **Create review PR** is recommended. It creates a branch and PR, and nothing goes live until that PR is merged.
+- **Publish directly to main** is for urgent changes. It commits immediately and starts the normal GitHub Pages deployment.
+
+Publishing is not instant: wait for the Pages workflow to finish, then allow up to five minutes for an already-open game to refresh. A newly opened game fetches the current file immediately.
+
+## Advanced JSON
+
+The Advanced JSON tab supports the complete validated remote schema, including detailed music assignments, social text/policies, themes, player presentation overrides, and rollout controls. **Validate and apply JSON** removes unknown or unsafe fields before publishing. No remote field is executed as code.

--- a/public/config/live-config.json
+++ b/public/config/live-config.json
@@ -1,0 +1,33 @@
+{
+  "broadcast": {
+    "enabled": false,
+    "title": "Big Brother Update",
+    "message": "",
+    "priority": "normal"
+  },
+  "season": {
+    "music": {
+      "tracks": []
+    }
+  },
+  "gameManager": {
+    "enabled": false,
+    "rules": []
+  },
+  "social": {
+    "schemaVersion": 1,
+    "revision": "remote-1",
+    "economy": {
+      "normal": {
+        "weeklyEnergy": 5,
+        "energyCap": 5
+      },
+      "drama": {
+        "weeklyEnergy": 10,
+        "energyCap": 30
+      },
+      "influenceCap": 10000,
+      "infoCap": 10000
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,46 +8,60 @@
  *
  * To add global providers (auth, theme, etc.) wrap them here.
  */
-import { useEffect, useState } from 'react';
-import { Provider } from 'react-redux';
-import { RouterProvider } from 'react-router/dom';
-import { store } from './store/store';
-import { router } from './routes';
-import { SoundManager } from './services/sound/SoundManager';
-import AudioStateSync from './services/sound/AudioStateSync';
-import AudioGate from './components/AudioGate/AudioGate';
-import { loadRemoteConfig } from './remoteConfig/remoteConfigSlice';
-import { installGameDiagnostics } from './services/diagnostics/gameDiagnostics';
-import LiveOpsController from './components/LiveOpsController/LiveOpsController';
-import VipEntitlementSync from './components/VipEntitlementSync/VipEntitlementSync';
-import { I18nProvider } from './i18n';
+import { useEffect, useState } from 'react'
+import { Provider } from 'react-redux'
+import { RouterProvider } from 'react-router/dom'
+import { store } from './store/store'
+import { router } from './routes'
+import { SoundManager } from './services/sound/SoundManager'
+import AudioStateSync from './services/sound/AudioStateSync'
+import AudioGate from './components/AudioGate/AudioGate'
+import { loadRemoteConfig } from './remoteConfig/remoteConfigSlice'
+import { installGameDiagnostics } from './services/diagnostics/gameDiagnostics'
+import LiveOpsController from './components/LiveOpsController/LiveOpsController'
+import VipEntitlementSync from './components/VipEntitlementSync/VipEntitlementSync'
+import { I18nProvider } from './i18n'
 
 if (import.meta.env.DEV) {
-  console.log('[router] bundle:', import.meta.url, '| pathname:', window.location.pathname, '| hash:', window.location.hash);
+  console.log(
+    '[router] bundle:',
+    import.meta.url,
+    '| pathname:',
+    window.location.pathname,
+    '| hash:',
+    window.location.hash
+  )
 }
 
 /** Returns true when a route owns its own full-screen audio/visual experience. */
 function suppressesAudioGate(hash: string): boolean {
-  return hash === '' || hash === '#' || hash === '#/' || hash.startsWith('#/cinematic');
+  return hash === '' || hash === '#' || hash === '#/' || hash.startsWith('#/cinematic')
 }
 
 export default function App() {
   // Track hash so we can hide AudioGate on the Intro/Home route — audio is
   // unlocked there via the Play gesture in HomeHub instead.
-  const [hash, setHash] = useState(window.location.hash);
+  const [hash, setHash] = useState(window.location.hash)
 
   useEffect(() => {
-    const onHashChange = () => setHash(window.location.hash);
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, []);
+    const onHashChange = () => setHash(window.location.hash)
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
 
   useEffect(() => {
-    installGameDiagnostics();
-    void SoundManager.init();
+    installGameDiagnostics()
+    void SoundManager.init()
     // Fetch the remote live-config on startup; falls back to cache or defaults.
-    void store.dispatch(loadRemoteConfig());
-  }, []);
+    void store.dispatch(loadRemoteConfig())
+    const refreshId = window.setInterval(
+      () => {
+        void store.dispatch(loadRemoteConfig())
+      },
+      5 * 60 * 1000
+    )
+    return () => window.clearInterval(refreshId)
+  }, [])
 
   return (
     <Provider store={store}>
@@ -61,5 +75,5 @@ export default function App() {
         <RouterProvider router={router} />
       </I18nProvider>
     </Provider>
-  );
+  )
 }

--- a/src/components/DebugPanel/DebugPanel.tsx
+++ b/src/components/DebugPanel/DebugPanel.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import {
   advance,
   setPhase,
@@ -26,32 +26,29 @@ import {
   breakCupidArrowNow,
   activateVoxPopuliNow,
   setVoxPopuliSchedule,
-} from '../../store/gameSlice';
-import { DEFAULT_SETTINGS, setSim } from '../../store/settingsSlice';
+} from '../../store/gameSlice'
+import { DEFAULT_SETTINGS, setSim } from '../../store/settingsSlice'
 import {
   clearIncomingInteractionLogs,
   pushIncomingInteraction,
   scheduleIncomingInteraction,
   selectIncomingInteractionLogs,
   updateSocialMemory,
-} from '../../social/socialSlice';
-import { autoResolveExpiredIncomingInteractionsForWeek } from '../../social/incomingInteractions';
-import { getIncomingInteractionPriority } from '../../social/incomingInteractionScheduler';
-import { INCOMING_INTERACTION_PHASE_ORDER } from '../../social/incomingInteractionPhases';
-import { socialConfig } from '../../social/socialConfig';
-import FinaleDebugControls from './FinaleControls.debug';
-import MinigameDebugControls from './MinigameDebugControls';
-import SurvivorDebugControls from './SurvivorDebugControls';
-import DebugDiagnostics from './DebugDiagnostics';
-import SimulationDebugControls from './SimulationDebugControls';
-import { isDebugAccessGranted, persistDebugAccess } from '../../utils/debugMode';
-import type { ForcedShockType, Phase } from '../../types';
-import type { IncomingInteraction, IncomingInteractionType } from '../../social/types';
-import {
-  selectDebugExpansionUnlocks,
-  setDebugExpansionUnlock,
-} from '../../store/uiSlice';
-import './DebugPanel.css';
+} from '../../social/socialSlice'
+import { autoResolveExpiredIncomingInteractionsForWeek } from '../../social/incomingInteractions'
+import { getIncomingInteractionPriority } from '../../social/incomingInteractionScheduler'
+import { INCOMING_INTERACTION_PHASE_ORDER } from '../../social/incomingInteractionPhases'
+import { socialConfig } from '../../social/socialConfig'
+import FinaleDebugControls from './FinaleControls.debug'
+import MinigameDebugControls from './MinigameDebugControls'
+import SurvivorDebugControls from './SurvivorDebugControls'
+import DebugDiagnostics from './DebugDiagnostics'
+import SimulationDebugControls from './SimulationDebugControls'
+import { isDebugAccessGranted, persistDebugAccess } from '../../utils/debugMode'
+import type { ForcedShockType, Phase } from '../../types'
+import type { IncomingInteraction, IncomingInteractionType } from '../../social/types'
+import { selectDebugExpansionUnlocks, setDebugExpansionUnlock } from '../../store/uiSlice'
+import './DebugPanel.css'
 
 const PHASES: Phase[] = [
   'season_start',
@@ -80,7 +77,7 @@ const PHASES: Phase[] = [
   'jury_announcement',
   'jury_cinematic',
   'jury',
-];
+]
 
 const INCOMING_TYPES: IncomingInteractionType[] = [
   'compliment',
@@ -92,7 +89,7 @@ const INCOMING_TYPES: IncomingInteractionType[] = [
   'check_in',
   'snide_remark',
   'other',
-];
+]
 
 const INCOMING_TEXT: Record<IncomingInteractionType, string[]> = {
   compliment: ['Your speech was iconic tonight.', 'You handled that ceremony like a pro.'],
@@ -107,9 +104,9 @@ const INCOMING_TEXT: Record<IncomingInteractionType, string[]> = {
   check_in: ['How are you feeling about the week?', 'Checking in — you okay?'],
   snide_remark: ['Nice move… if it actually works.', 'Bold choice. Hope it pays off.'],
   other: ['We need to talk later.', 'Just wanted to say hey.'],
-};
+}
 
-const INCOMING_BATCH_SIZE = 6;
+const INCOMING_BATCH_SIZE = 6
 const FORCED_SHOCK_OPTIONS: Array<{ value: ForcedShockType; label: string }> = [
   { value: 'doubleEviction', label: 'Double Elimination' },
   { value: 'dayStartShock', label: 'Morning Shock' },
@@ -120,16 +117,16 @@ const FORCED_SHOCK_OPTIONS: Array<{ value: ForcedShockType; label: string }> = [
   { value: 'spotlight', label: 'Force Majeure Safety' },
   { value: 'democracia', label: 'Democracia' },
   { value: 'twinShock', label: 'Twin Shock' },
-];
+]
 
-let incomingSeedCounter = 0;
+let incomingSeedCounter = 0
 
 function pickRandom<T>(list: readonly T[]): T {
-  return list[Math.floor(Math.random() * list.length)];
+  return list[Math.floor(Math.random() * list.length)]
 }
 
 function interactionRequiresResponse(type: IncomingInteractionType): boolean {
-  return type === 'alliance_proposal' || type === 'deal_offer' || type === 'nomination_plea';
+  return type === 'alliance_proposal' || type === 'deal_offer' || type === 'nomination_plea'
 }
 
 function buildIncomingInteraction(
@@ -137,11 +134,11 @@ function buildIncomingInteraction(
   week: number,
   overrides: { type?: IncomingInteractionType; expiresAtWeek?: number } = {}
 ): IncomingInteraction {
-  const type = overrides.type ?? pickRandom(INCOMING_TYPES);
-  const text = pickRandom(INCOMING_TEXT[type]);
-  const now = Date.now();
-  const canUseUuid = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function';
-  const id = canUseUuid ? crypto.randomUUID() : `incoming-${now}-${incomingSeedCounter++}`;
+  const type = overrides.type ?? pickRandom(INCOMING_TYPES)
+  const text = pickRandom(INCOMING_TEXT[type])
+  const now = Date.now()
+  const canUseUuid = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+  const id = canUseUuid ? crypto.randomUUID() : `incoming-${now}-${incomingSeedCounter++}`
   return {
     id,
     fromId,
@@ -153,7 +150,7 @@ function buildIncomingInteraction(
     read: false,
     requiresResponse: interactionRequiresResponse(type),
     resolved: false,
-  };
+  }
 }
 
 function buildScheduledInteraction(
@@ -162,7 +159,7 @@ function buildScheduledInteraction(
   phase: string,
   type: IncomingInteractionType
 ) {
-  const interaction = buildIncomingInteraction(fromId, week, { type, expiresAtWeek: week + 1 });
+  const interaction = buildIncomingInteraction(fromId, week, { type, expiresAtWeek: week + 1 })
   return {
     interaction,
     priority: getIncomingInteractionPriority(type),
@@ -170,118 +167,118 @@ function buildScheduledInteraction(
     scheduledForWeek: week,
     scheduledForPhase: phase,
     deliveryReason: 'debug_seed',
-  };
+  }
 }
 
 export default function DebugPanel() {
-  const [searchParams] = useSearchParams();
-  const isE2E = (window as { __E2E__?: boolean }).__E2E__ === true;
-  const isDebug = isE2E || isDebugAccessGranted(searchParams, window.location.hostname);
+  const [searchParams] = useSearchParams()
+  const isE2E = (window as { __E2E__?: boolean }).__E2E__ === true
+  const isDebug = isE2E || isDebugAccessGranted(searchParams, window.location.hostname)
 
   useEffect(() => {
     if (searchParams.get('debug') === '1' && searchParams.get('qa') === '1') {
-      persistDebugAccess();
+      persistDebugAccess()
     }
-  }, [searchParams]);
+  }, [searchParams])
 
-  if (!isDebug) return null;
+  if (!isDebug) return null
 
-  return <DebugPanelContent searchParams={searchParams} />;
+  return <DebugPanelContent searchParams={searchParams} />
 }
 
 function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) {
-  const navigate = useNavigate();
-  const dispatch = useAppDispatch();
-  const game = useAppSelector((s) => s.game);
-  const settings = useAppSelector((s) => s.settings ?? DEFAULT_SETTINGS);
-  const incomingLogs = useAppSelector(selectIncomingInteractionLogs);
-  const debugExpansionUnlocks = useAppSelector(selectDebugExpansionUnlocks);
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const game = useAppSelector((s) => s.game)
+  const settings = useAppSelector((s) => s.settings ?? DEFAULT_SETTINGS)
+  const incomingLogs = useAppSelector(selectIncomingInteractionLogs)
+  const debugExpansionUnlocks = useAppSelector(selectDebugExpansionUnlocks)
 
-  const [isOpen, setIsOpen] = useState(true);
-  const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase);
-  const [selectedHoH, setSelectedHoH] = useState('');
-  const [nominee1, setNominee1] = useState('');
-  const [nominee2, setNominee2] = useState('');
-  const [selectedPov, setSelectedPov] = useState('');
-  const [selectedStatusPlayer, setSelectedStatusPlayer] = useState('');
-  const [selectedF4Evictee, setSelectedF4Evictee] = useState('');
-  const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction');
+  const [isOpen, setIsOpen] = useState(true)
+  const [selectedPhase, setSelectedPhase] = useState<Phase>(game.phase)
+  const [selectedHoH, setSelectedHoH] = useState('')
+  const [nominee1, setNominee1] = useState('')
+  const [nominee2, setNominee2] = useState('')
+  const [selectedPov, setSelectedPov] = useState('')
+  const [selectedStatusPlayer, setSelectedStatusPlayer] = useState('')
+  const [selectedF4Evictee, setSelectedF4Evictee] = useState('')
+  const [selectedForcedShock, setSelectedForcedShock] = useState<ForcedShockType>('doubleEviction')
   const [cupidSeasonInput, setCupidSeasonInput] = useState(
     settings.sim.cupidArrowSeasonOverride?.toString() ?? ''
-  );
+  )
   const [voxSeasonInput, setVoxSeasonInput] = useState(
     settings.sim.voxPopuliSeasonOverride?.toString() ?? ''
-  );
+  )
 
   useEffect(() => {
     const handleShortcut = (event: KeyboardEvent) => {
       if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 'd') {
-        event.preventDefault();
-        setIsOpen((open) => !open);
+        event.preventDefault()
+        setIsOpen((open) => !open)
       }
-    };
-    window.addEventListener('keydown', handleShortcut);
-    return () => window.removeEventListener('keydown', handleShortcut);
-  }, []);
+    }
+    window.addEventListener('keydown', handleShortcut)
+    return () => window.removeEventListener('keydown', handleShortcut)
+  }, [])
 
   const jumpToSection = (sectionId: string) => {
-    document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  };
+    document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 
-  const alive = game.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury');
-  const evicted = game.players.filter((p) => p.status === 'evicted' || p.status === 'jury');
-  const humanPlayer = game.players.find((p) => p.isUser);
-  const aiPlayers = alive.filter((p) => !p.isUser);
+  const alive = game.players.filter((p) => p.status !== 'evicted' && p.status !== 'jury')
+  const evicted = game.players.filter((p) => p.status === 'evicted' || p.status === 'jury')
+  const humanPlayer = game.players.find((p) => p.isUser)
+  const aiPlayers = alive.filter((p) => !p.isUser)
 
   const hohName = game.lohId
     ? (game.players.find((p) => p.id === game.lohId)?.name ?? game.lohId)
-    : '—';
+    : '—'
   const povName = game.posWinnerId
     ? (game.players.find((p) => p.id === game.posWinnerId)?.name ?? game.posWinnerId)
-    : '—';
+    : '—'
   const nomineeNames = game.nomineeIds.length
     ? game.nomineeIds.map((id) => game.players.find((p) => p.id === id)?.name ?? id).join(', ')
-    : '—';
+    : '—'
 
   // Players eligible to be evicted in Final4 (current nominees)
-  const f4Nominees = game.players.filter((p) => game.nomineeIds.includes(p.id));
-  const canSeedInteraction = aiPlayers.length > 0 && !!humanPlayer;
-  const memoryCaps = socialConfig.socialMemoryConfig.caps;
+  const f4Nominees = game.players.filter((p) => game.nomineeIds.includes(p.id))
+  const canSeedInteraction = aiPlayers.length > 0 && !!humanPlayer
+  const memoryCaps = socialConfig.socialMemoryConfig.caps
 
   function handleSeedIncomingInteraction() {
-    if (!canSeedInteraction || !humanPlayer) return;
-    const fromPlayer = pickRandom(aiPlayers);
-    dispatch(pushIncomingInteraction(buildIncomingInteraction(fromPlayer.id, game.week)));
+    if (!canSeedInteraction || !humanPlayer) return
+    const fromPlayer = pickRandom(aiPlayers)
+    dispatch(pushIncomingInteraction(buildIncomingInteraction(fromPlayer.id, game.week)))
   }
 
   function handleSeedIncomingBatch() {
-    if (!canSeedInteraction || !humanPlayer) return;
-    const batchSize = Math.min(INCOMING_BATCH_SIZE, aiPlayers.length * 2);
+    if (!canSeedInteraction || !humanPlayer) return
+    const batchSize = Math.min(INCOMING_BATCH_SIZE, aiPlayers.length * 2)
     for (let i = 0; i < batchSize; i += 1) {
-      const fromPlayer = pickRandom(aiPlayers);
-      dispatch(pushIncomingInteraction(buildIncomingInteraction(fromPlayer.id, game.week)));
+      const fromPlayer = pickRandom(aiPlayers)
+      dispatch(pushIncomingInteraction(buildIncomingInteraction(fromPlayer.id, game.week)))
     }
   }
 
   function handleScheduleBusyWeek() {
-    if (!canSeedInteraction || !humanPlayer) return;
+    if (!canSeedInteraction || !humanPlayer) return
     INCOMING_INTERACTION_PHASE_ORDER.forEach((phase) => {
-      const fromPlayer = pickRandom(aiPlayers);
-      const type = pickRandom(INCOMING_TYPES);
+      const fromPlayer = pickRandom(aiPlayers)
+      const type = pickRandom(INCOMING_TYPES)
       dispatch(
         scheduleIncomingInteraction(
           buildScheduledInteraction(fromPlayer.id, game.week, phase, type)
         )
-      );
-    });
+      )
+    })
   }
 
   function handleAutoResolveIgnored() {
-    dispatch(autoResolveExpiredIncomingInteractionsForWeek(game.week + 1));
+    dispatch(autoResolveExpiredIncomingInteractionsForWeek(game.week + 1))
   }
 
   function handleBoostTrust() {
-    if (!humanPlayer) return;
+    if (!humanPlayer) return
     aiPlayers.forEach((player) => {
       dispatch(
         updateSocialMemory({
@@ -292,12 +289,12 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
             trustMomentum: memoryCaps.trustMomentum,
           },
         })
-      );
-    });
+      )
+    })
   }
 
   function handleBoostResentment() {
-    if (!humanPlayer) return;
+    if (!humanPlayer) return
     aiPlayers.forEach((player) => {
       dispatch(
         updateSocialMemory({
@@ -309,32 +306,32 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
             trustMomentum: -memoryCaps.trustMomentum,
           },
         })
-      );
-    });
+      )
+    })
   }
 
   function handleClearInteractionLogs() {
-    dispatch(clearIncomingInteractionLogs());
+    dispatch(clearIncomingInteractionLogs())
   }
 
   function handleQueueForcedShock() {
-    dispatch(queueForcedShock(selectedForcedShock));
+    dispatch(queueForcedShock(selectedForcedShock))
   }
 
   function handleCupidSeasonSchedule() {
-    const parsed = Number(cupidSeasonInput);
-    const season = Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-    dispatch(setSim({ cupidArrowSeasonOverride: season }));
-    dispatch(setCupidArrowSchedule(season));
-    setCupidSeasonInput(season?.toString() ?? '');
+    const parsed = Number(cupidSeasonInput)
+    const season = Number.isInteger(parsed) && parsed > 0 ? parsed : null
+    dispatch(setSim({ cupidArrowSeasonOverride: season }))
+    dispatch(setCupidArrowSchedule(season))
+    setCupidSeasonInput(season?.toString() ?? '')
   }
 
   function handleVoxSeasonSchedule() {
-    const parsed = Number(voxSeasonInput);
-    const season = Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-    dispatch(setSim({ voxPopuliSeasonOverride: season }));
-    dispatch(setVoxPopuliSchedule(season));
-    setVoxSeasonInput(season?.toString() ?? '');
+    const parsed = Number(voxSeasonInput)
+    const season = Number.isInteger(parsed) && parsed > 0 ? parsed : null
+    dispatch(setSim({ voxPopuliSeasonOverride: season }))
+    dispatch(setVoxPopuliSchedule(season))
+    setVoxSeasonInput(season?.toString() ?? '')
   }
 
   return (
@@ -399,6 +396,22 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
               >
                 {/* i18n-ignore: Debug-only navigation control intentionally uses canonical English */}
                 Open Broadcast Manager
+              </button>
+              <button
+                className="dbg-btn dbg-btn--wide"
+                type="button"
+                onClick={() => navigate('/game-manager?debug=1')}
+              >
+                {/* i18n-ignore: Debug-only navigation control intentionally uses canonical English */}
+                Open Game Manager
+              </button>
+              <button
+                className="dbg-btn dbg-btn--wide"
+                type="button"
+                onClick={() => navigate('/remote-manager?debug=1')}
+              >
+                {/* i18n-ignore: Debug-only navigation control intentionally uses canonical English */}
+                Open Remote Manager
               </button>
 
               <details className="dbg-players">
@@ -475,8 +488,8 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                   className="dbg-btn"
                   disabled={!selectedHoH}
                   onClick={() => {
-                    dispatch(forceHoH(selectedHoH));
-                    setSelectedHoH('');
+                    dispatch(forceHoH(selectedHoH))
+                    setSelectedHoH('')
                   }}
                 >
                   Set
@@ -514,9 +527,9 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                     className="dbg-btn"
                     disabled={!nominee1 || !nominee2}
                     onClick={() => {
-                      dispatch(forceNominees([nominee1, nominee2]));
-                      setNominee1('');
-                      setNominee2('');
+                      dispatch(forceNominees([nominee1, nominee2]))
+                      setNominee1('')
+                      setNominee2('')
                     }}
                   >
                     Set
@@ -542,8 +555,8 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                   className="dbg-btn"
                   disabled={!selectedPov}
                   onClick={() => {
-                    dispatch(forcePovWinner(selectedPov));
-                    setSelectedPov('');
+                    dispatch(forcePovWinner(selectedPov))
+                    setSelectedPov('')
                   }}
                 >
                   Set
@@ -721,9 +734,9 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                     className="dbg-btn"
                     type="button"
                     onClick={() => {
-                      setCupidSeasonInput('');
-                      dispatch(setSim({ cupidArrowSeasonOverride: null }));
-                      dispatch(setCupidArrowSchedule(null));
+                      setCupidSeasonInput('')
+                      dispatch(setSim({ cupidArrowSeasonOverride: null }))
+                      dispatch(setCupidArrowSchedule(null))
                     }}
                   >
                     Disable
@@ -777,9 +790,9 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                     className="dbg-btn"
                     type="button"
                     onClick={() => {
-                      setVoxSeasonInput('');
-                      dispatch(setSim({ voxPopuliSeasonOverride: null }));
-                      dispatch(setVoxPopuliSchedule(null));
+                      setVoxSeasonInput('')
+                      dispatch(setSim({ voxPopuliSeasonOverride: null }))
+                      dispatch(setVoxPopuliSchedule(null))
                     }}
                   >
                     Disable
@@ -865,8 +878,8 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                     className="dbg-btn"
                     disabled={!selectedF4Evictee}
                     onClick={() => {
-                      dispatch(finalizeFinal4Eviction(selectedF4Evictee));
-                      setSelectedF4Evictee('');
+                      dispatch(finalizeFinal4Eviction(selectedF4Evictee))
+                      setSelectedF4Evictee('')
                     }}
                   >
                     Evict
@@ -874,7 +887,7 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
                   <button
                     className="dbg-btn"
                     onClick={() => {
-                      dispatch(advance());
+                      dispatch(advance())
                     }}
                     title="⚠ Overrides human POS holder decision — for debug use only"
                   >
@@ -1044,5 +1057,5 @@ function DebugPanelContent({ searchParams }: { searchParams: URLSearchParams }) 
         </aside>
       )}
     </>
-  );
+  )
 }

--- a/src/components/SocialPanelV2/ActionGrid.tsx
+++ b/src/components/SocialPanelV2/ActionGrid.tsx
@@ -1,6 +1,10 @@
-﻿import { useRef } from 'react'
+﻿import { useMemo, useRef } from 'react'
 import { useI18n } from '../../i18n'
-import { isRealityExclusiveAction, SOCIAL_ACTIONS } from '../../social/socialActions'
+import { isRealityExclusiveAction, type SocialActionDefinition } from '../../social/socialActions'
+import {
+  buildEffectiveSocialActions,
+  isActionAllowedForRealityPreset,
+} from '../../social/socialActionManager'
 import { isHumanSocialActionVisible } from '../../social/socialActionCatalog'
 import { normalizeActionCosts } from '../../social/smExecNormalize'
 import { evaluateSocialActionEligibility } from '../../social/socialActionEligibility'
@@ -9,13 +13,6 @@ import type { Player, PlayerStatus } from '../../types'
 import type { DramaSocialNetwork, RelationshipsMap } from '../../social/types'
 import { useAppSelector } from '../../store/hooks'
 import { getCupidPartnerId } from '../../features/twists/cupidArrow'
-
-const ADULT_REALITY_ACTION_IDS = new Set([
-  'kiss_under_covers',
-  'pool_makeout',
-  'spend_night',
-  'skinny_dip',
-])
 
 export interface ActionGridProps {
   onActionClick?: (actionId: string) => void
@@ -67,6 +64,8 @@ export default function ActionGrid({
   const containerRef = useRef<HTMLDivElement>(null)
   const game = useAppSelector((state) => state.game)
   const realityModePreset = useAppSelector((state) => state.settings.gameUX.realityModePreset)
+  const actionOverrides = useAppSelector((state) => state.settings?.social?.actionOverrides ?? {})
+  const actions = useMemo(() => buildEffectiveSocialActions(actionOverrides), [actionOverrides])
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
@@ -104,19 +103,16 @@ export default function ActionGrid({
     )
   }
 
-  function getActionCosts(action: (typeof SOCIAL_ACTIONS)[number]) {
+  function getActionCosts(action: SocialActionDefinition) {
     const costs = normalizeActionCosts(action, selectedTargetIds?.size, dramaMode)
     const energyOverride = energyCostOverrides?.[action.id]
     return energyOverride === undefined ? costs : { ...costs, energy: energyOverride }
   }
 
-  function isAdultActionAllowed(actionId: string): boolean {
-    return !ADULT_REALITY_ACTION_IDS.has(actionId) || realityModePreset === 'adult'
-  }
-
-  function isContextEligible(action: (typeof SOCIAL_ACTIONS)[number]): boolean {
+  function isContextEligible(action: SocialActionDefinition): boolean {
     return (
-      isAdultActionAllowed(action.id) &&
+      action.enabled !== false &&
+      isActionAllowedForRealityPreset(action, realityModePreset) &&
       isHumanSocialActionVisible(action, dramaMode ? 'drama' : 'normal') &&
       !hiddenActionIds.has(action.id) &&
       evaluateSocialActionEligibility({
@@ -133,10 +129,11 @@ export default function ActionGrid({
     )
   }
 
-  function isRelevantRealityPreview(action: (typeof SOCIAL_ACTIONS)[number]): boolean {
+  function isRelevantRealityPreview(action: SocialActionDefinition): boolean {
     return (
+      action.enabled !== false &&
       !dramaMode &&
-      !ADULT_REALITY_ACTION_IDS.has(action.id) &&
+      isActionAllowedForRealityPreset(action, realityModePreset) &&
       isRealityExclusiveAction(action) &&
       !action.aiOnly &&
       !hiddenActionIds.has(action.id) &&
@@ -165,7 +162,7 @@ export default function ActionGrid({
   const safetyConsultationOpen =
     actorHasSafety && (currentPhase === 'pos_results' || currentPhase === 'pos_ceremony')
 
-  function contextualizeAction(action: (typeof SOCIAL_ACTIONS)[number]) {
+  function contextualizeAction(action: SocialActionDefinition) {
     if (action.id !== 'ask_loh_target') return action
     if (safetyConsultationOpen) {
       return {
@@ -199,20 +196,19 @@ export default function ActionGrid({
     }
   }
 
-  const isRealityPreview = (action: (typeof SOCIAL_ACTIONS)[number]) =>
-    isRelevantRealityPreview(action)
+  const isRealityPreview = (action: SocialActionDefinition) => isRelevantRealityPreview(action)
 
-  const visibleActions = SOCIAL_ACTIONS.filter(
-    (action) => isRealityPreview(action) || isContextEligible(action)
-  ).sort((left, right) => {
-    const leftPreview = isRealityPreview(left)
-    const rightPreview = isRealityPreview(right)
-    if (leftPreview !== rightPreview) return leftPreview ? 1 : -1
-    if (!safetyConsultationOpen) return 0
-    if (left.id === 'ask_loh_target') return -1
-    if (right.id === 'ask_loh_target') return 1
-    return 0
-  })
+  const visibleActions = actions
+    .filter((action) => isRealityPreview(action) || isContextEligible(action))
+    .sort((left, right) => {
+      const leftPreview = isRealityPreview(left)
+      const rightPreview = isRealityPreview(right)
+      if (leftPreview !== rightPreview) return leftPreview ? 1 : -1
+      if (!safetyConsultationOpen) return 0
+      if (left.id === 'ask_loh_target') return -1
+      if (right.id === 'ask_loh_target') return 1
+      return 0
+    })
 
   function getAvailabilityReason(costs: {
     energy: number

--- a/src/components/SocialPanelV2/SocialPanelV2.tsx
+++ b/src/components/SocialPanelV2/SocialPanelV2.tsx
@@ -27,8 +27,9 @@ import RecentActivity from './RecentActivity'
 import HousePulse from '../HousePulse/HousePulse'
 import PlayerAvatar from '../PlayerAvatar/PlayerAvatar'
 import type { Player } from '../../types'
-import { resolveActionTargetMode, SOCIAL_ACTIONS } from '../../social/socialActions'
+import { resolveActionTargetMode } from '../../social/socialActions'
 import type { SubjectPool } from '../../social/socialActions'
+import { buildEffectiveSocialActions } from '../../social/socialActionManager'
 import { getEffectiveSocialMode } from '../../social/socialMode'
 import { validateSocialExecution } from '../../social/socialExecutionGuard'
 import { getSocialActionPresentation } from '../../social/socialRuntimeConfig'
@@ -107,6 +108,10 @@ export default function SocialPanelV2() {
   const weekStartRelSnapshot = useAppSelector(selectWeekStartRelSnapshot)
   const dramaNetwork = useAppSelector(selectDramaNetwork)
   const dramaMode = getEffectiveSocialMode({ game, settings, vip }) === 'drama'
+  const socialActions = useMemo(
+    () => buildEffectiveSocialActions(settings?.social?.actionOverrides ?? {}),
+    [settings?.social?.actionOverrides]
+  )
 
   const humanPlayer = game.players.find((player) => player.isUser)
   const socialModuleAvailability = useMemo(() => getSocialModuleAvailability(game), [game])
@@ -369,7 +374,7 @@ export default function SocialPanelV2() {
       hidden.add('suggest_replacement')
       hidden.add('rally_votes_against')
     } else {
-      SOCIAL_ACTIONS.filter((action) => action.voxOnly).forEach((action) => hidden.add(action.id))
+      socialActions.filter((action) => action.voxOnly).forEach((action) => hidden.add(action.id))
     }
     if (!beforeNominations) hidden.add('pitch_target')
     if (!lohPlanOpen || !game.lohId) hidden.add('ask_loh_target')
@@ -403,6 +408,7 @@ export default function SocialPanelV2() {
     humanPlayer?.status,
     primaryTargetId,
     actionHistory,
+    socialActions,
   ])
 
   const handleActionClick = useCallback(

--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -29,3 +29,27 @@ body:has(.game-screen-shell) .app-shell {
   padding-bottom: 0;
   padding-left: var(--safe-left);
 }
+
+.app-shell__broadcast {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.65rem 0.9rem;
+  color: #fff;
+  background: var(--color-accent, #7c3aed);
+  border-bottom: 1px solid color-mix(in srgb, #fff 22%, transparent);
+  font-size: 0.78rem;
+  line-height: 1.25;
+  z-index: 20;
+}
+
+.app-shell__broadcast strong {
+  font-size: 0.68rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.app-shell__broadcast--critical {
+  background: #b91c1c;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,7 +4,7 @@ import NavBar from './NavBar'
 import { useAppSelector } from '../../store/hooks'
 import { selectFinale } from '../../store/finaleSlice'
 import { selectSettings } from '../../store/settingsSlice'
-import { selectRemoteConfig } from '../../remoteConfig/remoteConfigSlice'
+import { selectRemoteBroadcast, selectRemoteConfig } from '../../remoteConfig/remoteConfigSlice'
 import useGameMode from '../../hooks/useGameMode'
 import { buildViewportMetaContent } from './viewportMeta'
 import PortraitOrientationGuard from './PortraitOrientationGuard'
@@ -15,9 +15,7 @@ const THEME_PRESETS = ['midnight', 'neon', 'sunset', 'ocean']
 const DebugPanel = lazy(() => import('../DebugPanel/DebugPanel'))
 const FinalFaceoff = lazy(() => import('../FinalFaceoff/FinalFaceoff'))
 const SeasonFinaleOverlay = lazy(() => import('../SeasonFinale/SeasonFinaleOverlay'))
-const VoxPopuliFinaleOverlay = lazy(
-  () => import('../VoxPopuliFinale/VoxPopuliFinaleOverlay')
-)
+const VoxPopuliFinaleOverlay = lazy(() => import('../VoxPopuliFinale/VoxPopuliFinaleOverlay'))
 
 /**
  * AppShell — persistent wrapper around every screen.
@@ -43,6 +41,7 @@ export default function AppShell() {
   const settings = useAppSelector(selectSettings)
   const { display } = settings
   const remoteConfig = useAppSelector(selectRemoteConfig)
+  const remoteBroadcast = useAppSelector(selectRemoteBroadcast)
 
   useGameMode()
 
@@ -104,6 +103,16 @@ export default function AppShell() {
 
   return (
     <div className="app-shell">
+      {remoteBroadcast && (
+        <aside
+          className={`app-shell__broadcast app-shell__broadcast--${remoteBroadcast.priority ?? 'normal'}`}
+          role="status"
+          aria-label={remoteBroadcast.title ?? 'Broadcast announcement'}
+        >
+          {remoteBroadcast.title && <strong>{remoteBroadcast.title}</strong>}
+          <span>{remoteBroadcast.message}</span>
+        </aside>
+      )}
       <main className="app-shell__main">
         <Outlet />
       </main>

--- a/src/gameManager/gameManager.test.ts
+++ b/src/gameManager/gameManager.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGameManagerRule, type GameManagerRule } from './gameManager'
+
+const baseRule: GameManagerRule = {
+  id: 'base',
+  enabled: true,
+  priority: 10,
+  trigger: 'day',
+  day: 4,
+  competition: 'LOH',
+  selection: 'random',
+  outcome: 'play',
+}
+
+describe('resolveGameManagerRule', () => {
+  it('uses only matching enabled rules and honors their priority', () => {
+    const result = resolveGameManagerRule(
+      {
+        enabled: true,
+        rules: [
+          baseRule,
+          { ...baseRule, id: 'disabled', priority: 100, enabled: false },
+          { ...baseRule, id: 'pos', priority: 90, competition: 'POS' },
+          { ...baseRule, id: 'winning-rule', priority: 20, selection: 'game', gameKey: 'quickTap' },
+        ],
+      },
+      { day: 4, playerCount: 12, competition: 'LOH' }
+    )
+
+    expect(result?.id).toBe('winning-rule')
+  })
+
+  it('matches player-count rules and can be globally disabled', () => {
+    const playerRule: GameManagerRule = {
+      ...baseRule,
+      id: 'final-five',
+      trigger: 'players',
+      playerCount: 5,
+      day: undefined,
+      competition: 'any',
+    }
+
+    expect(
+      resolveGameManagerRule(
+        { enabled: true, rules: [playerRule] },
+        { day: 8, playerCount: 5, competition: 'POS' }
+      )?.id
+    ).toBe('final-five')
+    expect(
+      resolveGameManagerRule(
+        { enabled: false, rules: [playerRule] },
+        { day: 8, playerCount: 5, competition: 'POS' }
+      )
+    ).toBeNull()
+  })
+})

--- a/src/gameManager/gameManager.ts
+++ b/src/gameManager/gameManager.ts
@@ -1,0 +1,72 @@
+import type { GameCategory } from '../minigames/registry'
+
+export type ManagedCompetition = 'LOH' | 'POS' | 'any'
+export type GameManagerTrigger = 'day' | 'players'
+export type GameManagerSelection = 'random' | 'category' | 'game'
+export type GameManagerOutcome = 'play' | 'random' | 'player'
+
+export interface GameManagerRule {
+  id: string
+  enabled: boolean
+  /** Higher numbers win when more than one rule applies. */
+  priority: number
+  trigger: GameManagerTrigger
+  day?: number
+  playerCount?: number
+  competition: ManagedCompetition
+  selection: GameManagerSelection
+  category?: GameCategory
+  gameKey?: string
+  /** Play normally, pick a random winner after the game, or name the winner. */
+  outcome: GameManagerOutcome
+  winnerId?: string
+}
+
+export interface GameManagerConfig {
+  enabled: boolean
+  rules: GameManagerRule[]
+}
+
+export const DEFAULT_GAME_MANAGER_CONFIG: GameManagerConfig = {
+  enabled: true,
+  rules: [],
+}
+
+export function normalizeGameManagerConfig(config?: Partial<GameManagerConfig>): GameManagerConfig {
+  return {
+    enabled: config?.enabled !== false,
+    rules: Array.isArray(config?.rules)
+      ? config.rules.filter((rule): rule is GameManagerRule => Boolean(rule?.id))
+      : [],
+  }
+}
+
+export function resolveGameManagerRule(
+  config: GameManagerConfig | undefined,
+  context: { day: number; playerCount: number; competition: Exclude<ManagedCompetition, 'any'> }
+): GameManagerRule | null {
+  if (!config?.enabled) return null
+  return (
+    config.rules
+      .filter((rule) => {
+        if (!rule.enabled) return false
+        if (rule.competition !== 'any' && rule.competition !== context.competition) return false
+        return rule.trigger === 'day'
+          ? rule.day === context.day
+          : rule.playerCount === context.playerCount
+      })
+      .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id))[0] ?? null
+  )
+}
+
+export function describeGameManagerRule(rule: GameManagerRule): string {
+  const when =
+    rule.trigger === 'day' ? `Day ${rule.day ?? '?'}` : `${rule.playerCount ?? '?'} players`
+  const selection =
+    rule.selection === 'game'
+      ? (rule.gameKey ?? 'a selected game')
+      : rule.selection === 'category'
+        ? `${rule.category ?? 'any'} game`
+        : 'random game'
+  return `${when} · ${rule.competition} · ${selection}`
+}

--- a/src/remoteConfig/githubConfigPublisher.ts
+++ b/src/remoteConfig/githubConfigPublisher.ts
@@ -1,0 +1,146 @@
+import type { RemoteConfig } from './remoteConfigTypes'
+
+export interface GitHubPublishTarget {
+  owner: string
+  repo: string
+  branch: string
+  path: string
+}
+
+export interface GitHubPublishResult {
+  url: string
+  branch: string
+  pullRequestNumber?: number
+}
+
+const API_ROOT = 'https://api.github.com'
+
+function encodePath(path: string): string {
+  return path.split('/').filter(Boolean).map(encodeURIComponent).join('/')
+}
+
+function encodeUtf8Base64(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  return btoa(binary)
+}
+
+async function githubRequest<T>(token: string, path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_ROOT}${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { message?: string } | null
+    throw new Error(body?.message || `GitHub returned HTTP ${response.status}`)
+  }
+  return (await response.json()) as T
+}
+
+async function readFileSha(
+  token: string,
+  target: GitHubPublishTarget,
+  branch: string
+): Promise<string | undefined> {
+  const response = await fetch(
+    `${API_ROOT}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/contents/${encodePath(target.path)}?ref=${encodeURIComponent(branch)}`,
+    {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  )
+  if (response.status === 404) return undefined
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as { message?: string } | null
+    throw new Error(body?.message || `Could not read the existing config (HTTP ${response.status})`)
+  }
+  const body = (await response.json()) as { sha?: string }
+  return body.sha
+}
+
+async function writeConfig(
+  token: string,
+  target: GitHubPublishTarget,
+  branch: string,
+  config: RemoteConfig
+): Promise<{ html_url: string }> {
+  const sha = await readFileSha(token, target, branch)
+  const response = await githubRequest<{
+    content?: { html_url?: string }
+    commit: { html_url: string }
+  }>(
+    token,
+    `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/contents/${encodePath(target.path)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        message: 'Update remote manager configuration',
+        content: encodeUtf8Base64(`${JSON.stringify(config, null, 2)}\n`),
+        branch,
+        ...(sha ? { sha } : {}),
+      }),
+    }
+  )
+  return { html_url: response.content?.html_url ?? response.commit.html_url }
+}
+
+function createBranchName(): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z')
+  return `remote-config/${stamp}`
+}
+
+export async function publishConfigDirectly(
+  token: string,
+  target: GitHubPublishTarget,
+  config: RemoteConfig
+): Promise<GitHubPublishResult> {
+  const commit = await writeConfig(token, target, target.branch, config)
+  return { url: commit.html_url, branch: target.branch }
+}
+
+export async function publishConfigAsPullRequest(
+  token: string,
+  target: GitHubPublishTarget,
+  config: RemoteConfig
+): Promise<GitHubPublishResult> {
+  const repoPath = `/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`
+  const base = await githubRequest<{ object: { sha: string } }>(
+    token,
+    `${repoPath}/git/ref/heads/${encodeURIComponent(target.branch)}`
+  )
+  const branch = createBranchName()
+  await githubRequest(token, `${repoPath}/git/refs`, {
+    method: 'POST',
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: base.object.sha }),
+  })
+  await writeConfig(token, target, branch, config)
+  const pullRequest = await githubRequest<{ html_url: string; number: number }>(
+    token,
+    `${repoPath}/pulls`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        title: 'Update remote manager configuration',
+        head: branch,
+        base: target.branch,
+        body: 'Remote configuration update created from the in-game Remote Manager UI.',
+      }),
+    }
+  )
+  return { url: pullRequest.html_url, branch, pullRequestNumber: pullRequest.number }
+}

--- a/src/remoteConfig/remoteConfigService.ts
+++ b/src/remoteConfig/remoteConfigService.ts
@@ -27,10 +27,13 @@ import {
   sanitiseMusicConfigOverrides,
   sanitiseMusicTrackAssetOverrides,
 } from '../services/sound/musicConfigSanitizer'
+import type { GameManagerConfig, GameManagerRule } from '../gameManager/gameManager'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 export const REMOTE_CONFIG_STORAGE_KEY = 'bbmobilenew_remote_config_v1'
+export const GITHUB_PAGES_REMOTE_CONFIG_URL =
+  'https://georgi-cole.github.io/bbmobilenew/config/live-config.json'
 
 /** TTL for the localStorage cache (1 hour). */
 const CACHE_TTL_MS = 60 * 60 * 1000
@@ -43,7 +46,9 @@ const CACHE_TTL_MS = 60 * 60 * 1000
 export const DEFAULT_REMOTE_CONFIG_URL: string =
   (typeof import.meta !== 'undefined' &&
     (import.meta as { env?: { VITE_REMOTE_CONFIG_URL?: string } }).env?.VITE_REMOTE_CONFIG_URL) ||
-  apiUrl('/api/live-config')
+  (import.meta.env.DEV
+    ? apiUrl('/api/live-config')
+    : GITHUB_PAGES_REMOTE_CONFIG_URL)
 
 const FETCH_TIMEOUT_MS = 8000
 
@@ -89,6 +94,84 @@ function safeOpacity(value: unknown): number | undefined {
 function safePercentage(value: unknown): number | undefined {
   if (typeof value !== 'number' || !isFinite(value)) return undefined
   return Math.max(0, Math.min(100, value))
+}
+
+function sanitiseBroadcast(raw: unknown): RemoteConfig['broadcast'] | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const value = raw as Record<string, unknown>
+  const broadcast: NonNullable<RemoteConfig['broadcast']> = {}
+  if (typeof value.enabled === 'boolean') broadcast.enabled = value.enabled
+  const title = safeStr(value.title)
+  if (title) broadcast.title = title.slice(0, 100)
+  const message = safeStr(value.message)
+  if (message) broadcast.message = message.slice(0, 500)
+  if (value.priority === 'normal' || value.priority === 'critical') {
+    broadcast.priority = value.priority
+  }
+  const startsAt = safeStr(value.startsAt)
+  if (startsAt && !Number.isNaN(Date.parse(startsAt))) broadcast.startsAt = startsAt
+  const endsAt = safeStr(value.endsAt)
+  if (endsAt && !Number.isNaN(Date.parse(endsAt))) broadcast.endsAt = endsAt
+  return Object.keys(broadcast).length > 0 ? broadcast : undefined
+}
+
+function sanitiseGameManager(raw: unknown): GameManagerConfig | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const value = raw as Record<string, unknown>
+  const rules: GameManagerRule[] = []
+  if (Array.isArray(value.rules)) {
+    for (const entry of value.rules.slice(0, 100)) {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+      const rule = entry as Record<string, unknown>
+      const id = safeStr(rule.id)
+      if (!id) continue
+      if (rule.trigger !== 'day' && rule.trigger !== 'players') continue
+      if (rule.competition !== 'LOH' && rule.competition !== 'POS' && rule.competition !== 'any') {
+        continue
+      }
+      if (
+        rule.selection !== 'random' &&
+        rule.selection !== 'category' &&
+        rule.selection !== 'game'
+      ) {
+        continue
+      }
+      if (rule.outcome !== 'play' && rule.outcome !== 'random' && rule.outcome !== 'player')
+        continue
+      const next: GameManagerRule = {
+        id: id.slice(0, 80),
+        enabled: rule.enabled !== false,
+        priority:
+          typeof rule.priority === 'number' && Number.isFinite(rule.priority)
+            ? Math.max(-1000, Math.min(1000, Math.round(rule.priority)))
+            : 0,
+        trigger: rule.trigger,
+        competition: rule.competition,
+        selection: rule.selection,
+        outcome: rule.outcome,
+      }
+      if (rule.trigger === 'day' && typeof rule.day === 'number') {
+        next.day = Math.max(1, Math.min(100, Math.round(rule.day)))
+      }
+      if (rule.trigger === 'players' && typeof rule.playerCount === 'number') {
+        next.playerCount = Math.max(2, Math.min(50, Math.round(rule.playerCount)))
+      }
+      if (
+        rule.category === 'arcade' ||
+        rule.category === 'logic' ||
+        rule.category === 'trivia' ||
+        rule.category === 'endurance'
+      ) {
+        next.category = rule.category
+      }
+      const gameKey = safeStr(rule.gameKey)
+      if (gameKey) next.gameKey = gameKey.slice(0, 100)
+      const winnerId = safeStr(rule.winnerId)
+      if (winnerId) next.winnerId = winnerId.slice(0, 100)
+      rules.push(next)
+    }
+  }
+  return { enabled: value.enabled !== false, rules }
 }
 
 /** Returns true when the URL is an absolute http(s) URL. */
@@ -138,6 +221,12 @@ export function sanitiseRemoteConfig(raw: unknown): RemoteConfig | null {
 
   const r = raw as Record<string, unknown>
   const config: RemoteConfig = {}
+
+  const broadcast = sanitiseBroadcast(r.broadcast)
+  if (broadcast) config.broadcast = broadcast
+
+  const gameManager = sanitiseGameManager(r.gameManager)
+  if (gameManager) config.gameManager = gameManager
 
   // season
   if (r.season && typeof r.season === 'object' && !Array.isArray(r.season)) {
@@ -335,7 +424,7 @@ export async function fetchRemoteConfig(): Promise<RemoteConfig | null> {
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
   try {
-    const res = await fetch(url, { signal: controller.signal })
+    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const json: unknown = await res.json()
     const config = sanitiseRemoteConfig(json)

--- a/src/remoteConfig/remoteConfigService.ts
+++ b/src/remoteConfig/remoteConfigService.ts
@@ -46,9 +46,7 @@ const CACHE_TTL_MS = 60 * 60 * 1000
 export const DEFAULT_REMOTE_CONFIG_URL: string =
   (typeof import.meta !== 'undefined' &&
     (import.meta as { env?: { VITE_REMOTE_CONFIG_URL?: string } }).env?.VITE_REMOTE_CONFIG_URL) ||
-  (import.meta.env.DEV
-    ? apiUrl('/api/live-config')
-    : GITHUB_PAGES_REMOTE_CONFIG_URL)
+  (import.meta.env.DEV ? apiUrl('/api/live-config') : GITHUB_PAGES_REMOTE_CONFIG_URL)
 
 const FETCH_TIMEOUT_MS = 8000
 

--- a/src/remoteConfig/remoteConfigSlice.ts
+++ b/src/remoteConfig/remoteConfigSlice.ts
@@ -126,6 +126,16 @@ export const selectRemoteConfigStatus = (s: RootState) => s.remoteConfig?.status
 export const selectRemoteMainTvHeadline = (s: RootState) =>
   s.remoteConfig?.config?.season?.mainTv?.headline ?? null
 
+/** Returns the currently active scheduled global broadcast, if any. */
+export const selectRemoteBroadcast = (s: RootState) => {
+  const broadcast = s.remoteConfig?.config?.broadcast
+  if (!broadcast || broadcast.enabled === false || !broadcast.message) return null
+  const now = Date.now()
+  if (broadcast.startsAt && Date.parse(broadcast.startsAt) > now) return null
+  if (broadcast.endsAt && Date.parse(broadcast.endsAt) <= now) return null
+  return broadcast
+}
+
 /** Returns the remote intro-hub background image URL, or null. */
 export const selectRemoteIntroHubBg = (s: RootState) =>
   s.remoteConfig?.config?.season?.introHub?.backgroundImageUrl ?? null

--- a/src/remoteConfig/remoteConfigTypes.ts
+++ b/src/remoteConfig/remoteConfigTypes.ts
@@ -14,6 +14,7 @@ import type { CompSelectionMode } from '../components/compSelectionUtils'
 import type { SocialRuntimeOverride } from '../social/socialRuntimeConfig'
 import type { MusicConfigOverrides } from '../services/sound/musicConfig'
 import type { MusicTrackAssetOverride } from '../services/sound/musicCatalog'
+import type { GameManagerConfig } from '../gameManager/gameManager'
 
 // ── Theme ─────────────────────────────────────────────────────────────────────
 
@@ -76,6 +77,17 @@ export interface RemoteMainTv {
   headline?: string
   /** Optional secondary line (reserved for future expansion). */
   subtext?: string
+}
+
+// ── Broadcast ───────────────────────────────────────────────────────────────
+
+export interface RemoteBroadcast {
+  enabled?: boolean
+  title?: string
+  message?: string
+  priority?: 'normal' | 'critical'
+  startsAt?: string
+  endsAt?: string
 }
 
 // ── Challenge scheduling ──────────────────────────────────────────────────────
@@ -154,6 +166,10 @@ export interface RemoteConfig {
     music?: RemoteMusic
     mainTv?: RemoteMainTv
   }
+  /** Global, optionally scheduled message shown to every active client. */
+  broadcast?: RemoteBroadcast
+  /** Producer-authored competition schedule; remote rules override local rules. */
+  gameManager?: GameManagerConfig
   challenge?: RemoteChallenge
   /**
    * Overrides for individual AI houseguest profiles.

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -49,6 +49,8 @@ const load = (element: ReactNode) => (
 // while production testers can audit every minigame through the central panel.
 const GameDebug = lazy(() => import('./screens/GameDebug/GameDebug'))
 const BroadcastManager = lazy(() => import('./screens/BroadcastManager/BroadcastManager'))
+const GameManager = lazy(() => import('./screens/GameManager/GameManager'))
+const RemoteManager = lazy(() => import('./screens/RemoteManager/RemoteManager'))
 
 // Manual QA page. Normal release builds omit it; local production previews can
 // opt in with VITE_ENABLE_QA_ROUTES=true.
@@ -358,6 +360,22 @@ export const router = createHashRouter([
         element: (
           <Suspense fallback={null}>
             <BroadcastManager />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'game-manager',
+        element: (
+          <Suspense fallback={null}>
+            <GameManager />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'remote-manager',
+        element: (
+          <Suspense fallback={null}>
+            <RemoteManager />
           </Suspense>
         ),
       },

--- a/src/screens/GameManager/GameManager.css
+++ b/src/screens/GameManager/GameManager.css
@@ -1,0 +1,176 @@
+.game-manager {
+  min-height: 100%;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  color: #edf3ff;
+  background: radial-gradient(circle at top, #20355c, #07101f 55%);
+}
+
+.game-manager__header,
+.game-manager__controls,
+.game-manager__rule-heading {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.game-manager__header {
+  align-items: flex-start;
+  max-width: 76rem;
+  margin: 0 auto 1.5rem;
+}
+
+.game-manager h1,
+.game-manager h2,
+.game-manager p {
+  margin-top: 0;
+}
+
+.game-manager__header p {
+  max-width: 48rem;
+  color: #b9c8e6;
+  line-height: 1.5;
+}
+
+.game-manager__eyebrow {
+  color: #80d5ff !important;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.game-manager button {
+  border: 1px solid #516b98;
+  border-radius: 0.55rem;
+  padding: 0.62rem 0.85rem;
+  color: #edf3ff;
+  background: #172846;
+  cursor: pointer;
+}
+
+.game-manager button:hover {
+  background: #223a63;
+}
+
+.game-manager button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.game-manager__primary {
+  background: #0878ae !important;
+  border-color: #65d7ff !important;
+  font-weight: 800;
+}
+
+.game-manager__danger {
+  border-color: #a85b71 !important;
+  color: #ffbacb !important;
+}
+
+.game-manager__safety,
+.game-manager__controls,
+.game-manager__empty,
+.game-manager__rule {
+  max-width: 76rem;
+  box-sizing: border-box;
+  margin: 0 auto 1rem;
+  border: 1px solid rgba(149, 187, 255, 0.25);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: rgba(15, 29, 53, 0.84);
+}
+
+.game-manager__safety {
+  display: grid;
+  gap: 0.3rem;
+  border-left: 4px solid #f2bd58;
+  color: #c6d4ed;
+}
+
+.game-manager__safety strong {
+  color: #ffe0a0;
+}
+
+.game-manager__controls > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.game-manager__switch {
+  display: flex !important;
+  align-items: center;
+  gap: 0.55rem;
+  color: #dce9ff;
+  font-weight: 700;
+}
+
+.game-manager__switch input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.game-manager__rules {
+  max-width: 76rem;
+  margin: 0 auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.game-manager__rule {
+  margin: 0;
+}
+
+.game-manager__rule.is-disabled {
+  opacity: 0.6;
+}
+
+.game-manager__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.game-manager__wide {
+  grid-column: span 2;
+}
+
+.game-manager label:not(.game-manager__switch) {
+  display: grid;
+  gap: 0.34rem;
+  color: #b9c9e5;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.game-manager input:not([type='checkbox']),
+.game-manager select {
+  min-width: 0;
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid #4a628b;
+  border-radius: 0.45rem;
+  padding: 0.58rem;
+  color: #f2f6ff;
+  background: #091426;
+}
+
+@media (max-width: 760px) {
+  .game-manager__header,
+  .game-manager__controls,
+  .game-manager__rule-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .game-manager__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .game-manager__wide {
+    grid-column: span 2;
+  }
+}

--- a/src/screens/GameManager/GameManager.tsx
+++ b/src/screens/GameManager/GameManager.tsx
@@ -1,0 +1,296 @@
+import { useMemo } from 'react'
+import { Navigate, useNavigate, useSearchParams } from 'react-router'
+import { getAllGames, type GameCategory } from '../../minigames/registry'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { setGameUX } from '../../store/settingsSlice'
+import { isDebugAccessGranted } from '../../utils/debugMode'
+import {
+  DEFAULT_GAME_MANAGER_CONFIG,
+  describeGameManagerRule,
+  type GameManagerRule,
+} from '../../gameManager/gameManager'
+import './GameManager.css'
+
+const CATEGORIES: GameCategory[] = ['arcade', 'logic', 'trivia', 'endurance']
+
+function newRule(day: number): GameManagerRule {
+  return {
+    id: `game-rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    enabled: true,
+    priority: 100,
+    trigger: 'day',
+    day,
+    competition: 'any',
+    selection: 'random',
+    outcome: 'play',
+  }
+}
+
+export default function GameManager() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+  const game = useAppSelector((state) => state.game)
+  const config = useAppSelector((state) => state.settings.gameUX.gameManager)
+  const hasAccess = isDebugAccessGranted(searchParams, window.location.hostname)
+  const games = useMemo(() => getAllGames().filter((entry) => !entry.retired), [])
+  const activePlayers = useMemo(
+    () => game.players.filter((player) => player.status === 'active'),
+    [game.players]
+  )
+
+  if (!hasAccess) return <Navigate to="/" replace />
+
+  const save = (rules: GameManagerRule[], enabled = config.enabled) => {
+    dispatch(setGameUX({ gameManager: { enabled, rules } }))
+  }
+  const update = (id: string, changes: Partial<GameManagerRule>) =>
+    save(config.rules.map((rule) => (rule.id === id ? { ...rule, ...changes } : rule)))
+
+  return (
+    <main className="game-manager">
+      <header className="game-manager__header">
+        <div>
+          <p className="game-manager__eyebrow">Producer controls · Day {game.week}</p>
+          <h1>Game Manager</h1>
+          <p>
+            Schedule the exact competition experience by day or remaining-player count. Rules are
+            evaluated by priority; system twists always keep their safety and format precedence.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="game-manager__back"
+          onClick={() => navigate('/game?debug=1')}
+        >
+          Back to game
+        </button>
+      </header>
+
+      <section className="game-manager__safety" aria-label="Rule priority">
+        <strong>Priority protection</strong>
+        <span>
+          Democracia replaces the LOH competition on its active day. Ineligible players, roster
+          limits, expansion formats, and debug overrides are also respected before a schedule rule.
+        </span>
+      </section>
+
+      <section className="game-manager__controls">
+        <label className="game-manager__switch">
+          <input
+            type="checkbox"
+            checked={config.enabled}
+            onChange={(event) => save(config.rules, event.target.checked)}
+          />
+          Enable scheduled competition controls
+        </label>
+        <div>
+          <button
+            type="button"
+            className="game-manager__primary"
+            onClick={() => save([...config.rules, newRule(game.week)])}
+          >
+            Add rule
+          </button>
+          <button type="button" onClick={() => save([])} disabled={config.rules.length === 0}>
+            Clear rules
+          </button>
+          <button
+            type="button"
+            onClick={() => dispatch(setGameUX({ gameManager: DEFAULT_GAME_MANAGER_CONFIG }))}
+          >
+            Reset manager
+          </button>
+        </div>
+      </section>
+
+      {config.rules.length === 0 ? (
+        <section className="game-manager__empty">
+          <h2>No scheduled rules yet</h2>
+          <p>
+            Add a rule for a day or a player count. With no matching rule, the normal campaign
+            scheduler stays in charge.
+          </p>
+        </section>
+      ) : (
+        <section className="game-manager__rules" aria-label="Competition schedule rules">
+          {config.rules
+            .slice()
+            .sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id))
+            .map((rule) => (
+              <article
+                className={rule.enabled ? 'game-manager__rule' : 'game-manager__rule is-disabled'}
+                key={rule.id}
+              >
+                <div className="game-manager__rule-heading">
+                  <label className="game-manager__switch">
+                    <input
+                      type="checkbox"
+                      checked={rule.enabled}
+                      onChange={(event) => update(rule.id, { enabled: event.target.checked })}
+                    />
+                    {describeGameManagerRule(rule)}
+                  </label>
+                  <button
+                    type="button"
+                    className="game-manager__danger"
+                    onClick={() => save(config.rules.filter((entry) => entry.id !== rule.id))}
+                  >
+                    Remove
+                  </button>
+                </div>
+
+                <div className="game-manager__grid">
+                  <label>
+                    When
+                    <select
+                      value={rule.trigger}
+                      onChange={(event) =>
+                        update(rule.id, {
+                          trigger: event.target.value as GameManagerRule['trigger'],
+                          ...(event.target.value === 'day'
+                            ? { day: game.week }
+                            : { playerCount: activePlayers.length }),
+                        })
+                      }
+                    >
+                      <option value="day">On day</option>
+                      <option value="players">At player count</option>
+                    </select>
+                  </label>
+                  <label>
+                    {rule.trigger === 'day' ? 'Day' : 'Players remaining'}
+                    <input
+                      type="number"
+                      min={rule.trigger === 'day' ? 1 : 2}
+                      max={50}
+                      value={
+                        rule.trigger === 'day'
+                          ? (rule.day ?? game.week)
+                          : (rule.playerCount ?? activePlayers.length)
+                      }
+                      onChange={(event) =>
+                        update(
+                          rule.id,
+                          rule.trigger === 'day'
+                            ? { day: Math.max(1, Number(event.target.value) || 1) }
+                            : { playerCount: Math.max(2, Number(event.target.value) || 2) }
+                        )
+                      }
+                    />
+                  </label>
+                  <label>
+                    Competition
+                    <select
+                      value={rule.competition}
+                      onChange={(event) =>
+                        update(rule.id, {
+                          competition: event.target.value as GameManagerRule['competition'],
+                        })
+                      }
+                    >
+                      <option value="any">LOH or POS</option>
+                      <option value="LOH">LOH</option>
+                      <option value="POS">Power of Safety</option>
+                    </select>
+                  </label>
+                  <label>
+                    Priority
+                    <input
+                      type="number"
+                      value={rule.priority}
+                      onChange={(event) =>
+                        update(rule.id, { priority: Number(event.target.value) || 0 })
+                      }
+                    />
+                  </label>
+                </div>
+
+                <div className="game-manager__grid">
+                  <label>
+                    Game selection
+                    <select
+                      value={rule.selection}
+                      onChange={(event) =>
+                        update(rule.id, {
+                          selection: event.target.value as GameManagerRule['selection'],
+                        })
+                      }
+                    >
+                      <option value="random">Random eligible game</option>
+                      <option value="category">Random from type</option>
+                      <option value="game">Specific minigame</option>
+                    </select>
+                  </label>
+                  {rule.selection === 'category' && (
+                    <label>
+                      Game type
+                      <select
+                        value={rule.category ?? 'arcade'}
+                        onChange={(event) =>
+                          update(rule.id, { category: event.target.value as GameCategory })
+                        }
+                      >
+                        {CATEGORIES.map((category) => (
+                          <option key={category} value={category}>
+                            {category}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  {rule.selection === 'game' && (
+                    <label className="game-manager__wide">
+                      Minigame
+                      <select
+                        value={rule.gameKey ?? ''}
+                        onChange={(event) => update(rule.id, { gameKey: event.target.value })}
+                      >
+                        <option value="">Choose an eligible minigame</option>
+                        {games.map((entry) => (
+                          <option key={entry.key} value={entry.key}>
+                            {entry.title} · {entry.category}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  <label>
+                    Results control
+                    <select
+                      value={rule.outcome}
+                      onChange={(event) =>
+                        update(rule.id, {
+                          outcome: event.target.value as GameManagerRule['outcome'],
+                        })
+                      }
+                    >
+                      <option value="play">Play normally</option>
+                      <option value="random">Random winner after game</option>
+                      <option value="player">Force winner</option>
+                    </select>
+                  </label>
+                  {rule.outcome === 'player' && (
+                    <label>
+                      Winner
+                      <select
+                        value={rule.winnerId ?? ''}
+                        onChange={(event) => update(rule.id, { winnerId: event.target.value })}
+                      >
+                        <option value="">Choose an active player</option>
+                        {activePlayers.map((player) => (
+                          <option key={player.id} value={player.id}>
+                            {player.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </div>
+              </article>
+            ))}
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -334,9 +334,7 @@ export default function GameScreen() {
   const [spectatingAfterElimination, setSpectatingAfterElimination] = useState(false)
   const humanPlayerEliminated = humanPlayer?.status === 'evicted' || humanPlayer?.status === 'jury'
   const preJuryGameOver =
-    game.mode !== 'survival' &&
-    humanPlayer?.status === 'evicted' &&
-    !spectatingAfterElimination
+    game.mode !== 'survival' && humanPlayer?.status === 'evicted' && !spectatingAfterElimination
   const isVoxPopuli = game.voxPopuli?.status === 'active'
   const isVoxFinalFour = isVoxPopuli && alivePlayers.length === 4
   const voxAudiencePreviewWindow =
@@ -537,11 +535,7 @@ export default function GameScreen() {
       ballots: { ...(game.voxPopuli?.nominationBallots ?? {}) },
       status: 'ready',
     })
-  }, [
-    game.voxPopuli?.nominationBallots,
-    game.week,
-    voxNominationRevealReady,
-  ])
+  }, [game.voxPopuli?.nominationBallots, game.week, voxNominationRevealReady])
 
   useEffect(() => {
     if (!voxNominationRevealReady || hasSeenVoxNominationRevealIntro()) return
@@ -886,8 +880,11 @@ export default function GameScreen() {
 
     aiOnlyChallengeResolvedRef.current = pendingChallenge.id
     const rawResults = buildAiOnlyChallengeRawResults(pendingChallenge)
-    const scoreWinnerId = dispatch(completeChallenge(rawResults)) as string | null
-    const finalWinnerId = scoreWinnerId ?? pendingChallenge.participants[0]
+    const scoreWinnerId = dispatch(
+      completeChallenge(rawResults, { authoritativeWinnerId: pendingChallenge.forcedWinnerId })
+    ) as string | null
+    const finalWinnerId =
+      pendingChallenge.forcedWinnerId ?? scoreWinnerId ?? pendingChallenge.participants[0]
     const ranked =
       pendingChallenge.game.key === 'pressurePlank'
         ? rankPressurePlankResults(
@@ -1146,7 +1143,8 @@ export default function GameScreen() {
   // Final Three is a closed ceremony. Do not surface fresh social actions or
   // inbox requests once only three housemates remain.
   const isSocialPhase =
-    (isVoxPopuli && alivePlayers.length > 3) || (!isVoxPopuli && SOCIAL_INTERACTION_PHASES.has(game.phase))
+    (isVoxPopuli && alivePlayers.length > 3) ||
+    (!isVoxPopuli && SOCIAL_INTERACTION_PHASES.has(game.phase))
   const showSocialPanel = isSocialPhase && !!humanPlayer && isSocialModeEnabled(game.mode)
 
   // The individual controllers publish presentation signals; this coordinator
@@ -1155,7 +1153,10 @@ export default function GameScreen() {
   const showReplacementCeremony = pendingReplacementCeremony !== null || showAiReplacementAnim
   const showSaveCeremony = pendingSaveCeremony !== null
   const showFinal3Ceremony =
-    !isVoxPopuli && game.awaitingFinal3Plea === true && game.phase === 'final3_decision' && !!game.lohId
+    !isVoxPopuli &&
+    game.awaitingFinal3Plea === true &&
+    game.phase === 'final3_decision' &&
+    !!game.lohId
   const survivorTerminalActive = game.mode === 'survival' && isSurvivorRunTerminal(game)
   const favoriteAnnouncementPending =
     game.favoritePlayer?.active === true && game.favoritePlayer?.votingStarted !== true
@@ -1568,8 +1569,8 @@ export default function GameScreen() {
                 ? '🗳️ The secret nominations have been counted'
                 : nominationLabels[nomAnimPlayers[nomAnimPlayers.length - 1]?.id ?? ''] ===
                     'Last in LOH Comp'
-                ? '🎯 Nominations are set — including the LOH comp last-place finisher'
-                : '🎯 Nominations are set'
+                  ? '🎯 Nominations are set — including the LOH comp last-place finisher'
+                  : '🎯 Nominations are set'
             }
             onDone={showHumanNomAnim ? handleNomAnimDone : handleAiNomAnimDone}
             ariaLabel={`Nomination ceremony: ${nomAnimPlayers.map((n) => n.name).join(' and ')}`}
@@ -1879,9 +1880,7 @@ export default function GameScreen() {
                   badge: isVoxFinalFour ? '🏆' : isVoxPopuli ? '🛡️' : '👑',
                   badgeImageSrc: isVoxPopuli ? undefined : LOH_BADGE_SRC,
                   badgeVariant:
-                    !isVoxPopuli && isCupidArrowActive(game)
-                      ? ('cupid-kiss' as const)
-                      : undefined,
+                    !isVoxPopuli && isCupidArrowActive(game) ? ('cupid-kiss' as const) : undefined,
                   badgeStart: 'center' as const,
                   badgeLabel: `${winnerPlayer?.name ?? roleWinnerId} wins ${
                     isVoxFinalFour
@@ -1896,9 +1895,7 @@ export default function GameScreen() {
             caption={`${expandCupidIds(game, [game.lohId])
               .map((id) => game.players.find((player) => player.id === id)?.name)
               .filter(Boolean)
-              .join(' & ')} ${
-              !isVoxPopuli && isCupidArrowActive(game) ? 'win' : 'wins'
-            } ${
+              .join(' & ')} ${!isVoxPopuli && isCupidArrowActive(game) ? 'win' : 'wins'} ${
               isVoxFinalFour
                 ? 'the Final 4 competition!'
                 : isVoxPopuli
@@ -1977,8 +1974,7 @@ export default function GameScreen() {
               isVoxPopuli
                 ? `${activeReplacementAnimationTargetIds
                     .map((id) => {
-                      const name =
-                        game.players.find((player) => player.id === id)?.name ?? id
+                      const name = game.players.find((player) => player.id === id)?.name ?? id
                       const votes = game.voxPopuli?.nominationVoteCounts[id] ?? 0
                       return `${name} (${votes} vote${votes === 1 ? '' : 's'})`
                     })
@@ -1991,8 +1987,8 @@ export default function GameScreen() {
               isVoxPopuli
                 ? 'Next-highest secret-ballot rank'
                 : game.specialVeto?.activeType === 'diamond'
-                ? '😇 Halo Exchange names the backup nominee'
-                : '🎯 Nominations are set'
+                  ? '😇 Halo Exchange names the backup nominee'
+                  : '🎯 Nominations are set'
             }
             onDone={handleAiReplacementDone}
             ariaLabel="Backup nominee ceremony"
@@ -2160,9 +2156,7 @@ export default function GameScreen() {
           secondaryLabel={isVoxPopuli ? 'Return Home' : undefined}
           onConfirm={handleStartNewSeason}
           onCancel={
-            isVoxPopuli
-              ? () => setSpectatingAfterElimination(true)
-              : handlePreJuryReturnHome
+            isVoxPopuli ? () => setSpectatingAfterElimination(true) : handlePreJuryReturnHome
           }
           onSecondary={isVoxPopuli ? handlePreJuryReturnHome : undefined}
         />

--- a/src/screens/GameScreen/flows/useCompetitionFlow.ts
+++ b/src/screens/GameScreen/flows/useCompetitionFlow.ts
@@ -90,7 +90,12 @@ export function useCompetitionFlow({
   // When the human player is the outgoing LOH, no challenge is started at all
   // (the winner is determined randomly via advance() instead).
   useEffect(() => {
-    const isCompPhase = game.phase === 'loh_comp' || game.phase === 'pos_comp'
+    const democraciaOverridesLoh =
+      game.phase === 'loh_comp' &&
+      game.democracia?.active === true &&
+      game.democracia.activatedDay === game.week
+    const isCompPhase =
+      (game.phase === 'loh_comp' || game.phase === 'pos_comp') && !democraciaOverridesLoh
     // Do not start a challenge when the human player is the outgoing LOH —
     // they are ineligible to compete; advance() will pick a winner randomly.
     // Also skip when a CeremonyOverlay is pending (challenge result already
@@ -107,6 +112,9 @@ export function useCompetitionFlow({
     hohCompParticipants,
     aliveIds,
     game.seed,
+    game.week,
+    game.democracia?.active,
+    game.democracia?.activatedDay,
     dispatch,
     humanIsOutgoingHoh,
     pendingWinnerCeremony,
@@ -200,6 +208,7 @@ export function useCompetitionFlow({
       // pendingChallenge from Redux, but this closure still holds it.
       const capturedParticipants = pendingChallenge.participants
       const capturedGameKey = pendingChallenge.game.key
+      const scheduledWinnerId = pendingChallenge.forcedWinnerId
       // prizeType was recorded at challenge-start and is reliable even
       // after the phase advances (feature thunks can transition
       // loh_comp → loh_results before this callback fires).
@@ -292,7 +301,7 @@ export function useCompetitionFlow({
 
       const scoreWinnerId = dispatch(
         completeChallenge(rawResults, {
-          authoritativeWinnerId,
+          authoritativeWinnerId: scheduledWinnerId ?? authoritativeWinnerId,
           partial: partial === true,
         })
       ) as string | null
@@ -355,6 +364,7 @@ export function useCompetitionFlow({
       const liveState = store.getState()
       const featureAppliedWinner = isHohComp ? liveState.game.lohId : liveState.game.posWinnerId
       const finalWinnerId =
+        scheduledWinnerId ??
         explicitWinnerId ??
         (featureAppliedWinner && capturedParticipants.includes(featureAppliedWinner)
           ? featureAppliedWinner
@@ -456,11 +466,12 @@ export function useCompetitionFlow({
         rect: getTileRect(winnerPlayer.id),
         badge: winSymbol,
         badgeImageSrc: isHohComp && !isVoxComp ? LOH_BADGE_SRC : undefined,
-        badgeVariant: !isVoxComp && isCupidArrowActive(game)
-          ? isHohComp
-            ? 'cupid-kiss'
-            : 'cupid-hug'
-          : undefined,
+        badgeVariant:
+          !isVoxComp && isCupidArrowActive(game)
+            ? isHohComp
+              ? 'cupid-kiss'
+              : 'cupid-hug'
+            : undefined,
         badgeStart: 'center',
         badgeLabel: `${winnerPlayer.name} wins ${winLabel}`,
       }))
@@ -482,7 +493,16 @@ export function useCompetitionFlow({
         measureA: () => getTileRect(finalWinnerId),
       })
     },
-    [aliveIds.length, dispatch, game, getTileRect, humanPlayer, isF3MinigamePhase, pendingChallenge, store]
+    [
+      aliveIds.length,
+      dispatch,
+      game,
+      getTileRect,
+      humanPlayer,
+      isF3MinigamePhase,
+      pendingChallenge,
+      store,
+    ]
   )
 
   return {

--- a/src/screens/RemoteManager/RemoteManager.css
+++ b/src/screens/RemoteManager/RemoteManager.css
@@ -1,0 +1,174 @@
+.remote-manager {
+  width: min(1180px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: 32px 0 80px;
+  color: #f7f8ff;
+}
+.remote-manager__hero,
+.remote-manager__heading-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+}
+.remote-manager__hero h1,
+.remote-manager__card h2 {
+  margin: 0 0 8px;
+}
+.remote-manager__hero p,
+.remote-manager__card p {
+  color: #bdc4d8;
+}
+.remote-manager__eyebrow {
+  margin: 0 0 6px;
+  color: #7ee7ff !important;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.remote-manager button {
+  border: 1px solid #536283;
+  border-radius: 10px;
+  background: #223052;
+  color: #fff;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.remote-manager button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.remote-manager__notice {
+  margin: 20px 0;
+  border: 1px solid #394b72;
+  border-radius: 12px;
+  background: #111a30;
+  padding: 12px 16px;
+  color: #cfe6ff;
+  overflow-wrap: anywhere;
+}
+.remote-manager__tabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 3px 0 14px;
+}
+.remote-manager__tabs button {
+  white-space: nowrap;
+  background: #11182a;
+}
+.remote-manager__tabs button.is-active {
+  border-color: #62d9f5;
+  background: #17435a;
+}
+.remote-manager__card {
+  border: 1px solid #344361;
+  border-radius: 18px;
+  background: linear-gradient(145deg, #172137, #0e1526);
+  padding: 22px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+}
+.remote-manager__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+.remote-manager__grid--rules {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.remote-manager label {
+  display: grid;
+  gap: 7px;
+  color: #dce5f8;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+.remote-manager input,
+.remote-manager select,
+.remote-manager textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #42516f;
+  border-radius: 9px;
+  background: #080f1e;
+  color: #f7f8ff;
+  padding: 10px 11px;
+  font: inherit;
+}
+.remote-manager textarea {
+  resize: vertical;
+}
+.remote-manager__wide {
+  grid-column: 1 / -1;
+}
+.remote-manager__check {
+  display: flex !important;
+  grid-template-columns: none;
+  align-items: center;
+  gap: 9px !important;
+  margin: 16px 0;
+}
+.remote-manager__check input {
+  width: auto;
+}
+.remote-manager__row {
+  display: grid;
+  grid-template-columns: 1.2fr 2fr 0.55fr auto;
+  gap: 12px;
+  align-items: end;
+  border-top: 1px solid #2e3a55;
+  padding: 16px 0;
+}
+.remote-manager__rule {
+  margin-top: 16px;
+  border: 1px solid #303f5d;
+  border-radius: 13px;
+  padding: 16px;
+  background: rgba(2, 8, 20, 0.38);
+}
+.remote-manager__danger {
+  border-color: #9d4056 !important;
+  background: #501f31 !important;
+}
+.remote-manager__empty {
+  border: 1px dashed #465470;
+  border-radius: 10px;
+  padding: 16px;
+}
+.remote-manager__json {
+  min-height: 520px;
+  margin: 14px 0;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace !important;
+  line-height: 1.5;
+}
+.remote-manager__publish-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+}
+.remote-manager__endpoint {
+  overflow-wrap: anywhere;
+}
+.remote-manager__endpoint a {
+  color: #7ee7ff;
+}
+@media (max-width: 800px) {
+  .remote-manager__hero,
+  .remote-manager__heading-row {
+    flex-direction: column;
+  }
+  .remote-manager__grid,
+  .remote-manager__grid--rules,
+  .remote-manager__row {
+    grid-template-columns: 1fr;
+  }
+  .remote-manager__wide {
+    grid-column: auto;
+  }
+  .remote-manager__publish-actions {
+    flex-direction: column;
+  }
+}

--- a/src/screens/RemoteManager/RemoteManager.tsx
+++ b/src/screens/RemoteManager/RemoteManager.tsx
@@ -1,0 +1,742 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Navigate, useNavigate, useSearchParams } from 'react-router'
+import { getAllGames, type GameCategory } from '../../minigames/registry'
+import { MUSIC_TRACK_IDS, type CatalogMusicTrack } from '../../services/sound/musicCatalog'
+import type { MusicTrackAssetOverride } from '../../services/sound/musicCatalog'
+import type { SocialRuntimeOverride } from '../../social/socialRuntimeConfig'
+import type { GameManagerRule } from '../../gameManager/gameManager'
+import {
+  DEFAULT_REMOTE_CONFIG_URL,
+  GITHUB_PAGES_REMOTE_CONFIG_URL,
+  sanitiseRemoteConfig,
+} from '../../remoteConfig/remoteConfigService'
+import type { RemoteConfig } from '../../remoteConfig/remoteConfigTypes'
+import {
+  publishConfigAsPullRequest,
+  publishConfigDirectly,
+  type GitHubPublishTarget,
+} from '../../remoteConfig/githubConfigPublisher'
+import { isDebugAccessGranted } from '../../utils/debugMode'
+import './RemoteManager.css'
+
+type Section = 'broadcast' | 'music' | 'game' | 'social' | 'json' | 'publish'
+
+const DEFAULT_TARGET: GitHubPublishTarget = {
+  owner: 'georgi-cole',
+  repo: 'bbmobilenew',
+  branch: 'main',
+  path: 'public/config/live-config.json',
+}
+const CATEGORIES: GameCategory[] = ['arcade', 'logic', 'trivia', 'endurance']
+
+function initialConfig(): RemoteConfig {
+  return {
+    broadcast: { enabled: false, title: 'Big Brother Update', message: '', priority: 'normal' },
+    season: { music: { tracks: [] } },
+    gameManager: { enabled: false, rules: [] },
+    social: {
+      schemaVersion: 1,
+      revision: 'remote-1',
+      economy: {
+        normal: { weeklyEnergy: 5, energyCap: 5 },
+        drama: { weeklyEnergy: 10, energyCap: 30 },
+        influenceCap: 10_000,
+        infoCap: 10_000,
+      },
+    },
+  }
+}
+
+function newRule(): GameManagerRule {
+  return {
+    id: `remote-rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    enabled: true,
+    priority: 100,
+    trigger: 'day',
+    day: 1,
+    competition: 'any',
+    selection: 'random',
+    outcome: 'play',
+  }
+}
+
+function numberValue(value: string, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export default function RemoteManager() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const hasAccess = isDebugAccessGranted(searchParams, window.location.hostname)
+  const [section, setSection] = useState<Section>('broadcast')
+  const [config, setConfig] = useState<RemoteConfig>(initialConfig)
+  const [jsonDraft, setJsonDraft] = useState('')
+  const [token, setToken] = useState('')
+  const [target, setTarget] = useState(DEFAULT_TARGET)
+  const [status, setStatus] = useState('Loading the currently published configuration…')
+  const [busy, setBusy] = useState(false)
+  const games = useMemo(() => getAllGames().filter((game) => !game.retired), [])
+
+  const refreshJson = (next = config) => setJsonDraft(JSON.stringify(next, null, 2))
+
+  useEffect(() => {
+    if (!hasAccess) return
+    const controller = new AbortController()
+    fetch(GITHUB_PAGES_REMOTE_CONFIG_URL, { cache: 'no-store', signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        const loaded = sanitiseRemoteConfig(await response.json())
+        if (!loaded) throw new Error('The published file is not a valid config object.')
+        setConfig(loaded)
+        setJsonDraft(JSON.stringify(loaded, null, 2))
+        setStatus('Published configuration loaded. Your edits are local until you publish.')
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return
+        const fallback = initialConfig()
+        setConfig(fallback)
+        setJsonDraft(JSON.stringify(fallback, null, 2))
+        setStatus(`No published config could be loaded; using a safe template. ${String(error)}`)
+      })
+    return () => controller.abort()
+  }, [hasAccess])
+
+  if (!hasAccess) return <Navigate to="/" replace />
+
+  const broadcast = config.broadcast ?? {}
+  const tracks = config.season?.music?.tracks ?? []
+  const gameManager = config.gameManager ?? { enabled: false, rules: [] }
+  const social = config.social ?? {}
+  const economy = social.economy ?? {}
+
+  const updateBroadcast = (changes: Partial<NonNullable<RemoteConfig['broadcast']>>) =>
+    setConfig((current) => ({ ...current, broadcast: { ...current.broadcast, ...changes } }))
+
+  const updateTracks = (next: MusicTrackAssetOverride[]) =>
+    setConfig((current) => ({
+      ...current,
+      season: {
+        ...current.season,
+        music: { ...current.season?.music, tracks: next },
+      },
+    }))
+
+  const updateRules = (rules: GameManagerRule[]) =>
+    setConfig((current) => ({
+      ...current,
+      gameManager: { enabled: current.gameManager?.enabled ?? false, rules },
+    }))
+
+  const updateRule = (id: string, changes: Partial<GameManagerRule>) =>
+    updateRules(gameManager.rules.map((rule) => (rule.id === id ? { ...rule, ...changes } : rule)))
+
+  const updateEconomy = (
+    mode: 'normal' | 'drama',
+    key: 'weeklyEnergy' | 'energyCap',
+    value: number
+  ) =>
+    setConfig((current) => {
+      const currentSocial = current.social ?? {}
+      const currentEconomy = currentSocial.economy ?? {}
+      return {
+        ...current,
+        social: {
+          ...currentSocial,
+          schemaVersion: 1,
+          economy: {
+            ...currentEconomy,
+            [mode]: { ...currentEconomy[mode], [key]: value },
+          },
+        },
+      }
+    })
+
+  const applyJson = () => {
+    try {
+      const parsed = sanitiseRemoteConfig(JSON.parse(jsonDraft))
+      if (!parsed) throw new Error('The root value must be an object.')
+      setConfig(parsed)
+      setJsonDraft(JSON.stringify(parsed, null, 2))
+      setStatus('JSON validated and applied to the forms.')
+    } catch (error) {
+      setStatus(`JSON was not applied: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  const publish = async (mode: 'pr' | 'direct') => {
+    if (!token.trim()) {
+      setStatus('Enter a fine-grained GitHub token before publishing.')
+      setSection('publish')
+      return
+    }
+    const validated = sanitiseRemoteConfig(config)
+    if (!validated) {
+      setStatus('The current form data is not valid and was not published.')
+      return
+    }
+    setBusy(true)
+    setStatus(mode === 'pr' ? 'Creating a review branch and pull request…' : 'Publishing to main…')
+    try {
+      const result =
+        mode === 'pr'
+          ? await publishConfigAsPullRequest(token.trim(), target, validated)
+          : await publishConfigDirectly(token.trim(), target, validated)
+      setStatus(
+        mode === 'pr'
+          ? `Pull request #${result.pullRequestNumber} created: ${result.url}`
+          : `Configuration committed. GitHub Pages will deploy it shortly: ${result.url}`
+      )
+    } catch (error) {
+      setStatus(`Publish failed: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main className="remote-manager">
+      <header className="remote-manager__hero">
+        <div>
+          <p className="remote-manager__eyebrow">Central live operations</p>
+          <h1>Remote Manager</h1>
+          <p>Edit broadcasts, music, games, and social tuning without changing source code.</p>
+        </div>
+        <button type="button" onClick={() => navigate('/game?debug=1')}>
+          Back to game
+        </button>
+      </header>
+
+      <aside className="remote-manager__notice" aria-live="polite">
+        {status}
+      </aside>
+
+      <nav className="remote-manager__tabs" aria-label="Remote manager sections">
+        {(['broadcast', 'music', 'game', 'social', 'json', 'publish'] as Section[]).map((item) => (
+          <button
+            type="button"
+            className={section === item ? 'is-active' : ''}
+            onClick={() => {
+              if (item === 'json') refreshJson()
+              setSection(item)
+            }}
+            key={item}
+          >
+            {item === 'json' ? 'Advanced JSON' : item[0].toUpperCase() + item.slice(1)}
+          </button>
+        ))}
+      </nav>
+
+      {section === 'broadcast' && (
+        <section className="remote-manager__card">
+          <h2>Broadcast message</h2>
+          <p>Active games refresh this file every five minutes. Date fields are optional.</p>
+          <label className="remote-manager__check">
+            <input
+              type="checkbox"
+              checked={broadcast.enabled ?? false}
+              onChange={(event) => updateBroadcast({ enabled: event.target.checked })}
+            />
+            Show this message to all players
+          </label>
+          <div className="remote-manager__grid">
+            <label>
+              Title
+              <input
+                value={broadcast.title ?? ''}
+                maxLength={100}
+                onChange={(event) => updateBroadcast({ title: event.target.value })}
+              />
+            </label>
+            <label>
+              Priority
+              <select
+                value={broadcast.priority ?? 'normal'}
+                onChange={(event) =>
+                  updateBroadcast({ priority: event.target.value as 'normal' | 'critical' })
+                }
+              >
+                <option value="normal">Normal</option>
+                <option value="critical">Critical</option>
+              </select>
+            </label>
+            <label className="remote-manager__wide">
+              Message
+              <textarea
+                value={broadcast.message ?? ''}
+                maxLength={500}
+                rows={5}
+                onChange={(event) => updateBroadcast({ message: event.target.value })}
+              />
+            </label>
+            <label>
+              Starts at
+              <input
+                type="datetime-local"
+                value={broadcast.startsAt?.slice(0, 16) ?? ''}
+                onChange={(event) =>
+                  updateBroadcast({
+                    startsAt: event.target.value
+                      ? new Date(event.target.value).toISOString()
+                      : undefined,
+                  })
+                }
+              />
+            </label>
+            <label>
+              Ends at
+              <input
+                type="datetime-local"
+                value={broadcast.endsAt?.slice(0, 16) ?? ''}
+                onChange={(event) =>
+                  updateBroadcast({
+                    endsAt: event.target.value
+                      ? new Date(event.target.value).toISOString()
+                      : undefined,
+                  })
+                }
+              />
+            </label>
+          </div>
+        </section>
+      )}
+
+      {section === 'music' && (
+        <section className="remote-manager__card">
+          <div className="remote-manager__heading-row">
+            <div>
+              <h2>Music overrides</h2>
+              <p>Replace any bundled track with a remotely hosted HTTPS audio file.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => updateTracks([...tracks, { track: MUSIC_TRACK_IDS[0], src: '' }])}
+            >
+              Add track override
+            </button>
+          </div>
+          {tracks.length === 0 && (
+            <p className="remote-manager__empty">
+              No remote music overrides. Bundled music remains active.
+            </p>
+          )}
+          {tracks.map((track, index) => (
+            <div className="remote-manager__row" key={`${track.track}-${index}`}>
+              <label>
+                Game track
+                <select
+                  value={track.track}
+                  onChange={(event) =>
+                    updateTracks(
+                      tracks.map((entry, item) =>
+                        item === index
+                          ? { ...entry, track: event.target.value as CatalogMusicTrack }
+                          : entry
+                      )
+                    )
+                  }
+                >
+                  {MUSIC_TRACK_IDS.map((id) => (
+                    <option value={id} key={id}>
+                      {id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                HTTPS audio URL
+                <input
+                  type="url"
+                  value={track.src}
+                  placeholder="https://…/song.mp3"
+                  onChange={(event) =>
+                    updateTracks(
+                      tracks.map((entry, item) =>
+                        item === index ? { ...entry, src: event.target.value } : entry
+                      )
+                    )
+                  }
+                />
+              </label>
+              <label>
+                Volume
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  value={track.volume ?? 0.5}
+                  onChange={(event) =>
+                    updateTracks(
+                      tracks.map((entry, item) =>
+                        item === index
+                          ? { ...entry, volume: numberValue(event.target.value, 0.5) }
+                          : entry
+                      )
+                    )
+                  }
+                />
+              </label>
+              <button
+                type="button"
+                className="remote-manager__danger"
+                onClick={() => updateTracks(tracks.filter((_, item) => item !== index))}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {section === 'game' && (
+        <section className="remote-manager__card">
+          <div className="remote-manager__heading-row">
+            <div>
+              <h2>Competition schedule</h2>
+              <p>Higher-priority matching rules run first.</p>
+            </div>
+            <button type="button" onClick={() => updateRules([...gameManager.rules, newRule()])}>
+              Add rule
+            </button>
+          </div>
+          <label className="remote-manager__check">
+            <input
+              type="checkbox"
+              checked={gameManager.enabled}
+              onChange={(event) =>
+                setConfig((current) => ({
+                  ...current,
+                  gameManager: { ...gameManager, enabled: event.target.checked },
+                }))
+              }
+            />
+            Enable remote competition rules
+          </label>
+          {gameManager.rules.map((rule) => (
+            <article className="remote-manager__rule" key={rule.id}>
+              <div className="remote-manager__heading-row">
+                <label className="remote-manager__check">
+                  <input
+                    type="checkbox"
+                    checked={rule.enabled}
+                    onChange={(event) => updateRule(rule.id, { enabled: event.target.checked })}
+                  />
+                  Rule enabled
+                </label>
+                <button
+                  type="button"
+                  className="remote-manager__danger"
+                  onClick={() =>
+                    updateRules(gameManager.rules.filter((item) => item.id !== rule.id))
+                  }
+                >
+                  Remove
+                </button>
+              </div>
+              <div className="remote-manager__grid remote-manager__grid--rules">
+                <label>
+                  Trigger
+                  <select
+                    value={rule.trigger}
+                    onChange={(event) =>
+                      updateRule(rule.id, {
+                        trigger: event.target.value as GameManagerRule['trigger'],
+                      })
+                    }
+                  >
+                    <option value="day">Day</option>
+                    <option value="players">Players remaining</option>
+                  </select>
+                </label>
+                <label>
+                  {rule.trigger === 'day' ? 'Day' : 'Player count'}
+                  <input
+                    type="number"
+                    min="1"
+                    max="100"
+                    value={rule.trigger === 'day' ? (rule.day ?? 1) : (rule.playerCount ?? 2)}
+                    onChange={(event) =>
+                      updateRule(
+                        rule.id,
+                        rule.trigger === 'day'
+                          ? { day: numberValue(event.target.value, 1) }
+                          : { playerCount: numberValue(event.target.value, 2) }
+                      )
+                    }
+                  />
+                </label>
+                <label>
+                  Competition
+                  <select
+                    value={rule.competition}
+                    onChange={(event) =>
+                      updateRule(rule.id, {
+                        competition: event.target.value as GameManagerRule['competition'],
+                      })
+                    }
+                  >
+                    <option value="any">Any</option>
+                    <option value="LOH">LOH</option>
+                    <option value="POS">POS</option>
+                  </select>
+                </label>
+                <label>
+                  Game choice
+                  <select
+                    value={rule.selection}
+                    onChange={(event) =>
+                      updateRule(rule.id, {
+                        selection: event.target.value as GameManagerRule['selection'],
+                      })
+                    }
+                  >
+                    <option value="random">Random game</option>
+                    <option value="category">Category</option>
+                    <option value="game">Exact game</option>
+                  </select>
+                </label>
+                {rule.selection === 'category' && (
+                  <label>
+                    Category
+                    <select
+                      value={rule.category ?? 'arcade'}
+                      onChange={(event) =>
+                        updateRule(rule.id, { category: event.target.value as GameCategory })
+                      }
+                    >
+                      {CATEGORIES.map((category) => (
+                        <option value={category} key={category}>
+                          {category}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                {rule.selection === 'game' && (
+                  <label>
+                    Exact game
+                    <select
+                      value={rule.gameKey ?? games[0]?.key ?? ''}
+                      onChange={(event) => updateRule(rule.id, { gameKey: event.target.value })}
+                    >
+                      {games.map((game) => (
+                        <option value={game.key} key={game.key}>
+                          {game.title}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                <label>
+                  Winner
+                  <select
+                    value={rule.outcome}
+                    onChange={(event) =>
+                      updateRule(rule.id, {
+                        outcome: event.target.value as GameManagerRule['outcome'],
+                      })
+                    }
+                  >
+                    <option value="play">Play normally</option>
+                    <option value="random">Random winner</option>
+                    <option value="player">Specific player ID</option>
+                  </select>
+                </label>
+                {rule.outcome === 'player' && (
+                  <label>
+                    Winner player ID
+                    <input
+                      value={rule.winnerId ?? ''}
+                      onChange={(event) => updateRule(rule.id, { winnerId: event.target.value })}
+                    />
+                  </label>
+                )}
+                <label>
+                  Priority
+                  <input
+                    type="number"
+                    min="-1000"
+                    max="1000"
+                    value={rule.priority}
+                    onChange={(event) =>
+                      updateRule(rule.id, { priority: numberValue(event.target.value, 0) })
+                    }
+                  />
+                </label>
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {section === 'social' && (
+        <section className="remote-manager__card">
+          <h2>Social economy</h2>
+          <p>
+            Tune the most common Social and Drama limits. Advanced content remains available in the
+            JSON tab.
+          </p>
+          <div className="remote-manager__grid">
+            <label>
+              Normal weekly energy
+              <input
+                type="number"
+                min="1"
+                max="50"
+                value={economy.normal?.weeklyEnergy ?? 5}
+                onChange={(event) =>
+                  updateEconomy('normal', 'weeklyEnergy', numberValue(event.target.value, 5))
+                }
+              />
+            </label>
+            <label>
+              Normal energy cap
+              <input
+                type="number"
+                min="1"
+                max="100"
+                value={economy.normal?.energyCap ?? 5}
+                onChange={(event) =>
+                  updateEconomy('normal', 'energyCap', numberValue(event.target.value, 5))
+                }
+              />
+            </label>
+            <label>
+              Drama weekly energy
+              <input
+                type="number"
+                min="1"
+                max="50"
+                value={economy.drama?.weeklyEnergy ?? 10}
+                onChange={(event) =>
+                  updateEconomy('drama', 'weeklyEnergy', numberValue(event.target.value, 10))
+                }
+              />
+            </label>
+            <label>
+              Drama energy cap
+              <input
+                type="number"
+                min="1"
+                max="100"
+                value={economy.drama?.energyCap ?? 30}
+                onChange={(event) =>
+                  updateEconomy('drama', 'energyCap', numberValue(event.target.value, 30))
+                }
+              />
+            </label>
+            <label>
+              Revision note
+              <input
+                value={social.revision ?? ''}
+                onChange={(event) =>
+                  setConfig((current) => ({
+                    ...current,
+                    social: {
+                      ...current.social,
+                      revision: event.target.value,
+                    } as SocialRuntimeOverride,
+                  }))
+                }
+              />
+            </label>
+          </div>
+        </section>
+      )}
+
+      {section === 'json' && (
+        <section className="remote-manager__card">
+          <h2>Advanced JSON</h2>
+          <p>
+            Use this for manager fields that are not in the quick forms. Invalid and unknown fields
+            are removed when applied.
+          </p>
+          <textarea
+            className="remote-manager__json"
+            value={jsonDraft}
+            rows={28}
+            spellCheck={false}
+            onChange={(event) => setJsonDraft(event.target.value)}
+          />
+          <button type="button" onClick={applyJson}>
+            Validate and apply JSON
+          </button>
+        </section>
+      )}
+
+      {section === 'publish' && (
+        <section className="remote-manager__card">
+          <h2>Publish to GitHub Pages</h2>
+          <p>
+            Use a fine-grained token limited to this repository. It needs Contents read/write;
+            creating a PR also needs Pull requests read/write. The token is kept only in this tab.
+          </p>
+          <div className="remote-manager__grid">
+            <label>
+              Repository owner
+              <input
+                value={target.owner}
+                onChange={(event) => setTarget({ ...target, owner: event.target.value })}
+              />
+            </label>
+            <label>
+              Repository
+              <input
+                value={target.repo}
+                onChange={(event) => setTarget({ ...target, repo: event.target.value })}
+              />
+            </label>
+            <label>
+              Base branch
+              <input
+                value={target.branch}
+                onChange={(event) => setTarget({ ...target, branch: event.target.value })}
+              />
+            </label>
+            <label>
+              Config path
+              <input
+                value={target.path}
+                onChange={(event) => setTarget({ ...target, path: event.target.value })}
+              />
+            </label>
+            <label className="remote-manager__wide">
+              Fine-grained GitHub token
+              <input
+                type="password"
+                value={token}
+                autoComplete="off"
+                placeholder="github_pat_…"
+                onChange={(event) => setToken(event.target.value)}
+              />
+            </label>
+          </div>
+          <div className="remote-manager__publish-actions">
+            <button type="button" disabled={busy} onClick={() => void publish('pr')}>
+              Create review PR
+            </button>
+            <button
+              type="button"
+              className="remote-manager__danger"
+              disabled={busy}
+              onClick={() =>
+                window.confirm(
+                  'Publish directly to main? This starts the live deployment immediately.'
+                ) && void publish('direct')
+              }
+            >
+              Publish directly to main
+            </button>
+          </div>
+          <p className="remote-manager__endpoint">
+            Live endpoint:{' '}
+            <a href={DEFAULT_REMOTE_CONFIG_URL} target="_blank" rel="noreferrer">
+              {DEFAULT_REMOTE_CONFIG_URL}
+            </a>
+          </p>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/screens/SettingsAdmin/SettingsAdmin.tsx
+++ b/src/screens/SettingsAdmin/SettingsAdmin.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../store/settingsSlice'
 import CompSelection from '../../components/CompSelection'
 import MusicManagerPanel from './MusicManagerPanel'
+import SocialManagerPanel from './SocialManagerPanel'
 import type { CompGame, CompSelectionPayload } from '../../components/compSelectionUtils'
 import { getAllGames, type GameCategory } from '../../minigames/registry'
 import { restartApp } from '../../utils/restartApp'
@@ -59,11 +60,12 @@ function buildCompGamesFromRegistry(): CompGame[] {
     }))
 }
 
-type Tab = 'audio' | 'music' | 'display' | 'gameux' | 'about'
+type Tab = 'audio' | 'music' | 'social' | 'display' | 'gameux' | 'about'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'audio', label: '🔊 Audio' },
   { id: 'music', label: '🎵 Music Manager' },
+  { id: 'social', label: '🤝 Social Manager' },
   { id: 'display', label: '🎨 Display' },
   { id: 'gameux', label: '🎮 Game UX' },
   { id: 'about', label: 'ℹ️ About' },
@@ -250,6 +252,9 @@ export default function SettingsAdmin() {
 
         {/* ── Music Manager ──────────────────────────────────────────────── */}
         {activeTab === 'music' && <MusicManagerPanel />}
+
+        {/* ── Social Manager ─────────────────────────────────────────────── */}
+        {activeTab === 'social' && <SocialManagerPanel />}
 
         {/* ── Display ───────────────────────────────────────────────────── */}
         {activeTab === 'display' && (

--- a/src/screens/SettingsAdmin/SocialManagerPanel.css
+++ b/src/screens/SettingsAdmin/SocialManagerPanel.css
@@ -1,0 +1,460 @@
+.social-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.social-manager button,
+.social-manager input,
+.social-manager select,
+.social-manager textarea {
+  font: inherit;
+}
+
+.social-manager__hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 36%, var(--color-line));
+  border-radius: 14px;
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, #ec4899 17%, transparent),
+      transparent 48%
+    ),
+    var(--color-card);
+}
+
+.social-manager__hero h2,
+.social-manager__hero p,
+.social-manager__section-heading h3,
+.social-manager__section-heading p,
+.social-manager__editor-header h3,
+.social-manager__editor-header p {
+  margin: 0;
+}
+
+.social-manager__hero h2 {
+  font-size: 1.25rem;
+}
+
+.social-manager__hero > div > p:last-child {
+  max-width: 50rem;
+  margin-top: 0.45rem;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.social-manager__eyebrow {
+  margin-bottom: 0.22rem !important;
+  color: #f472b6 !important;
+  font-size: 0.62rem !important;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.social-manager__health {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  align-content: center;
+  gap: 0.05rem 0.65rem;
+  min-width: 11rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--color-line);
+  border-radius: 11px;
+  background: rgba(0 0 0 / 0.14);
+  text-align: center;
+}
+
+.social-manager__health strong {
+  font-size: 0.9rem;
+}
+
+.social-manager__health span {
+  grid-row: 2;
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+}
+
+.social-manager__view-tabs,
+.social-manager__segments,
+.social-manager__filters,
+.social-manager__data-actions,
+.social-manager__editor-actions,
+.social-manager__checks {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.social-manager__view-tabs,
+.social-manager__segments {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.social-manager__view-tabs button,
+.social-manager__segments button,
+.social-manager__data-actions button,
+.social-manager__editor-actions button {
+  flex: 0 0 auto;
+  padding: 0.42rem 0.68rem;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-card);
+  color: var(--color-text);
+  font-size: 0.7rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.social-manager__view-tabs button.is-active,
+.social-manager__segments button.is-active {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.social-manager__message {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 40%, var(--color-line));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-accent) 9%, var(--color-card));
+  font-size: 0.72rem;
+}
+
+.social-manager__message button {
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.social-manager__filters {
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.social-manager__filters > input,
+.social-manager__filters > select,
+.social-manager__field input,
+.social-manager__field select,
+.social-manager__field textarea,
+.social-manager__data > textarea,
+.social-manager__price-row input,
+.social-manager__effect-row input {
+  min-width: 0;
+  padding: 0.44rem 0.55rem;
+  border: 1px solid var(--color-line);
+  border-radius: 7px;
+  outline: none;
+  background: var(--color-card-2, var(--color-card));
+  color: var(--color-text);
+}
+
+.social-manager__filters > input:focus,
+.social-manager__field input:focus,
+.social-manager__field select:focus,
+.social-manager__field textarea:focus {
+  border-color: var(--color-accent);
+}
+
+.social-manager__filters > input {
+  flex: 1 1 12rem;
+  max-width: 22rem;
+}
+
+.social-manager__workspace {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.31fr) minmax(0, 1fr);
+  gap: 0.7rem;
+  align-items: start;
+}
+
+.social-manager__catalog {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-height: min(72vh, 46rem);
+  overflow-y: auto;
+  padding-right: 0.15rem;
+}
+
+.social-manager__catalog-count {
+  padding: 0.25rem 0.35rem;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.social-manager__catalog > button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.6rem;
+  border: 1px solid var(--color-line);
+  border-radius: 9px;
+  background: var(--color-card);
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.social-manager__catalog > button.is-selected {
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 11%, var(--color-card));
+}
+
+.social-manager__catalog > button.is-disabled {
+  opacity: 0.5;
+}
+
+.social-manager__catalog > button span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+}
+
+.social-manager__catalog strong,
+.social-manager__catalog small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.social-manager__catalog strong {
+  font-size: 0.72rem;
+}
+
+.social-manager__catalog small {
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+}
+
+.social-manager__catalog i {
+  color: #f472b6;
+  font-size: 0.55rem;
+}
+
+.social-manager__catalog-icon {
+  font-size: 1rem;
+}
+
+.social-manager__editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.social-manager__editor-header,
+.social-manager__editor details,
+.social-manager__data {
+  padding: 0.8rem;
+  border: 1px solid var(--color-line);
+  border-radius: 11px;
+  background: var(--color-card);
+}
+
+.social-manager__editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.social-manager__editor-header p,
+.social-manager__editor-header code {
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+}
+
+.social-manager__editor-header h3 {
+  margin-top: 0.15rem;
+  font-size: 1rem;
+}
+
+.social-manager__switch,
+.social-manager__checks label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--color-text-muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+}
+
+.social-manager__switch input,
+.social-manager__checks input {
+  accent-color: var(--color-accent);
+}
+
+.social-manager__editor details > summary {
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.social-manager__field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.7rem;
+}
+
+.social-manager__field-grid--compact {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.social-manager__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  min-width: 0;
+}
+
+.social-manager__field > span {
+  color: var(--color-text-muted);
+  font-size: 0.61rem;
+  font-weight: 750;
+}
+
+.social-manager__field small {
+  color: var(--color-text-muted);
+  font-size: 0.55rem;
+}
+
+.social-manager__checks {
+  flex-wrap: wrap;
+  margin-top: 0.7rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--color-line);
+}
+
+.social-manager__price-table,
+.social-manager__effect-table {
+  display: grid;
+  grid-template-columns: minmax(7rem, 1.3fr) repeat(3, minmax(4rem, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.7rem;
+  overflow-x: auto;
+}
+
+.social-manager__price-heading,
+.social-manager__effect-heading {
+  color: var(--color-text-muted);
+  font-size: 0.57rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.social-manager__price-row {
+  display: contents;
+}
+
+.social-manager__price-row strong,
+.social-manager__effect-row strong {
+  align-self: center;
+  font-size: 0.65rem;
+}
+
+.social-manager__resolved,
+.social-manager__effect-legend {
+  margin: 0.6rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+  line-height: 1.4;
+}
+
+.social-manager__editor h4 {
+  margin: 0.9rem 0 -0.15rem;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.social-manager__effect-table {
+  grid-template-columns: minmax(7rem, 1.5fr) repeat(4, minmax(4.2rem, 1fr));
+}
+
+.social-manager__effect-row {
+  display: contents;
+}
+
+.social-manager__data {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.social-manager__section-heading p {
+  margin-top: 0.2rem;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+}
+
+.social-manager__data > textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.65rem;
+  resize: vertical;
+}
+
+.social-manager__data-actions {
+  flex-wrap: wrap;
+}
+
+.social-manager__danger {
+  border-color: color-mix(in srgb, #ef4444 60%, var(--color-line)) !important;
+  color: #fca5a5 !important;
+}
+
+@media (max-width: 760px) {
+  .social-manager__hero,
+  .social-manager__workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .social-manager__catalog {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-height: 17rem;
+  }
+
+  .social-manager__catalog-count {
+    grid-column: 1 / -1;
+  }
+
+  .social-manager__field-grid--compact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .social-manager__field-grid,
+  .social-manager__field-grid--compact,
+  .social-manager__catalog {
+    grid-template-columns: 1fr;
+  }
+
+  .social-manager__editor-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/screens/SettingsAdmin/SocialManagerPanel.css
+++ b/src/screens/SettingsAdmin/SocialManagerPanel.css
@@ -41,12 +41,17 @@
   font-size: 1.25rem;
 }
 
-.social-manager__hero > div > p:last-child {
+.social-manager__hero > div > p:not(.social-manager__eyebrow) {
   max-width: 50rem;
   margin-top: 0.45rem;
   color: var(--color-text-muted);
   font-size: 0.75rem;
   line-height: 1.45;
+}
+
+.social-manager__hero .social-manager__help-intro {
+  color: color-mix(in srgb, var(--color-accent) 70%, var(--color-text)) !important;
+  font-weight: 700;
 }
 
 .social-manager__eyebrow {
@@ -327,10 +332,85 @@
   min-width: 0;
 }
 
-.social-manager__field > span {
+.social-manager__field > .social-manager__field-label {
   color: var(--color-text-muted);
   font-size: 0.61rem;
   font-weight: 750;
+}
+
+.social-manager__field-label,
+.social-manager__price-heading,
+.social-manager__price-row strong,
+.social-manager__effect-heading,
+.social-manager__effect-row strong {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.social-manager__help {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  text-align: left;
+  text-transform: none;
+}
+
+.social-manager .social-manager__help-trigger {
+  display: inline-grid;
+  place-items: center;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 60%, var(--color-line));
+  border-radius: 50%;
+  outline: none;
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-card));
+  color: color-mix(in srgb, var(--color-accent) 78%, var(--color-text));
+  font-size: 0.62rem;
+  font-weight: 900;
+  line-height: 1;
+  cursor: help;
+}
+
+.social-manager .social-manager__help-trigger:hover,
+.social-manager .social-manager__help-trigger:focus-visible {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.social-manager__tooltip {
+  position: absolute;
+  z-index: 50;
+  top: calc(100% + 0.4rem);
+  left: 50%;
+  width: max-content;
+  max-width: min(18rem, calc(100vw - 2rem));
+  padding: 0.55rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 55%, var(--color-line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-card) 94%, #000);
+  box-shadow: 0 10px 28px rgba(0 0 0 / 0.36);
+  color: var(--color-text);
+  font-size: 0.66rem;
+  font-weight: 550;
+  line-height: 1.42;
+  letter-spacing: normal;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -0.2rem);
+  transition:
+    opacity 0.12s ease,
+    transform 0.12s ease;
+  visibility: hidden;
+}
+
+.social-manager__help:hover .social-manager__tooltip,
+.social-manager__help:focus-within .social-manager__tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  visibility: visible;
 }
 
 .social-manager__field small {

--- a/src/screens/SettingsAdmin/SocialManagerPanel.tsx
+++ b/src/screens/SettingsAdmin/SocialManagerPanel.tsx
@@ -1,0 +1,888 @@
+import { useMemo, useState } from 'react'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { resetSocialActionOverrides, setSocialActionOverrides } from '../../store/settingsSlice'
+import type { SocialActionDefinition } from '../../social/socialActions'
+import {
+  REALITY_RELATIONSHIP_DIMENSIONS,
+  buildEffectiveSocialActions,
+  getAllowedRealityPresets,
+  getActionAffinityEffects,
+  getActionScoreEffects,
+  getDefaultRealityEffects,
+  getSocialActionGrouping,
+  sanitiseSocialActionOverrides,
+  type SocialActionLayer,
+  type SocialActionOverride,
+} from '../../social/socialActionManager'
+import { adaptLegacyActionContract } from '../../social/reality/actionContract'
+import { normalizeActionCosts, normalizeActionYields } from '../../social/smExecNormalize'
+import './SocialManagerPanel.css'
+
+type ManagerView = 'catalog' | 'data'
+type CostKey = 'baseCost' | 'dramaCost'
+type CostResource = 'energy' | 'influence' | 'info'
+type RealityEffectState = 'accepted' | 'rejected' | 'escalated' | 'deEscalated'
+
+const LAYERS: ReadonlyArray<{ id: 'all' | SocialActionLayer; label: string }> = [
+  { id: 'all', label: 'All actions' },
+  { id: 'basic', label: 'Basic' },
+  { id: 'reality', label: 'Reality Mode' },
+  { id: 'vox', label: 'Reality campaigns' },
+  { id: 'ai', label: 'AI & system' },
+]
+
+const REALITY_STATES: ReadonlyArray<{ id: RealityEffectState; label: string }> = [
+  { id: 'accepted', label: 'Accepted' },
+  { id: 'rejected', label: 'Rejected' },
+  { id: 'escalated', label: 'Escalated' },
+  { id: 'deEscalated', label: 'De-escalated' },
+]
+
+function toCostObject(cost: SocialActionDefinition['baseCost'] | undefined) {
+  if (typeof cost === 'number') return { energy: cost, influence: 0, info: 0 }
+  return {
+    energy: cost?.energy ?? 0,
+    influence: cost?.influence ?? 0,
+    info: cost?.info ?? 0,
+  }
+}
+
+function csv(values: readonly string[] | undefined): string {
+  return values?.join(', ') ?? ''
+}
+
+function parseCsv(value: string): string[] {
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+    ),
+  ]
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  step = 1,
+  hint,
+}: {
+  label: string
+  value: number
+  onChange: (value: number) => void
+  min?: number
+  max?: number
+  step?: number
+  hint?: string
+}) {
+  return (
+    <label className="social-manager__field">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(event) => {
+          const next = Number(event.target.value)
+          if (Number.isFinite(next)) onChange(next)
+        }}
+      />
+      {hint && <small>{hint}</small>}
+    </label>
+  )
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  hint,
+  multiline = false,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  hint?: string
+  multiline?: boolean
+}) {
+  return (
+    <label className="social-manager__field">
+      <span>{label}</span>
+      {multiline ? (
+        <textarea value={value} rows={3} onChange={(event) => onChange(event.target.value)} />
+      ) : (
+        <input type="text" value={value} onChange={(event) => onChange(event.target.value)} />
+      )}
+      {hint && <small>{hint}</small>}
+    </label>
+  )
+}
+
+export default function SocialManagerPanel() {
+  const dispatch = useAppDispatch()
+  const overrides = useAppSelector((state) => state.settings.social.actionOverrides)
+  const [view, setView] = useState<ManagerView>('catalog')
+  const [layer, setLayer] = useState<'all' | SocialActionLayer>('all')
+  const [subtype, setSubtype] = useState('all')
+  const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState('compliment')
+  const [dataText, setDataText] = useState('')
+  const [message, setMessage] = useState('')
+
+  const actions = useMemo(() => buildEffectiveSocialActions(overrides), [overrides])
+  const filteredActions = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    return actions
+      .filter((action) => {
+        const grouping = getSocialActionGrouping(action)
+        return (
+          (layer === 'all' || grouping.layer === layer) &&
+          (subtype === 'all' || grouping.subtype === subtype) &&
+          (!query ||
+            `${action.id} ${action.title} ${action.description ?? ''} ${action.outcomeTag ?? ''}`
+              .toLowerCase()
+              .includes(query))
+        )
+      })
+      .sort((left, right) => {
+        const leftGroup = getSocialActionGrouping(left)
+        const rightGroup = getSocialActionGrouping(right)
+        return (
+          leftGroup.layerLabel.localeCompare(rightGroup.layerLabel) ||
+          leftGroup.subtypeLabel.localeCompare(rightGroup.subtypeLabel) ||
+          left.title.localeCompare(right.title)
+        )
+      })
+  }, [actions, layer, search, subtype])
+
+  const subtypes = useMemo(() => {
+    const options = new Map<string, string>()
+    for (const action of actions) {
+      const grouping = getSocialActionGrouping(action)
+      if (layer === 'all' || grouping.layer === layer) {
+        options.set(grouping.subtype, grouping.subtypeLabel)
+      }
+    }
+    return [...options.entries()].sort((left, right) => left[1].localeCompare(right[1]))
+  }, [actions, layer])
+
+  const selected =
+    actions.find((action) => action.id === selectedId) ?? filteredActions[0] ?? actions[0]
+  if (!selected) return null
+
+  const grouping = getSocialActionGrouping(selected)
+  const contract = adaptLegacyActionContract(selected)
+  const affinityEffects = getActionAffinityEffects(selected)
+  const scoreEffects = getActionScoreEffects(selected)
+  const realityEffects = getDefaultRealityEffects(selected)
+  const normalCosts = normalizeActionCosts(selected, 1, false)
+  const realityCosts = normalizeActionCosts(selected, 1, true)
+  const resolvedYields = normalizeActionYields(selected)
+  const changedCount = Object.keys(overrides).length
+  const disabledCount = actions.filter((action) => action.enabled === false).length
+
+  function commit(patch: SocialActionOverride) {
+    dispatch(
+      setSocialActionOverrides({
+        ...overrides,
+        [selected.id]: { ...overrides[selected.id], ...patch },
+      })
+    )
+  }
+
+  function updateCost(key: CostKey, resource: CostResource, value: number) {
+    const source =
+      key === 'baseCost' ? selected.baseCost : (selected.dramaCost ?? selected.baseCost)
+    commit({ [key]: { ...toCostObject(source), [resource]: value } } as SocialActionOverride)
+  }
+
+  function updateArray(key: keyof SocialActionOverride, value: string) {
+    commit({ [key]: parseCsv(value) } as SocialActionOverride)
+  }
+
+  function updateRealityEffect(
+    state: RealityEffectState,
+    dimension: (typeof REALITY_RELATIONSHIP_DIMENSIONS)[number],
+    value: number
+  ) {
+    commit({
+      realityEffects: {
+        ...selected.realityEffects,
+        [state]: { ...realityEffects[state], [dimension]: value },
+      },
+    })
+  }
+
+  function resetSelected() {
+    const next = { ...overrides }
+    delete next[selected.id]
+    dispatch(setSocialActionOverrides(next))
+    setMessage(`${selected.title} restored to bundled defaults.`)
+  }
+
+  function exportData() {
+    const text = JSON.stringify({ schemaVersion: 1, actionOverrides: overrides }, null, 2)
+    setDataText(text)
+    void navigator.clipboard?.writeText(text).then(
+      () => setMessage('Social Manager JSON copied to the clipboard.'),
+      () => setMessage('Export prepared below. Copy it manually from the JSON field.')
+    )
+  }
+
+  function importData() {
+    try {
+      const parsed = JSON.parse(dataText) as { actionOverrides?: unknown }
+      const imported = sanitiseSocialActionOverrides(parsed.actionOverrides ?? parsed)
+      dispatch(setSocialActionOverrides(imported))
+      setMessage(`Imported ${Object.keys(imported).length} action override(s).`)
+    } catch {
+      setMessage('Import failed: the JSON is not valid.')
+    }
+  }
+
+  return (
+    <section className="social-manager" aria-label="Social Manager">
+      <header className="social-manager__hero">
+        <div>
+          <p className="social-manager__eyebrow">Central action contract</p>
+          <h2>Social Manager</h2>
+          <p>
+            Review and tune every outgoing social action. Changes are persistent and drive the
+            player catalog, AI execution, prices, eligibility, legacy affinity, and Reality
+            relationship effects.
+          </p>
+        </div>
+        <div className="social-manager__health" aria-label="Social action summary">
+          <strong>{actions.length}</strong>
+          <span>actions</span>
+          <strong>{changedCount}</strong>
+          <span>customized</span>
+          <strong>{disabledCount}</strong>
+          <span>disabled</span>
+        </div>
+      </header>
+
+      <nav className="social-manager__view-tabs" aria-label="Social Manager sections">
+        <button
+          className={view === 'catalog' ? 'is-active' : ''}
+          onClick={() => setView('catalog')}
+        >
+          Action catalog
+        </button>
+        <button className={view === 'data' ? 'is-active' : ''} onClick={() => setView('data')}>
+          Import / export
+        </button>
+      </nav>
+
+      {message && (
+        <div className="social-manager__message" role="status">
+          <span>{message}</span>
+          <button onClick={() => setMessage('')} aria-label="Dismiss message">
+            ×
+          </button>
+        </div>
+      )}
+
+      {view === 'data' ? (
+        <div className="social-manager__data">
+          <div className="social-manager__section-heading">
+            <h3>Portable authoring data</h3>
+            <p>Only your overrides are exported. Bundled defaults stay in source control.</p>
+          </div>
+          <textarea
+            rows={18}
+            value={dataText}
+            onChange={(event) => setDataText(event.target.value)}
+            spellCheck={false}
+            aria-label="Social Manager JSON"
+          />
+          <div className="social-manager__data-actions">
+            <button onClick={exportData}>Export & copy</button>
+            <button onClick={importData}>Import JSON</button>
+            <button
+              className="social-manager__danger"
+              onClick={() => {
+                if (!window.confirm('Reset every Social Manager override?')) return
+                dispatch(resetSocialActionOverrides())
+                setDataText('')
+                setMessage('All social actions restored to bundled defaults.')
+              }}
+            >
+              Reset all overrides
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="social-manager__filters">
+            <div className="social-manager__segments" aria-label="Action layer filter">
+              {LAYERS.map((item) => (
+                <button
+                  key={item.id}
+                  className={layer === item.id ? 'is-active' : ''}
+                  onClick={() => {
+                    setLayer(item.id)
+                    setSubtype('all')
+                  }}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+            <select value={subtype} onChange={(event) => setSubtype(event.target.value)}>
+              <option value="all">All subtypes</option>
+              {subtypes.map(([id, label]) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <input
+              type="search"
+              value={search}
+              placeholder="Search actions, tags, IDs…"
+              onChange={(event) => setSearch(event.target.value)}
+              aria-label="Search social actions"
+            />
+          </div>
+
+          <div className="social-manager__workspace">
+            <aside className="social-manager__catalog" aria-label="Social actions">
+              <div className="social-manager__catalog-count">{filteredActions.length} shown</div>
+              {filteredActions.map((action) => {
+                const actionGrouping = getSocialActionGrouping(action)
+                return (
+                  <button
+                    key={action.id}
+                    className={`${selected.id === action.id ? 'is-selected' : ''} ${action.enabled === false ? 'is-disabled' : ''}`}
+                    onClick={() => setSelectedId(action.id)}
+                  >
+                    <span className="social-manager__catalog-icon">{action.icon ?? '•'}</span>
+                    <span>
+                      <strong>{action.title}</strong>
+                      <small>
+                        {actionGrouping.subtypeLabel} · {action.id}
+                      </small>
+                    </span>
+                    {overrides[action.id] && <i title="Customized">●</i>}
+                  </button>
+                )
+              })}
+            </aside>
+
+            <article className="social-manager__editor">
+              <header className="social-manager__editor-header">
+                <div>
+                  <p>
+                    {grouping.layerLabel} / {grouping.subtypeLabel}
+                  </p>
+                  <h3>
+                    {selected.icon} {selected.title}
+                  </h3>
+                  <code>{selected.id}</code>
+                </div>
+                <div className="social-manager__editor-actions">
+                  <label className="social-manager__switch">
+                    <input
+                      type="checkbox"
+                      checked={selected.enabled !== false}
+                      onChange={(event) => commit({ enabled: event.target.checked })}
+                    />
+                    Enabled
+                  </label>
+                  <button onClick={resetSelected} disabled={!overrides[selected.id]}>
+                    Reset action
+                  </button>
+                </div>
+              </header>
+
+              <details open>
+                <summary>Identity & placement</summary>
+                <div className="social-manager__field-grid">
+                  <TextField
+                    label="Title"
+                    value={selected.title}
+                    onChange={(title) => commit({ title })}
+                  />
+                  <TextField
+                    label="Icon"
+                    value={selected.icon ?? ''}
+                    onChange={(icon) => commit({ icon })}
+                  />
+                  <TextField
+                    label="Description"
+                    value={selected.description ?? ''}
+                    onChange={(description) => commit({ description })}
+                    multiline
+                  />
+                  <TextField
+                    label="Availability hint"
+                    value={selected.availabilityHint ?? ''}
+                    onChange={(availabilityHint) => commit({ availabilityHint })}
+                  />
+                  <label className="social-manager__field">
+                    <span>Category</span>
+                    <select
+                      value={selected.category}
+                      onChange={(event) =>
+                        commit({
+                          category: event.target.value as SocialActionDefinition['category'],
+                        })
+                      }
+                    >
+                      <option value="friendly">Friendly</option>
+                      <option value="strategic">Strategic</option>
+                      <option value="aggressive">Aggressive</option>
+                      <option value="alliance">Alliance</option>
+                    </select>
+                  </label>
+                  <label className="social-manager__field">
+                    <span>Economy role</span>
+                    <select
+                      value={selected.kind ?? ''}
+                      onChange={(event) =>
+                        commit({
+                          kind: (event.target.value || undefined) as SocialActionDefinition['kind'],
+                        })
+                      }
+                    >
+                      <option value="">Unspecified</option>
+                      <option value="rapport">Rapport</option>
+                      <option value="intel_gain">Intel gain</option>
+                      <option value="intel_spend">Intel spend</option>
+                      <option value="political_spend">Political spend</option>
+                      <option value="aggressive">Aggressive</option>
+                    </select>
+                  </label>
+                </div>
+                <div className="social-manager__checks">
+                  {(
+                    [
+                      ['dramaOnly', 'Reality only'],
+                      ['realityExclusive', 'Locked Reality preview'],
+                      ['voxOnly', 'Vox Populi only'],
+                      ['aiOnly', 'AI only'],
+                      ['requiresKnownSecret', 'Requires known secret'],
+                      ['requiredArcPublic', 'Requires public story arc'],
+                      ['allowActorAsSubject', 'Actor may be subject'],
+                    ] as const
+                  ).map(([key, label]) => (
+                    <label key={key}>
+                      <input
+                        type="checkbox"
+                        checked={selected[key] === true}
+                        onChange={(event) => commit({ [key]: event.target.checked })}
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </details>
+
+              <details open>
+                <summary>Prices & resources</summary>
+                <div className="social-manager__price-table">
+                  <div className="social-manager__price-heading">Mode</div>
+                  <div className="social-manager__price-heading">Energy</div>
+                  <div className="social-manager__price-heading">Influence</div>
+                  <div className="social-manager__price-heading">Info</div>
+                  {(
+                    [
+                      ['baseCost', 'Basic', toCostObject(selected.baseCost)],
+                      [
+                        'dramaCost',
+                        'Reality',
+                        toCostObject(selected.dramaCost ?? selected.baseCost),
+                      ],
+                    ] as const
+                  ).map(([key, label, costs]) => (
+                    <div className="social-manager__price-row" key={key}>
+                      <strong>{label}</strong>
+                      {(['energy', 'influence', 'info'] as const).map((resource) => (
+                        <input
+                          key={resource}
+                          type="number"
+                          min={0}
+                          step={0.1}
+                          value={costs[resource]}
+                          aria-label={`${label} ${resource} price`}
+                          onChange={(event) =>
+                            updateCost(key, resource, Number(event.target.value))
+                          }
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+                <p className="social-manager__resolved">
+                  Runtime bank price for one target — Basic: ⚡{normalCosts.energy} · 🤝
+                  {normalCosts.influence} · 💡{normalCosts.info}; Reality: ⚡{realityCosts.energy} ·
+                  🤝{realityCosts.influence} · 💡{realityCosts.info}
+                </p>
+                <div className="social-manager__field-grid social-manager__field-grid--compact">
+                  <NumberField
+                    label="Influence yield (authored)"
+                    value={selected.yields?.influence ?? 0}
+                    step={0.01}
+                    onChange={(influence) => commit({ yields: { ...selected.yields, influence } })}
+                    hint={`Runtime: +${resolvedYields.influence}`}
+                  />
+                  <NumberField
+                    label="Info yield (authored)"
+                    value={selected.yields?.info ?? 0}
+                    step={0.1}
+                    onChange={(info) => commit({ yields: { ...selected.yields, info } })}
+                    hint={`Runtime: +${resolvedYields.info}`}
+                  />
+                  <NumberField
+                    label="Reality base weight"
+                    value={selected.successWeight ?? 1}
+                    min={0}
+                    step={0.05}
+                    onChange={(successWeight) => commit({ successWeight })}
+                  />
+                  <NumberField
+                    label="Normal AI selection weight"
+                    value={selected.aiWeight ?? 0}
+                    min={0}
+                    step={0.05}
+                    onChange={(aiWeight) => commit({ aiWeight })}
+                    hint="0 leaves bundled AI policy unchanged"
+                  />
+                  <NumberField
+                    label="Energy per target"
+                    value={selected.energyPerTarget ?? 0}
+                    min={0}
+                    step={0.1}
+                    onChange={(energyPerTarget) => commit({ energyPerTarget })}
+                  />
+                </div>
+              </details>
+
+              <details open>
+                <summary>Connections, targets & eligibility</summary>
+                <div className="social-manager__field-grid">
+                  <label className="social-manager__field">
+                    <span>Basic target shape</span>
+                    <select
+                      value={
+                        selected.targetMode ??
+                        (selected.needsTargets === false ? 'none' : 'primary')
+                      }
+                      onChange={(event) =>
+                        commit({
+                          targetMode: event.target.value as SocialActionDefinition['targetMode'],
+                        })
+                      }
+                    >
+                      <option value="none">No target</option>
+                      <option value="primary">One target</option>
+                      <option value="primaryPlusSubject">Target + subject</option>
+                      <option value="multi">Multiple targets</option>
+                    </select>
+                  </label>
+                  <label className="social-manager__field">
+                    <span>Reality target shape</span>
+                    <select
+                      value={selected.dramaTargetMode ?? selected.targetMode ?? 'primary'}
+                      onChange={(event) =>
+                        commit({
+                          dramaTargetMode: event.target
+                            .value as SocialActionDefinition['dramaTargetMode'],
+                        })
+                      }
+                    >
+                      <option value="none">No target</option>
+                      <option value="primary">One target</option>
+                      <option value="primaryPlusSubject">Target + subject</option>
+                      <option value="multi">Multiple targets</option>
+                    </select>
+                  </label>
+                  <label className="social-manager__field">
+                    <span>Subject pool</span>
+                    <select
+                      value={selected.subjectPool ?? 'houseguests'}
+                      onChange={(event) =>
+                        commit({
+                          subjectPool: event.target.value as SocialActionDefinition['subjectPool'],
+                        })
+                      }
+                    >
+                      <option value="houseguests">Houseguests</option>
+                      <option value="nominees">Nominees</option>
+                      <option value="non_nominees">Non-nominees</option>
+                      <option value="allies">Allies</option>
+                      <option value="voters">Voters</option>
+                    </select>
+                  </label>
+                  <NumberField
+                    label="Minimum targets"
+                    value={selected.minTargets ?? 1}
+                    min={0}
+                    max={32}
+                    onChange={(minTargets) => commit({ minTargets })}
+                  />
+                  <NumberField
+                    label="Maximum targets"
+                    value={selected.maxTargets ?? 1}
+                    min={0}
+                    max={32}
+                    onChange={(maxTargets) => commit({ maxTargets })}
+                  />
+                  <TextField
+                    label="Basic phases"
+                    value={csv(selected.allowedPhases)}
+                    onChange={(value) => updateArray('allowedPhases', value)}
+                    hint="Comma-separated; blank means any phase"
+                  />
+                  <TextField
+                    label="Reality phases"
+                    value={csv(selected.dramaAllowedPhases)}
+                    onChange={(value) => updateArray('dramaAllowedPhases', value)}
+                  />
+                  <TextField
+                    label="Actor roles"
+                    value={csv(selected.requiredActorStatus)}
+                    onChange={(value) => updateArray('requiredActorStatus', value)}
+                  />
+                  <TextField
+                    label="Reality actor roles"
+                    value={csv(selected.dramaRequiredActorStatus)}
+                    onChange={(value) => updateArray('dramaRequiredActorStatus', value)}
+                  />
+                  <TextField
+                    label="Target roles"
+                    value={csv(selected.requiredTargetStatus)}
+                    onChange={(value) => updateArray('requiredTargetStatus', value)}
+                  />
+                  <TextField
+                    label="Reality target roles"
+                    value={csv(selected.dramaRequiredTargetStatus)}
+                    onChange={(value) => updateArray('dramaRequiredTargetStatus', value)}
+                  />
+                  <TextField
+                    label="Required relationship tags"
+                    value={csv(selected.requiredRelationshipTags)}
+                    onChange={(value) => updateArray('requiredRelationshipTags', value)}
+                  />
+                  <TextField
+                    label="Excluded relationship tags"
+                    value={csv(selected.excludedRelationshipTags)}
+                    onChange={(value) => updateArray('excludedRelationshipTags', value)}
+                  />
+                  <TextField
+                    label="Reality required tags"
+                    value={csv(selected.dramaRequiredRelationshipTags)}
+                    onChange={(value) => updateArray('dramaRequiredRelationshipTags', value)}
+                  />
+                  <TextField
+                    label="Reality excluded tags"
+                    value={csv(selected.dramaExcludedRelationshipTags)}
+                    onChange={(value) => updateArray('dramaExcludedRelationshipTags', value)}
+                  />
+                  <NumberField
+                    label="Minimum affinity"
+                    value={selected.minAffinity ?? -100}
+                    min={-100}
+                    max={100}
+                    onChange={(minAffinity) => commit({ minAffinity })}
+                  />
+                  <NumberField
+                    label="Maximum affinity"
+                    value={selected.maxAffinity ?? 100}
+                    min={-100}
+                    max={100}
+                    onChange={(maxAffinity) => commit({ maxAffinity })}
+                  />
+                  <NumberField
+                    label="Reality minimum affinity"
+                    value={selected.dramaMinAffinity ?? selected.minAffinity ?? -100}
+                    min={-100}
+                    max={100}
+                    onChange={(dramaMinAffinity) => commit({ dramaMinAffinity })}
+                  />
+                  <NumberField
+                    label="Reality maximum affinity"
+                    value={selected.dramaMaxAffinity ?? selected.maxAffinity ?? 100}
+                    min={-100}
+                    max={100}
+                    onChange={(dramaMaxAffinity) => commit({ dramaMaxAffinity })}
+                  />
+                  <TextField
+                    label="Required story arcs"
+                    value={csv(selected.requiredArcTypes)}
+                    onChange={(value) => updateArray('requiredArcTypes', value)}
+                    hint="romance, bromance, rivalry, betrayal"
+                  />
+                  <TextField
+                    label="Excluded story arcs"
+                    value={csv(selected.excludedArcTypes)}
+                    onChange={(value) => updateArray('excludedArcTypes', value)}
+                  />
+                  <TextField
+                    label="Required arc stages"
+                    value={csv(selected.requiredArcStages)}
+                    onChange={(value) => updateArray('requiredArcStages', value)}
+                  />
+                </div>
+
+                <h4>Reality action-contract connections</h4>
+                <div className="social-manager__field-grid">
+                  <TextField
+                    label="Purposes"
+                    value={contract.purposes.join(', ')}
+                    onChange={(value) => updateArray('realityPurposes', value.toUpperCase())}
+                  />
+                  <TextField
+                    label="Directions"
+                    value={contract.allowedDirections.join(', ')}
+                    onChange={(value) =>
+                      updateArray('realityAllowedDirections', value.toUpperCase())
+                    }
+                  />
+                  <TextField
+                    label="Game modes"
+                    value={contract.allowedGameModes.join(', ')}
+                    onChange={(value) =>
+                      updateArray('realityAllowedGameModes', value.toUpperCase())
+                    }
+                  />
+                  <TextField
+                    label="Reality intensity presets"
+                    value={getAllowedRealityPresets(selected).join(', ')}
+                    onChange={(value) => updateArray('allowedRealityPresets', value.toLowerCase())}
+                    hint="casual, tv, adult"
+                  />
+                  <label className="social-manager__field">
+                    <span>Visibility</span>
+                    <select
+                      value={contract.visibility}
+                      onChange={(event) => commit({ realityVisibility: event.target.value })}
+                    >
+                      <option>PRIVATE</option>
+                      <option>PAIR_ONLY</option>
+                      <option>GROUP_VISIBLE</option>
+                      <option>HOUSE_PUBLIC</option>
+                      <option>CEREMONY_PUBLIC</option>
+                      <option>VIEWER_ONLY</option>
+                      <option>JURY_ONLY</option>
+                    </select>
+                  </label>
+                  <NumberField
+                    label="Cooldown phases"
+                    value={contract.cooldownPhases}
+                    min={0}
+                    max={100}
+                    onChange={(realityCooldownPhases) => commit({ realityCooldownPhases })}
+                  />
+                  <TextField
+                    label="Response set"
+                    value={contract.responseSetId}
+                    onChange={(responseSetId) => commit({ responseSetId })}
+                  />
+                  <TextField
+                    label="Outcome resolver"
+                    value={contract.outcomeResolverId}
+                    onChange={(outcomeResolverId) => commit({ outcomeResolverId })}
+                  />
+                  <TextField
+                    label="Memory template"
+                    value={contract.memoryTemplateId}
+                    onChange={(memoryTemplateId) => commit({ memoryTemplateId })}
+                  />
+                  <TextField
+                    label="Dialogue set"
+                    value={contract.dialogueSetId}
+                    onChange={(dialogueSetId) => commit({ dialogueSetId })}
+                  />
+                  <TextField
+                    label="Relationship outcome tag"
+                    value={selected.outcomeTag ?? ''}
+                    onChange={(outcomeTag) => commit({ outcomeTag })}
+                  />
+                </div>
+              </details>
+
+              <details open>
+                <summary>Effects</summary>
+                <div className="social-manager__field-grid social-manager__field-grid--compact">
+                  <NumberField
+                    label="Affinity on success"
+                    value={affinityEffects.success}
+                    min={-100}
+                    max={100}
+                    onChange={(success) =>
+                      commit({ affinityEffects: { ...affinityEffects, success } })
+                    }
+                  />
+                  <NumberField
+                    label="Affinity on failure"
+                    value={affinityEffects.failure}
+                    min={-100}
+                    max={100}
+                    onChange={(failure) =>
+                      commit({ affinityEffects: { ...affinityEffects, failure } })
+                    }
+                  />
+                  <NumberField
+                    label="Outcome score on success"
+                    value={scoreEffects.success}
+                    min={-1}
+                    max={1}
+                    step={0.01}
+                    onChange={(success) => commit({ scoreEffects: { ...scoreEffects, success } })}
+                  />
+                  <NumberField
+                    label="Outcome score on failure"
+                    value={scoreEffects.failure}
+                    min={-1}
+                    max={1}
+                    step={0.01}
+                    onChange={(failure) => commit({ scoreEffects: { ...scoreEffects, failure } })}
+                  />
+                </div>
+                <div className="social-manager__effect-legend">
+                  Reality effects are directed deltas from actor to target. Every relationship
+                  dimension can be tuned independently for each response state.
+                </div>
+                <div className="social-manager__effect-table">
+                  <div className="social-manager__effect-heading">Dimension</div>
+                  {REALITY_STATES.map((state) => (
+                    <div key={state.id} className="social-manager__effect-heading">
+                      {state.label}
+                    </div>
+                  ))}
+                  {REALITY_RELATIONSHIP_DIMENSIONS.map((dimension) => (
+                    <div className="social-manager__effect-row" key={dimension}>
+                      <strong>{dimension}</strong>
+                      {REALITY_STATES.map((state) => (
+                        <input
+                          key={state.id}
+                          type="number"
+                          step={1}
+                          min={-100}
+                          max={100}
+                          value={realityEffects[state.id][dimension] ?? 0}
+                          aria-label={`${dimension} when ${state.label.toLowerCase()}`}
+                          onChange={(event) =>
+                            updateRealityEffect(state.id, dimension, Number(event.target.value))
+                          }
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </details>
+            </article>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/screens/SettingsAdmin/SocialManagerPanel.tsx
+++ b/src/screens/SettingsAdmin/SocialManagerPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useId, useMemo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../../store/hooks'
 import { resetSocialActionOverrides, setSocialActionOverrides } from '../../store/settingsSlice'
 import type { SocialActionDefinition } from '../../social/socialActions'
@@ -38,6 +38,69 @@ const REALITY_STATES: ReadonlyArray<{ id: RealityEffectState; label: string }> =
   { id: 'deEscalated', label: 'De-escalated' },
 ]
 
+const REALITY_STATE_HELP: Record<RealityEffectState, string> = {
+  accepted:
+    'Applied when the target accepts or responds positively. Positive numbers strengthen that dimension; negative numbers weaken it.',
+  rejected:
+    'Applied when the target rejects the action. Positive numbers increase the dimension; negative numbers reduce it.',
+  escalated:
+    'Applied when the interaction intensifies into a stronger version. Use larger magnitudes for a more dramatic relationship shift.',
+  deEscalated:
+    'Applied when the interaction is cooled down or softened. Positive and negative values still change the named dimension directly.',
+}
+
+const REALITY_DIMENSION_HELP: Record<(typeof REALITY_RELATIONSHIP_DIMENSIONS)[number], string> = {
+  warmth: 'General fondness and emotional warmth toward the target.',
+  trust: 'Belief that the target is honest, safe, and dependable.',
+  loyalty: 'Willingness to stand by, protect, or vote with the target.',
+  respect: 'Admiration for the target’s competence, character, or status.',
+  attraction: 'Romantic or physical attraction toward the target.',
+  intimacy: 'Emotional or physical closeness beyond ordinary friendliness.',
+  gratitude: 'How thankful or indebted the actor feels toward the target.',
+  resentment: 'Stored anger or bitterness. Positive values create more resentment.',
+  fear: 'How threatened or intimidated the actor feels by the target.',
+  envy: 'Jealousy of the target’s position, bonds, attention, or success.',
+  suspicion: 'Doubt about the target’s motives or truthfulness.',
+  strategicValue: 'How useful the actor considers the target for their game.',
+  perceivedThreat: 'How dangerous the target appears strategically or socially.',
+  reliability: 'Expectation that the target will keep promises and follow through.',
+  familiarity: 'How well the actor feels they know the target.',
+  publicCloseness: 'Closeness that other houseguests or viewers can perceive.',
+  secretCloseness: 'Private closeness that may be hidden from the house.',
+}
+
+function HelpTooltip({ text }: { text: string }) {
+  const id = useId()
+  return (
+    <span className="social-manager__help">
+      <button
+        type="button"
+        className="social-manager__help-trigger"
+        aria-label="Explain this field"
+        aria-describedby={id}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+      >
+        ?
+      </button>
+      <span id={id} role="tooltip" className="social-manager__tooltip">
+        {text}
+      </span>
+    </span>
+  )
+}
+
+function FieldLabel({ label, help }: { label: string; help: string }) {
+  return (
+    <span className="social-manager__field-label">
+      <span>{label}</span>
+      <HelpTooltip text={help} />
+    </span>
+  )
+}
+
 function toCostObject(cost: SocialActionDefinition['baseCost'] | undefined) {
   if (typeof cost === 'number') return { energy: cost, influence: 0, info: 0 }
   return {
@@ -70,6 +133,7 @@ function NumberField({
   max,
   step = 1,
   hint,
+  help,
 }: {
   label: string
   value: number
@@ -78,10 +142,11 @@ function NumberField({
   max?: number
   step?: number
   hint?: string
+  help: string
 }) {
   return (
     <label className="social-manager__field">
-      <span>{label}</span>
+      <FieldLabel label={label} help={help} />
       <input
         type="number"
         value={value}
@@ -103,17 +168,19 @@ function TextField({
   value,
   onChange,
   hint,
+  help,
   multiline = false,
 }: {
   label: string
   value: string
   onChange: (value: string) => void
   hint?: string
+  help: string
   multiline?: boolean
 }) {
   return (
     <label className="social-manager__field">
-      <span>{label}</span>
+      <FieldLabel label={label} help={help} />
       {multiline ? (
         <textarea value={value} rows={3} onChange={(event) => onChange(event.target.value)} />
       ) : (
@@ -257,6 +324,10 @@ export default function SocialManagerPanel() {
             player catalog, AI execution, prices, eligibility, legacy affinity, and Reality
             relationship effects.
           </p>
+          <p className="social-manager__help-intro">
+            Hover, focus, or tap any <strong>?</strong> to see what a field controls and how
+            changing it affects the game.
+          </p>
         </div>
         <div className="social-manager__health" aria-label="Social action summary">
           <strong>{actions.length}</strong>
@@ -395,6 +466,7 @@ export default function SocialManagerPanel() {
                       onChange={(event) => commit({ enabled: event.target.checked })}
                     />
                     Enabled
+                    <HelpTooltip text="Master switch for this action. Disable it to remove it from player, AI, and Reality execution without deleting its configuration." />
                   </label>
                   <button onClick={resetSelected} disabled={!overrides[selected.id]}>
                     Reset action
@@ -407,27 +479,34 @@ export default function SocialManagerPanel() {
                 <div className="social-manager__field-grid">
                   <TextField
                     label="Title"
+                    help="The player-facing name shown on the action card and in Social Manager. Changing it affects wording only, not behavior."
                     value={selected.title}
                     onChange={(title) => commit({ title })}
                   />
                   <TextField
                     label="Icon"
+                    help="The emoji or short symbol displayed beside this action. Changing it is visual only."
                     value={selected.icon ?? ''}
                     onChange={(icon) => commit({ icon })}
                   />
                   <TextField
                     label="Description"
+                    help="Explains the action to the player. Change this when the action’s purpose or result needs clearer wording; it does not change mechanics."
                     value={selected.description ?? ''}
                     onChange={(description) => commit({ description })}
                     multiline
                   />
                   <TextField
                     label="Availability hint"
+                    help="Shown when the action is unavailable to explain what is missing. This is guidance text; the actual rules are set in the eligibility fields below."
                     value={selected.availabilityHint ?? ''}
                     onChange={(availabilityHint) => commit({ availabilityHint })}
                   />
                   <label className="social-manager__field">
-                    <span>Category</span>
+                    <FieldLabel
+                      label="Category"
+                      help="Controls where the action is grouped and how policies interpret its intent: friendly, strategic, aggressive, or alliance-focused."
+                    />
                     <select
                       value={selected.category}
                       onChange={(event) =>
@@ -443,7 +522,10 @@ export default function SocialManagerPanel() {
                     </select>
                   </label>
                   <label className="social-manager__field">
-                    <span>Economy role</span>
+                    <FieldLabel
+                      label="Economy role"
+                      help="Describes the action’s resource purpose to selection and balancing systems. For example, intel gain earns information while intel spend consumes it."
+                    />
                     <select
                       value={selected.kind ?? ''}
                       onChange={(event) =>
@@ -464,15 +546,43 @@ export default function SocialManagerPanel() {
                 <div className="social-manager__checks">
                   {(
                     [
-                      ['dramaOnly', 'Reality only'],
-                      ['realityExclusive', 'Locked Reality preview'],
-                      ['voxOnly', 'Vox Populi only'],
-                      ['aiOnly', 'AI only'],
-                      ['requiresKnownSecret', 'Requires known secret'],
-                      ['requiredArcPublic', 'Requires public story arc'],
-                      ['allowActorAsSubject', 'Actor may be subject'],
+                      [
+                        'dramaOnly',
+                        'Reality only',
+                        'When enabled, this action is hidden and blocked outside Reality Mode.',
+                      ],
+                      [
+                        'realityExclusive',
+                        'Locked Reality preview',
+                        'Marks the action as exclusive Reality content that may appear as a locked preview when Reality Mode is unavailable.',
+                      ],
+                      [
+                        'voxOnly',
+                        'Vox Populi only',
+                        'Restricts the action to Vox Populi games and campaign systems.',
+                      ],
+                      [
+                        'aiOnly',
+                        'AI only',
+                        'Prevents the player from choosing this action directly; AI and system flows can still execute it.',
+                      ],
+                      [
+                        'requiresKnownSecret',
+                        'Requires known secret',
+                        'The actor must possess usable secret information before this action becomes eligible.',
+                      ],
+                      [
+                        'requiredArcPublic',
+                        'Requires public story arc',
+                        'The required relationship story arc must already be publicly known, not merely active in private.',
+                      ],
+                      [
+                        'allowActorAsSubject',
+                        'Actor may be subject',
+                        'Allows the acting houseguest to also fill the secondary subject slot. Disable it to require somebody else.',
+                      ],
                     ] as const
-                  ).map(([key, label]) => (
+                  ).map(([key, label, help]) => (
                     <label key={key}>
                       <input
                         type="checkbox"
@@ -480,6 +590,7 @@ export default function SocialManagerPanel() {
                         onChange={(event) => commit({ [key]: event.target.checked })}
                       />
                       {label}
+                      <HelpTooltip text={help} />
                     </label>
                   ))}
                 </div>
@@ -489,9 +600,18 @@ export default function SocialManagerPanel() {
                 <summary>Prices & resources</summary>
                 <div className="social-manager__price-table">
                   <div className="social-manager__price-heading">Mode</div>
-                  <div className="social-manager__price-heading">Energy</div>
-                  <div className="social-manager__price-heading">Influence</div>
-                  <div className="social-manager__price-heading">Info</div>
+                  <div className="social-manager__price-heading">
+                    Energy
+                    <HelpTooltip text="Energy spent when the action runs. Higher values make the action harder to afford and reduce how often it can be used." />
+                  </div>
+                  <div className="social-manager__price-heading">
+                    Influence
+                    <HelpTooltip text="Influence spent when the action runs. Raise it for politically powerful actions; lower it to make them easier to access." />
+                  </div>
+                  <div className="social-manager__price-heading">
+                    Info
+                    <HelpTooltip text="Information resource spent when the action runs. Use this to price actions that reveal, weaponize, or trade secrets." />
+                  </div>
                   {(
                     [
                       ['baseCost', 'Basic', toCostObject(selected.baseCost)],
@@ -503,7 +623,16 @@ export default function SocialManagerPanel() {
                     ] as const
                   ).map(([key, label, costs]) => (
                     <div className="social-manager__price-row" key={key}>
-                      <strong>{label}</strong>
+                      <strong>
+                        {label}
+                        <HelpTooltip
+                          text={
+                            key === 'baseCost'
+                              ? 'These prices apply in normal/basic social play.'
+                              : 'These prices apply in Reality Mode and override Basic prices there.'
+                          }
+                        />
+                      </strong>
                       {(['energy', 'influence', 'info'] as const).map((resource) => (
                         <input
                           key={resource}
@@ -512,6 +641,7 @@ export default function SocialManagerPanel() {
                           step={0.1}
                           value={costs[resource]}
                           aria-label={`${label} ${resource} price`}
+                          title={`${label} ${resource} cost. Higher values make this action more expensive in ${label.toLowerCase()} mode.`}
                           onChange={(event) =>
                             updateCost(key, resource, Number(event.target.value))
                           }
@@ -528,6 +658,7 @@ export default function SocialManagerPanel() {
                 <div className="social-manager__field-grid social-manager__field-grid--compact">
                   <NumberField
                     label="Influence yield (authored)"
+                    help="Influence awarded after using the action. Increasing it makes this action a stronger source of political currency; the runtime value below shows the normalized award."
                     value={selected.yields?.influence ?? 0}
                     step={0.01}
                     onChange={(influence) => commit({ yields: { ...selected.yields, influence } })}
@@ -535,6 +666,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Info yield (authored)"
+                    help="Information awarded after using the action. Increasing it makes the action a stronger source of intel; the runtime value below shows the normalized award."
                     value={selected.yields?.info ?? 0}
                     step={0.1}
                     onChange={(info) => commit({ yields: { ...selected.yields, info } })}
@@ -542,6 +674,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Reality base weight"
+                    help="Relative chance or strength used by Reality action selection. Higher values make the action more favored compared with other eligible Reality actions; 0 effectively removes its weight."
                     value={selected.successWeight ?? 1}
                     min={0}
                     step={0.05}
@@ -549,6 +682,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Normal AI selection weight"
+                    help="Overrides how strongly normal-mode AI prefers this action. Higher values make selection more likely; 0 keeps the bundled AI policy’s original weighting."
                     value={selected.aiWeight ?? 0}
                     min={0}
                     step={0.05}
@@ -557,6 +691,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Energy per target"
+                    help="Extra energy charged for every selected target. Increasing it makes multi-target use progressively more expensive; 0 adds no target-based surcharge."
                     value={selected.energyPerTarget ?? 0}
                     min={0}
                     step={0.1}
@@ -569,7 +704,10 @@ export default function SocialManagerPanel() {
                 <summary>Connections, targets & eligibility</summary>
                 <div className="social-manager__field-grid">
                   <label className="social-manager__field">
-                    <span>Basic target shape</span>
+                    <FieldLabel
+                      label="Basic target shape"
+                      help="Defines the people the player must choose in normal mode: nobody, one primary target, a target plus a discussed subject, or several targets."
+                    />
                     <select
                       value={
                         selected.targetMode ??
@@ -588,7 +726,10 @@ export default function SocialManagerPanel() {
                     </select>
                   </label>
                   <label className="social-manager__field">
-                    <span>Reality target shape</span>
+                    <FieldLabel
+                      label="Reality target shape"
+                      help="Reality Mode’s target structure. It overrides the Basic target shape while Reality Mode is active."
+                    />
                     <select
                       value={selected.dramaTargetMode ?? selected.targetMode ?? 'primary'}
                       onChange={(event) =>
@@ -605,7 +746,10 @@ export default function SocialManagerPanel() {
                     </select>
                   </label>
                   <label className="social-manager__field">
-                    <span>Subject pool</span>
+                    <FieldLabel
+                      label="Subject pool"
+                      help="Limits who may be selected as the secondary subject: everyone, nominees, non-nominees, allies, or eligible voters."
+                    />
                     <select
                       value={selected.subjectPool ?? 'houseguests'}
                       onChange={(event) =>
@@ -623,6 +767,7 @@ export default function SocialManagerPanel() {
                   </label>
                   <NumberField
                     label="Minimum targets"
+                    help="The fewest primary targets required before the action can run. Raising it blocks the action when too few valid people are available."
                     value={selected.minTargets ?? 1}
                     min={0}
                     max={32}
@@ -630,6 +775,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Maximum targets"
+                    help="The largest number of primary targets the player or AI may select. Lower it to cap group actions; raise it to allow broader reach."
                     value={selected.maxTargets ?? 1}
                     min={0}
                     max={32}
@@ -637,57 +783,69 @@ export default function SocialManagerPanel() {
                   />
                   <TextField
                     label="Basic phases"
+                    help="Comma-separated game phase IDs in which normal mode may use this action. A blank list means it is allowed in every phase."
                     value={csv(selected.allowedPhases)}
                     onChange={(value) => updateArray('allowedPhases', value)}
                     hint="Comma-separated; blank means any phase"
                   />
                   <TextField
                     label="Reality phases"
+                    help="Comma-separated phase IDs allowed specifically in Reality Mode. This overrides or narrows the Basic phase list for Reality execution."
                     value={csv(selected.dramaAllowedPhases)}
                     onChange={(value) => updateArray('dramaAllowedPhases', value)}
+                    hint="Comma-separated; blank inherits broad availability"
                   />
                   <TextField
                     label="Actor roles"
+                    help="Comma-separated statuses the acting houseguest must have in normal mode, such as nominee, HOH, voter, or juror. Blank allows any actor role."
                     value={csv(selected.requiredActorStatus)}
                     onChange={(value) => updateArray('requiredActorStatus', value)}
                   />
                   <TextField
                     label="Reality actor roles"
+                    help="Reality-specific statuses required for the acting houseguest. Use this to make an action available only to certain Reality roles."
                     value={csv(selected.dramaRequiredActorStatus)}
                     onChange={(value) => updateArray('dramaRequiredActorStatus', value)}
                   />
                   <TextField
                     label="Target roles"
+                    help="Comma-separated statuses a valid primary target must have in normal mode. Blank accepts targets of any role."
                     value={csv(selected.requiredTargetStatus)}
                     onChange={(value) => updateArray('requiredTargetStatus', value)}
                   />
                   <TextField
                     label="Reality target roles"
+                    help="Reality-specific statuses required of the target. These rules are checked when Reality Mode executes the action."
                     value={csv(selected.dramaRequiredTargetStatus)}
                     onChange={(value) => updateArray('dramaRequiredTargetStatus', value)}
                   />
                   <TextField
                     label="Required relationship tags"
+                    help="Every listed relationship tag must exist between actor and target for normal-mode eligibility. Add tags to narrow when the action appears."
                     value={csv(selected.requiredRelationshipTags)}
                     onChange={(value) => updateArray('requiredRelationshipTags', value)}
                   />
                   <TextField
                     label="Excluded relationship tags"
+                    help="Any listed relationship tag blocks this action in normal mode. Use it to prevent actions in incompatible relationships."
                     value={csv(selected.excludedRelationshipTags)}
                     onChange={(value) => updateArray('excludedRelationshipTags', value)}
                   />
                   <TextField
                     label="Reality required tags"
+                    help="Relationship tags required only in Reality Mode. These create Reality-specific eligibility connections."
                     value={csv(selected.dramaRequiredRelationshipTags)}
                     onChange={(value) => updateArray('dramaRequiredRelationshipTags', value)}
                   />
                   <TextField
                     label="Reality excluded tags"
+                    help="Relationship tags that block the action only in Reality Mode."
                     value={csv(selected.dramaExcludedRelationshipTags)}
                     onChange={(value) => updateArray('dramaExcludedRelationshipTags', value)}
                   />
                   <NumberField
                     label="Minimum affinity"
+                    help="Lowest allowed normal-mode affinity from actor to target, from -100 to 100. Raising it requires a friendlier relationship."
                     value={selected.minAffinity ?? -100}
                     min={-100}
                     max={100}
@@ -695,6 +853,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Maximum affinity"
+                    help="Highest allowed normal-mode affinity. Lowering it can reserve hostile or confrontational actions for colder relationships."
                     value={selected.maxAffinity ?? 100}
                     min={-100}
                     max={100}
@@ -702,6 +861,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Reality minimum affinity"
+                    help="Reality Mode’s minimum actor-to-target affinity. It replaces the Basic minimum during Reality eligibility checks."
                     value={selected.dramaMinAffinity ?? selected.minAffinity ?? -100}
                     min={-100}
                     max={100}
@@ -709,6 +869,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Reality maximum affinity"
+                    help="Reality Mode’s maximum actor-to-target affinity. Lower it to prevent the action between very close houseguests."
                     value={selected.dramaMaxAffinity ?? selected.maxAffinity ?? 100}
                     min={-100}
                     max={100}
@@ -716,17 +877,20 @@ export default function SocialManagerPanel() {
                   />
                   <TextField
                     label="Required story arcs"
+                    help="Comma-separated arc types that must be active, such as romance, bromance, rivalry, or betrayal. The action is blocked without a matching arc."
                     value={csv(selected.requiredArcTypes)}
                     onChange={(value) => updateArray('requiredArcTypes', value)}
                     hint="romance, bromance, rivalry, betrayal"
                   />
                   <TextField
                     label="Excluded story arcs"
+                    help="Comma-separated story arc types that make the action ineligible when active."
                     value={csv(selected.excludedArcTypes)}
                     onChange={(value) => updateArray('excludedArcTypes', value)}
                   />
                   <TextField
                     label="Required arc stages"
+                    help="Comma-separated stages an active story arc must have reached. Use this to unlock actions only after a relationship story develops."
                     value={csv(selected.requiredArcStages)}
                     onChange={(value) => updateArray('requiredArcStages', value)}
                   />
@@ -736,11 +900,13 @@ export default function SocialManagerPanel() {
                 <div className="social-manager__field-grid">
                   <TextField
                     label="Purposes"
+                    help="Comma-separated Reality intent codes describing why the action is performed. Selection systems use these connections to match an action to a social goal."
                     value={contract.purposes.join(', ')}
                     onChange={(value) => updateArray('realityPurposes', value.toUpperCase())}
                   />
                   <TextField
                     label="Directions"
+                    help="Comma-separated relationship directions the contract supports. This determines which actor-to-target connection the Reality engine may update."
                     value={contract.allowedDirections.join(', ')}
                     onChange={(value) =>
                       updateArray('realityAllowedDirections', value.toUpperCase())
@@ -748,6 +914,7 @@ export default function SocialManagerPanel() {
                   />
                   <TextField
                     label="Game modes"
+                    help="Comma-separated Reality game-mode codes allowed to execute this contract. Removing a mode blocks this action within that mode."
                     value={contract.allowedGameModes.join(', ')}
                     onChange={(value) =>
                       updateArray('realityAllowedGameModes', value.toUpperCase())
@@ -755,12 +922,16 @@ export default function SocialManagerPanel() {
                   />
                   <TextField
                     label="Reality intensity presets"
+                    help="Controls which Reality content settings expose this action: casual is mild, TV allows broadcast-style drama, and adult allows mature content for eligible profiles."
                     value={getAllowedRealityPresets(selected).join(', ')}
                     onChange={(value) => updateArray('allowedRealityPresets', value.toLowerCase())}
                     hint="casual, tv, adult"
                   />
                   <label className="social-manager__field">
-                    <span>Visibility</span>
+                    <FieldLabel
+                      label="Visibility"
+                      help="Who can observe or remember the Reality interaction. More public values can affect the house, viewers, ceremonies, or jury instead of only the participants."
+                    />
                     <select
                       value={contract.visibility}
                       onChange={(event) => commit({ realityVisibility: event.target.value })}
@@ -776,6 +947,7 @@ export default function SocialManagerPanel() {
                   </label>
                   <NumberField
                     label="Cooldown phases"
+                    help="Number of Reality phases that must pass before this action may repeat. Raise it to reduce repetition; 0 permits immediate reuse when otherwise eligible."
                     value={contract.cooldownPhases}
                     min={0}
                     max={100}
@@ -783,26 +955,31 @@ export default function SocialManagerPanel() {
                   />
                   <TextField
                     label="Response set"
+                    help="ID of the response-choice set offered to the target. Changing it connects the action to different accept, reject, escalate, or de-escalate options."
                     value={contract.responseSetId}
                     onChange={(responseSetId) => commit({ responseSetId })}
                   />
                   <TextField
                     label="Outcome resolver"
+                    help="ID of the runtime resolver that calculates what happens after the response. Only use a registered resolver ID; an unknown ID can prevent the intended outcome."
                     value={contract.outcomeResolverId}
                     onChange={(outcomeResolverId) => commit({ outcomeResolverId })}
                   />
                   <TextField
                     label="Memory template"
+                    help="ID of the template used to record this interaction in social memory. Changing it alters how characters remember and later reference the event."
                     value={contract.memoryTemplateId}
                     onChange={(memoryTemplateId) => commit({ memoryTemplateId })}
                   />
                   <TextField
                     label="Dialogue set"
+                    help="ID of the dialogue bank used to present this action. Changing it swaps the available spoken or written lines without changing the core mechanics."
                     value={contract.dialogueSetId}
                     onChange={(dialogueSetId) => commit({ dialogueSetId })}
                   />
                   <TextField
                     label="Relationship outcome tag"
+                    help="Tag written onto the relationship outcome so later rules, summaries, and story systems can recognize what happened."
                     value={selected.outcomeTag ?? ''}
                     onChange={(outcomeTag) => commit({ outcomeTag })}
                   />
@@ -814,6 +991,7 @@ export default function SocialManagerPanel() {
                 <div className="social-manager__field-grid social-manager__field-grid--compact">
                   <NumberField
                     label="Affinity on success"
+                    help="Direct normal-mode affinity change when the action succeeds. Positive values make actor and target closer; negative values damage the relationship."
                     value={affinityEffects.success}
                     min={-100}
                     max={100}
@@ -823,6 +1001,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Affinity on failure"
+                    help="Direct normal-mode affinity change when the action fails. Negative values create fallout; positive values can model a well-received failed attempt."
                     value={affinityEffects.failure}
                     min={-100}
                     max={100}
@@ -832,6 +1011,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Outcome score on success"
+                    help="Normalized success signal from -1 to 1 used by downstream evaluation and summaries. Higher values mark the outcome as more beneficial."
                     value={scoreEffects.success}
                     min={-1}
                     max={1}
@@ -840,6 +1020,7 @@ export default function SocialManagerPanel() {
                   />
                   <NumberField
                     label="Outcome score on failure"
+                    help="Normalized failure signal from -1 to 1. More negative values mark harsher failures; positive values allow a nominal failure to retain some benefit."
                     value={scoreEffects.failure}
                     min={-1}
                     max={1}
@@ -856,11 +1037,15 @@ export default function SocialManagerPanel() {
                   {REALITY_STATES.map((state) => (
                     <div key={state.id} className="social-manager__effect-heading">
                       {state.label}
+                      <HelpTooltip text={REALITY_STATE_HELP[state.id]} />
                     </div>
                   ))}
                   {REALITY_RELATIONSHIP_DIMENSIONS.map((dimension) => (
                     <div className="social-manager__effect-row" key={dimension}>
-                      <strong>{dimension}</strong>
+                      <strong>
+                        {dimension}
+                        <HelpTooltip text={REALITY_DIMENSION_HELP[dimension]} />
+                      </strong>
                       {REALITY_STATES.map((state) => (
                         <input
                           key={state.id}
@@ -870,6 +1055,7 @@ export default function SocialManagerPanel() {
                           max={100}
                           value={realityEffects[state.id][dimension] ?? 0}
                           aria-label={`${dimension} when ${state.label.toLowerCase()}`}
+                          title={`${state.label}: ${REALITY_DIMENSION_HELP[dimension]} Positive increases it; negative decreases it.`}
                           onChange={(event) =>
                             updateRealityEffect(state.id, dimension, Number(event.target.value))
                           }

--- a/src/social/SocialManeuvers.ts
+++ b/src/social/SocialManeuvers.ts
@@ -12,7 +12,7 @@
  */
 
 import { getSocialOutcomeCopy, type SocialOutcomeKind } from './socialOutcomeCopy'
-import { SOCIAL_ACTIONS, resolveActionTargetMode } from './socialActions'
+import { resolveActionTargetMode } from './socialActions'
 import type { SocialActionDefinition } from './socialActions'
 import { evaluateSocialActionEligibility } from './socialActionEligibility'
 import { socialConfig } from './socialConfig'
@@ -36,6 +36,11 @@ import type { SocialActionLogEntry, SocialState } from './types'
 import { getSocialResourceEffect } from './socialResourceEconomy'
 import { getEffectiveSocialMode } from './socialMode'
 import { getPersistentSocialHistory, type SocialStateWithHistory } from './socialHistory'
+import {
+  getRuntimeSocialActionById,
+  getRuntimeSocialActions,
+  isActionAllowedForRealityPreset,
+} from './socialActionManager'
 
 // ── Internal store reference ──────────────────────────────────────────────
 
@@ -86,7 +91,7 @@ interface ManeuverGameState {
 
 interface StateForManeuvers {
   game?: ManeuverGameState
-  settings?: { gameUX?: { dramaMode?: boolean } }
+  settings?: { gameUX?: { dramaMode?: boolean; realityModePreset?: string } }
   vip?: {
     isActive?: boolean
     entitlements?: { dramaMode?: boolean }
@@ -450,7 +455,7 @@ export function initManeuvers(store: StoreAPI): void {
 
 /** Return the action definition for the given id, or undefined if not found. */
 export function getActionById(id: string): SocialActionDefinition | undefined {
-  return SOCIAL_ACTIONS.find((a) => a.id === id)
+  return getRuntimeSocialActionById(id)
 }
 
 // ── Availability & cost ───────────────────────────────────────────────────
@@ -495,7 +500,7 @@ export function getAvailableActions(
   const resolvedState = state ?? (_store?.getState() as StateForManeuvers | null)
   const socialState = resolvedState?.social
   const dramaMode = getEffectiveSocialMode(resolvedState ?? {}) === 'drama'
-  return SOCIAL_ACTIONS.filter((action) => {
+  return getRuntimeSocialActions().filter((action) => {
     if (!canAfford(actorId, normalizeActionCosts(action, 0, dramaMode), state)) {
       return false
     }
@@ -639,7 +644,7 @@ export function executeAction(
   const state = _store.getState() as {
     social: SocialState
     game?: ManeuverGameState
-    settings?: { gameUX?: { dramaMode?: boolean } }
+    settings?: { gameUX?: { dramaMode?: boolean; realityModePreset?: string } }
     vip?: {
       isActive?: boolean
       entitlements?: { dramaMode?: boolean }
@@ -647,6 +652,17 @@ export function executeAction(
   }
 
   const dramaMode = getEffectiveSocialMode(state) === 'drama'
+  const realityPreset = state.settings?.gameUX?.realityModePreset
+  if (realityPreset && !isActionAllowedForRealityPreset(action, realityPreset)) {
+    return {
+      success: false,
+      delta: 0,
+      newEnergy: currentEnergy,
+      summary: 'Unavailable for the selected Reality intensity',
+      score: 0,
+      label: 'Unavailable',
+    }
+  }
   const normalizedCosts = normalizeActionCosts(action, 0, dramaMode)
   const costs = options?.waiveCosts
     ? { energy: 0, influence: 0, info: 0 }
@@ -730,7 +746,7 @@ export function executeAction(
   const recipientTrust = state.social.relationships[targetId]?.[actorId]?.affinity ?? 0
   const rootState = _store.getState() as {
     social: SocialState
-    settings?: { gameUX?: { dramaMode?: boolean } }
+    settings?: { gameUX?: { dramaMode?: boolean; realityModePreset?: string } }
     game?: {
       week?: number
       phase?: string
@@ -1262,13 +1278,17 @@ export function executeGroupAction(
   const state = _store.getState() as {
     social: SocialState
     game?: ManeuverGameState
-    settings?: { gameUX?: { dramaMode?: boolean } }
+    settings?: { gameUX?: { dramaMode?: boolean; realityModePreset?: string } }
     vip?: {
       isActive?: boolean
       entitlements?: { dramaMode?: boolean }
     }
   }
   const dramaMode = getEffectiveSocialMode(state) === 'drama'
+  const realityPreset = state.settings?.gameUX?.realityModePreset
+  if (realityPreset && !isActionAllowedForRealityPreset(action, realityPreset)) {
+    return unavailable('Unavailable for the selected Reality intensity')
+  }
   if (resolveActionTargetMode(action, dramaMode) !== 'multi')
     return unavailable('This is not a group action')
   const eligibility = evaluateSocialActionEligibility({

--- a/src/social/SocialPolicy.ts
+++ b/src/social/SocialPolicy.ts
@@ -7,6 +7,11 @@ import { normalizeAffinity } from './affinityUtils'
 import { hasAllianceBetween } from './socialAlliance'
 import { getSocialPersonality } from './socialPersonalityBank'
 import { getSocialRuntimeConfig } from './socialRuntimeConfig'
+import {
+  getActionAffinityEffects,
+  getActionScoreEffects,
+  getRuntimeSocialActionById,
+} from './socialActionManager'
 import type { PolicyContext, RelationshipsMap, SocialActionLogEntry } from './types'
 
 // ── Evaluator configuration ───────────────────────────────────────────────
@@ -80,7 +85,11 @@ function recentCount(
  */
 export function chooseActionFor(playerId: string, rawContext: PolicyContext): string {
   const context = rawContext as RichPolicyContext
-  const configuredWeights = socialConfig.actionWeights
+  const configuredWeights = { ...socialConfig.actionWeights }
+  for (const actionId of context.availableActionIds ?? []) {
+    const managedWeight = getRuntimeSocialActionById(actionId)?.aiWeight
+    if (managedWeight !== undefined) configuredWeights[actionId] = managedWeight
+  }
   const configuredEntries = Object.entries(configuredWeights)
   if (configuredEntries.length === 0) return 'idle'
 
@@ -96,9 +105,13 @@ export function chooseActionFor(playerId: string, rawContext: PolicyContext): st
   const { friendlyActions, aggressiveActions } = socialConfig.actionCategories
 
   const candidates = configuredEntries
-    .filter(([actionId]) => !allowed || allowed.has(actionId))
+    .filter(
+      ([actionId]) =>
+        getRuntimeSocialActionById(actionId) !== undefined && (!allowed || allowed.has(actionId))
+    )
     .map(([actionId, authoredWeight]) => {
-      let utility = runtime.ai.basicActionWeights[actionId] ?? authoredWeight
+      const managedWeight = getRuntimeSocialActionById(actionId)?.aiWeight
+      let utility = managedWeight ?? runtime.ai.basicActionWeights[actionId] ?? authoredWeight
       const repeats = recentCount(context, playerId, actionId)
 
       if (friendlyActions.includes(actionId)) {
@@ -299,6 +312,11 @@ export function computeOutcomeDelta(
   _targetId: string,
   outcome: string
 ): number {
+  const action = getRuntimeSocialActionById(actionId)
+  if (action) {
+    const effects = getActionAffinityEffects(action)
+    return outcome === 'success' ? effects.success : effects.failure
+  }
   const { friendlyActions, aggressiveActions } = socialConfig.actionCategories
   const deltas = socialConfig.affinityDeltas
 
@@ -338,16 +356,22 @@ export function computeOutcomeScore(
   const { friendlyActions, aggressiveActions } = socialConfig.actionCategories
   const deltas = socialConfig.scoreDeltas
   const runtime = getSocialRuntimeConfig()
+  const action = getRuntimeSocialActionById(actionId)
 
-  const baseScore: number = friendlyActions.includes(actionId)
-    ? outcome === 'success'
-      ? deltas.friendlySuccess
-      : deltas.friendlyFailure
-    : aggressiveActions.includes(actionId)
+  const baseScore: number = action
+    ? (() => {
+        const effects = getActionScoreEffects(action)
+        return outcome === 'success' ? effects.success : effects.failure
+      })()
+    : friendlyActions.includes(actionId)
       ? outcome === 'success'
-        ? deltas.aggressiveSuccess
-        : deltas.aggressiveFailure
-      : 0
+        ? deltas.friendlySuccess
+        : deltas.friendlyFailure
+      : aggressiveActions.includes(actionId)
+        ? outcome === 'success'
+          ? deltas.aggressiveSuccess
+          : deltas.aggressiveFailure
+        : 0
 
   const existingAffinity = relationships?.[actorId]?.[targetId]?.affinity ?? 0
   const actorBias = outcomeAffinity(existingAffinity) * runtime.ai.outcomeAffinityBiasWeight

--- a/src/social/__tests__/socialActionManager.test.ts
+++ b/src/social/__tests__/socialActionManager.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildEffectiveSocialActions,
+  getActionAffinityEffects,
+  getDefaultRealityEffects,
+  isActionAllowedForRealityPreset,
+  getRuntimeSocialActionById,
+  sanitiseSocialActionOverrides,
+  setRuntimeSocialActionOverrides,
+} from '../socialActionManager'
+import { adaptLegacyActionContract } from '../reality/actionContract'
+import { computeOutcomeDelta } from '../SocialPolicy'
+
+afterEach(() => setRuntimeSocialActionOverrides({}))
+
+describe('Social Manager action overrides', () => {
+  it('sanitises known actions and rejects unknown actions and relationship dimensions', () => {
+    const result = sanitiseSocialActionOverrides({
+      compliment: {
+        title: '  Build Trust  ',
+        baseCost: { energy: 2, influence: 3 },
+        realityEffects: {
+          accepted: { warmth: 11, madeUpDimension: 99 },
+        },
+      },
+      invented_action: { title: 'Nope' },
+    })
+
+    expect(result).toEqual({
+      compliment: {
+        title: 'Build Trust',
+        baseCost: { energy: 2, influence: 3 },
+        realityEffects: { accepted: { warmth: 11 } },
+      },
+    })
+  })
+
+  it('builds effective definitions without mutating bundled defaults', () => {
+    const [original] = buildEffectiveSocialActions()
+    const [effective] = buildEffectiveSocialActions({
+      compliment: {
+        title: 'Warm Compliment',
+        affinityEffects: { success: 12, failure: -1 },
+      },
+    })
+
+    expect(original.title).toBe('Compliment')
+    expect(effective.title).toBe('Warm Compliment')
+    expect(getActionAffinityEffects(effective)).toEqual({ success: 12, failure: -1 })
+  })
+
+  it('makes enabled and disabled overrides authoritative at runtime', () => {
+    setRuntimeSocialActionOverrides({
+      compliment: { enabled: false },
+      whisper: { title: 'Quiet Deal' },
+    })
+
+    expect(getRuntimeSocialActionById('compliment')).toBeUndefined()
+    expect(getRuntimeSocialActionById('compliment', { includeDisabled: true })?.enabled).toBe(false)
+    expect(getRuntimeSocialActionById('whisper')?.title).toBe('Quiet Deal')
+  })
+
+  it('feeds per-action affinity effects into live outcome resolution', () => {
+    setRuntimeSocialActionOverrides({
+      compliment: { affinityEffects: { success: 17, failure: -4 } },
+    })
+
+    expect(computeOutcomeDelta('compliment', 'actor', 'target', 'success')).toBe(17)
+    expect(computeOutcomeDelta('compliment', 'actor', 'target', 'failure')).toBe(-4)
+  })
+
+  it('supports per-action Reality intensity subtype connections', () => {
+    const action = buildEffectiveSocialActions({
+      compliment: { allowedRealityPresets: ['adult'] },
+    }).find((candidate) => candidate.id === 'compliment')!
+
+    expect(isActionAllowedForRealityPreset(action, 'tv')).toBe(false)
+    expect(isActionAllowedForRealityPreset(action, 'adult')).toBe(true)
+  })
+
+  it('projects contract connections and multidimensional effects into Reality execution data', () => {
+    const action = buildEffectiveSocialActions({
+      flirt: {
+        realityAllowedGameModes: ['SURVIVAL'],
+        realityPurposes: ['ROMANCE', 'PERFORM'],
+        realityVisibility: 'HOUSE_PUBLIC',
+        realityCooldownPhases: 5,
+        responseSetId: 'custom_romance_response',
+        realityEffects: {
+          accepted: { attraction: 20, trust: 7 },
+          rejected: { suspicion: 6 },
+        },
+      },
+    }).find((candidate) => candidate.id === 'flirt')!
+
+    const contract = adaptLegacyActionContract(action)
+    const effects = getDefaultRealityEffects(action)
+
+    expect(contract.allowedGameModes).toEqual(['SURVIVAL'])
+    expect(contract.purposes).toEqual(['ROMANCE', 'PERFORM'])
+    expect(contract.visibility).toBe('HOUSE_PUBLIC')
+    expect(contract.cooldownPhases).toBe(5)
+    expect(contract.responseSetId).toBe('custom_romance_response')
+    expect(effects.accepted).toMatchObject({ attraction: 20, trust: 7 })
+    expect(effects.rejected).toMatchObject({ suspicion: 6 })
+  })
+})

--- a/src/social/reality/actionContract.ts
+++ b/src/social/reality/actionContract.ts
@@ -2,6 +2,12 @@ import { SOCIAL_ACTIONS, resolveActionTargetMode } from '../socialActions'
 import type { SocialActionDefinition } from '../socialActions'
 import { normalizeActionCosts } from '../smExecNormalize'
 import { actorHasBelief } from './knowledge'
+import {
+  getDefaultRealityEffects,
+  getRuntimeSocialActionById,
+  getRuntimeSocialActions,
+  type EffectiveRealityEffects,
+} from '../socialActionManager'
 import type {
   RealityContext,
   RealityDirection,
@@ -56,6 +62,7 @@ export interface RealityActionContract {
   outcomeResolverId: string
   memoryTemplateId: string
   dialogueSetId: string
+  relationshipEffects: EffectiveRealityEffects
   targetMode: ReturnType<typeof resolveActionTargetMode>
   dramaTargetMode: ReturnType<typeof resolveActionTargetMode>
   aiOnly: boolean
@@ -85,6 +92,41 @@ export interface RealityCandidateEvaluation {
 }
 
 const BROAD_PHASES = ['*']
+const REALITY_PURPOSES = new Set<RealityActionPurpose>([
+  'BOND',
+  'REPAIR',
+  'INFORMATION',
+  'PERSUADE',
+  'COMMITMENT',
+  'PROTECT',
+  'CONFLICT',
+  'ROMANCE',
+  'PERFORM',
+  'WITHDRAW',
+])
+const REALITY_DIRECTIONS = new Set<RealityDirection>([
+  'AI_TO_AI',
+  'AI_TO_HUMAN',
+  'HUMAN_TO_AI',
+  'GROUP',
+  'SELF',
+])
+const REALITY_VISIBILITIES = new Set<RealityVisibility>([
+  'PRIVATE',
+  'PAIR_ONLY',
+  'GROUP_VISIBLE',
+  'HOUSE_PUBLIC',
+  'CEREMONY_PUBLIC',
+  'VIEWER_ONLY',
+  'JURY_ONLY',
+])
+
+function filteredValues<T extends string>(
+  values: readonly string[] | undefined,
+  allowed: Set<T>
+): T[] {
+  return (values ?? []).filter((value): value is T => allowed.has(value as T))
+}
 
 function purposesFor(action: SocialActionDefinition): RealityActionPurpose[] {
   if (action.id === 'idle') return ['WITHDRAW']
@@ -131,15 +173,26 @@ export function adaptLegacyActionContract(action: SocialActionDefinition): Reali
       : dramaTargetMode === 'multi'
         ? ['GROUP']
         : ['AI_TO_AI', 'AI_TO_HUMAN', 'HUMAN_TO_AI', 'GROUP']
+  const configuredDirections = filteredValues(action.realityAllowedDirections, REALITY_DIRECTIONS)
+  const configuredPurposes = filteredValues(action.realityPurposes, REALITY_PURPOSES)
+  const configuredModes = filteredValues(
+    action.realityAllowedGameModes,
+    new Set<'CLASSIC' | 'SURVIVAL'>(['CLASSIC', 'SURVIVAL'])
+  )
+  const configuredVisibility = REALITY_VISIBILITIES.has(
+    action.realityVisibility as RealityVisibility
+  )
+    ? (action.realityVisibility as RealityVisibility)
+    : undefined
   return {
     id: action.id,
     legacyActionId: action.id,
     title: action.title,
     category: action.category,
-    purposes: purposesFor(action),
-    allowedDirections: directions,
+    purposes: configuredPurposes.length > 0 ? configuredPurposes : purposesFor(action),
+    allowedDirections: configuredDirections.length > 0 ? configuredDirections : directions,
     allowedPhases: [...(action.dramaAllowedPhases ?? action.allowedPhases ?? BROAD_PHASES)],
-    allowedGameModes: ['CLASSIC', 'SURVIVAL'],
+    allowedGameModes: configuredModes.length > 0 ? configuredModes : ['CLASSIC', 'SURVIVAL'],
     allowedIntensities: action.dramaOnly ? ['REALITY'] : ['NORMAL', 'REALITY'],
     baseWeight: Math.max(0.05, action.successWeight ?? 1),
     requiredActorRoles: [...(action.requiredActorStatus ?? [])],
@@ -171,12 +224,13 @@ export function adaptLegacyActionContract(action: SocialActionDefinition): Reali
       NORMAL: normalizeActionCosts(action, 1, false),
       REALITY: normalizeActionCosts(action, 1, true),
     },
-    cooldownPhases: action.category === 'aggressive' ? 3 : 1,
-    visibility: visibilityFor(action),
-    responseSetId: responseSetFor(action),
-    outcomeResolverId: `legacy:${action.id}`,
-    memoryTemplateId: `memory:${action.category}`,
-    dialogueSetId: `dialogue:${action.id}`,
+    cooldownPhases: action.realityCooldownPhases ?? (action.category === 'aggressive' ? 3 : 1),
+    visibility: configuredVisibility ?? visibilityFor(action),
+    responseSetId: action.responseSetId ?? responseSetFor(action),
+    outcomeResolverId: action.outcomeResolverId ?? `legacy:${action.id}`,
+    memoryTemplateId: action.memoryTemplateId ?? `memory:${action.category}`,
+    dialogueSetId: action.dialogueSetId ?? `dialogue:${action.id}`,
+    relationshipEffects: getDefaultRealityEffects(action),
     targetMode,
     dramaTargetMode,
     aiOnly: action.aiOnly === true,
@@ -187,6 +241,16 @@ export const REALITY_ACTION_CONTRACTS = SOCIAL_ACTIONS.map(adaptLegacyActionCont
 export const REALITY_ACTION_BY_ID = new Map(
   REALITY_ACTION_CONTRACTS.map((action) => [action.id, action])
 )
+
+/** Runtime-aware contracts used by gameplay after Social Manager overrides. */
+export function getRealityActionContracts(): RealityActionContract[] {
+  return getRuntimeSocialActions().map(adaptLegacyActionContract)
+}
+
+export function getRealityActionContract(id: string): RealityActionContract | undefined {
+  const action = getRuntimeSocialActionById(id)
+  return action ? adaptLegacyActionContract(action) : undefined
+}
 
 export function validateRealityActionContract(action: RealityActionContract): string[] {
   const errors: string[] = []

--- a/src/social/reality/humanFlow.ts
+++ b/src/social/reality/humanFlow.ts
@@ -9,7 +9,7 @@ import {
   createInitialRealitySimulationState,
   deriveRealitySimulationSeed,
 } from '../realitySimulation'
-import { REALITY_ACTION_BY_ID, type RealityActorSnapshot } from './actionContract'
+import { getRealityActionContract, type RealityActorSnapshot } from './actionContract'
 import { runRealityOpportunity } from './orchestrator'
 import { getRealityModeAdapter } from './modeAdapters'
 import { applyRealityRelationshipChange } from './relationships'
@@ -33,7 +33,7 @@ function getHumanRepetitionSuccessChances(actionId: string): readonly number[] |
   if (legacyAction?.kind === 'intel_gain' && legacyAction.targetMode !== 'none') {
     return INFORMATION_REPETITION_SUCCESS_CHANCES
   }
-  const contract = REALITY_ACTION_BY_ID.get(actionId)
+  const contract = getRealityActionContract(actionId)
   if (
     contract?.purposes.includes('BOND') &&
     !contract.purposes.includes('COMMITMENT') &&
@@ -263,7 +263,7 @@ export function executeHumanRealityAction(input: HumanRealityActionInput) {
       )
     }
 
-    const contract = REALITY_ACTION_BY_ID.get(input.actionId)
+    const contract = getRealityActionContract(input.actionId)
     if (!contract) return result(false, 'Unknown action', energy)
     const direction =
       targetIds.length === 0 ? 'SELF' : targetIds.length > 1 ? 'GROUP' : 'HUMAN_TO_AI'

--- a/src/social/reality/orchestrator.ts
+++ b/src/social/reality/orchestrator.ts
@@ -5,8 +5,8 @@ import {
   type RealitySimulationState,
 } from '../realitySimulation'
 import {
-  REALITY_ACTION_BY_ID,
   evaluateRealityCandidate,
+  getRealityActionContract,
   type RealityActionContract,
   type RealityActorSnapshot,
 } from './actionContract'
@@ -86,27 +86,12 @@ function selectWeighted<T extends { weight: number; id: string }>(
 function relationshipDeltas(action: RealityActionContract, response: RealityResponseResolution) {
   if (action.purposes.includes('CONFLICT')) {
     return response.kind === 'DE_ESCALATE'
-      ? { warmth: -2, trust: -2, resentment: 3, familiarity: 2 }
-      : { warmth: -8, trust: -9, resentment: 14, suspicion: 6, familiarity: 3 }
-  }
-  if (action.purposes.includes('ROMANCE')) {
-    return response.accepted
-      ? { warmth: 6, trust: 3, attraction: 12, intimacy: 9, familiarity: 3 }
-      : { warmth: -2, attraction: -3, embarrassment: 0, familiarity: 2 }
-  }
-  if (action.purposes.includes('COMMITMENT')) {
-    return response.accepted
-      ? { trust: 8, loyalty: 10, strategicValue: 7, familiarity: 2 }
-      : { trust: -3, suspicion: 4, familiarity: 2 }
-  }
-  if (action.purposes.includes('INFORMATION')) {
-    return response.accepted
-      ? { trust: 4, strategicValue: 4, familiarity: 2 }
-      : { suspicion: 3, familiarity: 1 }
+      ? action.relationshipEffects.deEscalated
+      : action.relationshipEffects.escalated
   }
   return response.accepted
-    ? { warmth: 6, trust: 3, familiarity: 3 }
-    : { warmth: -2, familiarity: 1 }
+    ? action.relationshipEffects.accepted
+    : action.relationshipEffects.rejected
 }
 
 function makeMemory(input: {
@@ -723,7 +708,7 @@ export function resolvePendingHumanRealityInteraction(input: {
   if (!interaction || interaction.status !== 'AWAITING_HUMAN') {
     return { domain, event: null }
   }
-  const action = REALITY_ACTION_BY_ID.get(interaction.actionId)
+  const action = getRealityActionContract(interaction.actionId)
   if (!action) {
     interaction.status = 'INVALIDATED'
     return { domain, event: null }

--- a/src/social/realitySeasonSimulation.ts
+++ b/src/social/realitySeasonSimulation.ts
@@ -1,5 +1,5 @@
 import {
-  REALITY_ACTION_CONTRACTS,
+  getRealityActionContracts,
   createInitialRealityDomainState,
   ensureRealityActors,
   recordRealityCeremonyOutcome,
@@ -120,7 +120,7 @@ export function simulateRealitySeason(
   let deadlockDays = 0
   const selectedActions: string[] = []
 
-  const candidateActions = REALITY_ACTION_CONTRACTS.filter(
+  const candidateActions = getRealityActionContracts().filter(
     (action) =>
       action.allowedDirections.includes('AI_TO_AI') &&
       action.dramaTargetMode !== 'multi' &&

--- a/src/social/socialAIDriver.ts
+++ b/src/social/socialAIDriver.ts
@@ -47,7 +47,7 @@ import type {
 } from './types'
 import type { RealityDomainState } from './reality'
 import {
-  REALITY_ACTION_BY_ID,
+  getRealityActionContract,
   projectRealityAffinity,
   runRealityOpportunity,
   type RealityActorSnapshot,
@@ -162,7 +162,7 @@ function executeRealityCandidate(
   candidate: CandidateMove
 ): boolean {
   if (!_store) return false
-  const contract = REALITY_ACTION_BY_ID.get(candidate.actionId)
+  const contract = getRealityActionContract(candidate.actionId)
   if (!contract || !state.social.realitySimulation.rng) return false
   const action = getActionById(candidate.actionId)
   if (!action) return false
@@ -509,7 +509,7 @@ function routeHumanFacingAction(
       deriveRealitySimulationSeed(current.game.seed ?? 0, `social:${current.game.week}`)
     )
   }
-  const contract = REALITY_ACTION_BY_ID.get(actionId)
+  const contract = getRealityActionContract(actionId)
   if (!contract) return 'blocked'
   const targetIds = sceneTargetIds?.length ? sceneTargetIds : [human.id]
   const realityResult = runRealityOpportunity({

--- a/src/social/socialActionManager.ts
+++ b/src/social/socialActionManager.ts
@@ -1,0 +1,513 @@
+import { socialConfig } from './socialConfig'
+import { SOCIAL_ACTIONS, isRealityExclusiveAction } from './socialActions'
+import type {
+  ActionCategory,
+  SocialActionDefinition,
+  SocialActionKind,
+  SubjectPool,
+  TargetMode,
+} from './socialActions'
+
+type MutableActionField<T> = T extends readonly (infer Item)[] ? Item[] : T
+export type SocialActionOverride = {
+  [Key in keyof Omit<SocialActionDefinition, 'id'>]?: MutableActionField<
+    Omit<SocialActionDefinition, 'id'>[Key]
+  >
+}
+export type SocialActionOverrides = Record<string, SocialActionOverride>
+
+export type SocialActionLayer = 'basic' | 'reality' | 'vox' | 'ai'
+export type SocialActionSubtype =
+  | 'friendly'
+  | 'strategy'
+  | 'conflict'
+  | 'alliances'
+  | 'romance'
+  | 'bromance'
+  | 'intel'
+  | 'vox_populi'
+  | 'automation'
+
+export interface SocialActionGrouping {
+  layer: SocialActionLayer
+  subtype: SocialActionSubtype
+  layerLabel: string
+  subtypeLabel: string
+}
+
+export const REALITY_RELATIONSHIP_DIMENSIONS = [
+  'warmth',
+  'trust',
+  'loyalty',
+  'respect',
+  'attraction',
+  'intimacy',
+  'gratitude',
+  'resentment',
+  'fear',
+  'envy',
+  'suspicion',
+  'strategicValue',
+  'perceivedThreat',
+  'reliability',
+  'familiarity',
+  'publicCloseness',
+  'secretCloseness',
+] as const
+
+type RealityRelationshipDimension = (typeof REALITY_RELATIONSHIP_DIMENSIONS)[number]
+export type RealityRelationshipEffects = Partial<Record<RealityRelationshipDimension, number>>
+
+export interface EffectiveRealityEffects {
+  accepted: RealityRelationshipEffects
+  rejected: RealityRelationshipEffects
+  escalated: RealityRelationshipEffects
+  deEscalated: RealityRelationshipEffects
+}
+
+const CATEGORIES = new Set<ActionCategory>(['friendly', 'strategic', 'aggressive', 'alliance'])
+const KINDS = new Set<SocialActionKind>([
+  'rapport',
+  'intel_gain',
+  'intel_spend',
+  'political_spend',
+  'aggressive',
+])
+const TARGET_MODES = new Set<TargetMode>(['none', 'primary', 'primaryPlusSubject', 'multi'])
+const SUBJECT_POOLS = new Set<SubjectPool>([
+  'houseguests',
+  'nominees',
+  'non_nominees',
+  'allies',
+  'voters',
+])
+const KNOWN_ACTION_IDS = new Set(SOCIAL_ACTIONS.map((action) => action.id))
+const REALITY_DIMENSIONS = new Set<string>(REALITY_RELATIONSHIP_DIMENSIONS)
+const REALITY_PRESETS = ['casual', 'tv', 'adult'] as const
+const ADULT_REALITY_ACTION_IDS = new Set([
+  'kiss_under_covers',
+  'pool_makeout',
+  'spend_night',
+  'skinny_dip',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function safeString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed && trimmed.length <= maxLength ? trimmed : undefined
+}
+
+function safeNumber(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+  return Math.max(min, Math.min(max, value))
+}
+
+function safeInteger(value: unknown, min: number, max: number): number | undefined {
+  const valueInRange = safeNumber(value, min, max)
+  return valueInRange === undefined ? undefined : Math.round(valueInRange)
+}
+
+function safeStringArray(value: unknown, maxEntries = 32): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value
+    .slice(0, maxEntries)
+    .map((entry) => safeString(entry, 80))
+    .filter((entry): entry is string => Boolean(entry))
+}
+
+function sanitiseCost(value: unknown): SocialActionDefinition['baseCost'] | undefined {
+  const scalar = safeNumber(value, 0, 1_000)
+  if (scalar !== undefined) return scalar
+  if (!isRecord(value)) return undefined
+  const result: { energy?: number; influence?: number; info?: number } = {}
+  const energy = safeNumber(value.energy, 0, 100)
+  const influence = safeNumber(value.influence, 0, 1_000)
+  const info = safeNumber(value.info, 0, 1_000)
+  if (energy !== undefined) result.energy = energy
+  if (influence !== undefined) result.influence = influence
+  if (info !== undefined) result.info = info
+  return result
+}
+
+function sanitiseYields(value: unknown): SocialActionDefinition['yields'] | undefined {
+  if (!isRecord(value)) return undefined
+  const result: NonNullable<SocialActionDefinition['yields']> = {}
+  const influence = safeNumber(value.influence, -1_000, 1_000)
+  const info = safeNumber(value.info, -1_000, 1_000)
+  if (influence !== undefined) result.influence = influence
+  if (info !== undefined) result.info = info
+  return result
+}
+
+function sanitisePair(
+  value: unknown,
+  min: number,
+  max: number
+): { success: number; failure: number } | undefined {
+  if (!isRecord(value)) return undefined
+  const success = safeNumber(value.success, min, max)
+  const failure = safeNumber(value.failure, min, max)
+  if (success === undefined || failure === undefined) return undefined
+  return { success, failure }
+}
+
+function sanitiseRealityVector(value: unknown): RealityRelationshipEffects | undefined {
+  if (!isRecord(value)) return undefined
+  const result: RealityRelationshipEffects = {}
+  for (const [key, rawDelta] of Object.entries(value)) {
+    if (!REALITY_DIMENSIONS.has(key)) continue
+    const delta = safeNumber(rawDelta, -100, 100)
+    if (delta !== undefined) result[key as RealityRelationshipDimension] = delta
+  }
+  return result
+}
+
+function sanitiseRealityEffects(
+  value: unknown
+): SocialActionDefinition['realityEffects'] | undefined {
+  if (!isRecord(value)) return undefined
+  const result: NonNullable<SocialActionDefinition['realityEffects']> = {}
+  for (const key of ['accepted', 'rejected', 'escalated', 'deEscalated'] as const) {
+    const vector = sanitiseRealityVector(value[key])
+    if (vector) result[key] = vector
+  }
+  return result
+}
+
+export function sanitiseSocialActionOverrides(raw: unknown): SocialActionOverrides {
+  if (!isRecord(raw)) return {}
+  const result: SocialActionOverrides = {}
+
+  for (const [id, value] of Object.entries(raw)) {
+    if (!KNOWN_ACTION_IDS.has(id) || !isRecord(value)) continue
+    const override: SocialActionOverride = {}
+
+    const title = safeString(value.title, 80)
+    const description = safeString(value.description, 300)
+    const icon = safeString(value.icon, 16)
+    const availabilityHint = safeString(value.availabilityHint, 160)
+    const outcomeTag = safeString(value.outcomeTag, 80)
+    const realityVisibility = safeString(value.realityVisibility, 40)
+    const responseSetId = safeString(value.responseSetId, 80)
+    const outcomeResolverId = safeString(value.outcomeResolverId, 80)
+    const memoryTemplateId = safeString(value.memoryTemplateId, 80)
+    const dialogueSetId = safeString(value.dialogueSetId, 80)
+    if (title) override.title = title
+    if (description) override.description = description
+    if (icon) override.icon = icon
+    if (availabilityHint) override.availabilityHint = availabilityHint
+    if (outcomeTag) override.outcomeTag = outcomeTag
+    if (realityVisibility) override.realityVisibility = realityVisibility
+    if (responseSetId) override.responseSetId = responseSetId
+    if (outcomeResolverId) override.outcomeResolverId = outcomeResolverId
+    if (memoryTemplateId) override.memoryTemplateId = memoryTemplateId
+    if (dialogueSetId) override.dialogueSetId = dialogueSetId
+
+    if (typeof value.enabled === 'boolean') override.enabled = value.enabled
+    if (typeof value.aiOnly === 'boolean') override.aiOnly = value.aiOnly
+    if (typeof value.needsTargets === 'boolean') override.needsTargets = value.needsTargets
+    if (typeof value.allowActorAsSubject === 'boolean') {
+      override.allowActorAsSubject = value.allowActorAsSubject
+    }
+    if (typeof value.dramaOnly === 'boolean') override.dramaOnly = value.dramaOnly
+    if (typeof value.realityExclusive === 'boolean') {
+      override.realityExclusive = value.realityExclusive
+    }
+    if (typeof value.voxOnly === 'boolean') override.voxOnly = value.voxOnly
+    if (typeof value.requiresKnownSecret === 'boolean') {
+      override.requiresKnownSecret = value.requiresKnownSecret
+    }
+    if (typeof value.requiredArcPublic === 'boolean') {
+      override.requiredArcPublic = value.requiredArcPublic
+    }
+
+    if (CATEGORIES.has(value.category as ActionCategory)) {
+      override.category = value.category as ActionCategory
+    }
+    if (KINDS.has(value.kind as SocialActionKind)) override.kind = value.kind as SocialActionKind
+    if (TARGET_MODES.has(value.targetMode as TargetMode)) {
+      override.targetMode = value.targetMode as TargetMode
+    }
+    if (TARGET_MODES.has(value.dramaTargetMode as TargetMode)) {
+      override.dramaTargetMode = value.dramaTargetMode as TargetMode
+    }
+    if (SUBJECT_POOLS.has(value.subjectPool as SubjectPool)) {
+      override.subjectPool = value.subjectPool as SubjectPool
+    }
+
+    const baseCost = sanitiseCost(value.baseCost)
+    const dramaCost = sanitiseCost(value.dramaCost)
+    const yields = sanitiseYields(value.yields)
+    const affinityEffects = sanitisePair(value.affinityEffects, -100, 100)
+    const scoreEffects = sanitisePair(value.scoreEffects, -1, 1)
+    const realityEffects = sanitiseRealityEffects(value.realityEffects)
+    if (baseCost !== undefined) override.baseCost = baseCost
+    if (dramaCost !== undefined) override.dramaCost = dramaCost
+    if (yields !== undefined) override.yields = yields
+    if (affinityEffects) override.affinityEffects = affinityEffects
+    if (scoreEffects) override.scoreEffects = scoreEffects
+    if (realityEffects) override.realityEffects = realityEffects
+
+    for (const [key, min, max, integer] of [
+      ['successWeight', 0, 100, false],
+      ['aiWeight', 0, 100, false],
+      ['minTargets', 0, 32, true],
+      ['maxTargets', 0, 32, true],
+      ['energyPerTarget', 0, 100, false],
+      ['minAffinity', -100, 100, false],
+      ['maxAffinity', -100, 100, false],
+      ['dramaMinAffinity', -100, 100, false],
+      ['dramaMaxAffinity', -100, 100, false],
+      ['realityCooldownPhases', 0, 100, true],
+    ] as const) {
+      const parsed = integer ? safeInteger(value[key], min, max) : safeNumber(value[key], min, max)
+      if (parsed !== undefined) Object.assign(override, { [key]: parsed })
+    }
+
+    for (const key of [
+      'allowedPhases',
+      'dramaAllowedPhases',
+      'requiredActorStatus',
+      'requiredTargetStatus',
+      'dramaRequiredActorStatus',
+      'dramaRequiredTargetStatus',
+      'requiredRelationshipTags',
+      'excludedRelationshipTags',
+      'dramaRequiredRelationshipTags',
+      'dramaExcludedRelationshipTags',
+      'requiredArcTypes',
+      'excludedArcTypes',
+      'requiredArcStages',
+      'realityPurposes',
+      'realityAllowedDirections',
+      'realityAllowedGameModes',
+      'allowedRealityPresets',
+    ] as const) {
+      const values = safeStringArray(value[key])
+      if (values !== undefined) Object.assign(override, { [key]: values })
+    }
+
+    result[id] = override
+  }
+  return result
+}
+
+export function applySocialActionOverride(
+  action: SocialActionDefinition,
+  override?: SocialActionOverride
+): SocialActionDefinition {
+  if (!override) return action
+  return {
+    ...action,
+    ...override,
+    baseCost: override.baseCost ?? action.baseCost,
+    yields: override.yields ? { ...override.yields } : action.yields,
+    affinityEffects: override.affinityEffects
+      ? { ...override.affinityEffects }
+      : action.affinityEffects,
+    scoreEffects: override.scoreEffects ? { ...override.scoreEffects } : action.scoreEffects,
+    realityEffects: override.realityEffects
+      ? {
+          ...action.realityEffects,
+          ...override.realityEffects,
+        }
+      : action.realityEffects,
+  }
+}
+
+export function buildEffectiveSocialActions(
+  overrides?: SocialActionOverrides
+): SocialActionDefinition[] {
+  return SOCIAL_ACTIONS.map((action) => applySocialActionOverride(action, overrides?.[action.id]))
+}
+
+let runtimeOverrides: SocialActionOverrides = {}
+
+export function setRuntimeSocialActionOverrides(overrides: unknown): void {
+  runtimeOverrides = sanitiseSocialActionOverrides(overrides)
+}
+
+export function getRuntimeSocialActions(options?: {
+  includeDisabled?: boolean
+}): SocialActionDefinition[] {
+  const actions = buildEffectiveSocialActions(runtimeOverrides)
+  return options?.includeDisabled ? actions : actions.filter((action) => action.enabled !== false)
+}
+
+export function getRuntimeSocialActionById(
+  id: string,
+  options?: { includeDisabled?: boolean }
+): SocialActionDefinition | undefined {
+  const action = SOCIAL_ACTIONS.find((candidate) => candidate.id === id)
+  if (!action) return undefined
+  const effective = applySocialActionOverride(action, runtimeOverrides[id])
+  return options?.includeDisabled || effective.enabled !== false ? effective : undefined
+}
+
+export function getAllowedRealityPresets(action: SocialActionDefinition): string[] {
+  const configured = (action.allowedRealityPresets ?? []).filter((preset) =>
+    REALITY_PRESETS.includes(preset as (typeof REALITY_PRESETS)[number])
+  )
+  if (configured.length > 0) return configured
+  return ADULT_REALITY_ACTION_IDS.has(action.id) ? ['adult'] : [...REALITY_PRESETS]
+}
+
+export function isActionAllowedForRealityPreset(
+  action: SocialActionDefinition,
+  preset: string | undefined
+): boolean {
+  return getAllowedRealityPresets(action).includes(preset ?? 'tv')
+}
+
+export function getActionAffinityEffects(action: SocialActionDefinition): {
+  success: number
+  failure: number
+} {
+  if (action.affinityEffects) return action.affinityEffects
+  if (socialConfig.actionCategories.friendlyActions.includes(action.id)) {
+    return {
+      success: socialConfig.affinityDeltas.friendlySuccess,
+      failure: socialConfig.affinityDeltas.friendlyFailure,
+    }
+  }
+  if (socialConfig.actionCategories.aggressiveActions.includes(action.id)) {
+    return {
+      success: socialConfig.affinityDeltas.aggressiveSuccess,
+      failure: socialConfig.affinityDeltas.aggressiveFailure,
+    }
+  }
+  return { success: 0, failure: 0 }
+}
+
+export function getActionScoreEffects(action: SocialActionDefinition): {
+  success: number
+  failure: number
+} {
+  if (action.scoreEffects) return action.scoreEffects
+  if (socialConfig.actionCategories.friendlyActions.includes(action.id)) {
+    return {
+      success: socialConfig.scoreDeltas.friendlySuccess,
+      failure: socialConfig.scoreDeltas.friendlyFailure,
+    }
+  }
+  if (socialConfig.actionCategories.aggressiveActions.includes(action.id)) {
+    return {
+      success: socialConfig.scoreDeltas.aggressiveSuccess,
+      failure: socialConfig.scoreDeltas.aggressiveFailure,
+    }
+  }
+  return { success: 0, failure: 0 }
+}
+
+function hasToken(action: SocialActionDefinition, token: string): boolean {
+  return (
+    action.id.includes(token) ||
+    action.outcomeTag?.includes(token) === true ||
+    action.requiredArcTypes?.includes(token as never) === true ||
+    action.excludedArcTypes?.includes(token as never) === true
+  )
+}
+
+export function getSocialActionGrouping(action: SocialActionDefinition): SocialActionGrouping {
+  if (action.aiOnly) {
+    return {
+      layer: 'ai',
+      subtype: 'automation',
+      layerLabel: 'AI & system',
+      subtypeLabel: 'Automation',
+    }
+  }
+  if (action.voxOnly) {
+    return {
+      layer: 'vox',
+      subtype: 'vox_populi',
+      layerLabel: 'Reality campaigns',
+      subtypeLabel: 'Vox Populi',
+    }
+  }
+
+  const layer: SocialActionLayer = isRealityExclusiveAction(action) ? 'reality' : 'basic'
+  const layerLabel = layer === 'reality' ? 'Reality Mode' : 'Basic'
+  if (
+    hasToken(action, 'romance') ||
+    ['flirt', 'cuddle', 'kiss_under_covers', 'pool_makeout', 'spend_night', 'go_public'].includes(
+      action.id
+    )
+  ) {
+    return { layer, subtype: 'romance', layerLabel, subtypeLabel: 'Romance' }
+  }
+  if (hasToken(action, 'bromance') || action.id === 'ride_or_die') {
+    return { layer, subtype: 'bromance', layerLabel, subtypeLabel: 'Bromance' }
+  }
+  if (action.category === 'alliance' || hasToken(action, 'alliance') || action.id === 'protect') {
+    return { layer, subtype: 'alliances', layerLabel, subtypeLabel: 'Alliances & commitments' }
+  }
+  if (
+    action.kind === 'intel_gain' ||
+    action.kind === 'intel_spend' ||
+    /secret|snoop|eavesdrop|rumor|rumour/.test(`${action.id} ${action.outcomeTag ?? ''}`)
+  ) {
+    return { layer, subtype: 'intel', layerLabel, subtypeLabel: 'Information & exposure' }
+  }
+  if (action.category === 'aggressive') {
+    return { layer, subtype: 'conflict', layerLabel, subtypeLabel: 'Conflict & rivalry' }
+  }
+  if (action.category === 'friendly') {
+    return { layer, subtype: 'friendly', layerLabel, subtypeLabel: 'Bonds & rapport' }
+  }
+  return { layer, subtype: 'strategy', layerLabel, subtypeLabel: 'Strategy & power' }
+}
+
+export function getDefaultRealityEffects(action: SocialActionDefinition): EffectiveRealityEffects {
+  const grouping = getSocialActionGrouping(action)
+  const conflict = grouping.subtype === 'conflict'
+  const romance = grouping.subtype === 'romance'
+  const commitment = grouping.subtype === 'alliances'
+  const information = grouping.subtype === 'intel'
+
+  const defaults: EffectiveRealityEffects = conflict
+    ? {
+        accepted: { warmth: -8, trust: -9, resentment: 14, suspicion: 6, familiarity: 3 },
+        rejected: { warmth: -8, trust: -9, resentment: 14, suspicion: 6, familiarity: 3 },
+        escalated: { warmth: -8, trust: -9, resentment: 14, suspicion: 6, familiarity: 3 },
+        deEscalated: { warmth: -2, trust: -2, resentment: 3, familiarity: 2 },
+      }
+    : romance
+      ? {
+          accepted: { warmth: 6, trust: 3, attraction: 12, intimacy: 9, familiarity: 3 },
+          rejected: { warmth: -2, attraction: -3, familiarity: 2 },
+          escalated: { warmth: 6, trust: 3, attraction: 12, intimacy: 9, familiarity: 3 },
+          deEscalated: { warmth: -2, attraction: -3, familiarity: 2 },
+        }
+      : commitment
+        ? {
+            accepted: { trust: 8, loyalty: 10, strategicValue: 7, familiarity: 2 },
+            rejected: { trust: -3, suspicion: 4, familiarity: 2 },
+            escalated: { trust: 8, loyalty: 10, strategicValue: 7, familiarity: 2 },
+            deEscalated: { trust: -3, suspicion: 4, familiarity: 2 },
+          }
+        : information
+          ? {
+              accepted: { trust: 4, strategicValue: 4, familiarity: 2 },
+              rejected: { suspicion: 3, familiarity: 1 },
+              escalated: { trust: 4, strategicValue: 4, familiarity: 2 },
+              deEscalated: { suspicion: 3, familiarity: 1 },
+            }
+          : {
+              accepted: { warmth: 6, trust: 3, familiarity: 3 },
+              rejected: { warmth: -2, familiarity: 1 },
+              escalated: { warmth: 6, trust: 3, familiarity: 3 },
+              deEscalated: { warmth: -2, familiarity: 1 },
+            }
+
+  return {
+    accepted: { ...defaults.accepted, ...action.realityEffects?.accepted },
+    rejected: { ...defaults.rejected, ...action.realityEffects?.rejected },
+    escalated: { ...defaults.escalated, ...action.realityEffects?.escalated },
+    deEscalated: { ...defaults.deEscalated, ...action.realityEffects?.deEscalated },
+  }
+}

--- a/src/social/socialActions.ts
+++ b/src/social/socialActions.ts
@@ -67,6 +67,8 @@ export type SubjectPool = 'houseguests' | 'nominees' | 'non_nominees' | 'allies'
 
 export interface SocialActionDefinition {
   id: string
+  /** Manager-controlled master switch. Omitted means enabled. */
+  enabled?: boolean
   title: string
   /**
    * UI metadata category for display and filtering purposes.
@@ -104,6 +106,32 @@ export interface SocialActionDefinition {
   description?: string
   /** Optional weight hint for future AI probability weighting. */
   successWeight?: number
+  /** Optional Normal Mode AI selection weight managed independently from outcome odds. */
+  aiWeight?: number
+  /** Per-action legacy relationship effects. Falls back to the category defaults. */
+  affinityEffects?: { success: number; failure: number }
+  /** Per-action outcome-score effects used for Bad/Good/Great feedback. */
+  scoreEffects?: { success: number; failure: number }
+  /**
+   * Multidimensional Reality relationship effects. Keys are Reality relationship
+   * dimensions such as warmth, trust, attraction, resentment, and suspicion.
+   */
+  realityEffects?: {
+    accepted?: Record<string, number>
+    rejected?: Record<string, number>
+    escalated?: Record<string, number>
+    deEscalated?: Record<string, number>
+  }
+  /** Optional Reality contract connections; omitted values are derived from the action. */
+  realityPurposes?: readonly string[]
+  realityAllowedDirections?: readonly string[]
+  realityAllowedGameModes?: readonly string[]
+  realityVisibility?: string
+  realityCooldownPhases?: number
+  responseSetId?: string
+  outcomeResolverId?: string
+  memoryTemplateId?: string
+  dialogueSetId?: string
   /** Tag applied to relationship entries when this action fires (e.g. 'betrayal'). */
   outcomeTag?: string
   /**
@@ -166,6 +194,8 @@ export interface SocialActionDefinition {
    * a locked preview card rather than making the core catalogue feel smaller.
    */
   realityExclusive?: boolean
+  /** Reality intensity presets where this action may run (casual, tv, adult). */
+  allowedRealityPresets?: readonly string[]
   allowedPhases?: readonly string[]
   requiredRelationshipTags?: readonly string[]
   excludedRelationshipTags?: readonly string[]

--- a/src/social/socialExecutionGuard.ts
+++ b/src/social/socialExecutionGuard.ts
@@ -3,6 +3,7 @@ import { evaluateSocialActionEligibility } from './socialActionEligibility'
 import { resolveActionTargetMode, type SocialActionDefinition } from './socialActions'
 import { getEffectiveSocialMode } from './socialMode'
 import type { DramaSocialNetwork, RelationshipsMap } from './types'
+import { isActionAllowedForRealityPreset } from './socialActionManager'
 
 interface SocialExecutionState {
   game?: {
@@ -11,7 +12,7 @@ interface SocialExecutionState {
     dramaSocialMode?: boolean
     players?: Array<{ id: string; status: string; isUser?: boolean }>
   }
-  settings?: { gameUX?: { dramaMode?: boolean } }
+  settings?: { gameUX?: { dramaMode?: boolean; realityModePreset?: string } }
   vip?: {
     isActive?: boolean
     entitlements?: { dramaMode?: boolean }
@@ -40,6 +41,10 @@ export function validateSocialExecution(
   state: SocialExecutionState,
   selection: SocialExecutionSelection
 ) {
+  const realityPreset = state.settings?.gameUX?.realityModePreset
+  if (realityPreset && !isActionAllowedForRealityPreset(selection.action, realityPreset)) {
+    return { eligible: false, reason: 'Unavailable for the selected Reality intensity.' }
+  }
   const dramaMode = getEffectiveSocialMode(state) === 'drama'
   const targetMode = resolveActionTargetMode(selection.action, dramaMode)
   const targetIds = targetMode === 'none' ? [] : (selection.targetIds ?? [])

--- a/src/store/challengeSlice.ts
+++ b/src/store/challengeSlice.ts
@@ -30,6 +30,7 @@ import type { CwgoPrizeType } from '../features/cwgo/cwgoCompetitionSlice'
 import { TWIN_SHOCK_LIA_ID } from '../bb/twinShock'
 import type { MusicMinigameVariant } from '../services/sound/musicConfig'
 import { rankPressurePlankResults } from '../components/PressurePlank/pressurePlankLogic'
+import { resolveGameManagerRule } from '../gameManager/gameManager'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -109,6 +110,8 @@ export interface PendingChallenge {
   aiTiebreakers?: Record<string, number>
   /** Prize type captured at challenge creation (LOH or POS). */
   prizeType?: CwgoPrizeType | string
+  /** A valid producer-selected winner, resolved when this challenge was scheduled. */
+  forcedWinnerId?: string
 }
 
 const initialState: ChallengeState = {
@@ -240,6 +243,14 @@ export const startChallenge =
     // Late-season bias is based on active competitors (jury members no longer play comps).
     const activeCompetitorCount = selectAlivePlayers(state).length
     const scheduledPlayerCount = participants.length || activeCompetitorCount
+    const competitionType = opts.prizeType === 'POS' ? 'POS' : 'LOH'
+    const managerConfig =
+      state.remoteConfig?.config?.gameManager ?? state.settings?.gameUX?.gameManager
+    const managerRule = resolveGameManagerRule(managerConfig, {
+      day: state.game.week,
+      playerCount: scheduledPlayerCount,
+      competition: competitionType,
+    })
     const eligibleForRoster = (game: GameRegistryEntry) =>
       supportsPlayerCount(game, scheduledPlayerCount)
     const lateSeasonBias =
@@ -346,6 +357,14 @@ export const startChallenge =
       const found = getGame(forceKey)
       if (!found) throw new Error(`[challengeSlice] Unknown game key: ${forceKey}`)
       gameEntry = found
+    } else if (managerRule?.selection === 'game') {
+      const configured = managerRule.gameKey ? getGame(managerRule.gameKey) : undefined
+      gameEntry =
+        configured && !configured.retired && eligibleForRoster(configured)
+          ? configured
+          : pickFromRegistry()
+    } else if (managerRule?.selection === 'category' && managerRule.category) {
+      gameEntry = pickFromRegistry(managerRule.category)
     } else if (state.game.mode === 'survival') {
       gameEntry = pickSurvivorGame(opts.category, opts.excludeKeys)
     } else {
@@ -510,6 +529,18 @@ export const startChallenge =
         : resolvedParticipants
     const finalParticipants =
       eligibleParticipants.length > 0 ? eligibleParticipants : resolvedParticipants
+    const forcedWinnerId =
+      managerRule?.outcome === 'player' &&
+      managerRule.winnerId &&
+      finalParticipants.includes(managerRule.winnerId)
+        ? managerRule.winnerId
+        : managerRule?.outcome === 'random' && finalParticipants.length > 0
+          ? finalParticipants[
+              Math.floor(
+                mulberry32((selectionSeed ^ 0x6d2b79f5) >>> 0)() * finalParticipants.length
+              )
+            ]
+          : undefined
 
     // Pre-compute AI scores for all non-human participants.
     const humanId = gameState?.players?.find((p) => p.isUser)?.id
@@ -570,6 +601,7 @@ export const startChallenge =
       aiScores,
       aiTiebreakers,
       prizeType: opts.prizeType,
+      forcedWinnerId,
     }
 
     dispatch(setPendingChallenge(pending))
@@ -628,7 +660,12 @@ export const completeChallenge =
       participants.includes(options.authoritativeWinnerId)
         ? options.authoritativeWinnerId
         : null
-    const winnerId = explicitWinnerId ?? winner?.playerId ?? participants[0] ?? ''
+    const scheduledWinnerId =
+      pending.forcedWinnerId && participants.includes(pending.forcedWinnerId)
+        ? pending.forcedWinnerId
+        : null
+    const winnerId =
+      scheduledWinnerId ?? explicitWinnerId ?? winner?.playerId ?? participants[0] ?? ''
 
     const run: ChallengeRun = {
       id: pending.id,
@@ -642,13 +679,14 @@ export const completeChallenge =
       timestamp: Date.now(),
       authoritative:
         game.key === 'pressurePlank' ||
+        scheduledWinnerId !== null ||
         explicitWinnerId !== null ||
         winner?.authoritativeWinner === true,
       partial: options?.partial === true,
     }
 
     dispatch(recordRun(run))
-    if (explicitWinnerId) {
+    if (scheduledWinnerId || explicitWinnerId) {
       // An authoritative React minigame winner may not align with the generic
       // challenge-score ranking, so apply only the winner boost here and avoid
       // placement bonuses based on fallback scores.

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -13,6 +13,10 @@ import {
   type RealityModePreset,
 } from '../modes/realityMode'
 import { normalizeLanguagePreference, type LanguagePreference } from '../i18n/languages'
+import {
+  sanitiseSocialActionOverrides,
+  type SocialActionOverrides,
+} from '../social/socialActionManager'
 
 export const STORAGE_KEY = 'bbmobilenew_settings_v1'
 
@@ -32,6 +36,10 @@ export interface SettingsState {
   localization: {
     /** Device-following or explicit UI language preference. */
     language: LanguagePreference
+  }
+  social: {
+    /** Persistent local Social Manager layer applied over bundled action definitions. */
+    actionOverrides: SocialActionOverrides
   }
   display: {
     themePreset: ThemePreset
@@ -152,6 +160,12 @@ function normalizeLocalization(
   }
 }
 
+function normalizeSocial(social?: Partial<SettingsState['social']>): SettingsState['social'] {
+  return {
+    actionOverrides: sanitiseSocialActionOverrides(social?.actionOverrides),
+  }
+}
+
 function normalizeGameUX(gameUX?: Partial<SettingsState['gameUX']>): SettingsState['gameUX'] {
   const legacyCompactRosterLayout = (gameUX as { compactRosterLayout?: unknown } | undefined)
     ?.compactRosterLayout
@@ -175,6 +189,9 @@ export const DEFAULT_SETTINGS: SettingsState = {
   },
   localization: {
     language: 'system',
+  },
+  social: {
+    actionOverrides: {},
   },
   display: {
     themePreset: 'midnight',
@@ -252,6 +269,7 @@ export function loadSettings(): SettingsState {
     return {
       audio: normalizeAudio(parsed.audio),
       localization: normalizeLocalization(parsed.localization),
+      social: normalizeSocial(parsed.social),
       display: { ...DEFAULT_SETTINGS.display, ...parsed.display },
       gameUX: mergedGameUX,
       sim: mergedSim,
@@ -264,7 +282,11 @@ export function loadSettings(): SettingsState {
 
 export function saveSettings(state: SettingsState): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+    const serialized = JSON.stringify(state)
+    // Avoid storage-event ping-pong when Advanced Settings is open beside the game.
+    if (localStorage.getItem(STORAGE_KEY) !== serialized) {
+      localStorage.setItem(STORAGE_KEY, serialized)
+    }
   } catch {
     // ignore write errors (e.g. private browsing quota)
   }
@@ -311,6 +333,12 @@ const settingsSlice = createSlice({
         state.localization.language = normalizeLanguagePreference(action.payload.language)
       }
     },
+    setSocialActionOverrides(state, action: PayloadAction<SocialActionOverrides>) {
+      state.social.actionOverrides = sanitiseSocialActionOverrides(action.payload)
+    },
+    resetSocialActionOverrides(state) {
+      state.social.actionOverrides = {}
+    },
     setDisplay(state, action: PayloadAction<Partial<SettingsState['display']>>) {
       Object.assign(state.display, action.payload)
     },
@@ -333,6 +361,7 @@ const settingsSlice = createSlice({
       return {
         audio: normalizeAudio(action.payload.audio),
         localization: normalizeLocalization(action.payload.localization),
+        social: normalizeSocial(action.payload.social),
         display: { ...DEFAULT_SETTINGS.display, ...action.payload.display },
         gameUX: normalizeGameUX(action.payload.gameUX),
         sim: { ...DEFAULT_SETTINGS.sim, ...action.payload.sim },
@@ -349,6 +378,8 @@ export const {
   setMusicTrackAssets,
   resetMusicTrackAssets,
   setLocalization,
+  setSocialActionOverrides,
+  resetSocialActionOverrides,
   setDisplay,
   setGameUX,
   setSim,

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -17,6 +17,11 @@ import {
   sanitiseSocialActionOverrides,
   type SocialActionOverrides,
 } from '../social/socialActionManager'
+import {
+  DEFAULT_GAME_MANAGER_CONFIG,
+  normalizeGameManagerConfig,
+  type GameManagerConfig,
+} from '../gameManager/gameManager'
 
 export const STORAGE_KEY = 'bbmobilenew_settings_v1'
 
@@ -65,6 +70,8 @@ export interface SettingsState {
     castSize: number
     /** Comp Selection configuration: which games are eligible, optional weekly draw limit, and category filter. */
     compSelection: CompSelectionPayload
+    /** Producer controls for scheduling individual LOH and POS competitions. */
+    gameManager: GameManagerConfig
   }
   sim: {
     /** Enables the public-influence ruleset (3rd nominee + pre-veto public save). */
@@ -172,6 +179,7 @@ function normalizeGameUX(gameUX?: Partial<SettingsState['gameUX']>): SettingsSta
   const merged = { ...DEFAULT_SETTINGS.gameUX, ...(gameUX ?? {}) }
   merged.realityModePreset = normalizeRealityModePreset(gameUX?.realityModePreset)
   merged.compSelection = normalizeCompSelection(gameUX?.compSelection)
+  merged.gameManager = normalizeGameManagerConfig(gameUX?.gameManager)
   if (legacyCompactRosterLayout === 'small') {
     merged.compactRoster = true
   }
@@ -217,6 +225,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
       weeklyLimit: null,
       filterCategory: null,
     },
+    gameManager: DEFAULT_GAME_MANAGER_CONFIG,
   },
   sim: {
     publicMode: false,
@@ -346,6 +355,9 @@ const settingsSlice = createSlice({
       Object.assign(state.gameUX, action.payload)
       if (action.payload.compSelection !== undefined) {
         state.gameUX.compSelection = normalizeCompSelection(action.payload.compSelection)
+      }
+      if (action.payload.gameManager !== undefined) {
+        state.gameUX.gameManager = normalizeGameManagerConfig(action.payload.gameManager)
       }
     },
     setSim(state, action: PayloadAction<Partial<SettingsState['sim']>>) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,7 +2,12 @@ import { configureStore } from '@reduxjs/toolkit'
 import gameReducer, { replaceBroadcastConfig } from './gameSlice'
 import finaleReducer from './finaleSlice'
 import challengeReducer from './challengeSlice'
-import settingsReducer, { loadSettings, saveSettings } from './settingsSlice'
+import settingsReducer, {
+  STORAGE_KEY as SETTINGS_STORAGE_KEY,
+  importSettings,
+  loadSettings,
+  saveSettings,
+} from './settingsSlice'
 import userProfileReducer, { loadUserProfile, saveUserProfile } from './userProfileSlice'
 import profilesReducer, {
   loadProfilesState,
@@ -55,6 +60,7 @@ import {
   loadBroadcastConfig,
   saveBroadcastConfig,
 } from '../broadcasting/broadcastConfigPersistence'
+import { setRuntimeSocialActionOverrides } from '../social/socialActionManager'
 
 export const store = configureStore({
   reducer: {
@@ -107,6 +113,8 @@ export const store = configureStore({
     ),
 })
 
+setRuntimeSocialActionOverrides(store.getState().settings.social.actionOverrides)
+
 // The Broadcast Manager is commonly kept open beside the game. localStorage
 // persists its authoring data; this listener makes a save in that manager tab
 // immediately update the live game tab and its ordered presentation queue.
@@ -115,6 +123,14 @@ if (typeof window !== 'undefined') {
     if (event.key !== BROADCAST_CONFIG_STORAGE_KEY) return
     const config = loadBroadcastConfig()
     store.dispatch(replaceBroadcastConfig(config))
+  })
+}
+
+// Keep Social Manager edits synchronized with a game running in another tab.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== SETTINGS_STORAGE_KEY) return
+    store.dispatch(importSettings(loadSettings()))
   })
 }
 
@@ -172,6 +188,7 @@ store.subscribe(() => {
     // settings so that mute controls and Settings screen are the canonical source
     // of truth and stale localStorage flags cannot silently disable audio.
     syncRuntimeAudioSettings(current.settings.audio)
+    setRuntimeSocialActionOverrides(current.settings.social.actionOverrides)
   }
   if (current.userProfile !== prevUserProfile) {
     prevUserProfile = current.userProfile

--- a/tests/unit/remoteConfig.test.ts
+++ b/tests/unit/remoteConfig.test.ts
@@ -19,8 +19,8 @@
  * 15. selectRemotePlayerOverrides returns overrides or empty array.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { configureStore } from '@reduxjs/toolkit';
+import { describe, it, expect, beforeEach } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
 import remoteConfigReducer, {
   setRemoteConfig,
   loadRemoteConfig,
@@ -28,34 +28,34 @@ import remoteConfigReducer, {
   selectRemoteMainTvHeadline,
   selectRemoteIntroHubBg,
   selectRemotePlayerOverrides,
-} from '../../src/remoteConfig/remoteConfigSlice';
+} from '../../src/remoteConfig/remoteConfigSlice'
 import {
   sanitiseRemoteConfig,
   shouldFetchRemoteConfig,
-} from '../../src/remoteConfig/remoteConfigService';
+} from '../../src/remoteConfig/remoteConfigService'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function makeStore() {
-  return configureStore({ reducer: { remoteConfig: remoteConfigReducer } });
+  return configureStore({ reducer: { remoteConfig: remoteConfigReducer } })
 }
 
 // ─── sanitiseRemoteConfig ─────────────────────────────────────────────────────
 
 describe('sanitiseRemoteConfig', () => {
   it('returns null for null', () => {
-    expect(sanitiseRemoteConfig(null)).toBeNull();
-  });
+    expect(sanitiseRemoteConfig(null)).toBeNull()
+  })
 
   it('returns null for a non-object', () => {
-    expect(sanitiseRemoteConfig('string')).toBeNull();
-    expect(sanitiseRemoteConfig(42)).toBeNull();
-    expect(sanitiseRemoteConfig([])).toBeNull();
-  });
+    expect(sanitiseRemoteConfig('string')).toBeNull()
+    expect(sanitiseRemoteConfig(42)).toBeNull()
+    expect(sanitiseRemoteConfig([])).toBeNull()
+  })
 
   it('returns an empty object for an empty object', () => {
-    expect(sanitiseRemoteConfig({})).toEqual({});
-  });
+    expect(sanitiseRemoteConfig({})).toEqual({})
+  })
 
   it('keeps valid string fields', () => {
     const raw = {
@@ -63,14 +63,72 @@ describe('sanitiseRemoteConfig', () => {
         theme: { accent: '#7c3aed', accent2: '#a78bfa', background: '#08101f' },
         mainTv: { headline: 'Hello week!', subtext: 'Sub' },
       },
-    };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.season?.theme?.accent).toBe('#7c3aed');
-    expect(result?.season?.theme?.accent2).toBe('#a78bfa');
-    expect(result?.season?.theme?.background).toBe('#08101f');
-    expect(result?.season?.mainTv?.headline).toBe('Hello week!');
-    expect(result?.season?.mainTv?.subtext).toBe('Sub');
-  });
+    }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.season?.theme?.accent).toBe('#7c3aed')
+    expect(result?.season?.theme?.accent2).toBe('#a78bfa')
+    expect(result?.season?.theme?.background).toBe('#08101f')
+    expect(result?.season?.mainTv?.headline).toBe('Hello week!')
+    expect(result?.season?.mainTv?.subtext).toBe('Sub')
+  })
+
+  it('sanitises scheduled broadcast messages', () => {
+    const result = sanitiseRemoteConfig({
+      broadcast: {
+        enabled: true,
+        title: 'Maintenance',
+        message: 'The house will reopen shortly.',
+        priority: 'critical',
+        startsAt: '2026-08-09T20:00:00.000Z',
+        endsAt: 'not-a-date',
+      },
+    })
+    expect(result?.broadcast).toEqual({
+      enabled: true,
+      title: 'Maintenance',
+      message: 'The house will reopen shortly.',
+      priority: 'critical',
+      startsAt: '2026-08-09T20:00:00.000Z',
+    })
+  })
+
+  it('sanitises remote game-manager rules', () => {
+    const result = sanitiseRemoteConfig({
+      gameManager: {
+        enabled: true,
+        rules: [
+          {
+            id: 'week-three-loh',
+            enabled: true,
+            priority: 5000,
+            trigger: 'day',
+            day: 3.4,
+            competition: 'LOH',
+            selection: 'category',
+            category: 'logic',
+            outcome: 'random',
+          },
+          { id: 'invalid', trigger: 'whenever' },
+        ],
+      },
+    })
+    expect(result?.gameManager).toEqual({
+      enabled: true,
+      rules: [
+        {
+          id: 'week-three-loh',
+          enabled: true,
+          priority: 1000,
+          trigger: 'day',
+          day: 3,
+          competition: 'LOH',
+          selection: 'category',
+          category: 'logic',
+          outcome: 'random',
+        },
+      ],
+    })
+  })
 
   it('drops javascript: and data: URLs', () => {
     const raw = {
@@ -78,11 +136,11 @@ describe('sanitiseRemoteConfig', () => {
         introHub: { backgroundImageUrl: 'javascript:alert(1)' },
         music: { introTrackUrl: 'data:audio/mp3;base64,abc' },
       },
-    };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.season?.introHub).toBeUndefined();
-    expect(result?.season?.music).toBeUndefined();
-  });
+    }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.season?.introHub).toBeUndefined()
+    expect(result?.season?.music).toBeUndefined()
+  })
 
   it('accepts valid http and https URLs', () => {
     const raw = {
@@ -93,18 +151,18 @@ describe('sanitiseRemoteConfig', () => {
           mainTrackUrl: 'http://cdn.example.com/main.mp3',
         },
       },
-    };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.season?.introHub?.backgroundImageUrl).toBe('https://cdn.example.com/bg.jpg');
-    expect(result?.season?.music?.introTrackUrl).toBe('https://cdn.example.com/intro.mp3');
-    expect(result?.season?.music?.mainTrackUrl).toBe('http://cdn.example.com/main.mp3');
-  });
+    }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.season?.introHub?.backgroundImageUrl).toBe('https://cdn.example.com/bg.jpg')
+    expect(result?.season?.music?.introTrackUrl).toBe('https://cdn.example.com/intro.mp3')
+    expect(result?.season?.music?.mainTrackUrl).toBe('http://cdn.example.com/main.mp3')
+  })
 
   it('drops invalid weeklyMode values', () => {
-    const raw = { challenge: { weeklyMode: 'hack-everything' } };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.challenge).toBeUndefined();
-  });
+    const raw = { challenge: { weeklyMode: 'hack-everything' } }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.challenge).toBeUndefined()
+  })
 
   it('accepts valid weeklyMode values', () => {
     const modes = [
@@ -118,12 +176,12 @@ describe('sanitiseRemoteConfig', () => {
       'retired',
       'misc',
       'unique',
-    ] as const;
+    ] as const
     for (const mode of modes) {
-      const result = sanitiseRemoteConfig({ challenge: { weeklyMode: mode } });
-      expect(result?.challenge?.weeklyMode).toBe(mode);
+      const result = sanitiseRemoteConfig({ challenge: { weeklyMode: mode } })
+      expect(result?.challenge?.weeklyMode).toBe(mode)
     }
-  });
+  })
 
   it('sanitises player overrides — drops entries without id', () => {
     const raw = {
@@ -132,36 +190,38 @@ describe('sanitiseRemoteConfig', () => {
         { avatarUrl: 'https://cdn.example.com/no-id.png' }, // no id
         { id: '', avatarUrl: 'https://cdn.example.com/empty-id.png' }, // empty id
       ],
-    };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.players).toHaveLength(1);
-    expect(result?.players?.[0].id).toBe('finn');
-  });
+    }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.players).toHaveLength(1)
+    expect(result?.players?.[0].id).toBe('finn')
+  })
 
   it('drops avatar URLs that are not http/https', () => {
     const raw = {
-      players: [
-        { id: 'finn', avatarUrl: 'javascript:alert(1)' },
-      ],
-    };
-    const result = sanitiseRemoteConfig(raw);
+      players: [{ id: 'finn', avatarUrl: 'javascript:alert(1)' }],
+    }
+    const result = sanitiseRemoteConfig(raw)
     // Player entry preserved (id is valid), but avatarUrl dropped
-    expect(result?.players?.[0].avatarUrl).toBeUndefined();
-  });
+    expect(result?.players?.[0].avatarUrl).toBeUndefined()
+  })
 
   it('clamps overlayOpacity to [0, 1]', () => {
     const raw = {
-      season: { introHub: { backgroundImageUrl: 'https://example.com/bg.jpg', overlayOpacity: 1.5 } },
-    };
-    const result = sanitiseRemoteConfig(raw);
-    expect(result?.season?.introHub?.overlayOpacity).toBe(1);
+      season: {
+        introHub: { backgroundImageUrl: 'https://example.com/bg.jpg', overlayOpacity: 1.5 },
+      },
+    }
+    const result = sanitiseRemoteConfig(raw)
+    expect(result?.season?.introHub?.overlayOpacity).toBe(1)
 
     const raw2 = {
-      season: { introHub: { backgroundImageUrl: 'https://example.com/bg.jpg', overlayOpacity: -0.5 } },
-    };
-    const result2 = sanitiseRemoteConfig(raw2);
-    expect(result2?.season?.introHub?.overlayOpacity).toBe(0);
-  });
+      season: {
+        introHub: { backgroundImageUrl: 'https://example.com/bg.jpg', overlayOpacity: -0.5 },
+      },
+    }
+    const result2 = sanitiseRemoteConfig(raw2)
+    expect(result2?.season?.introHub?.overlayOpacity).toBe(0)
+  })
 
   it('keeps weeklyGameKeys array of strings', () => {
     const raw = {
@@ -169,172 +229,207 @@ describe('sanitiseRemoteConfig', () => {
         weeklyMode: 'user-selection',
         weeklyGameKeys: ['quickTapRace', 'colorMatch', 42, null, ''],
       },
-    };
-    const result = sanitiseRemoteConfig(raw);
+    }
+    const result = sanitiseRemoteConfig(raw)
     // Only non-empty strings are kept
-    expect(result?.challenge?.weeklyGameKeys).toEqual(['quickTapRace', 'colorMatch']);
-  });
+    expect(result?.challenge?.weeklyGameKeys).toEqual(['quickTapRace', 'colorMatch'])
+  })
 
   it('sanitises rollout controls and telemetry endpoints', () => {
     const result = sanitiseRemoteConfig({
       operations: {
         killSwitches: { refinedGameChrome: true, unknown: true },
         rollouts: { refinedGameChrome: { enabled: true, percentage: 140, salt: 'july' } },
-        telemetry: { enabled: true, samplePercentage: -5, endpointUrl: 'https://events.example.com/v1' },
+        telemetry: {
+          enabled: true,
+          samplePercentage: -5,
+          endpointUrl: 'https://events.example.com/v1',
+        },
       },
-    });
+    })
 
     expect(result?.operations).toEqual({
       killSwitches: { refinedGameChrome: true },
       rollouts: { refinedGameChrome: { enabled: true, percentage: 100, salt: 'july' } },
-      telemetry: { enabled: true, samplePercentage: 0, endpointUrl: 'https://events.example.com/v1' },
-    });
-  });
+      telemetry: {
+        enabled: true,
+        samplePercentage: 0,
+        endpointUrl: 'https://events.example.com/v1',
+      },
+    })
+  })
 
   it('drops unsafe telemetry collector URLs', () => {
     const result = sanitiseRemoteConfig({
       operations: { telemetry: { enabled: true, endpointUrl: 'javascript:alert(1)' } },
-    });
-    expect(result?.operations?.telemetry?.endpointUrl).toBeUndefined();
-  });
-});
+    })
+    expect(result?.operations?.telemetry?.endpointUrl).toBeUndefined()
+  })
+})
 
 // ─── remote config endpoint policy ────────────────────────────────────────────
 
 describe('shouldFetchRemoteConfig', () => {
   it('allows the dev proxy path during development', () => {
-    expect(shouldFetchRemoteConfig('/api/live-config', true)).toBe(true);
-  });
+    expect(shouldFetchRemoteConfig('/api/live-config', true)).toBe(true)
+  })
 
   it('skips the relative proxy path in production', () => {
-    expect(shouldFetchRemoteConfig('/api/live-config', false)).toBe(false);
-  });
+    expect(shouldFetchRemoteConfig('/api/live-config', false)).toBe(false)
+  })
 
   it('allows absolute http and https endpoints in production', () => {
-    expect(shouldFetchRemoteConfig('https://cdn.example.com/live-config.json', false)).toBe(true);
-    expect(shouldFetchRemoteConfig('http://localhost:4000/live-config.json', false)).toBe(true);
-  });
-});
+    expect(shouldFetchRemoteConfig('https://cdn.example.com/live-config.json', false)).toBe(true)
+    expect(shouldFetchRemoteConfig('http://localhost:4000/live-config.json', false)).toBe(true)
+  })
+})
 
 // ─── remoteConfigSlice ───────────────────────────────────────────────────────
 
 describe('remoteConfigSlice', () => {
-  let store: ReturnType<typeof makeStore>;
+  let store: ReturnType<typeof makeStore>
 
   beforeEach(() => {
-    store = makeStore();
-  });
+    store = makeStore()
+  })
 
   it('starts with idle status and null config (no cache in test env)', () => {
-    const state = store.getState().remoteConfig;
+    const state = store.getState().remoteConfig
     // Status is idle; config may be null or a cached value (null in fresh test env).
-    expect(state.status).toBe('idle');
-  });
+    expect(state.status).toBe('idle')
+  })
 
   it('setRemoteConfig updates config and sets status to ok', () => {
-    const config = { season: { mainTv: { headline: 'Test week!' } } };
-    store.dispatch(setRemoteConfig(config));
-    const state = store.getState().remoteConfig;
-    expect(state.config).toEqual(config);
-    expect(state.status).toBe('ok');
-    expect(state.fetchedAt).toBeGreaterThan(0);
-  });
+    const config = { season: { mainTv: { headline: 'Test week!' } } }
+    store.dispatch(setRemoteConfig(config))
+    const state = store.getState().remoteConfig
+    expect(state.config).toEqual(config)
+    expect(state.status).toBe('ok')
+    expect(state.fetchedAt).toBeGreaterThan(0)
+  })
 
   it('setRemoteConfig with null clears the config but stays healthy', () => {
-    store.dispatch(setRemoteConfig(null));
-    const state = store.getState().remoteConfig;
-    expect(state.config).toBeNull();
-    expect(state.status).toBe('ok');
-  });
+    store.dispatch(setRemoteConfig(null))
+    const state = store.getState().remoteConfig
+    expect(state.config).toBeNull()
+    expect(state.status).toBe('ok')
+  })
 
   it('loadRemoteConfig.pending sets status to loading', () => {
-    store.dispatch({ type: loadRemoteConfig.pending.type, meta: { requestId: '1', requestStatus: 'pending' } });
-    const state = store.getState().remoteConfig;
-    expect(state.status).toBe('loading');
-  });
+    store.dispatch({
+      type: loadRemoteConfig.pending.type,
+      meta: { requestId: '1', requestStatus: 'pending' },
+    })
+    const state = store.getState().remoteConfig
+    expect(state.status).toBe('loading')
+  })
 
   it('loadRemoteConfig.fulfilled updates config', () => {
-    const config = { season: { theme: { accent: '#abc' } } };
-    store.dispatch({ type: loadRemoteConfig.fulfilled.type, payload: config, meta: { requestId: '1', requestStatus: 'fulfilled' } });
-    const state = store.getState().remoteConfig;
-    expect(state.config).toEqual(config);
-    expect(state.status).toBe('ok');
-  });
+    const config = { season: { theme: { accent: '#abc' } } }
+    store.dispatch({
+      type: loadRemoteConfig.fulfilled.type,
+      payload: config,
+      meta: { requestId: '1', requestStatus: 'fulfilled' },
+    })
+    const state = store.getState().remoteConfig
+    expect(state.config).toEqual(config)
+    expect(state.status).toBe('ok')
+  })
 
   it('loadRemoteConfig.fulfilled with null keeps the slice healthy', () => {
-    store.dispatch({ type: loadRemoteConfig.fulfilled.type, payload: null, meta: { requestId: '1', requestStatus: 'fulfilled' } });
-    const state = store.getState().remoteConfig;
-    expect(state.config).toBeNull();
-    expect(state.status).toBe('ok');
-  });
+    store.dispatch({
+      type: loadRemoteConfig.fulfilled.type,
+      payload: null,
+      meta: { requestId: '1', requestStatus: 'fulfilled' },
+    })
+    const state = store.getState().remoteConfig
+    expect(state.config).toBeNull()
+    expect(state.status).toBe('ok')
+  })
 
   it('loadRemoteConfig.rejected sets status to error', () => {
-    store.dispatch({ type: loadRemoteConfig.rejected.type, meta: { requestId: '1', requestStatus: 'rejected' }, error: { message: 'fail' } });
-    const state = store.getState().remoteConfig;
-    expect(state.status).toBe('error');
-  });
-});
+    store.dispatch({
+      type: loadRemoteConfig.rejected.type,
+      meta: { requestId: '1', requestStatus: 'rejected' },
+      error: { message: 'fail' },
+    })
+    const state = store.getState().remoteConfig
+    expect(state.status).toBe('error')
+  })
+})
 
 // ─── Selectors ────────────────────────────────────────────────────────────────
 
 describe('remoteConfig selectors', () => {
-  let store: ReturnType<typeof makeStore>;
+  let store: ReturnType<typeof makeStore>
 
   beforeEach(() => {
-    store = makeStore();
-  });
+    store = makeStore()
+  })
 
   it('selectRemoteConfig returns null initially', () => {
     // In test env there is no localStorage cache.
-    const s = store.getState();
-    const cfg = selectRemoteConfig(s as Parameters<typeof selectRemoteConfig>[0]);
-    expect(cfg === null || typeof cfg === 'object').toBe(true);
-  });
+    const s = store.getState()
+    const cfg = selectRemoteConfig(s as Parameters<typeof selectRemoteConfig>[0])
+    expect(cfg === null || typeof cfg === 'object').toBe(true)
+  })
 
   it('selectRemoteMainTvHeadline returns headline when set', () => {
-    store.dispatch(setRemoteConfig({ season: { mainTv: { headline: 'QuickTap week' } } }));
-    const s = store.getState();
-    const headline = selectRemoteMainTvHeadline(s as Parameters<typeof selectRemoteMainTvHeadline>[0]);
-    expect(headline).toBe('QuickTap week');
-  });
+    store.dispatch(setRemoteConfig({ season: { mainTv: { headline: 'QuickTap week' } } }))
+    const s = store.getState()
+    const headline = selectRemoteMainTvHeadline(
+      s as Parameters<typeof selectRemoteMainTvHeadline>[0]
+    )
+    expect(headline).toBe('QuickTap week')
+  })
 
   it('selectRemoteMainTvHeadline returns null when not set', () => {
-    store.dispatch(setRemoteConfig({ season: {} }));
-    const s = store.getState();
-    const headline = selectRemoteMainTvHeadline(s as Parameters<typeof selectRemoteMainTvHeadline>[0]);
-    expect(headline).toBeNull();
-  });
+    store.dispatch(setRemoteConfig({ season: {} }))
+    const s = store.getState()
+    const headline = selectRemoteMainTvHeadline(
+      s as Parameters<typeof selectRemoteMainTvHeadline>[0]
+    )
+    expect(headline).toBeNull()
+  })
 
   it('selectRemoteIntroHubBg returns background URL when set', () => {
-    store.dispatch(setRemoteConfig({
-      season: { introHub: { backgroundImageUrl: 'https://example.com/bg.jpg' } },
-    }));
-    const s = store.getState();
-    const bg = selectRemoteIntroHubBg(s as Parameters<typeof selectRemoteIntroHubBg>[0]);
-    expect(bg).toBe('https://example.com/bg.jpg');
-  });
+    store.dispatch(
+      setRemoteConfig({
+        season: { introHub: { backgroundImageUrl: 'https://example.com/bg.jpg' } },
+      })
+    )
+    const s = store.getState()
+    const bg = selectRemoteIntroHubBg(s as Parameters<typeof selectRemoteIntroHubBg>[0])
+    expect(bg).toBe('https://example.com/bg.jpg')
+  })
 
   it('selectRemoteIntroHubBg returns null when not set', () => {
-    store.dispatch(setRemoteConfig({}));
-    const s = store.getState();
-    const bg = selectRemoteIntroHubBg(s as Parameters<typeof selectRemoteIntroHubBg>[0]);
-    expect(bg).toBeNull();
-  });
+    store.dispatch(setRemoteConfig({}))
+    const s = store.getState()
+    const bg = selectRemoteIntroHubBg(s as Parameters<typeof selectRemoteIntroHubBg>[0])
+    expect(bg).toBeNull()
+  })
 
   it('selectRemotePlayerOverrides returns array when set', () => {
-    store.dispatch(setRemoteConfig({
-      players: [{ id: 'finn', avatarUrl: 'https://example.com/finn.png' }],
-    }));
-    const s = store.getState();
-    const overrides = selectRemotePlayerOverrides(s as Parameters<typeof selectRemotePlayerOverrides>[0]);
-    expect(overrides).toHaveLength(1);
-    expect(overrides[0].id).toBe('finn');
-  });
+    store.dispatch(
+      setRemoteConfig({
+        players: [{ id: 'finn', avatarUrl: 'https://example.com/finn.png' }],
+      })
+    )
+    const s = store.getState()
+    const overrides = selectRemotePlayerOverrides(
+      s as Parameters<typeof selectRemotePlayerOverrides>[0]
+    )
+    expect(overrides).toHaveLength(1)
+    expect(overrides[0].id).toBe('finn')
+  })
 
   it('selectRemotePlayerOverrides returns empty array when not set', () => {
-    store.dispatch(setRemoteConfig({}));
-    const s = store.getState();
-    const overrides = selectRemotePlayerOverrides(s as Parameters<typeof selectRemotePlayerOverrides>[0]);
-    expect(overrides).toEqual([]);
-  });
-});
+    store.dispatch(setRemoteConfig({}))
+    const s = store.getState()
+    const overrides = selectRemotePlayerOverrides(
+      s as Parameters<typeof selectRemotePlayerOverrides>[0]
+    )
+    expect(overrides).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- include the centralized Social Manager and new Game Manager
- add a validated remote JSON contract for broadcasts and competition scheduling
- refresh live config every five minutes and render scheduled global broadcasts
- add a mobile-friendly Remote Manager UI for broadcast, music, game, and social controls
- publish safely through a review PR or, when explicitly chosen, directly to main
- serve the starter config from GitHub Pages and document the operator workflow

## Safety

- remote data is strictly sanitized and never executed
- GitHub tokens remain in browser memory only and are not persisted
- protected twist precedence and participant eligibility remain enforced
- generated non-manager content was excluded from this branch

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/gameManager/gameManager.test.ts tests/unit/remoteConfig.test.ts` (35 passed)
- `npm run build`
- visual desktop/mobile-width browser review of the Remote Manager flow