### PR TITLE
Fix QA manager navigation and Broadcast Manager layout

### DIFF
--- a/src/components/DebugPanel/QaManagerShortcuts.tsx
+++ b/src/components/DebugPanel/QaManagerShortcuts.tsx
@@ -26,7 +26,8 @@ export default function QaManagerShortcuts() {
         host.style.display = 'grid'
         host.style.gap = '0.5rem'
 
-        const remoteManagerButton = [...inspector.querySelectorAll<HTMLButtonElement>('button')].find(
+        const inspectorButtons = inspector.querySelectorAll<HTMLButtonElement>('button')
+        const remoteManagerButton = [...inspectorButtons].find(
           (button) => button.textContent?.trim() === 'Open Remote Manager'
         )
         if (remoteManagerButton) {
@@ -52,13 +53,15 @@ export default function QaManagerShortcuts() {
   useEffect(() => {
     if (location.pathname !== '/remote-manager') return undefined
 
-    const requestedSection = new URLSearchParams(location.search).get('section') as ManagerSection | null
+    const requestedSection = new URLSearchParams(location.search).get('section')
     if (requestedSection !== 'music' && requestedSection !== 'social') return undefined
 
     let attempts = 0
     const selectRequestedSection = () => {
       attempts += 1
-      const button = [...document.querySelectorAll<HTMLButtonElement>('.remote-manager__tabs button')].find(
+      const tabSelector = '.remote-manager__tabs button'
+      const tabButtons = document.querySelectorAll<HTMLButtonElement>(tabSelector)
+      const button = [...tabButtons].find(
         (candidate) => candidate.textContent?.trim().toLowerCase() === requestedSection
       )
 

--- a/src/components/DebugPanel/QaManagerShortcuts.tsx
+++ b/src/components/DebugPanel/QaManagerShortcuts.tsx
@@ -88,18 +88,10 @@ export default function QaManagerShortcuts() {
 
   return createPortal(
     <>
-      <button
-        className="dbg-btn dbg-btn--wide"
-        type="button"
-        onClick={() => openManager('music')}
-      >
+      <button className="dbg-btn dbg-btn--wide" type="button" onClick={() => openManager('music')}>
         Open Music Manager
       </button>
-      <button
-        className="dbg-btn dbg-btn--wide"
-        type="button"
-        onClick={() => openManager('social')}
-      >
+      <button className="dbg-btn dbg-btn--wide" type="button" onClick={() => openManager('social')}>
         Open Social Manager
       </button>
     </>,

--- a/src/components/DebugPanel/QaManagerShortcuts.tsx
+++ b/src/components/DebugPanel/QaManagerShortcuts.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useLocation, useNavigate } from 'react-router'
+
+type ManagerSection = 'music' | 'social'
+
+const SHORTCUT_HOST_ATTR = 'data-qa-manager-shortcuts'
+
+export default function QaManagerShortcuts() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [portalHost, setPortalHost] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const ensureShortcutHost = () => {
+      const inspector = document.querySelector<HTMLElement>('#dbg-overview')
+      if (!inspector) {
+        setPortalHost((current) => (current?.isConnected ? current : null))
+        return
+      }
+
+      let host = inspector.querySelector<HTMLElement>(`[${SHORTCUT_HOST_ATTR}]`)
+      if (!host) {
+        host = document.createElement('div')
+        host.setAttribute(SHORTCUT_HOST_ATTR, 'true')
+        host.style.display = 'grid'
+        host.style.gap = '0.5rem'
+
+        const remoteManagerButton = [...inspector.querySelectorAll<HTMLButtonElement>('button')].find(
+          (button) => button.textContent?.trim() === 'Open Remote Manager'
+        )
+        if (remoteManagerButton) {
+          remoteManagerButton.insertAdjacentElement('afterend', host)
+        } else {
+          inspector.appendChild(host)
+        }
+      }
+
+      setPortalHost((current) => (current === host ? current : host))
+    }
+
+    ensureShortcutHost()
+    const observer = new MutationObserver(ensureShortcutHost)
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return () => {
+      observer.disconnect()
+      document.querySelector<HTMLElement>(`[${SHORTCUT_HOST_ATTR}]`)?.remove()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (location.pathname !== '/remote-manager') return undefined
+
+    const requestedSection = new URLSearchParams(location.search).get('section') as ManagerSection | null
+    if (requestedSection !== 'music' && requestedSection !== 'social') return undefined
+
+    let attempts = 0
+    const selectRequestedSection = () => {
+      attempts += 1
+      const button = [...document.querySelectorAll<HTMLButtonElement>('.remote-manager__tabs button')].find(
+        (candidate) => candidate.textContent?.trim().toLowerCase() === requestedSection
+      )
+
+      if (button) {
+        if (!button.classList.contains('is-active')) button.click()
+        return true
+      }
+      return attempts >= 40
+    }
+
+    if (selectRequestedSection()) return undefined
+    const intervalId = window.setInterval(() => {
+      if (selectRequestedSection()) window.clearInterval(intervalId)
+    }, 50)
+
+    return () => window.clearInterval(intervalId)
+  }, [location.pathname, location.search])
+
+  const openManager = (section: ManagerSection) => {
+    navigate(`/remote-manager?debug=1&section=${section}`)
+  }
+
+  if (!portalHost) return null
+
+  return createPortal(
+    <>
+      <button
+        className="dbg-btn dbg-btn--wide"
+        type="button"
+        onClick={() => openManager('music')}
+      >
+        Open Music Manager
+      </button>
+      <button
+        className="dbg-btn dbg-btn--wide"
+        type="button"
+        onClick={() => openManager('social')}
+      >
+        Open Social Manager
+      </button>
+    </>,
+    portalHost
+  )
+}

--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -15,6 +15,30 @@ body:has(.game-screen-shell) .app-shell {
   background: var(--color-bg);
 }
 
+/* The player UI intentionally uses a phone-width shell, but Broadcast Manager
+   is a desktop QA authoring surface with a two-column phase/message layout.
+   Give it the available desktop canvas instead of squeezing it into 480px. */
+@media (min-width: 900px) {
+  body:has(.broadcast-manager) .app-shell {
+    width: min(1180px, calc(100vw - 2rem));
+    max-width: none;
+  }
+
+  /* When the QA drawer is open, reserve its 28rem width instead of letting it
+     cover the authoring surface. */
+  body:has(.broadcast-manager):has(.dbg-panel) .app-shell {
+    width: calc(100vw - 28rem);
+    max-width: none;
+    margin-left: 0;
+    margin-right: 28rem;
+  }
+
+  body:has(.broadcast-manager) .broadcast-manager__messages,
+  body:has(.broadcast-manager) .broadcast-manager__layout > * {
+    min-width: 0;
+  }
+}
+
 .app-shell__main {
   position: relative;
   flex: 1 1 0;

--- a/src/components/layout/AppShell.css
+++ b/src/components/layout/AppShell.css
@@ -39,6 +39,27 @@ body:has(.game-screen-shell) .app-shell {
   }
 }
 
+/* On medium desktop widths the open QA drawer leaves less room for two useful
+   columns, so switch the manager to the same horizontal phase-strip pattern
+   used by its mobile layout. */
+@media (min-width: 900px) and (max-width: 1200px) {
+  body:has(.broadcast-manager):has(.dbg-panel) .broadcast-manager__layout {
+    grid-template-columns: 1fr;
+  }
+
+  body:has(.broadcast-manager):has(.dbg-panel) .broadcast-manager__phases {
+    display: flex;
+    max-height: none;
+    overflow-x: auto;
+    padding: 0.45rem;
+  }
+
+  body:has(.broadcast-manager):has(.dbg-panel) .broadcast-manager__phases button {
+    min-width: max-content;
+    width: auto;
+  }
+}
+
 .app-shell__main {
   position: relative;
   flex: 1 1 0;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@ import './AppShell.css'
 
 const THEME_PRESETS = ['midnight', 'neon', 'sunset', 'ocean']
 const DebugPanel = lazy(() => import('../DebugPanel/DebugPanel'))
+const QaManagerShortcuts = lazy(() => import('../DebugPanel/QaManagerShortcuts'))
 const FinalFaceoff = lazy(() => import('../FinalFaceoff/FinalFaceoff'))
 const SeasonFinaleOverlay = lazy(() => import('../SeasonFinale/SeasonFinaleOverlay'))
 const VoxPopuliFinaleOverlay = lazy(() => import('../VoxPopuliFinale/VoxPopuliFinaleOverlay'))
@@ -119,6 +120,7 @@ export default function AppShell() {
       <NavBar />
       <Suspense fallback={null}>
         <DebugPanel />
+        <QaManagerShortcuts />
       </Suspense>
       {/* Mount FinalFaceoff when entering jury so it can initialise the finale.
           Also remount it for the rare recovery case where jury voting already


### PR DESCRIPTION
## What changed
- adds **Open Music Manager** and **Open Social Manager** shortcuts to the QA Control Center inspector
- opens the matching Music/Social section in Remote Manager directly
- expands Broadcast Manager out of the normal 480px phone shell on desktop
- reserves space for the 28rem QA drawer so it no longer crushes or covers the Broadcast Manager
- switches Broadcast Manager to a single-column layout on medium desktop widths when the QA drawer is open

## Why
The Broadcast Manager was being rendered inside the app's normal phone-width shell, which made its two-column authoring UI unusably narrow. The QA panel also lacked direct access to Music and Social manager sections.