### PR TITLE
Add publish workflow to local managers

### DIFF
--- a/src/components/ManagerPublishBar/ManagerPublishBar.css
+++ b/src/components/ManagerPublishBar/ManagerPublishBar.css
@@ -1,0 +1,78 @@
+.manager-publish {
+  display: grid;
+  gap: 12px;
+  margin: 0 0 18px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 45%, var(--color-line));
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--color-accent) 9%, var(--color-card));
+}
+.manager-publish__copy {
+  display: grid;
+  gap: 3px;
+}
+.manager-publish__copy span,
+.manager-publish small,
+.manager-publish__status {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+.manager-publish__controls {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  align-items: end;
+  gap: 10px;
+}
+.manager-publish label {
+  display: grid;
+  gap: 5px;
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+.manager-publish input {
+  min-width: 0;
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-card);
+  color: var(--color-text);
+  padding: 9px 10px;
+  font: inherit;
+}
+.manager-publish__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.manager-publish button {
+  border: 1px solid var(--color-line);
+  border-radius: 8px;
+  background: var(--color-card-2, var(--color-card));
+  color: var(--color-text);
+  padding: 9px 11px;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+.manager-publish button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+.manager-publish__main {
+  border-color: #d97706 !important;
+  background: #7c2d12 !important;
+}
+.manager-publish__status {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 620px) {
+  .manager-publish__controls {
+    grid-template-columns: 1fr;
+  }
+  .manager-publish__actions > button {
+    flex: 1 1 140px;
+  }
+}

--- a/src/components/ManagerPublishBar/ManagerPublishBar.tsx
+++ b/src/components/ManagerPublishBar/ManagerPublishBar.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import {
+  GITHUB_PAGES_REMOTE_CONFIG_URL,
+  sanitiseRemoteConfig,
+} from '../../remoteConfig/remoteConfigService'
+import {
+  publishConfigAsPullRequest,
+  publishConfigDirectly,
+  type GitHubPublishTarget,
+} from '../../remoteConfig/githubConfigPublisher'
+import type { RemoteConfig } from '../../remoteConfig/remoteConfigTypes'
+import './ManagerPublishBar.css'
+
+const DEFAULT_TARGET: GitHubPublishTarget = {
+  owner: 'georgi-cole',
+  repo: 'bbmobilenew',
+  branch: 'main',
+  path: 'public/config/live-config.json',
+}
+
+type Props = {
+  managerName: string
+  exportFileName: string
+  getPatch: () => Partial<RemoteConfig>
+}
+
+function mergeRemoteConfig(base: RemoteConfig, patch: Partial<RemoteConfig>): RemoteConfig {
+  return {
+    ...base,
+    ...patch,
+    ...(patch.season
+      ? {
+          season: {
+            ...base.season,
+            ...patch.season,
+            ...(patch.season.music
+              ? { music: { ...base.season?.music, ...patch.season.music } }
+              : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+function downloadJson(fileName: string, value: unknown): void {
+  const blob = new Blob([`${JSON.stringify(value, null, 2)}\n`], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = fileName
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+export default function ManagerPublishBar({ managerName, exportFileName, getPatch }: Props) {
+  const [token, setToken] = useState('')
+  const [status, setStatus] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const exportChanges = () => {
+    downloadJson(exportFileName, getPatch())
+    setStatus('Export downloaded. You can keep it as a backup or inspect it before publishing.')
+  }
+
+  const publish = async (mode: 'pr' | 'main') => {
+    if (!token.trim()) {
+      setStatus('Enter a GitHub token with repository Contents and Pull requests permission.')
+      return
+    }
+    if (mode === 'main' && !window.confirm(`Publish ${managerName} changes directly to main?`))
+      return
+
+    setBusy(true)
+    setStatus('Loading the current published configuration…')
+    try {
+      const response = await fetch(GITHUB_PAGES_REMOTE_CONFIG_URL, { cache: 'no-store' })
+      const existing = response.ok ? (sanitiseRemoteConfig(await response.json()) ?? {}) : {}
+      const config = mergeRemoteConfig(existing, getPatch())
+      const result =
+        mode === 'pr'
+          ? await publishConfigAsPullRequest(token.trim(), DEFAULT_TARGET, config)
+          : await publishConfigDirectly(token.trim(), DEFAULT_TARGET, config)
+      setStatus(
+        mode === 'pr'
+          ? `Pull request #${result.pullRequestNumber ?? ''} created: ${result.url}`
+          : `Published to main: ${result.url}`
+      )
+      setToken('')
+    } catch (error) {
+      setStatus(`Publish failed: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="manager-publish" aria-label={`${managerName} export and publishing`}>
+      <div className="manager-publish__copy">
+        <strong>Save {managerName} changes for users</strong>
+        <span>Export a backup, create a review PR, or publish directly to main.</span>
+      </div>
+      <div className="manager-publish__controls">
+        <label>
+          GitHub token
+          <input
+            type="password"
+            value={token}
+            onChange={(event) => setToken(event.target.value)}
+            placeholder="Token stays in this tab only"
+            autoComplete="off"
+          />
+        </label>
+        <div className="manager-publish__actions">
+          <button type="button" onClick={exportChanges} disabled={busy}>
+            Export JSON
+          </button>
+          <button type="button" onClick={() => void publish('pr')} disabled={busy}>
+            {busy ? 'Working…' : 'Create PR'}
+          </button>
+          <button
+            type="button"
+            className="manager-publish__main"
+            onClick={() => void publish('main')}
+            disabled={busy}
+          >
+            Publish to main
+          </button>
+        </div>
+      </div>
+      {status && (
+        <p className="manager-publish__status" role="status">
+          {status}
+        </p>
+      )}
+      <small>
+        PR is recommended. Direct main publishing immediately changes the live configuration after
+        deployment.
+      </small>
+    </section>
+  )
+}

--- a/src/screens/BroadcastManager/BroadcastManager.tsx
+++ b/src/screens/BroadcastManager/BroadcastManager.tsx
@@ -19,6 +19,7 @@ import type {
   TvEvent,
 } from '../../types'
 import { isDebugAccessGranted } from '../../utils/debugMode'
+import ManagerPublishBar from '../../components/ManagerPublishBar/ManagerPublishBar'
 import {
   ALL_BROADCAST_PHASES,
   BROADCAST_CAMPAIGNS,
@@ -475,6 +476,17 @@ export default function BroadcastManager() {
           Back to game
         </button>
       </header>
+      <ManagerPublishBar
+        managerName="Broadcast Manager"
+        exportFileName="broadcast-manager-remote-config.json"
+        getPatch={() => ({
+          broadcastManager: {
+            enabled: true,
+            overrides: game.broadcastOverrides ?? {},
+            customMessages: game.customBroadcasts ?? [],
+          },
+        })}
+      />
 
       <label className="broadcast-manager__campaign-filter">
         Campaign filter

--- a/src/screens/GameManager/GameManager.tsx
+++ b/src/screens/GameManager/GameManager.tsx
@@ -10,6 +10,7 @@ import {
   type GameManagerRule,
 } from '../../gameManager/gameManager'
 import './GameManager.css'
+import ManagerPublishBar from '../../components/ManagerPublishBar/ManagerPublishBar'
 
 const CATEGORIES: GameCategory[] = ['arcade', 'logic', 'trivia', 'endurance']
 
@@ -66,6 +67,11 @@ export default function GameManager() {
           Back to game
         </button>
       </header>
+      <ManagerPublishBar
+        managerName="Game Manager"
+        exportFileName="game-manager-remote-config.json"
+        getPatch={() => ({ gameManager: { enabled: config.enabled, rules: config.rules } })}
+      />
 
       <section className="game-manager__safety" aria-label="Rule priority">
         <strong>Priority protection</strong>

--- a/src/screens/SettingsAdmin/MusicManagerPanel.tsx
+++ b/src/screens/SettingsAdmin/MusicManagerPanel.tsx
@@ -44,6 +44,7 @@ import {
 import MusicCueEditor from './MusicCueEditor'
 import type { MusicCueDefinition } from '../../services/sound/musicCue'
 import './MusicManagerPanel.css'
+import ManagerPublishBar from '../../components/ManagerPublishBar/ManagerPublishBar'
 
 type ManagerSection = 'phases' | 'minigames' | 'events' | 'tracks' | 'cues' | 'data'
 type EditableMode = Exclude<MusicConfigMode, 'any'>
@@ -437,6 +438,18 @@ export default function MusicManagerPanel() {
 
   return (
     <section className="music-manager" aria-label="Music Manager">
+      <ManagerPublishBar
+        managerName="Music Manager"
+        exportFileName="music-manager-remote-config.json"
+        getPatch={() => ({
+          season: {
+            music: {
+              assignments: localOverrides,
+              tracks: localAssets,
+            },
+          },
+        })}
+      />
       <header className="music-manager__hero">
         <div>
           <p className="music-manager__eyebrow">Advanced audio direction</p>

--- a/src/screens/SettingsAdmin/SocialManagerPanel.tsx
+++ b/src/screens/SettingsAdmin/SocialManagerPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { adaptLegacyActionContract } from '../../social/reality/actionContract'
 import { normalizeActionCosts, normalizeActionYields } from '../../social/smExecNormalize'
 import './SocialManagerPanel.css'
+import ManagerPublishBar from '../../components/ManagerPublishBar/ManagerPublishBar'
 
 type ManagerView = 'catalog' | 'data'
 type CostKey = 'baseCost' | 'dramaCost'
@@ -315,6 +316,13 @@ export default function SocialManagerPanel() {
 
   return (
     <section className="social-manager" aria-label="Social Manager">
+      <ManagerPublishBar
+        managerName="Social Manager"
+        exportFileName="social-manager-remote-config.json"
+        getPatch={() => ({
+          socialManager: { enabled: true, actionOverrides: overrides },
+        })}
+      />
       <header className="social-manager__hero">
         <div>
           <p className="social-manager__eyebrow">Central action contract</p>


### PR DESCRIPTION
## Summary\n- add Export JSON, Create PR, and Publish to main controls to Broadcast, Music, Social, and Game Manager\n- merge each manager’s saved data into the currently published live configuration\n- keep GitHub tokens in browser memory only and confirm direct main publishing\n\n## Validation\n- npm run typecheck\n- targeted ESLint\n- prettier and git diff --check