### PR TITLE
Temporarily unlock store content for testing

### DIFF
--- a/src/components/TVLog/TVLog.tsx
+++ b/src/components/TVLog/TVLog.tsx
@@ -79,7 +79,9 @@ export default function TVLog({
     });
   }
 
-  const activityContent = (
+  const openFullLogFromInlineFeed = refined && inlineVisible;
+
+  const activityContent = (isInlineFeed = false) => (
     <>
       <div className="tv-log__toolbar">
         <div className="tv-log__heading-group">
@@ -121,9 +123,11 @@ export default function TVLog({
               <button
                 type="button"
                 className="tv-log__event"
-                onClick={() => toggleExpand(event.id)}
-                aria-expanded={isExpanded}
-                aria-label={`${TYPE_LABELS[event.type]} event: ${event.text}`}
+                onClick={() => isInlineFeed ? setLogOpen(true) : toggleExpand(event.id)}
+                aria-expanded={isInlineFeed ? undefined : isExpanded}
+                aria-label={isInlineFeed
+                  ? `Open game log from ${TYPE_LABELS[event.type]} event: ${event.text}`
+                  : `${TYPE_LABELS[event.type]} event: ${event.text}`}
               >
                 <span className="tv-log__icon" aria-hidden="true">{TYPE_ICONS[event.type]}</span>
                 <span className="tv-log__copy">
@@ -139,8 +143,21 @@ export default function TVLog({
     </>
   );
 
+  const logModal = logOpen && createPortal(
+    <div className="tv-log-modal__backdrop" role="presentation" onClick={() => setLogOpen(false)}>
+      <section className="tv-log-modal" role="dialog" aria-modal="true" aria-labelledby="tv-log-modal-title" onClick={(event) => event.stopPropagation()}>
+        <header className="tv-log-modal__header">
+          <div><span className="tv-log-modal__eyebrow">House history</span><h2 id="tv-log-modal-title">Game log</h2></div>
+          <button type="button" className="tv-log-modal__close" aria-label="Close game log" onClick={() => setLogOpen(false)}>×</button>
+        </header>
+        {activityContent()}
+      </section>
+    </div>,
+    document.body,
+  );
+
   if (!refined || inlineVisible) {
-    return <section className={`tv-log-shell${refined ? ' tv-log-shell--inline' : ''}`} aria-labelledby="tv-log-heading">{activityContent}</section>;
+    return <><section className={`tv-log-shell${refined ? ' tv-log-shell--inline' : ''}`} aria-labelledby="tv-log-heading">{activityContent(openFullLogFromInlineFeed)}</section>{logModal}</>;
   }
 
   return (
@@ -154,27 +171,7 @@ export default function TVLog({
         <span aria-hidden="true">☷</span>
         <span>Log</span>
       </button>
-      {logOpen && createPortal(
-        <div className="tv-log-modal__backdrop" role="presentation" onClick={() => setLogOpen(false)}>
-          <section
-            className="tv-log-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="tv-log-modal-title"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <header className="tv-log-modal__header">
-              <div>
-                <span className="tv-log-modal__eyebrow">House history</span>
-                <h2 id="tv-log-modal-title">Game log</h2>
-              </div>
-              <button type="button" className="tv-log-modal__close" aria-label="Close game log" onClick={() => setLogOpen(false)}>×</button>
-            </header>
-            {activityContent}
-          </section>
-        </div>,
-        document.body,
-      )}
+      {logModal}
     </>
   );
 }

--- a/src/components/TVLog/__tests__/TVLog.test.tsx
+++ b/src/components/TVLog/__tests__/TVLog.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TVLog from '../TVLog';
 import { tease } from '../../../utils/tvLogTemplates';
@@ -186,8 +186,23 @@ describe('TVLog — refined on-demand module', () => {
     render(<TVLog entries={entries} maxVisible={2} inlineVisible />);
 
     expect(screen.getByText('Survivor round begins')).toBeDefined();
-    expect(screen.queryByRole('button', { name: /Open game log/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Open game log, /i })).toBeNull();
     expect(screen.queryByRole('dialog')).toBeNull();
+
+    document.body.classList.remove('experiment-game-chrome-refined');
+  });
+
+  it('opens the full log when an inline House Feed row is tapped', async () => {
+    document.body.classList.add('experiment-game-chrome-refined');
+    const entries: TvEvent[] = [
+      makeEvent({ id: 'latest', text: 'The POV ceremony is complete', type: 'game' }),
+      makeEvent({ id: 'earlier', text: 'The nominees react to the result', type: 'social' }),
+    ];
+    render(<TVLog entries={entries} inlineVisible />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Open game log from Game event/i }));
+    const dialog = screen.getByRole('dialog', { name: 'Game log' });
+    expect(within(dialog).getByText('The nominees react to the result')).toBeDefined();
 
     document.body.classList.remove('experiment-game-chrome-refined');
   });

--- a/src/screens/HomeHub/__tests__/HomeHub.test.tsx
+++ b/src/screens/HomeHub/__tests__/HomeHub.test.tsx
@@ -395,7 +395,7 @@ describe('HomeHub', () => {
     expect(screen.queryByRole('button', { name: 'Debug Menu: Off' })).toBeNull();
   });
 
-  it('opens the store from Surveyeval without VIP or survivalMode access', async () => {
+  it('opens Surveyeval directly while temporary store unlocks are enabled', async () => {
     const view = renderHomeHub();
 
     fireEvent.click(screen.getByTestId('kolequant-splash'));
@@ -407,8 +407,8 @@ describe('HomeHub', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Play' }));
     fireEvent.click(screen.getByRole('button', { name: 'Surveyeval' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/store', { state: { returnTo: '/?menu=play' } });
-    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/store', { state: { returnTo: '/?menu=play' } });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     view.unmount();
   });

--- a/src/store/vipSlice.ts
+++ b/src/store/vipSlice.ts
@@ -9,6 +9,7 @@ import {
 import {
   createEmptyStoreEntitlements,
   loadCachedVipEntitlement,
+  TEMPORARY_STORE_UNLOCKS_ENABLED,
   type StoreEntitlements,
 } from '../vip/vipStorage'
 import type { StoreEntitlementKey, StoreProductKey } from '../vip/vipConfig'
@@ -129,11 +130,13 @@ const vipSlice = createSlice({
 })
 
 function selectHasEntitlement(state: RootState, entitlement: StoreEntitlementKey): boolean {
+  if (TEMPORARY_STORE_UNLOCKS_ENABLED) return true
   return (state.vip?.isActive ?? false) || (state.vip?.entitlements?.[entitlement] ?? false)
 }
 
 export const selectVip = (state: RootState) => state.vip
-export const selectIsVipActive = (state: RootState) => state.vip?.isActive ?? false
+export const selectIsVipActive = (state: RootState) =>
+  TEMPORARY_STORE_UNLOCKS_ENABLED || (state.vip?.isActive ?? false)
 export const selectHasPublicModeAccess = (state: RootState) =>
   selectHasEntitlement(state, 'publicMode')
 export const selectHasSurvivalModeAccess = (state: RootState) =>

--- a/src/vip/vipStorage.ts
+++ b/src/vip/vipStorage.ts
@@ -2,6 +2,13 @@ import type { StoreEntitlementKey } from './vipConfig'
 
 const VIP_STORAGE_KEY = 'bbmobilenew:vip:v2'
 
+/**
+ * Temporary public testing switch. Set to false before the release build that
+ * connects store purchases or rewarded ads. It affects store entitlements only,
+ * never ordinary gameplay-state locks.
+ */
+export const TEMPORARY_STORE_UNLOCKS_ENABLED = true
+
 export interface StoreEntitlements {
   survivalMode: boolean
   publicMode: boolean
@@ -80,10 +87,12 @@ export function saveCachedVipEntitlement(value: PersistedVipEntitlement): void {
 }
 
 export function hasCachedVipAccess(): boolean {
+  if (TEMPORARY_STORE_UNLOCKS_ENABLED) return true
   return loadCachedVipEntitlement().isActive
 }
 
 export function hasCachedStoreAccess(entitlement: StoreEntitlementKey): boolean {
+  if (TEMPORARY_STORE_UNLOCKS_ENABLED) return true
   const cached = loadCachedVipEntitlement()
   return cached.isActive || cached.entitlements[entitlement]
 }


### PR DESCRIPTION
## Summary
- temporarily treats store-gated content as owned for public testing
- keeps ordinary gameplay locks unchanged
- opens the full game log when a House Feed row is tapped

## Verification
- npx vitest run src/components/TVLog/__tests__/TVLog.test.tsx
- npm run typecheck

Before a real purchase/ad release, set TEMPORARY_STORE_UNLOCKS_ENABLED to alse.