### PR TITLE
Polish ceremony audio, Twin Shock TV hints, and Confessional return

### DIFF
--- a/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
+++ b/src/components/ui/__tests__/tvZoneBroadcastGuards.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../tvZoneBroadcastGuards'
 
 type EventOptions = {
+  text?: string
   major?: string
   level?: 'minor' | 'major' | 'critical'
   phase?: Phase
@@ -13,10 +14,10 @@ type EventOptions = {
 }
 
 function makeEvent(options: EventOptions = {}): TvEvent {
-  const { major, level, phase = 'social_1', week = 2 } = options
+  const { text = 'Test broadcast', major, level, phase = 'social_1', week = 2 } = options
   return {
     id: 'test-event',
-    text: 'Test broadcast',
+    text,
     type: 'social',
     timestamp: 1,
     ...(major ? { major } : {}),
@@ -37,6 +38,15 @@ describe('tvZoneBroadcastGuards', () => {
       expect(getTvPresentationBroadcastLevel(event)).toBe('minor')
     }
   )
+
+  it('keeps a canonical Lia clue minor after managed refresh rewrites its key to custom_major', () => {
+    const event = makeEvent({
+      text: 'Someone mentioned that Lia looked different in the garden, but nobody pushed it further.',
+      major: 'custom_major',
+      level: 'major',
+    })
+    expect(getTvPresentationBroadcastLevel(event)).toBe('minor')
+  })
 
   it('preserves major presentation for unrelated broadcasts', () => {
     const event = makeEvent({ major: 'double_eviction', level: 'major' })

--- a/src/components/ui/tvZoneBroadcastGuards.ts
+++ b/src/components/ui/tvZoneBroadcastGuards.ts
@@ -6,18 +6,31 @@ const AMBIENT_TWIN_SHOCK_KEYS = new Set([
   'twin_shock_bond',
 ])
 
+const AMBIENT_TWIN_SHOCK_CLUES = new Set([
+  'Lia seemed unusually quiet this morning, then suddenly full of energy by lunch.',
+  'Lia laughed at a joke she claimed not to understand yesterday.',
+  'Someone mentioned that Lia looked different in the garden, but nobody pushed it further.',
+  'Lia forgot a conversation she had only a day ago.',
+])
+
 /**
  * Twin Shock foreshadowing is intentionally ambient. Older story code tags
  * these beats with `major` as a semantic identifier, which the broadcast
- * pipeline also interprets as presentation priority. Keep the identifiers for
- * backwards compatibility while presenting only these ambient beats as minor.
+ * pipeline also interprets as presentation priority. Managed broadcast refresh
+ * can additionally normalize an unregistered semantic major to `custom_major`,
+ * so recognise the canonical clue copy as well. The events remain queued/forced
+ * onto the faux TV, but render as the ordinary minor-TV treatment rather than a
+ * BIG EYE BROADCAST card.
  */
 export function getTvPresentationBroadcastLevel(
   event: TvEvent | null | undefined
 ): BroadcastLevel | undefined {
   if (!event) return undefined
   const majorKey = event.meta?.major ?? event.major
-  if (typeof majorKey === 'string' && AMBIENT_TWIN_SHOCK_KEYS.has(majorKey)) {
+  if (
+    (typeof majorKey === 'string' && AMBIENT_TWIN_SHOCK_KEYS.has(majorKey)) ||
+    AMBIENT_TWIN_SHOCK_CLUES.has(event.text)
+  ) {
     return 'minor'
   }
   return event.meta?.broadcastLevel as BroadcastLevel | undefined

--- a/src/screens/DiaryRoom/RequiredConfessionalSession.tsx
+++ b/src/screens/DiaryRoom/RequiredConfessionalSession.tsx
@@ -149,7 +149,24 @@ export default function RequiredConfessionalSession({ decision, onReturnToGame }
         data-testid="required-confessional-shell"
       >
         <header className="diary-room__header required-confessional__header">
-          <span className="required-confessional__header-spacer" aria-hidden="true" />
+          {decisionComplete || decision === null ? (
+            <button
+              className="diary-room__back"
+              type="button"
+              onClick={handleReturnToGame}
+              aria-label="Return to the House"
+            >
+              ‹ Back
+            </button>
+          ) : (
+            <span
+              className="diary-room__back diary-room__back--locked"
+              aria-label="Decision required — complete your choice before leaving"
+              title="You must complete your decision before leaving the Confessional."
+            >
+              🔒 Locked
+            </span>
+          )}
           <h1 className="diary-room__title">🚪 Confessional</h1>
         </header>
 
@@ -202,35 +219,11 @@ export default function RequiredConfessionalSession({ decision, onReturnToGame }
                       }
                     }}
                   />
-
-                  {decisionComplete && (
-                    <div className="required-confessional__complete">
-                      <span className="diary-room__bubble-text">
-                        Your decision has been recorded. Return to the house when you are ready.
-                      </span>
-                      <button
-                        className="diary-room__submit required-confessional__return"
-                        type="button"
-                        onClick={handleReturnToGame}
-                      >
-                        Return to the House
-                      </button>
-                    </div>
-                  )}
                 </div>
               ) : (
-                <div className="diary-room__bubble diary-room__bubble--bb required-confessional__complete">
+                <div className="diary-room__bubble diary-room__bubble--bb">
                   <span className="diary-room__bubble-author">📺 The Big Eye</span>
-                  <span className="diary-room__bubble-text">
-                    Your decision has been recorded. Return to the house when you are ready.
-                  </span>
-                  <button
-                    className="diary-room__submit required-confessional__return"
-                    type="button"
-                    onClick={handleReturnToGame}
-                  >
-                    Return to the House
-                  </button>
+                  <span className="diary-room__bubble-text">Your decision has been recorded.</span>
                 </div>
               )}
             </div>

--- a/src/services/sound/AudioStateSync.tsx
+++ b/src/services/sound/AudioStateSync.tsx
@@ -58,7 +58,20 @@ function enrichMinigameTransition(
 }
 
 export default function AudioStateSync() {
-  const musicMix = useSelector((root: RootState) => root.ui.musicMix ?? 'normal')
+  const musicMix = useSelector((root: RootState) => {
+    const evictionOverlayPlayerId = root.game.evictionOverlayPlayerId ?? null
+    const battleBackReturnActive =
+      evictionOverlayPlayerId != null &&
+      root.game.battleBack?.used === true &&
+      root.game.battleBack?.winnerId === evictionOverlayPlayerId
+    const voteResultsRevealActive = root.game.voteResults != null
+    const evictionCinematicActive = evictionOverlayPlayerId != null && !battleBackReturnActive
+
+    // Music only makes room for the two SFX-heavy reveal sequences themselves.
+    // Live-vote title cards, Confessional prompts and other surrounding screens
+    // stay at full strength even though they share the same game phases.
+    return voteResultsRevealActive || evictionCinematicActive ? 'ducked' : 'normal'
+  })
   const musicState = useSelector(
     (root: RootState) => ({
       gamePhase: root.game.phase,

--- a/src/services/sound/specialMusicCues.ts
+++ b/src/services/sound/specialMusicCues.ts
@@ -11,6 +11,20 @@ import type { MusicCueDefinition } from './musicCue'
 const GENERAL_TRACK = 'move_into_me_instrumental_general' as CatalogMusicTrack
 const CONFESSIONAL_TRACK = 'move_into_me_confessional' as CatalogMusicTrack
 
+const COMPETITION_TO_NOMINATION_CUE: MusicCueDefinition = {
+  id: 'ceremony:competition-to-nominations',
+  displayName: 'Competition bed — hold to nominations',
+  track: 'competition',
+  startAtSec: 0,
+  loop: true,
+  volume: 1,
+  fadeInMs: 0,
+  fadeOutMs: 650,
+  crossfadeMs: 650,
+  restartPolicy: 'continue',
+  effectPreset: 'none',
+}
+
 const NOMINATION_CEREMONY_CUE: MusicCueDefinition = {
   id: 'ceremony:nominations-soft-exit',
   displayName: 'Nominations ceremony — soft exit',
@@ -130,6 +144,17 @@ export function resolveSpecialMusicCue({
   // Preserve server/admin overrides. These ceremony replacements only take over
   // while the phase still resolves to the legacy default bed they replace.
   if (baseCue.source !== 'phase') return null
+
+  // The LOH competition bed should not drop out during the brief post-result
+  // social beat. Keep it running at full continuity until the nomination
+  // ceremony takes ownership and crossfades to its own bed.
+  if (gamePhase === 'social_1' && baseCue.selection.kind === 'silence') {
+    return resolvedCue(
+      COMPETITION_TO_NOMINATION_CUE,
+      COMPETITION_TO_NOMINATION_CUE.id,
+      'phase'
+    )
+  }
 
   if (
     baseCue.track === 'nominations' &&

--- a/src/services/sound/specialMusicCues.ts
+++ b/src/services/sound/specialMusicCues.ts
@@ -149,11 +149,7 @@ export function resolveSpecialMusicCue({
   // social beat. Keep it running at full continuity until the nomination
   // ceremony takes ownership and crossfades to its own bed.
   if (gamePhase === 'social_1' && baseCue.selection.kind === 'silence') {
-    return resolvedCue(
-      COMPETITION_TO_NOMINATION_CUE,
-      COMPETITION_TO_NOMINATION_CUE.id,
-      'phase'
-    )
+    return resolvedCue(COMPETITION_TO_NOMINATION_CUE, COMPETITION_TO_NOMINATION_CUE.id, 'phase')
   }
 
   if (

--- a/tests/unit/sound/specialMusicCues.test.ts
+++ b/tests/unit/sound/specialMusicCues.test.ts
@@ -12,6 +12,16 @@ function phaseCue(track: 'nominations' | 'veto' | 'competition'): ResolvedMusicC
   }
 }
 
+function silentPhaseCue(assignmentId = 'phase:social_1'): ResolvedMusicCue {
+  return {
+    track: 'none',
+    selection: { kind: 'silence' },
+    assignmentId,
+    source: 'phase',
+    inheritedAssignments: [],
+  }
+}
+
 describe('specialMusicCues', () => {
   it('loops the confessional bed from 2:48 to 3:35', () => {
     const cue = resolveSpecialMusicCue({
@@ -47,6 +57,34 @@ describe('specialMusicCues', () => {
       loopEndSec: 215,
       crossfadeMs: 300,
     })
+  })
+
+  it('holds the competition bed through social_1 until nominations takes over', () => {
+    const cue = resolveSpecialMusicCue({
+      baseCue: silentPhaseCue(),
+      gamePhase: 'social_1',
+      hash: '#/',
+      confessionalMusicMode: 'normal',
+    })
+
+    expect(cue?.track).toBe('competition')
+    expect(cue?.playbackCue).toMatchObject({
+      id: 'ceremony:competition-to-nominations',
+      loop: true,
+      restartPolicy: 'continue',
+      crossfadeMs: 650,
+    })
+  })
+
+  it('does not overwrite a configured social_1 track while extending the default competition bed', () => {
+    const cue = resolveSpecialMusicCue({
+      baseCue: phaseCue('competition'),
+      gamePhase: 'social_1',
+      hash: '#/',
+      confessionalMusicMode: 'normal',
+    })
+
+    expect(cue).toBeNull()
   })
 
   it('uses the general track from 0:01 through the Power of Safety sequence', () => {


### PR DESCRIPTION
## Summary
- keep the LOH competition bed continuous through the post-results social beat until the Nomination Ceremony takes over
- keep elimination music at full strength through the live-vote setup and Confessional call; duck only while vote-result tallies or the actual eviction cinematic are active
- keep Lia/Twin Shock foreshadowing forced onto the faux TV as minor ambient beats, never as a major BIG EYE BROADCAST card
- replace the appended post-vote Return CTA with the existing Confessional upper-left Back navigation pattern; keep it locked until the required decision is complete

## Regression coverage
- canonical Lia garden hint remains minor even if managed broadcast refresh rewrites its legacy key to `custom_major`
- competition music continues through `social_1` without overriding configured phase tracks

## Context
Follow-up polish to merged PR #1363 based on in-game verification screenshots.