### PR TITLE
Add Intro Hub and player eviction audio loops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { store } from './store/store'
 import { router } from './routes'
 import { SoundManager } from './services/sound/SoundManager'
 import AudioStateSync from './services/sound/AudioStateSync'
+import RouteLoopAudioSync from './services/sound/RouteLoopAudioSync'
 import AudioGate from './components/AudioGate/AudioGate'
 import { loadRemoteConfig } from './remoteConfig/remoteConfigSlice'
 import { installGameDiagnostics } from './services/diagnostics/gameDiagnostics'
@@ -68,6 +69,7 @@ export default function App() {
       <I18nProvider>
         <LiveOpsController />
         <AudioStateSync />
+        <RouteLoopAudioSync hash={hash} />
         <VipEntitlementSync />
         {/* AudioGate is suppressed on the Intro/Home route because HomeHub
             unlocks audio via the Play gesture (see HomeHub.handlePlay). */}

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -16,6 +16,10 @@ function isSelfEvictedHash(hash: string): boolean {
   return /^#\/self-evicted(?:[/?#]|$)/.test(hash)
 }
 
+function isHumanEviction(humanId: string | null, overlayId: string | null): boolean {
+  return humanId != null && overlayId === humanId
+}
+
 /**
  * Owns the two long-form loops that are tied to route/overlay visibility rather
  * than a normal gameplay phase.
@@ -37,8 +41,7 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
 
   const introHubActive = isIntroHubHash(hash)
   const playerEvictionActive =
-    isSelfEvictedHash(hash) ||
-    (humanPlayerId != null && evictionOverlayPlayerId === humanPlayerId)
+    isSelfEvictedHash(hash) || isHumanEviction(humanPlayerId, evictionOverlayPlayerId)
 
   useEffect(() => {
     SoundManager.registerDynamic({

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -1,0 +1,91 @@
+import { useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import type { RootState } from '../../store/store'
+import { SoundManager } from './SoundManager'
+
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+const INTRO_HUB_LOOP_KEY = 'music:intro_hub_loop'
+const PLAYER_EVICTION_LOOP_KEY = 'player:self_evict_loop'
+
+function isIntroHubHash(hash: string): boolean {
+  return hash === '' || hash === '#' || hash === '#/'
+}
+
+function isSelfEvictedHash(hash: string): boolean {
+  return /^#\/self-evicted(?:[/?#]|$)/.test(hash)
+}
+
+/**
+ * Owns the two long-form loops that are tied to route/overlay visibility rather
+ * than a normal gameplay phase.
+ *
+ * Intro Hub uses the music category so it obeys the user's music setting and
+ * master music volume. The eviction loop uses the player category so it can
+ * sit above the already-ducked eviction ceremony bed without taking ownership
+ * of the centralized BGM channel.
+ */
+export default function RouteLoopAudioSync({ hash }: { hash: string }) {
+  const musicOn = useSelector((state: RootState) => state.settings.audio.musicOn)
+  const sfxOn = useSelector((state: RootState) => state.settings.audio.sfxOn)
+  const evictionOverlayPlayerId = useSelector(
+    (state: RootState) => state.game.evictionOverlayPlayerId ?? null
+  )
+  const humanPlayerId = useSelector(
+    (state: RootState) => state.game.players.find((player) => player.isUser)?.id ?? null
+  )
+
+  const introHubActive = isIntroHubHash(hash)
+  const playerEvictionActive =
+    isSelfEvictedHash(hash) ||
+    (humanPlayerId != null && evictionOverlayPlayerId === humanPlayerId)
+
+  useEffect(() => {
+    SoundManager.registerDynamic({
+      key: INTRO_HUB_LOOP_KEY,
+      category: 'music',
+      src: `${BASE}/assets/sounds/cinematic/Intro_hub_loop.mp3`,
+      preload: false,
+      volume: 0.55,
+      loop: true,
+    })
+    SoundManager.registerDynamic({
+      key: PLAYER_EVICTION_LOOP_KEY,
+      category: 'player',
+      src: `${BASE}/assets/sounds/events/player_self_evict.mp3`,
+      preload: false,
+      volume: 1,
+      loop: true,
+    })
+
+    return () => {
+      SoundManager.stop(INTRO_HUB_LOOP_KEY)
+      SoundManager.stop(PLAYER_EVICTION_LOOP_KEY)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (introHubActive && musicOn && !playerEvictionActive) {
+      // The hub is outside gameplay. Clear any stale gameplay BGM before
+      // starting its dedicated loop so returning home never layers two beds.
+      SoundManager.stopAllMusic()
+      void SoundManager.play(INTRO_HUB_LOOP_KEY, { allowDuplicate: true })
+    } else {
+      SoundManager.stop(INTRO_HUB_LOOP_KEY)
+    }
+
+    return () => SoundManager.stop(INTRO_HUB_LOOP_KEY)
+  }, [introHubActive, musicOn, playerEvictionActive])
+
+  useEffect(() => {
+    if (playerEvictionActive && sfxOn) {
+      void SoundManager.play(PLAYER_EVICTION_LOOP_KEY, { allowDuplicate: true })
+    } else {
+      SoundManager.stop(PLAYER_EVICTION_LOOP_KEY)
+    }
+
+    return () => SoundManager.stop(PLAYER_EVICTION_LOOP_KEY)
+  }, [playerEvictionActive, sfxOn])
+
+  return null
+}

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -65,21 +65,38 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
   }, [])
 
   useEffect(() => {
-    if (introHubActive && musicOn && !playerEvictionActive) {
-      // The hub is outside gameplay. Clear any stale gameplay BGM before
-      // starting its dedicated loop so returning home never layers two beds.
-      SoundManager.stopAllMusic()
-      void SoundManager.play(INTRO_HUB_LOOP_KEY, { allowDuplicate: true })
-    } else {
+    if (!introHubActive || !musicOn || playerEvictionActive) {
       SoundManager.stop(INTRO_HUB_LOOP_KEY)
+      return
     }
 
-    return () => SoundManager.stop(INTRO_HUB_LOOP_KEY)
+    // The hub is outside gameplay. Clear any stale gameplay BGM before
+    // starting its dedicated loop so returning home never layers two beds.
+    SoundManager.stopAllMusic()
+
+    // Browser/WebView autoplay rules may reject audio until the first user
+    // gesture. Arm the manager's normal unlock listeners and also retry this
+    // route-owned loop from that same gesture after the manager has unlocked.
+    SoundManager.unlockOnUserGesture()
+    void SoundManager.play(INTRO_HUB_LOOP_KEY)
+
+    const startAfterGesture = () => {
+      SoundManager.stop(INTRO_HUB_LOOP_KEY)
+      void SoundManager.play(INTRO_HUB_LOOP_KEY)
+    }
+    document.addEventListener('pointerdown', startAfterGesture, { once: true })
+    document.addEventListener('keydown', startAfterGesture, { once: true })
+
+    return () => {
+      document.removeEventListener('pointerdown', startAfterGesture)
+      document.removeEventListener('keydown', startAfterGesture)
+      SoundManager.stop(INTRO_HUB_LOOP_KEY)
+    }
   }, [introHubActive, musicOn, playerEvictionActive])
 
   useEffect(() => {
     if (playerEvictionActive && sfxOn) {
-      void SoundManager.play(PLAYER_EVICTION_LOOP_KEY, { allowDuplicate: true })
+      void SoundManager.play(PLAYER_EVICTION_LOOP_KEY)
     } else {
       SoundManager.stop(PLAYER_EVICTION_LOOP_KEY)
     }


### PR DESCRIPTION
## What changed
- Play and loop `public/assets/sounds/cinematic/Intro_hub_loop.mp3` while the Intro/Home Hub route is active.
- Stop stale gameplay BGM before starting the Intro Hub loop so tracks do not layer.
- Respect browser/WebView autoplay restrictions by retrying the hub loop from the first permitted pointer/keyboard gesture.
- Play and loop `public/assets/sounds/events/player_self_evict.mp3` when the human player's eviction overlay is active.
- Play the same loop on the dedicated `#/self-evicted` route.
- Stop both loops immediately when their owning route/overlay closes.
- Register both assets through the existing `SoundManager` runtime registry, preserving existing music/SFX settings and volume categories.

## Scope
No minigame, ceremony, or existing phase-music mappings were changed.