### PR TITLE
Fix live ceremony tile measurements

### DIFF
--- a/src/components/SpotlightAnimation/spotlight-animation.tsx
+++ b/src/components/SpotlightAnimation/spotlight-animation.tsx
@@ -26,6 +26,11 @@ import CeremonyOverlay from '../CeremonyOverlay/CeremonyOverlay';
 import type { CeremonyOverlayProps, CeremonyTile } from '../CeremonyOverlay/CeremonyOverlay';
 
 export interface SpotlightAnimationProps extends Omit<CeremonyOverlayProps, 'resolveTiles'> {
+  /**
+   * Rebuilds every spotlight tile from the live roster DOM. Prefer this for
+   * ceremonies that can start while another fullscreen surface is unmounting.
+   */
+  measureTiles?: () => CeremonyTile[];
   /** Re-measures tile A (index 0) position on viewport changes. */
   measureA?: () => DOMRect | null;
   /** Re-measures tile B (index 1) position on viewport changes. */
@@ -40,38 +45,64 @@ export interface SpotlightAnimationProps extends Omit<CeremonyOverlayProps, 'res
 
 export default function SpotlightAnimation({
   tiles: initialTiles,
+  measureTiles,
   measureA,
   measureB,
   tileRefs,
+  layoutSignal,
   onDone,
   ...rest
 }: SpotlightAnimationProps) {
-  const [tiles, setTiles] = useState<CeremonyTile[]>(initialTiles);
+  // A live resolver must get the first frame. Rendering captured rectangles
+  // here would briefly punch holes at the pre-minigame layout on mobile.
+  const [tiles, setTiles] = useState<CeremonyTile[]>(() =>
+    measureTiles ? [] : initialTiles,
+  );
+  const [hasInitialMeasurement, setHasInitialMeasurement] = useState(!measureTiles);
   const rafRef = useRef<number>(0);
+  const settleRafRef = useRef<number>(0);
   const activeRef = useRef(true);
 
-  const hasMeasure = measureA != null || measureB != null;
+  const hasMeasure = measureTiles != null || measureA != null || measureB != null;
   const hasRefs = (tileRefs?.length ?? 0) > 0;
+
+  const measureNow = useCallback((allowEmptyFallback = false) => {
+    if (!activeRef.current) return;
+    if (measureTiles) {
+      const measuredTiles = measureTiles();
+      setTiles(measuredTiles);
+      if (
+        allowEmptyFallback ||
+        measuredTiles.some((tile) =>
+          tile.rect != null && (tile.rect.width > 0 || tile.rect.height > 0)
+        )
+      ) {
+        setHasInitialMeasurement(true);
+      }
+      return;
+    }
+    setTiles((prev) =>
+      prev.map((tile, idx) => {
+        const measureFn = idx === 0 ? measureA : idx === 1 ? measureB : undefined;
+        const refEl = tileRefs?.[idx]?.current ?? null;
+        if (!measureFn && !refEl) return tile;
+        const rect = measureFn
+          ? measureFn()
+          : (refEl?.getBoundingClientRect() ?? null);
+        if (!rect) return tile;
+        return { ...tile, rect };
+      }),
+    );
+  }, [measureA, measureB, measureTiles, tileRefs]);
 
   const remeasure = useCallback(() => {
     if (!activeRef.current) return;
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
     rafRef.current = requestAnimationFrame(() => {
       if (!activeRef.current) return;
-      setTiles((prev) =>
-        prev.map((tile, idx) => {
-          const measureFn = idx === 0 ? measureA : idx === 1 ? measureB : undefined;
-          const refEl = tileRefs?.[idx]?.current ?? null;
-          if (!measureFn && !refEl) return tile;
-          const rect = measureFn
-            ? measureFn()
-            : (refEl?.getBoundingClientRect() ?? null);
-          if (!rect) return tile;
-          return { ...tile, rect };
-        }),
-      );
+      measureNow();
     });
-  }, [measureA, measureB, tileRefs]);
+  }, [measureNow]);
 
   useEffect(() => {
     activeRef.current = true;
@@ -103,21 +134,44 @@ export default function SpotlightAnimation({
       }
     }
 
-    // Trigger an initial re-measure in case applying overflow:hidden caused a
-    // layout shift (e.g. scrollbar removal) that staled the passed-in DOMRects.
+    // Trigger an initial re-measure only after the minigame/unrelated fullscreen
+    // surface has committed its unmount. Keep sampling for the first few frames:
+    // Android WebView commonly settles the restored roster over multiple frames.
     remeasure();
+    if (measureTiles) {
+      let remainingSettleFrames = 24;
+      const sampleSettlingLayout = () => {
+        if (!activeRef.current || remainingSettleFrames <= 0) return;
+        remainingSettleFrames -= 1;
+        // If the roster never becomes measurable, let CeremonyOverlay use its
+        // normal empty-geometry fallback after the settling window expires.
+        measureNow(remainingSettleFrames === 0);
+        settleRafRef.current = requestAnimationFrame(sampleSettlingLayout);
+      };
+      settleRafRef.current = requestAnimationFrame(sampleSettlingLayout);
+    }
 
     return () => {
       activeRef.current = false;
       document.body.style.overflow = prevOverflow;
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (settleRafRef.current) cancelAnimationFrame(settleRafRef.current);
       window.removeEventListener('resize', remeasure);
       window.removeEventListener('scroll', remeasure, { capture: true });
       window.visualViewport?.removeEventListener('resize', remeasure);
       window.visualViewport?.removeEventListener('scroll', remeasure);
       ro?.disconnect();
     };
-  }, [hasMeasure, hasRefs, remeasure, tileRefs]);
+  }, [hasMeasure, hasRefs, layoutSignal, measureNow, measureTiles, remeasure, tileRefs]);
 
-  return <CeremonyOverlay {...rest} tiles={tiles} onDone={onDone} />;
+  if (!hasInitialMeasurement) return null;
+
+  return (
+    <CeremonyOverlay
+      {...rest}
+      tiles={tiles}
+      layoutSignal={layoutSignal}
+      onDone={onDone}
+    />
+  );
 }

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -1832,7 +1832,8 @@ export default function GameScreen() {
             subtitle={pendingWinnerCeremony.subtitle}
             onDone={handleWinnerCeremonyDone}
             ariaLabel={pendingWinnerCeremony.ariaLabel}
-            measureA={pendingWinnerCeremony.measureA}
+            layoutSignal={responsiveGameLayout.revision}
+            measureTiles={pendingWinnerCeremony.measureTiles}
           />
         )}
 

--- a/src/screens/GameScreen/flows/useCompetitionFlow.ts
+++ b/src/screens/GameScreen/flows/useCompetitionFlow.ts
@@ -68,8 +68,8 @@ export function useCompetitionFlow({
     caption: string
     subtitle?: string
     ariaLabel: string
-    /** Optional live-measure callback for viewport-tracking during zoom/scroll. */
-    measureA?: () => DOMRect | null
+    /** Rebuilds every cutout from the live post-minigame roster layout. */
+    measureTiles: () => CeremonyTile[]
   } | null>(null)
   const pendingWinnerDispatchRef = useRef<(() => void) | null>(null)
 
@@ -432,10 +432,8 @@ export function useCompetitionFlow({
       const winnerPlayers = winnerIds
         .map((id) => game.players.find((player) => player.id === id))
         .filter((player): player is Player => Boolean(player))
-      const sourceDomRect = getTileRect(finalWinnerId)
-
-      if (winnerPlayers.length === 0 || !sourceDomRect) {
-        // Defensive fallback: no DOMRect available (headless / test) — commit immediately.
+      if (winnerPlayers.length === 0) {
+        // Defensive fallback: an invalid winner cannot produce a ceremony.
         dispatch(
           applyMinigameWinner({
             winnerId: finalWinnerId,
@@ -462,8 +460,8 @@ export function useCompetitionFlow({
           screen: 'GameScreen',
         })
       }
-      const tiles: CeremonyTile[] = winnerPlayers.map((winnerPlayer) => ({
-        rect: getTileRect(winnerPlayer.id),
+      const winnerTileMetadata: CeremonyTile[] = winnerPlayers.map((winnerPlayer) => ({
+        rect: null,
         badge: winSymbol,
         badgeImageSrc: isHohComp && !isVoxComp ? LOH_BADGE_SRC : undefined,
         badgeVariant:
@@ -475,6 +473,11 @@ export function useCompetitionFlow({
         badgeStart: 'center',
         badgeLabel: `${winnerPlayer.name} wins ${winLabel}`,
       }))
+      const measureWinnerTiles = (): CeremonyTile[] =>
+        winnerTileMetadata.map((tile, index) => ({
+          ...tile,
+          rect: getTileRect(winnerPlayers[index].id),
+        }))
       const winnerNames = winnerPlayers.map((player) => player.name).join(' & ')
       pendingWinnerDispatchRef.current = () =>
         dispatch(
@@ -486,11 +489,13 @@ export function useCompetitionFlow({
         )
       setPendingWinnerCeremony({
         winnerId: finalWinnerId,
-        tiles,
+        // Metadata is available immediately, but geometry is deliberately null
+        // until SpotlightAnimation measures after MinigameHost has unmounted.
+        tiles: winnerTileMetadata,
         caption: `${winnerNames} ${isCupidArrowActive(game) ? 'win' : 'wins'} ${winLabel}!`,
         subtitle: winSymbol,
         ariaLabel: `${winnerNames} ${isCupidArrowActive(game) ? 'win' : 'wins'} ${winLabel}`,
-        measureA: () => getTileRect(finalWinnerId),
+        measureTiles: measureWinnerTiles,
       })
     },
     [

--- a/tests/spotlight.viewport.test.tsx
+++ b/tests/spotlight.viewport.test.tsx
@@ -282,6 +282,39 @@ describe('SpotlightAnimation — viewport tracking with measureA', () => {
   });
 });
 
+describe('SpotlightAnimation — post-minigame layout settling', () => {
+  it('does not render captured cutouts before measuring every live tile', async () => {
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      rafCallback = callback;
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const measureTiles = vi.fn(() => [
+      { rect: makeRect(90, 140), badge: '👑' },
+      { rect: makeRect(190, 140), badge: '👑' },
+    ] satisfies CeremonyTile[]);
+    const { container } = render(
+      <SpotlightAnimation
+        tiles={[{ rect: makeRect(1, 2), badge: '👑' }]}
+        measureTiles={measureTiles}
+        caption="Fresh geometry"
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('.ceremony-overlay')).toBeNull();
+    expect(rafCallback).not.toBeNull();
+    await act(async () => {
+      rafCallback?.(0);
+    });
+
+    expect(measureTiles).toHaveBeenCalled();
+    expect(container.querySelectorAll('.ceremony-overlay__glow')).toHaveLength(2);
+  });
+});
+
 describe('SpotlightAnimation — immediate fallback for null tiles', () => {
   it('fires onDone immediately when tile rect is null (headless fallback via CeremonyOverlay)', async () => {
     const onDone = vi.fn();


### PR DESCRIPTION
## Summary

Keep LOH and POS winner cutouts aligned with the live avatar roster after a competition minigame closes.

- defer the first cutout render until the restored roster can be measured
- remeasure every highlighted winner across the Android/iOS WebView settling window
- continue tracking viewport and responsive-layout changes
- preserve the safe empty-geometry fallback

## Why is this change needed?

The winner ceremony captured avatar rectangles while the minigame surface was still closing. On mobile layouts, especially Android compact mode, the roster can reflow for several frames afterward, leaving the dim-layer cutout at stale coordinates.

## Files / areas touched

- SpotlightAnimation live measurement lifecycle
- LOH/POS competition winner ceremony wiring
- viewport regression coverage

## Test plan

- [x] Targeted ESLint passes
- [x] TypeScript typecheck passes
- [x] 27 focused spotlight and ceremony tests pass
- [ ] GitHub Actions checks