### PR TITLE
Prevent mojibake in manager exports and publishes

### DIFF
--- a/src/components/ManagerPublishBar/ManagerPublishBar.tsx
+++ b/src/components/ManagerPublishBar/ManagerPublishBar.tsx
@@ -9,6 +9,7 @@ import {
   type GitHubPublishTarget,
 } from '../../remoteConfig/githubConfigPublisher'
 import type { RemoteConfig } from '../../remoteConfig/remoteConfigTypes'
+import { repairRemoteConfigTextEncoding } from '../../remoteConfig/remoteConfigService'
 import './ManagerPublishBar.css'
 
 const DEFAULT_TARGET: GitHubPublishTarget = {
@@ -58,7 +59,7 @@ export default function ManagerPublishBar({ managerName, exportFileName, getPatc
   const [busy, setBusy] = useState(false)
 
   const exportChanges = () => {
-    downloadJson(exportFileName, getPatch())
+    downloadJson(exportFileName, repairRemoteConfigTextEncoding(getPatch() as RemoteConfig))
     setStatus('Export downloaded. You can keep it as a backup or inspect it before publishing.')
   }
 

--- a/src/remoteConfig/githubConfigPublisher.ts
+++ b/src/remoteConfig/githubConfigPublisher.ts
@@ -1,4 +1,5 @@
 import type { RemoteConfig } from './remoteConfigTypes'
+import { repairRemoteConfigTextEncoding } from './remoteConfigService'
 
 export interface GitHubPublishTarget {
   owner: string
@@ -77,6 +78,7 @@ async function writeConfig(
   config: RemoteConfig
 ): Promise<{ html_url: string }> {
   const sha = await readFileSha(token, target, branch)
+  const safeConfig = repairRemoteConfigTextEncoding(config)
   const response = await githubRequest<{
     content?: { html_url?: string }
     commit: { html_url: string }
@@ -87,7 +89,7 @@ async function writeConfig(
       method: 'PUT',
       body: JSON.stringify({
         message: 'Update remote manager configuration',
-        content: encodeUtf8Base64(`${JSON.stringify(config, null, 2)}\n`),
+        content: encodeUtf8Base64(`${JSON.stringify(safeConfig, null, 2)}\n`),
         branch,
         ...(sha ? { sha } : {}),
       }),

--- a/src/remoteConfig/remoteConfigService.ts
+++ b/src/remoteConfig/remoteConfigService.ts
@@ -97,6 +97,30 @@ function safePercentage(value: unknown): number | undefined {
   return Math.max(0, Math.min(100, value))
 }
 
+/** Repairs UTF-8 text that was incorrectly interpreted as Latin-1. */
+function repairMojibakeString(value: string): string {
+  if (!/[ðÃÂâ]/.test(value)) return value
+  try {
+    const bytes = Uint8Array.from(Array.from(value, (character) => character.charCodeAt(0) & 0xff))
+    return new TextDecoder('utf-8').decode(bytes)
+  } catch {
+    return value
+  }
+}
+
+function repairMojibakeValue(value: unknown): unknown {
+  if (typeof value === 'string') return repairMojibakeString(value)
+  if (Array.isArray(value)) return value.map(repairMojibakeValue)
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, repairMojibakeValue(entry)])
+  )
+}
+
+export function repairRemoteConfigTextEncoding(config: RemoteConfig): RemoteConfig {
+  return repairMojibakeValue(config) as RemoteConfig
+}
+
 function sanitiseBroadcast(raw: unknown): RemoteConfig['broadcast'] | undefined {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
   const value = raw as Record<string, unknown>

--- a/tests/unit/remoteConfig.test.ts
+++ b/tests/unit/remoteConfig.test.ts
@@ -30,6 +30,7 @@ import remoteConfigReducer, {
   selectRemotePlayerOverrides,
 } from '../../src/remoteConfig/remoteConfigSlice'
 import {
+  repairRemoteConfigTextEncoding,
   sanitiseRemoteConfig,
   shouldFetchRemoteConfig,
 } from '../../src/remoteConfig/remoteConfigService'
@@ -316,6 +317,15 @@ describe('sanitiseRemoteConfig', () => {
 })
 
 // ─── remote config endpoint policy ────────────────────────────────────────────
+
+describe('repairRemoteConfigTextEncoding', () => {
+  it('repairs mojibake emoji before export and publish', () => {
+    const result = repairRemoteConfigTextEncoding({
+      broadcastManager: { overrides: { 'season.welcome': { text: 'Welcome ð ' } } },
+    })
+    expect(result.broadcastManager?.overrides?.['season.welcome']?.text).toBe('Welcome 🏠')
+  })
+})
 
 describe('shouldFetchRemoteConfig', () => {
   it('allows the dev proxy path during development', () => {


### PR DESCRIPTION
## Summary\n- normalize common UTF-8/Latin-1 mojibake before manager JSON downloads\n- normalize again at the shared GitHub PR/direct-main write boundary\n- add regression coverage for corrupted emoji text such as ð \n\n## Validation\n- 35 remote-config tests passed\n- npm run typecheck