### PR TITLE
Enforce Intro Hub audio ownership boundaries

### DIFF
--- a/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
+++ b/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { getAll } from '../../data/houseguests';
 import { resolveAvatar } from '../../utils/avatar';
 import { preloadImage, preloadImages } from '../../utils/preload';
+import { stopIntroHubAudioForGameplayExit } from '../../services/sound/RouteLoopAudioSync';
 import KolequantSplash from '../KolequantSplash/KolequantSplash';
 import GAMEPLAY_BG from '../../assets/bb-gameplay-bg.svg';
 
@@ -34,6 +35,10 @@ export default function AssetPreloaderOverlay({
 
   useEffect(() => {
     let cancelled = false;
+
+    // Gameplay owns audio from the moment its preloader opens, even though the
+    // URL is still the Intro Hub until preloading completes.
+    stopIntroHubAudioForGameplayExit();
 
     async function run() {
       setStatus('Loading the competition background.');

--- a/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
+++ b/src/components/AssetPreloaderOverlay/AssetPreloaderOverlay.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router';
 import { getAll } from '../../data/houseguests';
 import { resolveAvatar } from '../../utils/avatar';
 import { preloadImage, preloadImages } from '../../utils/preload';
-import { stopIntroHubAudioForGameplayExit } from '../../services/sound/RouteLoopAudioSync';
 import KolequantSplash from '../KolequantSplash/KolequantSplash';
 import GAMEPLAY_BG from '../../assets/bb-gameplay-bg.svg';
 
@@ -38,7 +37,7 @@ export default function AssetPreloaderOverlay({
 
     // Gameplay owns audio from the moment its preloader opens, even though the
     // URL is still the Intro Hub until preloading completes.
-    stopIntroHubAudioForGameplayExit();
+    window.dispatchEvent(new Event('introhub:gameplay-exit'));
 
     async function run() {
       setStatus('Loading the competition background.');

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -11,12 +11,33 @@ const INTRO_HUB_AUDIO_PATH = '/assets/sounds/cinematic/Intro_hub_loop.mp3'
 const INTRO_HUB_VOLUME = 0.55
 const INTRO_HUB_FADE_MS = 260
 
+const INTRO_HUB_AUDIO_PATHS = new Set([
+  '/',
+  '/rules',
+  '/vox-populi-rules',
+  '/profile',
+  '/profile-edit',
+  '/profile-picker',
+  '/leaderboard',
+  '/settings',
+  '/store',
+  '/legal',
+  '/public-meter',
+])
+
 let introHubAudio: HTMLAudioElement | null = null
 let introHubFadeGeneration = 0
 let introHubGameplayExitPending = false
 
-function isIntroHubHash(hash: string): boolean {
-  return hash === '' || hash === '#' || hash === '#/'
+function normalizedHashPath(hash: string): string {
+  const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash
+  const path = withoutHash.split(/[?#]/, 1)[0] || '/'
+  if (path === '/') return '/'
+  return path.replace(/\/+$/, '') || '/'
+}
+
+function isIntroHubAudioHash(hash: string): boolean {
+  return INTRO_HUB_AUDIO_PATHS.has(normalizedHashPath(hash))
 }
 
 function isCreditsHash(hash: string): boolean {
@@ -71,9 +92,9 @@ function resetIntroHubLoop(): void {
 }
 
 /**
- * Called by HomeHub when gameplay is actually being entered or resumed.
- * New-game preloading still uses the Intro Hub URL for a short time, so route
- * checks alone cannot distinguish that transition from an active Home Hub.
+ * Called when gameplay is actually being entered or resumed.
+ * New-game preloading still uses an Intro Hub-family URL for a short time, so
+ * route checks alone cannot distinguish that transition from normal hub use.
  */
 export function stopIntroHubAudioForGameplayExit(): void {
   introHubGameplayExitPending = true
@@ -96,7 +117,7 @@ function primeIntroHubPermissionFromCreditsGesture(musicVolume: number): void {
   void el
     .play()
     .then(() => {
-      if (!isIntroHubHash(window.location.hash)) {
+      if (!isIntroHubAudioHash(window.location.hash)) {
         el.pause()
         try {
           el.currentTime = 0
@@ -112,12 +133,12 @@ function primeIntroHubPermissionFromCreditsGesture(musicVolume: number): void {
 }
 
 function startIntroHubLoop(musicVolume: number): void {
-  // Hard ownership invariant: this soundtrack can only start while the live
-  // browser route is the Intro Hub, never from stale React state or a late
-  // gesture callback. Gameplay preloading is also explicitly excluded.
+  // Intro Hub music owns the whole hub utility family, but never gameplay or
+  // a screen/cinematic that owns its own audio. A late gesture callback must
+  // re-check the live route instead of trusting stale React state.
   if (
     introHubGameplayExitPending ||
-    !isIntroHubHash(window.location.hash) ||
+    !isIntroHubAudioHash(window.location.hash) ||
     document.querySelector('.hbc') != null
   ) {
     resetIntroHubLoop()
@@ -126,8 +147,8 @@ function startIntroHubLoop(musicVolume: number): void {
 
   cancelIntroHubFade()
 
-  // The hub is outside gameplay. Clear central gameplay BGM and any legacy
-  // pooled Intro Hub copy before touching the one dedicated hub element.
+  // Hub-family screens are outside gameplay. Clear central gameplay BGM and
+  // any legacy pooled Intro Hub copy before touching the dedicated singleton.
   SoundManager.stopAllMusic()
   SoundManager.stop(INTRO_HUB_LOOP_KEY)
 
@@ -186,14 +207,16 @@ function isCreditsExitControl(target: EventTarget | null): boolean {
 }
 
 /**
- * Owns the two long-form loops that are tied to route/overlay visibility rather
- * than a normal gameplay phase.
+ * Owns long-form loops tied to route/overlay visibility rather than a normal
+ * gameplay phase.
  *
  * Intro Hub deliberately uses one dedicated HTMLAudioElement instead of the
- * generic SoundManager.play() pool. The invariant is strict: that element may
- * play only while the live route is the Intro Hub and Hubmates is not covering
- * it. Every other route/flow hard-stops and resets it. Returning home starts the
- * same singleton fresh; the music toggle pauses/resumes it in-place.
+ * generic SoundManager.play() pool. That singleton belongs to the whole Intro
+ * Hub utility family (Home, Rules, Profile, Leaderboard, Settings, Store, etc.)
+ * and keeps playing continuously while navigating among those screens. Credits,
+ * Hubmates and gameplay take audio ownership, so they stop/reset it. Returning
+ * from one of those owners starts the singleton fresh once. The music toggle
+ * pauses/resumes the same instance in place.
  */
 export default function RouteLoopAudioSync({ hash }: { hash: string }) {
   const musicOn = useSelector((state: RootState) => state.settings.audio.musicOn)
@@ -207,7 +230,7 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
   )
   const [introHubSuppressed, setIntroHubSuppressed] = useState(false)
 
-  const introHubActive = isIntroHubHash(hash)
+  const introHubAudioEligible = isIntroHubAudioHash(hash)
   const playerEvictionActive =
     isSelfEvictedHash(hash) || isHumanEviction(humanPlayerId, evictionOverlayPlayerId)
 
@@ -223,8 +246,9 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
     })
 
     const enforceLiveRouteOwnership = () => {
-      if (isIntroHubHash(window.location.hash)) {
-        // A real navigation back to Home ends any gameplay-exit suppression.
+      if (isIntroHubAudioHash(window.location.hash)) {
+        // Entering any normal hub-family screen ends gameplay-exit suppression.
+        // Navigation within the family leaves the same audio instance untouched.
         introHubGameplayExitPending = false
         return
       }
@@ -264,7 +288,7 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
   }, [hash, musicOn, musicVolume])
 
   useEffect(() => {
-    if (!introHubActive) return undefined
+    if (!introHubAudioEligible) return undefined
 
     const handleTakeoverClick = (event: Event) => {
       if (!isHubAudioTakeoverControl(event.target)) return
@@ -273,10 +297,10 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
 
     document.addEventListener('click', handleTakeoverClick, true)
     return () => document.removeEventListener('click', handleTakeoverClick, true)
-  }, [introHubActive])
+  }, [introHubAudioEligible])
 
   useEffect(() => {
-    if (!introHubActive) return undefined
+    if (!introHubAudioEligible) return undefined
 
     const syncHubmatesSuppression = () => {
       const suppressed = document.querySelector('.hbc') != null
@@ -288,10 +312,10 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
     const observer = new MutationObserver(syncHubmatesSuppression)
     observer.observe(document.body, { childList: true, subtree: true })
     return () => observer.disconnect()
-  }, [introHubActive])
+  }, [introHubAudioEligible])
 
   useEffect(() => {
-    if (!introHubActive || playerEvictionActive || introHubSuppressed) {
+    if (!introHubAudioEligible || playerEvictionActive || introHubSuppressed) {
       resetIntroHubLoop()
       return
     }
@@ -314,7 +338,7 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
       document.removeEventListener('click', startAfterGesture)
       document.removeEventListener('keydown', startAfterGesture)
     }
-  }, [introHubActive, introHubSuppressed, musicOn, musicVolume, playerEvictionActive])
+  }, [introHubAudioEligible, introHubSuppressed, musicOn, musicVolume, playerEvictionActive])
 
   useEffect(() => {
     if (playerEvictionActive && sfxOn) {

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -10,6 +10,7 @@ const PLAYER_EVICTION_LOOP_KEY = 'player:self_evict_loop'
 const INTRO_HUB_AUDIO_PATH = '/assets/sounds/cinematic/Intro_hub_loop.mp3'
 const INTRO_HUB_VOLUME = 0.55
 const INTRO_HUB_FADE_MS = 260
+const INTRO_HUB_GAMEPLAY_EXIT_EVENT = 'introhub:gameplay-exit'
 
 const INTRO_HUB_AUDIO_PATHS = new Set([
   '/',
@@ -89,16 +90,6 @@ function resetIntroHubLoop(): void {
   } catch {
     // Some WebViews reject currentTime while media state is settling.
   }
-}
-
-/**
- * Called when gameplay is actually being entered or resumed.
- * New-game preloading still uses an Intro Hub-family URL for a short time, so
- * route checks alone cannot distinguish that transition from normal hub use.
- */
-export function stopIntroHubAudioForGameplayExit(): void {
-  introHubGameplayExitPending = true
-  resetIntroHubLoop()
 }
 
 function primeIntroHubPermissionFromCreditsGesture(musicVolume: number): void {
@@ -245,6 +236,13 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
       loop: true,
     })
 
+    const handleGameplayExit = () => {
+      // New-game preloading temporarily retains a hub-family URL. The preloader
+      // emits this event so gameplay takes audio ownership immediately.
+      introHubGameplayExitPending = true
+      resetIntroHubLoop()
+    }
+
     const enforceLiveRouteOwnership = () => {
       if (isIntroHubAudioHash(window.location.hash)) {
         // Entering any normal hub-family screen ends gameplay-exit suppression.
@@ -255,10 +253,12 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
       resetIntroHubLoop()
     }
 
+    window.addEventListener(INTRO_HUB_GAMEPLAY_EXIT_EVENT, handleGameplayExit)
     window.addEventListener('hashchange', enforceLiveRouteOwnership)
     enforceLiveRouteOwnership()
 
     return () => {
+      window.removeEventListener(INTRO_HUB_GAMEPLAY_EXIT_EVENT, handleGameplayExit)
       window.removeEventListener('hashchange', enforceLiveRouteOwnership)
       resetIntroHubLoop()
       introHubGameplayExitPending = false

--- a/src/services/sound/RouteLoopAudioSync.tsx
+++ b/src/services/sound/RouteLoopAudioSync.tsx
@@ -13,7 +13,7 @@ const INTRO_HUB_FADE_MS = 260
 
 let introHubAudio: HTMLAudioElement | null = null
 let introHubFadeGeneration = 0
-let introHubReturnPrimed = false
+let introHubGameplayExitPending = false
 
 function isIntroHubHash(hash: string): boolean {
   return hash === '' || hash === '#' || hash === '#/'
@@ -49,67 +49,14 @@ function ensureIntroHubAudio(musicVolume: number): HTMLAudioElement {
 
 function pauseIntroHubLoop(): void {
   cancelIntroHubFade()
-  introHubReturnPrimed = false
   introHubAudio?.pause()
   // #1375/#1376 used SoundManager.play(), which put this loop in the SFX pool.
   // Stop any legacy pooled copy so a stale duplicate can never survive mute.
   SoundManager.stop(INTRO_HUB_LOOP_KEY)
 }
 
-function primeIntroHubReturnFromGesture(musicVolume: number): void {
-  cancelIntroHubFade()
-  SoundManager.stop(INTRO_HUB_LOOP_KEY)
-
-  const el = ensureIntroHubAudio(musicVolume)
-  try {
-    el.currentTime = 0
-  } catch {
-    // Some WebViews reject currentTime while media state is settling.
-  }
-
-  // Credits navigates home only after its exit fade, which is too late for
-  // Safari/iOS's transient user-activation window. Start the singleton hub
-  // element muted during the actual Skip/Escape gesture, then unmute/reset it
-  // when the Intro Hub route becomes active again.
-  el.muted = true
-  introHubReturnPrimed = true
-  void el.play().catch(() => {
-    introHubReturnPrimed = false
-  })
-}
-
-function startIntroHubLoop(musicVolume: number): void {
-  cancelIntroHubFade()
-
-  // The hub is outside gameplay. Clear central gameplay BGM and any legacy
-  // pooled Intro Hub copy before touching the one dedicated hub element.
-  SoundManager.stopAllMusic()
-  SoundManager.stop(INTRO_HUB_LOOP_KEY)
-
-  const el = ensureIntroHubAudio(musicVolume)
-  if (introHubReturnPrimed) {
-    introHubReturnPrimed = false
-    try {
-      el.currentTime = 0
-    } catch {
-      // Some WebViews reject currentTime while media state is settling.
-    }
-    el.muted = false
-    if (!el.paused) return
-  } else {
-    el.muted = false
-  }
-
-  if (!el.paused) return
-
-  // Keep play() in the user-activation call stack when this runs from the
-  // pointer/key retry below. Safari/iOS can reject delayed media playback.
-  void el.play().catch(() => undefined)
-}
-
 function resetIntroHubLoop(): void {
   cancelIntroHubFade()
-  introHubReturnPrimed = false
   SoundManager.stop(INTRO_HUB_LOOP_KEY)
 
   const el = introHubAudio
@@ -123,8 +70,75 @@ function resetIntroHubLoop(): void {
   }
 }
 
+/**
+ * Called by HomeHub when gameplay is actually being entered or resumed.
+ * New-game preloading still uses the Intro Hub URL for a short time, so route
+ * checks alone cannot distinguish that transition from an active Home Hub.
+ */
+export function stopIntroHubAudioForGameplayExit(): void {
+  introHubGameplayExitPending = true
+  resetIntroHubLoop()
+}
+
+function primeIntroHubPermissionFromCreditsGesture(musicVolume: number): void {
+  const el = ensureIntroHubAudio(musicVolume)
+  try {
+    el.currentTime = 0
+  } catch {
+    // Some WebViews reject currentTime while media state is settling.
+  }
+
+  // Credits exits only after its fade. Touch the already-singleton media
+  // element during the actual Skip/Escape gesture, but keep it muted and pause
+  // it again immediately. This preserves the browser media permission without
+  // allowing Intro Hub audio to remain playing underneath Credits.
+  el.muted = true
+  void el
+    .play()
+    .then(() => {
+      if (!isIntroHubHash(window.location.hash)) {
+        el.pause()
+        try {
+          el.currentTime = 0
+        } catch {
+          // Some WebViews reject currentTime while media state is settling.
+        }
+      }
+      el.muted = false
+    })
+    .catch(() => {
+      el.muted = false
+    })
+}
+
+function startIntroHubLoop(musicVolume: number): void {
+  // Hard ownership invariant: this soundtrack can only start while the live
+  // browser route is the Intro Hub, never from stale React state or a late
+  // gesture callback. Gameplay preloading is also explicitly excluded.
+  if (
+    introHubGameplayExitPending ||
+    !isIntroHubHash(window.location.hash) ||
+    document.querySelector('.hbc') != null
+  ) {
+    resetIntroHubLoop()
+    return
+  }
+
+  cancelIntroHubFade()
+
+  // The hub is outside gameplay. Clear central gameplay BGM and any legacy
+  // pooled Intro Hub copy before touching the one dedicated hub element.
+  SoundManager.stopAllMusic()
+  SoundManager.stop(INTRO_HUB_LOOP_KEY)
+
+  const el = ensureIntroHubAudio(musicVolume)
+  el.muted = false
+  if (!el.paused) return
+
+  void el.play().catch(() => undefined)
+}
+
 function fadeOutAndResetIntroHubLoop(durationMs = INTRO_HUB_FADE_MS): void {
-  // Always clean up the old pooled path as well as the dedicated element.
   SoundManager.stop(INTRO_HUB_LOOP_KEY)
 
   const el = introHubAudio
@@ -176,9 +190,10 @@ function isCreditsExitControl(target: EventTarget | null): boolean {
  * than a normal gameplay phase.
  *
  * Intro Hub deliberately uses one dedicated HTMLAudioElement instead of the
- * generic SoundManager.play() pool. A looping background bed must be singleton:
- * mute/unmute pauses/resumes that exact element, while route/cinematic takeover
- * fades and resets it before the next owner starts.
+ * generic SoundManager.play() pool. The invariant is strict: that element may
+ * play only while the live route is the Intro Hub and Hubmates is not covering
+ * it. Every other route/flow hard-stops and resets it. Returning home starts the
+ * same singleton fresh; the music toggle pauses/resumes it in-place.
  */
 export default function RouteLoopAudioSync({ hash }: { hash: string }) {
   const musicOn = useSelector((state: RootState) => state.settings.audio.musicOn)
@@ -197,7 +212,6 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
     isSelfEvictedHash(hash) || isHumanEviction(humanPlayerId, evictionOverlayPlayerId)
 
   useEffect(() => {
-    // Clean up any pooled Intro Hub instance left by the pre-hotfix implementation.
     SoundManager.stop(INTRO_HUB_LOOP_KEY)
     SoundManager.registerDynamic({
       key: PLAYER_EVICTION_LOOP_KEY,
@@ -208,8 +222,22 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
       loop: true,
     })
 
-    return () => {
+    const enforceLiveRouteOwnership = () => {
+      if (isIntroHubHash(window.location.hash)) {
+        // A real navigation back to Home ends any gameplay-exit suppression.
+        introHubGameplayExitPending = false
+        return
+      }
       resetIntroHubLoop()
+    }
+
+    window.addEventListener('hashchange', enforceLiveRouteOwnership)
+    enforceLiveRouteOwnership()
+
+    return () => {
+      window.removeEventListener('hashchange', enforceLiveRouteOwnership)
+      resetIntroHubLoop()
+      introHubGameplayExitPending = false
       introHubAudio = null
       SoundManager.stop(PLAYER_EVICTION_LOOP_KEY)
     }
@@ -220,16 +248,13 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
 
     const handleCreditsReturnClick = (event: Event) => {
       if (!isCreditsExitControl(event.target)) return
-      primeIntroHubReturnFromGesture(musicVolume)
+      primeIntroHubPermissionFromCreditsGesture(musicVolume)
     }
     const handleCreditsReturnKey = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
-      primeIntroHubReturnFromGesture(musicVolume)
+      primeIntroHubPermissionFromCreditsGesture(musicVolume)
     }
 
-    // Credits waits for its 420ms exit fade before navigating home. Prime the
-    // dedicated hub element during the actual exit gesture so returning home
-    // does not depend on a fresh tap to satisfy mobile autoplay policy.
     document.addEventListener('click', handleCreditsReturnClick, true)
     document.addEventListener('keydown', handleCreditsReturnKey, true)
     return () => {
@@ -246,8 +271,6 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
       fadeOutAndResetIntroHubLoop()
     }
 
-    // Capture phase runs before the destination's React click handler, so the
-    // hub bed starts fading before Credits/Hubmates starts its own soundtrack.
     document.addEventListener('click', handleTakeoverClick, true)
     return () => document.removeEventListener('click', handleTakeoverClick, true)
   }, [introHubActive])
@@ -256,7 +279,9 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
     if (!introHubActive) return undefined
 
     const syncHubmatesSuppression = () => {
-      setIntroHubSuppressed(document.querySelector('.hbc') != null)
+      const suppressed = document.querySelector('.hbc') != null
+      if (suppressed) resetIntroHubLoop()
+      setIntroHubSuppressed(suppressed)
     }
 
     syncHubmatesSuppression()
@@ -267,7 +292,7 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
 
   useEffect(() => {
     if (!introHubActive || playerEvictionActive || introHubSuppressed) {
-      fadeOutAndResetIntroHubLoop()
+      resetIntroHubLoop()
       return
     }
 
@@ -281,14 +306,12 @@ export default function RouteLoopAudioSync({ hash }: { hash: string }) {
 
     const startAfterGesture = () => {
       startIntroHubLoop(musicVolume)
-      document.removeEventListener('pointerdown', startAfterGesture)
-      document.removeEventListener('keydown', startAfterGesture)
     }
-    document.addEventListener('pointerdown', startAfterGesture, { once: true })
+    document.addEventListener('click', startAfterGesture, { once: true })
     document.addEventListener('keydown', startAfterGesture, { once: true })
 
     return () => {
-      document.removeEventListener('pointerdown', startAfterGesture)
+      document.removeEventListener('click', startAfterGesture)
       document.removeEventListener('keydown', startAfterGesture)
     }
   }, [introHubActive, introHubSuppressed, musicOn, musicVolume, playerEvictionActive])


### PR DESCRIPTION
Fixes the remaining Intro Hub audio ownership leaks after #1377/#1378.

Correct ownership model:
- Intro Hub music belongs to the whole normal Intro Hub utility family, not only the literal Home route.
- It continues seamlessly, using the same singleton and playback position, across Home, Rules, Profile/Edit/Profile Picker, Leaderboard, Settings, Store, Legal, Public Meter and Vox Populi Rules.
- Screens/flows that own their own audio take ownership away from Intro Hub: Hubmates, Credits, and entering/resuming gameplay.
- Returning from Hubmates, Credits or gameplay starts the Intro Hub singleton fresh once.
- Music toggle within the Intro Hub family pauses/resumes that same singleton without creating another copy.

Important edge cases fixed:
- New-game preloading still uses a Home-family URL temporarily, so `AssetPreloaderOverlay` explicitly transfers audio ownership to gameplay as soon as it mounts.
- Continue/resume navigation hard-stops/reset the Intro Hub singleton when the route becomes gameplay.
- Late gesture retry callbacks re-check the live route before playing, so stale React state cannot restart Intro Hub music after an ownership transfer.
- Native `hashchange` ownership guard resets Intro Hub audio only when leaving the normal hub family, not when navigating among hub utility screens.
- Credits Skip/Escape autoplay priming cannot leave a hidden Intro Hub track running underneath Credits.
- Hubmates DOM suppression hard-stops the singleton while the cinematic owns audio.

Expected behavior:
- Home -> Settings/Leaderboard/Profile/Rules/Store/etc.: same Intro Hub music keeps playing continuously; no restart.
- Home -> Hubmates or Credits: Intro Hub music stops/reset; destination owns audio.
- Start/resume/Continue game: Intro Hub music stops before gameplay ownership begins.
- Return from Hubmates/Credits/game to the Intro Hub family: Intro Hub music starts fresh once.
- No duplicate, layered, superimposed or surviving Intro Hub copies.