### PR TITLE
Make local manager screens responsive

### DIFF
--- a/src/screens/SettingsAdmin/MusicManagerPanel.css
+++ b/src/screens/SettingsAdmin/MusicManagerPanel.css
@@ -10,6 +10,7 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.85rem;
   align-items: start;
+  min-width: 0;
   padding: 0.9rem;
   border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-line));
   border-radius: 14px;
@@ -239,6 +240,7 @@
 .music-manager__row-main {
   justify-content: space-between;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
 .music-manager__row-main > div {
@@ -290,6 +292,8 @@
 .music-manager__row-controls,
 .music-manager__event-controls {
   align-items: stretch;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .music-manager__select,
@@ -389,6 +393,8 @@
 
 .music-manager__asset-editor {
   align-items: stretch;
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .music-manager__asset-editor input {
@@ -465,6 +471,14 @@
   .music-manager__event-controls,
   .music-manager__asset-editor {
     flex-direction: column;
+    align-items: stretch;
+  }
+
+  .music-manager__row-controls > *,
+  .music-manager__event-controls > *,
+  .music-manager__asset-editor > * {
+    width: 100%;
+    box-sizing: border-box;
   }
 
   .music-manager__select {
@@ -480,6 +494,24 @@
   .music-manager__preview,
   .music-manager__asset-editor button {
     min-height: 2.15rem;
+  }
+}
+
+@media (max-width: 460px) {
+  .settings-content {
+    padding: 0.7rem;
+  }
+
+  .music-manager__hero,
+  .music-manager__cue-library,
+  .music-manager__cue-editor {
+    padding: 0.75rem;
+  }
+
+  .music-manager__tabs,
+  .music-manager__stage-tabs {
+    margin-inline: -0.25rem;
+    padding-inline: 0.25rem;
   }
 }
 

--- a/src/screens/SettingsAdmin/SettingsAdmin.css
+++ b/src/screens/SettingsAdmin/SettingsAdmin.css
@@ -1,9 +1,17 @@
 /* ─── Settings Screen ─────────────────────────────────────────────────────── */
 
+.app-shell:has(.settings-screen) {
+  max-width: min(100%, 1280px);
+}
+
 .settings-screen {
   display: flex;
   flex-direction: column;
   min-height: 100%;
+  min-width: 0;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
   background: var(--color-bg);
   color: var(--color-text);
 }
@@ -13,6 +21,7 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  min-width: 0;
   padding: 1rem 1rem 0.5rem;
   flex-shrink: 0;
 }
@@ -34,6 +43,10 @@
 
 .settings-screen__title {
   margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 1.3rem;
   font-weight: 900;
 }
@@ -62,7 +75,9 @@
   font-weight: 600;
   padding: 0.6rem 0.75rem;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
   white-space: nowrap;
 }
 .settings-tab--active {
@@ -76,7 +91,11 @@
 /* Scrollable content area */
 .settings-content {
   flex: 1;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 1rem;
 }
 
@@ -188,7 +207,7 @@
 
 .settings-helper-text {
   font-size: 0.75rem;
-  color: var(--color-text-muted, rgba(255,255,255,0.5));
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.5));
   margin-top: 4px;
 }
 
@@ -211,7 +230,9 @@
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
 }
 .settings-theme-btn--active {
   border-color: var(--color-accent);
@@ -280,22 +301,22 @@
 /* ── Theme preset CSS variables ──────────────────────────────────────────── */
 
 body.theme-midnight {
-  --color-accent:   #6366f1;
+  --color-accent: #6366f1;
   --color-accent-2: #8b5cf6;
 }
 
 body.theme-neon {
-  --color-accent:   #22d3ee;
+  --color-accent: #22d3ee;
   --color-accent-2: #a78bfa;
 }
 
 body.theme-sunset {
-  --color-accent:   #f97316;
+  --color-accent: #f97316;
   --color-accent-2: #ec4899;
 }
 
 body.theme-ocean {
-  --color-accent:   #0ea5e9;
+  --color-accent: #0ea5e9;
   --color-accent-2: #06b6d4;
 }
 
@@ -311,9 +332,9 @@ body.reduce-motion *::after {
 }
 
 body.high-contrast {
-  --color-text:       #ffffff;
+  --color-text: #ffffff;
   --color-text-muted: rgba(255, 255, 255, 0.75);
-  --color-line:       rgba(255, 255, 255, 0.3);
+  --color-line: rgba(255, 255, 255, 0.3);
 }
 
 /* ── Comp Selection panel ───────────────────────────────────────────────── */
@@ -359,7 +380,10 @@ body.high-contrast {
   font-weight: 600;
   padding: 0.3rem 0.75rem;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
 .comp-selection__filter-btn--active {
   background: var(--color-accent);


### PR DESCRIPTION
## Summary\n- allow the local manager shell to use the laptop width up to 1280px\n- prevent intrinsic manager controls from forcing horizontal clipping\n- stack Music Manager controls and cue editor panels on narrow screens\n- preserve compact tab scrolling and touch-friendly controls on mobile\n\n## Validation\n- prettier\n- git diff --check\n- browser inspection at desktop and mobile breakpoints