### PR TITLE
Fix Twin Shock broadcast priority and stale eviction replay

### DIFF
--- a/src/components/ui/TvZone.tsx
+++ b/src/components/ui/TvZone.tsx
@@ -38,6 +38,10 @@ import { isVisibleInMainLog, isVisibleOnTv } from '../../services/activityServic
 import type { TvEvent } from '../../types'
 import TopUtilityButton from '../TopUtilityButton/TopUtilityButton'
 import { getViewportMessageKey } from './tvZoneKeys'
+import {
+  getTvPresentationBroadcastLevel,
+  isCurrentPhaseBroadcastEvent,
+} from './tvZoneBroadcastGuards'
 import { LIVE_VOTE_PITCHES_EVENT_KEY } from '../../constants/tvEvents'
 import { getPhaseCardTemplate } from '../../broadcasting/broadcastTemplateCatalog'
 import {
@@ -595,13 +599,11 @@ export default function TvZone(props: TvZoneProps) {
   const mainLogFeed = useMemo(() => gameState.tvFeed.filter(isVisibleInMainLog), [gameState.tvFeed])
   const queuedBroadcastEvent = useMemo(() => {
     const queuedId = gameState.broadcastQueue?.[0]
-    return queuedId ? (gameState.tvFeed.find((event) => event.id === queuedId) ?? null) : null
-  }, [gameState.broadcastQueue, gameState.tvFeed])
-  const queuedBroadcastLevel = queuedBroadcastEvent?.meta?.broadcastLevel as
-    | 'minor'
-    | 'major'
-    | 'critical'
-    | undefined
+    if (!queuedId) return null
+    const event = gameState.tvFeed.find((candidate) => candidate.id === queuedId) ?? null
+    return isCurrentPhaseBroadcastEvent(event, gameState.phase, gameState.week) ? event : null
+  }, [gameState.broadcastQueue, gameState.phase, gameState.tvFeed, gameState.week])
+  const queuedBroadcastLevel = getTvPresentationBroadcastLevel(queuedBroadcastEvent)
   const queuedBroadcastIsCard =
     queuedBroadcastLevel === 'major' || queuedBroadcastLevel === 'critical'
   const lastPlainBroadcastEvent = useMemo(() => {

--- a/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
+++ b/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
@@ -5,12 +5,14 @@ import {
   isCurrentPhaseBroadcastEvent,
 } from '../tvZoneBroadcastGuards'
 
-function makeEvent(options: {
+type EventOptions = {
   major?: string
   level?: 'minor' | 'major' | 'critical'
   phase?: Phase
   week?: number
-} = {}): TvEvent {
+}
+
+function makeEvent(options: EventOptions = {}): TvEvent {
   const { major, level, phase = 'social_1', week = 2 } = options
   return {
     id: 'test-event',
@@ -31,20 +33,14 @@ describe('tvZoneBroadcastGuards', () => {
   it.each(['twin_shock_clue', 'twin_shock_confessional', 'twin_shock_bond'])(
     'presents ambient Twin Shock beat %s as minor even when legacy metadata says major',
     (major) => {
-      expect(
-        getTvPresentationBroadcastLevel(
-          makeEvent({ major, level: 'major' })
-        )
-      ).toBe('minor')
+      const event = makeEvent({ major, level: 'major' })
+      expect(getTvPresentationBroadcastLevel(event)).toBe('minor')
     }
   )
 
   it('preserves major presentation for unrelated broadcasts', () => {
-    expect(
-      getTvPresentationBroadcastLevel(
-        makeEvent({ major: 'double_eviction', level: 'major' })
-      )
-    ).toBe('major')
+    const event = makeEvent({ major: 'double_eviction', level: 'major' })
+    expect(getTvPresentationBroadcastLevel(event)).toBe('major')
   })
 
   it('accepts a queued event from the current day and phase', () => {

--- a/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
+++ b/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import type { Phase, TvEvent } from '../../../types'
+import {
+  getTvPresentationBroadcastLevel,
+  isCurrentPhaseBroadcastEvent,
+} from '../tvZoneBroadcastGuards'
+
+function makeEvent(options: {
+  major?: string
+  level?: 'minor' | 'major' | 'critical'
+  phase?: Phase
+  week?: number
+} = {}): TvEvent {
+  const { major, level, phase = 'social_1', week = 2 } = options
+  return {
+    id: 'test-event',
+    text: 'Test broadcast',
+    type: 'social',
+    timestamp: 1,
+    ...(major ? { major } : {}),
+    meta: {
+      phase,
+      week,
+      ...(major ? { major } : {}),
+      ...(level ? { broadcastLevel: level } : {}),
+    },
+  }
+}
+
+describe('tvZoneBroadcastGuards', () => {
+  it.each(['twin_shock_clue', 'twin_shock_confessional', 'twin_shock_bond'])(
+    'presents ambient Twin Shock beat %s as minor even when legacy metadata says major',
+    (major) => {
+      expect(
+        getTvPresentationBroadcastLevel(
+          makeEvent({ major, level: 'major' })
+        )
+      ).toBe('minor')
+    }
+  )
+
+  it('preserves major presentation for unrelated broadcasts', () => {
+    expect(
+      getTvPresentationBroadcastLevel(
+        makeEvent({ major: 'double_eviction', level: 'major' })
+      )
+    ).toBe('major')
+  })
+
+  it('accepts a queued event from the current day and phase', () => {
+    const event = makeEvent({ phase: 'live_vote', week: 2, level: 'minor' })
+    expect(isCurrentPhaseBroadcastEvent(event, 'live_vote', 2)).toBe(true)
+  })
+
+  it('rejects a queued event from a previous day', () => {
+    const remyEviction = makeEvent({ phase: 'eviction_results', week: 1, level: 'minor' })
+    expect(isCurrentPhaseBroadcastEvent(remyEviction, 'live_vote', 2)).toBe(false)
+  })
+
+  it('rejects a queued event from a previous phase on the same day', () => {
+    const oldPhaseEvent = makeEvent({ phase: 'social_2', week: 2, level: 'minor' })
+    expect(isCurrentPhaseBroadcastEvent(oldPhaseEvent, 'live_vote', 2)).toBe(false)
+  })
+})

--- a/src/components/ui/tvZoneBroadcastGuards.ts
+++ b/src/components/ui/tvZoneBroadcastGuards.ts
@@ -1,0 +1,37 @@
+import type { BroadcastLevel, Phase, TvEvent } from '../../types'
+
+const AMBIENT_TWIN_SHOCK_KEYS = new Set([
+  'twin_shock_clue',
+  'twin_shock_confessional',
+  'twin_shock_bond',
+])
+
+/**
+ * Twin Shock foreshadowing is intentionally ambient. Older story code tags
+ * these beats with `major` as a semantic identifier, which the broadcast
+ * pipeline also interprets as presentation priority. Keep the identifiers for
+ * backwards compatibility while presenting only these ambient beats as minor.
+ */
+export function getTvPresentationBroadcastLevel(
+  event: TvEvent | null | undefined
+): BroadcastLevel | undefined {
+  if (!event) return undefined
+  const majorKey = event.meta?.major ?? event.major
+  if (typeof majorKey === 'string' && AMBIENT_TWIN_SHOCK_KEYS.has(majorKey)) {
+    return 'minor'
+  }
+  return event.meta?.broadcastLevel as BroadcastLevel | undefined
+}
+
+/**
+ * A queued broadcast is renderable only in the exact day/phase that produced
+ * it. This prevents a saved or route-remount queue head from flashing an old
+ * eviction/result message before the phase synchronizer rebuilds the queue.
+ */
+export function isCurrentPhaseBroadcastEvent(
+  event: TvEvent | null | undefined,
+  phase: Phase,
+  week: number
+): event is TvEvent {
+  return Boolean(event && event.meta?.phase === phase && event.meta?.week === week)
+}


### PR DESCRIPTION
## What changed

- Treat the three ambient Twin Shock story beats (`twin_shock_clue`, `twin_shock_confessional`, and `twin_shock_bond`) as **minor presentation events** even though legacy story code still carries their `major` identifiers.
- Keep the identifiers intact for backwards compatibility and story tracing; only their TV presentation priority is downgraded.
- Reject a queued TV broadcast unless its recorded `week` and `phase` match the currently rendered game state.
- Add focused regression coverage for all three ambient Twin Shock keys and for stale previous-day / previous-phase queue entries.

## Why

Twin Shock foreshadowing is intentionally subtle, but the older story events use the `major` field as a semantic identifier. The newer broadcast pipeline also interprets that field as presentation priority, so those quiet hints can receive too much TV emphasis.

Separately, after returning from the Confessional, `TvZone` could briefly resolve the head of a persisted/stale `broadcastQueue` before phase synchronization rebuilt it. That allowed a Day 1 eviction message (for example, “Remy … eliminated”) to flash during Day 2 even though the player was not being eliminated again.

## User impact

- Lia/Ali foreshadowing remains present and discoverable but behaves like ambient house-feed storytelling rather than a major broadcast.
- The actual Twin Shock reveal is untouched.
- Old eviction/result broadcasts cannot flash after a day/phase transition or Confessional route remount.

## Validation

- Added pure regression tests for presentation priority and exact day/phase queue relevance.
- Compared the branch against `main`: only `TvZone.tsx` plus the new guard and test files are changed.