### PR TITLE
Harden ceremony cutouts across mobile coordinate spaces

### DIFF
--- a/src/components/CeremonyOverlay/CeremonyOverlay.css
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.css
@@ -5,11 +5,17 @@
  * real tile DOMRects.
  * ──────────────────────────────────────────────────────────────────────────── */
 
-.ceremony-overlay {
+.ceremony-overlay-surface {
   position: fixed;
   inset: 0;
   z-index: 8700;
   pointer-events: none;
+  overflow: visible;
+}
+
+.ceremony-overlay {
+  position: absolute;
+  inset: 0;
   opacity: 0;
   transition: opacity 0.35s ease;
 }
@@ -35,7 +41,7 @@
 
 /* ── Animated badge ─────────────────────────────────────────────────────────── */
 .ceremony-overlay__badge {
-  position: fixed;
+  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -193,7 +199,7 @@
 
 /* ── Tile highlight glow (placed over cutout area) ─────────────────────────── */
 .ceremony-overlay__glow {
-  position: fixed;
+  position: absolute;
   border-radius: 10px;
   pointer-events: none;
   z-index: 8700;
@@ -238,7 +244,7 @@
 
 /* ── Optional tile label pills ─────────────────────────────────────────────── */
 .ceremony-overlay__tile-label {
-  position: fixed;
+  position: absolute;
   transform: translateX(-50%);
   z-index: 8702;
   pointer-events: none;
@@ -265,7 +271,7 @@
 
 /* ── Caption label ──────────────────────────────────────────────────────────── */
 .ceremony-overlay__caption {
-  position: fixed;
+  position: absolute;
   left: 50%;
   transform: translateX(-50%);
   z-index: 8702;

--- a/src/components/CeremonyOverlay/CeremonyOverlay.tsx
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.tsx
@@ -20,15 +20,7 @@
  *   />
  */
 
-import {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useCallback,
-  useMemo,
-  useRef,
-  useId,
-} from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { createPortal } from 'react-dom'
 import {
   normalizeRectToCeremonySurface,
@@ -587,12 +579,7 @@ export default function CeremonyOverlay({
                   ))}
                 </mask>
               </defs>
-              <rect
-                width="100%"
-                height="100%"
-                fill="rgba(0,0,0,0.78)"
-                mask={`url(#${maskId})`}
-              />
+              <rect width="100%" height="100%" fill="rgba(0,0,0,0.78)" mask={`url(#${maskId})`} />
             </svg>
           </div>
         )}

--- a/src/components/CeremonyOverlay/CeremonyOverlay.tsx
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.tsx
@@ -20,7 +20,21 @@
  *   />
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useMemo,
+  useRef,
+  useId,
+} from 'react'
+import { createPortal } from 'react-dom'
+import {
+  normalizeRectToCeremonySurface,
+  sameCeremonySurface,
+  type CeremonySurfaceMetrics,
+} from './ceremonyCoordinateSpace'
 import './CeremonyOverlay.css'
 
 export interface CeremonyTile {
@@ -231,7 +245,11 @@ export default function CeremonyOverlay({
 }: CeremonyOverlayProps) {
   const [visible, setVisible] = useState(true)
   const [badgePhase, setBadgePhase] = useState<BadgePhase>('hidden')
+  const [surface, setSurface] = useState<CeremonySurfaceMetrics | null>(null)
   const timersRef = useRef<number[]>([])
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const surfaceRafRef = useRef(0)
+  const maskId = `ceremony-cutout-mask-${useId().replace(/:/g, '')}`
 
   // Lazily resolve tiles: if resolveTiles is provided, use it on mount
   // (after DOM commit) to get accurate DOMRects. Otherwise use tilesProp.
@@ -274,6 +292,7 @@ export default function CeremonyOverlay({
   const hasValidTiles = validTiles.length > 0
   // Track whether we're still waiting for resolveTiles to run
   const pendingResolve = resolveTiles != null && resolvedTiles === null
+  const pendingSurface = hasValidTiles && surface === null
 
   const clearTimers = useCallback(() => {
     timersRef.current.forEach((id) => window.clearTimeout(id))
@@ -294,10 +313,80 @@ export default function CeremonyOverlay({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layoutSignal])
 
+  const measureSurface = useCallback(() => {
+    const element = surfaceRef.current
+    if (!element || typeof window === 'undefined') return
+
+    const bounds = element.getBoundingClientRect()
+    const layoutWidth = element.clientWidth
+    const layoutHeight = element.clientHeight
+
+    // jsdom and pre-layout browser frames report zero client dimensions. Keep
+    // those paths deterministic without mistaking a mocked child-sized rect for
+    // the full-screen ceremony surface.
+    const next: CeremonySurfaceMetrics =
+      layoutWidth > 0 && layoutHeight > 0
+        ? {
+            left: bounds.left,
+            top: bounds.top,
+            width: layoutWidth,
+            height: layoutHeight,
+            scaleX: bounds.width > 0 ? bounds.width / layoutWidth : 1,
+            scaleY: bounds.height > 0 ? bounds.height / layoutHeight : 1,
+          }
+        : {
+            left: 0,
+            top: 0,
+            width: window.visualViewport?.width ?? window.innerWidth ?? SSR_VIEWPORT_WIDTH,
+            height: window.visualViewport?.height ?? window.innerHeight ?? SSR_VIEWPORT_HEIGHT,
+            scaleX: 1,
+            scaleY: 1,
+          }
+
+    setSurface((current) => (sameCeremonySurface(current, next) ? current : next))
+  }, [])
+
+  const scheduleSurfaceMeasurement = useCallback(() => {
+    if (surfaceRafRef.current) window.cancelAnimationFrame(surfaceRafRef.current)
+    surfaceRafRef.current = window.requestAnimationFrame(() => {
+      surfaceRafRef.current = 0
+      measureSurface()
+    })
+  }, [measureSurface])
+
+  useLayoutEffect(() => {
+    measureSurface()
+  }, [hasValidTiles, layoutSignal, measureSurface])
+
+  useEffect(() => {
+    if (!hasValidTiles || typeof window === 'undefined') return undefined
+
+    window.addEventListener('resize', scheduleSurfaceMeasurement)
+    window.addEventListener('scroll', scheduleSurfaceMeasurement, { capture: true, passive: true })
+    window.visualViewport?.addEventListener('resize', scheduleSurfaceMeasurement)
+    window.visualViewport?.addEventListener('scroll', scheduleSurfaceMeasurement)
+
+    const observer =
+      typeof ResizeObserver !== 'undefined' && surfaceRef.current
+        ? new ResizeObserver(scheduleSurfaceMeasurement)
+        : null
+    if (observer && surfaceRef.current) observer.observe(surfaceRef.current)
+
+    scheduleSurfaceMeasurement()
+    return () => {
+      if (surfaceRafRef.current) window.cancelAnimationFrame(surfaceRafRef.current)
+      window.removeEventListener('resize', scheduleSurfaceMeasurement)
+      window.removeEventListener('scroll', scheduleSurfaceMeasurement, { capture: true })
+      window.visualViewport?.removeEventListener('resize', scheduleSurfaceMeasurement)
+      window.visualViewport?.removeEventListener('scroll', scheduleSurfaceMeasurement)
+      observer?.disconnect()
+    }
+  }, [hasValidTiles, scheduleSurfaceMeasurement])
+
   // Headless fallback: fire onDone immediately
   useEffect(() => {
     // Wait for tiles to be resolved before starting animation.
-    if (pendingResolve) return
+    if (pendingResolve || pendingSurface) return
 
     if (!hasValidTiles) {
       onDone()
@@ -318,11 +407,14 @@ export default function CeremonyOverlay({
 
     return clearTimers
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasValidTiles, durationMs, pendingResolve])
+  }, [hasValidTiles, durationMs, pendingResolve, pendingSurface])
+
+  const normalizedRects = surface
+    ? validTiles.map((tile) => normalizeRectToCeremonySurface(tile.rect!, surface))
+    : []
 
   // Compute cutout rects for the SVG mask
-  const cutouts = validTiles.map((t) => {
-    const r = t.rect!
+  const cutouts = normalizedRects.map((r) => {
     return {
       x: r.left - CUTOUT_PAD,
       y: r.top - CUTOUT_PAD,
@@ -331,16 +423,19 @@ export default function CeremonyOverlay({
     }
   })
 
-  const viewportWidth = typeof window === 'undefined' ? SSR_VIEWPORT_WIDTH : window.innerWidth
-  const viewportHeight = typeof window === 'undefined' ? SSR_VIEWPORT_HEIGHT : window.innerHeight
+  const viewportWidth = surface?.width ?? SSR_VIEWPORT_WIDTH
+  const viewportHeight = surface?.height ?? SSR_VIEWPORT_HEIGHT
 
   // Caption placement: below the lowest cutout
   const maxBottom = cutouts.length > 0 ? Math.max(...cutouts.map((c) => c.y + c.h)) : 0
   const captionTop = Math.min(maxBottom + 16, viewportHeight - 80)
 
   // Badge start/target positions
-  const badgePositions = validTiles.map((t) => {
-    const r = t.rect!
+  const badgePositions = validTiles.map((t, index) => {
+    const r = normalizedRects[index]
+    if (!r) {
+      return { startX: 0, startY: 0, targetX: 0, targetY: 0, endY: 0 }
+    }
     // Left-side anchor: align with .badgeStack { top: 4px; left: 4px } in AvatarTile.
     // Badge uses transform translate(-50%, -100%), so targetX = badge center x,
     // targetY = badge bottom y. Permanent badge center ≈ tile.left+14, bottom ≈ tile.top+24.
@@ -357,8 +452,11 @@ export default function CeremonyOverlay({
       endY = Math.max(BADGE_EXTRACT_MIN_TOP, targetY - BADGE_EXTRACT_Y_OFFSET)
     } else if (t.badgeStart && t.badgeStart !== 'center' && 'left' in t.badgeStart) {
       // Transfer from another tile
-      startX = t.badgeStart.left + t.badgeStart.width / 2
-      startY = t.badgeStart.top
+      const startRect = surface
+        ? normalizeRectToCeremonySurface(t.badgeStart, surface)
+        : t.badgeStart
+      startX = startRect.left + startRect.width / 2
+      startY = startRect.top
     } else {
       // Centre of viewport
       startX = viewportWidth / 2
@@ -402,6 +500,7 @@ export default function CeremonyOverlay({
       if (!tile.label) return layouts
 
       const cutout = cutouts[i]
+      if (!cutout) return layouts
       const displayLabel = getDisplayTileLabel(tile.label, useCompactTileLabels)
       const estimatedWidth = calculateLabelWidth(displayLabel, useCompactTileLabels)
       const clampedLeft = Math.min(
@@ -454,9 +553,9 @@ export default function CeremonyOverlay({
     }, [])
   }, [cutouts, useCompactTileLabels, validTiles, viewportWidth])
 
-  if (pendingResolve || !hasValidTiles) return null
+  if (pendingResolve || !hasValidTiles || typeof document === 'undefined') return null
 
-  return (
+  const contents = surface ? (
     <>
       <div
         className={`ceremony-overlay ${visible ? 'ceremony-overlay--visible' : 'ceremony-overlay--exiting'}`}
@@ -470,7 +569,7 @@ export default function CeremonyOverlay({
           <div className="ceremony-overlay__dim">
             <svg xmlns="http://www.w3.org/2000/svg">
               <defs>
-                <mask id="ceremony-cutout-mask">
+                <mask id={maskId}>
                   {/* White fill = fully dimmed */}
                   <rect width="100%" height="100%" fill="white" />
                   {/* Black rects = cutout holes (transparent in the dim) */}
@@ -492,7 +591,7 @@ export default function CeremonyOverlay({
                 width="100%"
                 height="100%"
                 fill="rgba(0,0,0,0.78)"
-                mask="url(#ceremony-cutout-mask)"
+                mask={`url(#${maskId})`}
               />
             </svg>
           </div>
@@ -548,7 +647,7 @@ export default function CeremonyOverlay({
             style={{
               ...getBadgeStyle(i),
               zIndex: 8701,
-              position: 'fixed',
+              position: 'absolute',
             }}
             data-badge-origin={isTileBadgeOrigin(t.badgeStart) ? 'tile' : 'center'}
             data-badge-motion={t.badgeMotion ?? 'land'}
@@ -572,5 +671,12 @@ export default function CeremonyOverlay({
         )
       })}
     </>
+  ) : null
+
+  return createPortal(
+    <div ref={surfaceRef} className="ceremony-overlay-surface" data-ceremony-overlay-surface="true">
+      {contents}
+    </div>,
+    document.body
   )
 }

--- a/src/components/CeremonyOverlay/ceremonyCoordinateSpace.ts
+++ b/src/components/CeremonyOverlay/ceremonyCoordinateSpace.ts
@@ -1,0 +1,60 @@
+export interface CeremonySurfaceMetrics {
+  left: number
+  top: number
+  width: number
+  height: number
+  scaleX: number
+  scaleY: number
+}
+
+export interface CeremonySurfaceRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+  width: number
+  height: number
+}
+
+/**
+ * Converts a viewport-relative DOMRect into the overlay surface's local CSS
+ * coordinate system. This is intentionally explicit: fixed positioning can
+ * acquire a non-viewport containing block in mobile WebViews, and browser zoom
+ * or native-shell scaling can make one surface CSS pixel differ from one
+ * client-rect pixel.
+ */
+export function normalizeRectToCeremonySurface(
+  rect: DOMRect,
+  surface: CeremonySurfaceMetrics
+): CeremonySurfaceRect {
+  const scaleX = surface.scaleX > 0 ? surface.scaleX : 1
+  const scaleY = surface.scaleY > 0 ? surface.scaleY : 1
+  const left = (rect.left - surface.left) / scaleX
+  const top = (rect.top - surface.top) / scaleY
+  const width = rect.width / scaleX
+  const height = rect.height / scaleY
+
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+  }
+}
+
+export function sameCeremonySurface(
+  a: CeremonySurfaceMetrics | null,
+  b: CeremonySurfaceMetrics
+): boolean {
+  if (!a) return false
+  return (
+    Math.abs(a.left - b.left) < 0.25 &&
+    Math.abs(a.top - b.top) < 0.25 &&
+    Math.abs(a.width - b.width) < 0.25 &&
+    Math.abs(a.height - b.height) < 0.25 &&
+    Math.abs(a.scaleX - b.scaleX) < 0.001 &&
+    Math.abs(a.scaleY - b.scaleY) < 0.001
+  )
+}

--- a/src/components/HouseguestGrid/AvatarTile.tsx
+++ b/src/components/HouseguestGrid/AvatarTile.tsx
@@ -416,6 +416,7 @@ export default function AvatarTile({
             .filter(Boolean)
             .join(' ')}
           layoutId={layoutId}
+          data-ceremony-tile="true"
           data-nomination-ceremony-state={nominationCeremonyState}
           animate={
             // Only apply opacity animation when layoutId is present (shared-layout path).

--- a/src/components/HouseguestGrid/HouseguestGrid.tsx
+++ b/src/components/HouseguestGrid/HouseguestGrid.tsx
@@ -309,6 +309,7 @@ export default function HouseguestGrid({
         data-compact-layout={effectiveCompactLayout}
         data-roster-mode={rosterMode}
         data-header-mode={headerMode}
+        data-houseguest-roster="true"
       >
         <div key={headerSignal} className={styles.headerRow} aria-live="polite">
           <h3 id="houseguests-heading" className={styles.header}>

--- a/src/screens/GameScreen/ceremonyTileMeasurement.ts
+++ b/src/screens/GameScreen/ceremonyTileMeasurement.ts
@@ -1,4 +1,6 @@
 export const ROSTER_SCROLL_SELECTOR = '[data-roster-scroll="true"]'
+export const HOUSEGUEST_ROSTER_SELECTOR = '[data-houseguest-roster="true"]'
+export const CEREMONY_TILE_SELECTOR = '[data-ceremony-tile="true"]'
 
 function escapePlayerIdForAttributeSelector(playerId: string): string {
   if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
@@ -10,17 +12,26 @@ function escapePlayerIdForAttributeSelector(playerId: string): string {
 
 export function getCeremonyTileRect(playerId: string, root: ParentNode = document): DOMRect | null {
   const escaped = escapePlayerIdForAttributeSelector(playerId)
-  const el = root.querySelector<HTMLElement>(`[data-player-id="${escaped}"]`)
-  if (!el) return null
+  const roster =
+    root instanceof Element && root.matches(HOUSEGUEST_ROSTER_SELECTOR)
+      ? root
+      : root.querySelector<HTMLElement>(HOUSEGUEST_ROSTER_SELECTOR)
+  const playerHost = (roster ?? root).querySelector<HTMLElement>(`[data-player-id="${escaped}"]`)
+  if (!playerHost) return null
 
-  const scrollRoot = el.closest<HTMLElement>(ROSTER_SCROLL_SELECTOR)
+  // Measure the painted square, not its grid cell. Framer Motion can transform
+  // the avatar wrapper independently during shared-layout transitions, so the
+  // outer <li> can report a different rectangle from what the user sees.
+  const el = playerHost.querySelector<HTMLElement>(CEREMONY_TILE_SELECTOR) ?? playerHost
+
+  const scrollRoot = playerHost.closest<HTMLElement>(ROSTER_SCROLL_SELECTOR)
   if (scrollRoot) {
     const tileRect = el.getBoundingClientRect()
     const scrollRect = scrollRoot.getBoundingClientRect()
     const isOutsideVisibleRoster = tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom
 
-    if (isOutsideVisibleRoster && typeof el.scrollIntoView === 'function') {
-      el.scrollIntoView({ block: 'center', inline: 'nearest' })
+    if (isOutsideVisibleRoster && typeof playerHost.scrollIntoView === 'function') {
+      playerHost.scrollIntoView({ block: 'center', inline: 'nearest' })
     }
   }
 

--- a/tests/ceremony.coordinateSpace.test.tsx
+++ b/tests/ceremony.coordinateSpace.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import CeremonyOverlay from '../src/components/CeremonyOverlay/CeremonyOverlay'
+import { normalizeRectToCeremonySurface } from '../src/components/CeremonyOverlay/ceremonyCoordinateSpace'
+import { getCeremonyTileRect } from '../src/screens/GameScreen/ceremonyTileMeasurement'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ceremony coordinate space', () => {
+  it('normalizes viewport geometry against a shifted and scaled overlay surface', () => {
+    const target = new DOMRect(150, 260, 80, 100)
+
+    expect(
+      normalizeRectToCeremonySurface(target, {
+        left: 50,
+        top: 60,
+        width: 400,
+        height: 800,
+        scaleX: 2,
+        scaleY: 2,
+      })
+    ).toEqual({
+      left: 50,
+      top: 100,
+      right: 90,
+      bottom: 150,
+      width: 40,
+      height: 50,
+    })
+  })
+
+  it('portals overlays to body and gives simultaneous SVG masks unique ids', () => {
+    const rect = new DOMRect(30, 40, 70, 70)
+    render(
+      <>
+        <CeremonyOverlay tiles={[{ rect }]} caption="First" onDone={vi.fn()} />
+        <CeremonyOverlay tiles={[{ rect }]} caption="Second" onDone={vi.fn()} />
+      </>
+    )
+
+    const surfaces = document.querySelectorAll<HTMLElement>('[data-ceremony-overlay-surface]')
+    expect(surfaces).toHaveLength(2)
+    expect(surfaces[0].parentElement).toBe(document.body)
+    expect(surfaces[1].parentElement).toBe(document.body)
+
+    const masks = document.querySelectorAll<SVGMaskElement>('.ceremony-overlay mask')
+    expect(masks).toHaveLength(2)
+    expect(masks[0].id).not.toBe(masks[1].id)
+
+    const dimRects = document.querySelectorAll<SVGRectElement>(
+      '.ceremony-overlay__dim > svg > rect'
+    )
+    expect(dimRects[0].getAttribute('mask')).toBe(`url(#${masks[0].id})`)
+    expect(dimRects[1].getAttribute('mask')).toBe(`url(#${masks[1].id})`)
+  })
+})
+
+describe('ceremony roster target selection', () => {
+  it('ignores duplicate player ids outside the roster and measures the painted avatar square', () => {
+    const outsideRect = new DOMRect(1, 2, 10, 10)
+    const hostRect = new DOMRect(20, 30, 90, 110)
+    const paintedRect = new DOMRect(24, 34, 82, 82)
+    const view = render(
+      <>
+        <div data-player-id="winner" data-testid="outside" />
+        <section data-houseguest-roster="true">
+          <div data-player-id="winner" data-testid="host">
+            <div data-ceremony-tile="true" data-testid="painted" />
+          </div>
+        </section>
+      </>
+    )
+
+    vi.spyOn(view.getByTestId('outside'), 'getBoundingClientRect').mockReturnValue(outsideRect)
+    vi.spyOn(view.getByTestId('host'), 'getBoundingClientRect').mockReturnValue(hostRect)
+    vi.spyOn(view.getByTestId('painted'), 'getBoundingClientRect').mockReturnValue(paintedRect)
+
+    expect(getCeremonyTileRect('winner')).toBe(paintedRect)
+  })
+})

--- a/tests/integration/nomination.animation.test.tsx
+++ b/tests/integration/nomination.animation.test.tsx
@@ -383,12 +383,12 @@ describe('NominationAnimator wiring in GameScreen', () => {
           publicSaveApplied: false,
         },
       });
-      const view = renderWithStore(store);
+      renderWithStore(store);
 
       await act(async () => {});
 
       const labelTops = Array.from(
-        view.container.querySelectorAll<HTMLElement>('.ceremony-overlay__tile-label'),
+        document.querySelectorAll<HTMLElement>('.ceremony-overlay__tile-label'),
       ).map((node) => node.style.top);
 
       expect(new Set(labelTops).size).toBeGreaterThan(1);
@@ -403,13 +403,13 @@ describe('NominationAnimator wiring in GameScreen', () => {
       publicModeEnabled: false,
       lastHohCompFinisherId: 'p3',
     });
-    const view = renderWithStore(store);
+    renderWithStore(store);
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Play Nomination Animation/i }));
     });
 
-    expect(view.container.querySelectorAll('.ceremony-overlay__glow')).toHaveLength(3);
+    expect(document.querySelectorAll('.ceremony-overlay__glow')).toHaveLength(3);
     expect(screen.queryByText('Last in LOH Comp')).toBeNull();
 
     await act(async () => { vi.advanceTimersByTime(2800); });

--- a/tests/integration/spotlight.animation.test.tsx
+++ b/tests/integration/spotlight.animation.test.tsx
@@ -245,6 +245,9 @@ describe('GameScreen – CeremonyOverlay defers LOH/POS store mutations', () => 
 
     // Simulate minigame completion.
     await act(async () => { capturedMinigameOnDone!(100); });
+    // SpotlightAnimation samples the restored roster for up to 24 frames before
+    // accepting an empty-geometry fallback.
+    await act(async () => { vi.advanceTimersByTime(500); });
 
     // Zero DOMRect → no animation → phase transitions immediately.
     expect(store.getState().game.phase).toBe('loh_results');
@@ -268,6 +271,8 @@ describe('GameScreen – CeremonyOverlay defers LOH/POS store mutations', () => 
 
     // Trigger minigame done.
     await act(async () => { capturedMinigameOnDone!(100); });
+    // Allow the first post-minigame roster measurement frame to run.
+    await act(async () => { vi.advanceTimersByTime(20); });
 
     // Valid DOMRect → CeremonyOverlay is showing → phase NOT yet committed.
     expect(store.getState().game.phase).toBe('loh_comp');

--- a/tests/spotlight.viewport.test.tsx
+++ b/tests/spotlight.viewport.test.tsx
@@ -114,8 +114,10 @@ describe('SpotlightAnimation — fast-path (no measure callbacks)', () => {
     const scrollCalls = (window.addEventListener as ReturnType<typeof vi.spyOn>).mock.calls.filter(
       ([type]) => type === 'scroll',
     );
-    expect(resizeCalls).toHaveLength(0);
-    expect(scrollCalls).toHaveLength(0);
+    // CeremonyOverlay owns one surface-coordinate listener pair even when the
+    // SpotlightAnimation wrapper itself has no live tile callbacks.
+    expect(resizeCalls).toHaveLength(1);
+    expect(scrollCalls).toHaveLength(1);
 
     unmount();
   });
@@ -311,7 +313,7 @@ describe('SpotlightAnimation — post-minigame layout settling', () => {
     });
 
     expect(measureTiles).toHaveBeenCalled();
-    expect(container.querySelectorAll('.ceremony-overlay__glow')).toHaveLength(2);
+    expect(document.querySelectorAll('.ceremony-overlay__glow')).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #1379 after device testing showed that fresh timing measurements alone did not fix the LOH/POS cutout alignment.

- render ceremony visuals in a body-level, full-screen portal so app-shell scrolling and containing blocks cannot shift the overlay
- normalize every tile and badge rectangle into the measured overlay surface coordinate system, including offset and scale
- measure the painted avatar square instead of its outer grid cell
- scope player lookup to the live houseguest roster
- give every simultaneous SVG cutout mask a unique id
- retain the post-minigame settling measurements from #1379

## Why this is more robust

`getBoundingClientRect()` is viewport-relative, while the previous overlay assumed its own `(0, 0)` was always the same viewport origin. Mobile WebViews, safe areas, browser UI, transformed containing blocks, and native-shell scaling can break that assumption. The overlay now measures its own rendered surface and converts all target geometry into that exact local space before drawing cutouts.

## Test plan

- [x] TypeScript project build
- [x] Targeted ESLint
- [x] 60 focused ceremony/spotlight tests
- [x] Regression: shifted and scaled overlay surface
- [x] Regression: duplicate player IDs outside live roster
- [x] Regression: painted avatar target vs outer grid cell
- [x] Regression: multiple overlays use isolated SVG masks
