### PR TITLE
Replace winner cutouts with lifted tile animation

### DIFF
--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
@@ -1,0 +1,166 @@
+.winner-tile-lift {
+  position: fixed;
+  inset: 0;
+  z-index: 8800;
+  pointer-events: none;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.winner-tile-lift__backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 34%, rgba(255, 216, 92, 0.14), transparent 34%),
+    rgba(0, 0, 0, 0.82);
+  opacity: 0;
+  transition: opacity 320ms ease;
+}
+
+.winner-tile-lift--lifted .winner-tile-lift__backdrop,
+.winner-tile-lift--awarded .winner-tile-lift__backdrop,
+.winner-tile-lift--returning .winner-tile-lift__backdrop {
+  opacity: 1;
+}
+
+.winner-tile-lift--returning .winner-tile-lift__backdrop {
+  opacity: 0;
+  transition-duration: 500ms;
+}
+
+.winner-tile-lift__tile {
+  position: fixed;
+  z-index: 2;
+  border-radius: 10px;
+  transition:
+    left 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    top 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 520ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 520ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: left, top, width, height;
+}
+
+.winner-tile-lift--returning .winner-tile-lift__tile {
+  transition-duration: 560ms;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.winner-tile-lift__snapshot,
+.winner-tile-lift__snapshot > * {
+  width: 100%;
+  height: 100%;
+}
+
+.winner-tile-lift__snapshot {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.winner-tile-lift__glow {
+  position: absolute;
+  inset: -3px;
+  z-index: -1;
+  border-radius: 13px;
+  opacity: 0;
+  box-shadow:
+    0 0 0 2px rgba(255, 229, 133, 0.82),
+    0 0 30px 10px rgba(255, 203, 58, 0.48);
+  transition: opacity 240ms ease;
+}
+
+.winner-tile-lift--lifted .winner-tile-lift__glow,
+.winner-tile-lift--awarded .winner-tile-lift__glow {
+  opacity: 1;
+}
+
+.winner-tile-lift__badge {
+  position: absolute;
+  top: -11px;
+  right: -11px;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  width: 43px;
+  height: 43px;
+  border: 1px solid rgba(255, 243, 195, 0.74);
+  border-radius: 50%;
+  background: rgba(20, 23, 31, 0.94);
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.58),
+    0 0 20px rgba(255, 209, 65, 0.48);
+  font-size: 25px;
+  line-height: 1;
+  opacity: 0;
+  transform: translate(-38px, -42px) scale(1.7) rotate(-12deg);
+}
+
+.winner-tile-lift__badge--active {
+  animation: winnerTileBadgeLand 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.winner-tile-lift__badge img {
+  display: block;
+  width: 31px;
+  height: 31px;
+  object-fit: contain;
+}
+
+.winner-tile-lift__caption {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  top: calc(34% + min(184px, 25vw) + 32px);
+  z-index: 3;
+  text-align: center;
+  color: #fff;
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 260ms ease,
+    transform 260ms ease;
+  text-shadow: 0 3px 16px rgba(0, 0, 0, 0.9);
+}
+
+.winner-tile-lift--lifted .winner-tile-lift__caption,
+.winner-tile-lift--awarded .winner-tile-lift__caption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.winner-tile-lift__caption p {
+  margin: 0;
+  font-size: clamp(1rem, 4.4vw, 1.45rem);
+  font-weight: 800;
+}
+
+.winner-tile-lift__caption span {
+  display: block;
+  margin-top: 5px;
+  font-size: 1.45rem;
+}
+
+@keyframes winnerTileBadgeLand {
+  from {
+    opacity: 0;
+    transform: translate(-38px, -42px) scale(1.7) rotate(-12deg);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1) rotate(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .winner-tile-lift__backdrop,
+  .winner-tile-lift__tile,
+  .winner-tile-lift__glow,
+  .winner-tile-lift__caption {
+    transition-duration: 1ms !important;
+  }
+
+  .winner-tile-lift__badge {
+    animation-duration: 1ms;
+  }
+}

--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
@@ -1,0 +1,295 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react'
+import { createPortal } from 'react-dom'
+import type { CeremonyTile } from '../CeremonyOverlay/CeremonyOverlay'
+import './WinnerTileLiftAnimation.css'
+
+const MAX_CAPTURE_FRAMES = 24
+const LIFT_DURATION_MS = 520
+const RETURN_DURATION_MS = 560
+const MIN_STAGE_TILE_SIZE = 112
+const MAX_STAGE_TILE_SIZE = 184
+const STAGE_GAP = 18
+
+type LiftPhase = 'captured' | 'lifted' | 'awarded' | 'returning'
+
+interface LiftTarget {
+  id: string
+  source: HTMLElement
+  snapshot: HTMLElement
+  sourceRect: DOMRect
+  returnRect: DOMRect
+  tile: CeremonyTile
+}
+
+export interface WinnerTileLiftAnimationProps {
+  targetIds: string[]
+  tiles: CeremonyTile[]
+  caption: string
+  subtitle?: string
+  ariaLabel?: string
+  durationMs?: number
+  resolveTarget: (playerId: string) => HTMLElement | null
+  onDone: () => void
+}
+
+function isMeasurable(element: HTMLElement | null): element is HTMLElement {
+  if (!element || !element.isConnected) return false
+  const rect = element.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+function stripDuplicateIds(root: HTMLElement) {
+  root.removeAttribute('id')
+  root.querySelectorAll<HTMLElement>('[id]').forEach((element) => element.removeAttribute('id'))
+}
+
+function freezeVisualStyles(source: HTMLElement, clone: HTMLElement) {
+  const computed = window.getComputedStyle(source)
+  for (let propertyIndex = 0; propertyIndex < computed.length; propertyIndex += 1) {
+    const property = computed.item(propertyIndex)
+    if (property.startsWith('--')) {
+      clone.style.setProperty(property, computed.getPropertyValue(property))
+    }
+  }
+
+  ;[clone, ...clone.querySelectorAll<HTMLElement>('*')].forEach((cloneElement) => {
+    cloneElement.style.animation = 'none'
+    cloneElement.style.transition = 'none'
+  })
+
+  clone.style.width = '100%'
+  clone.style.height = '100%'
+  clone.style.transform = 'none'
+  clone.style.pointerEvents = 'none'
+  stripDuplicateIds(clone)
+}
+
+function FrozenTile({ snapshot }: { snapshot: HTMLElement }) {
+  const hostRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    host.replaceChildren(snapshot)
+    return () => snapshot.remove()
+  }, [snapshot])
+
+  return <div ref={hostRef} className="winner-tile-lift__snapshot" aria-hidden="true" />
+}
+
+function getVisibleViewport() {
+  const viewport = window.visualViewport
+  return {
+    left: viewport?.offsetLeft ?? 0,
+    top: viewport?.offsetTop ?? 0,
+    width: viewport?.width ?? window.innerWidth,
+    height: viewport?.height ?? window.innerHeight,
+  }
+}
+
+function calculateStageRects(targets: LiftTarget[]): DOMRect[] {
+  const viewport = getVisibleViewport()
+  const availableWidth = Math.max(1, viewport.width - 32 - STAGE_GAP * (targets.length - 1))
+  const maxPerTile = availableWidth / Math.max(1, targets.length)
+  const largestSource = Math.max(...targets.map((target) => target.sourceRect.width))
+  const size = Math.min(
+    maxPerTile,
+    MAX_STAGE_TILE_SIZE,
+    Math.max(MIN_STAGE_TILE_SIZE, largestSource * 1.35)
+  )
+  const totalWidth = size * targets.length + STAGE_GAP * (targets.length - 1)
+  const left = viewport.left + (viewport.width - totalWidth) / 2
+  const top = viewport.top + Math.max(28, (viewport.height - size) * 0.34)
+
+  return targets.map((_, index) => new DOMRect(left + index * (size + STAGE_GAP), top, size, size))
+}
+
+function rectStyle(rect: DOMRect): CSSProperties {
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+export default function WinnerTileLiftAnimation({
+  targetIds,
+  tiles,
+  caption,
+  subtitle,
+  ariaLabel,
+  durationMs = 2800,
+  resolveTarget,
+  onDone,
+}: WinnerTileLiftAnimationProps) {
+  const [targets, setTargets] = useState<LiftTarget[]>([])
+  const [phase, setPhase] = useState<LiftPhase>('captured')
+  const targetsRef = useRef<LiftTarget[]>([])
+  const originalVisibilityRef = useRef(new Map<HTMLElement, string>())
+  const finishedRef = useRef(false)
+
+  const restoreOriginals = useCallback(() => {
+    originalVisibilityRef.current.forEach((visibility, element) => {
+      element.style.visibility = visibility
+      element.removeAttribute('data-ceremony-tile-lifted')
+    })
+    originalVisibilityRef.current.clear()
+  }, [])
+
+  const finish = useCallback(() => {
+    if (finishedRef.current) return
+    finishedRef.current = true
+    restoreOriginals()
+    onDone()
+  }, [onDone, restoreOriginals])
+
+  useLayoutEffect(() => {
+    let frame = 0
+    let raf = 0
+    let cancelled = false
+
+    const capture = () => {
+      if (cancelled) return
+      const elements = targetIds.map((targetId) => resolveTarget(targetId))
+      if (elements.every(isMeasurable)) {
+        const currentRects = elements.map((element) => element.getBoundingClientRect())
+        const captured = elements.map((source, index) => {
+          const sourceRect = currentRects[index]
+          const snapshot = source.cloneNode(true) as HTMLElement
+          freezeVisualStyles(source, snapshot)
+          originalVisibilityRef.current.set(source, source.style.visibility)
+          source.style.visibility = 'hidden'
+          source.setAttribute('data-ceremony-tile-lifted', 'true')
+          return {
+            id: targetIds[index],
+            source,
+            snapshot,
+            sourceRect,
+            returnRect: sourceRect,
+            tile: tiles[index] ?? tiles[0] ?? { rect: sourceRect },
+          }
+        })
+        targetsRef.current = captured
+        setTargets(captured)
+        return
+      }
+
+      frame += 1
+      if (frame >= MAX_CAPTURE_FRAMES) {
+        finish()
+        return
+      }
+      raf = requestAnimationFrame(capture)
+    }
+
+    raf = requestAnimationFrame(capture)
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+      restoreOriginals()
+    }
+  }, [finish, resolveTarget, restoreOriginals, targetIds, tiles])
+
+  useEffect(() => {
+    if (targets.length === 0) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    let secondFrame = 0
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => setPhase('lifted'))
+    })
+    const awardTimer = window.setTimeout(() => setPhase('awarded'), LIFT_DURATION_MS)
+    const returnAt = Math.max(LIFT_DURATION_MS + 650, durationMs - RETURN_DURATION_MS)
+    const returnTimer = window.setTimeout(() => {
+      const refreshed = targetsRef.current.map((target) => {
+        const rect = target.source.getBoundingClientRect()
+        return {
+          ...target,
+          returnRect: rect.width > 0 && rect.height > 0 ? rect : target.sourceRect,
+        }
+      })
+      targetsRef.current = refreshed
+      setTargets(refreshed)
+      setPhase('returning')
+    }, returnAt)
+    const doneTimer = window.setTimeout(finish, returnAt + RETURN_DURATION_MS)
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      cancelAnimationFrame(firstFrame)
+      cancelAnimationFrame(secondFrame)
+      window.clearTimeout(awardTimer)
+      window.clearTimeout(returnTimer)
+      window.clearTimeout(doneTimer)
+    }
+  }, [durationMs, finish, targets.length])
+
+  const stageRects = useMemo(() => calculateStageRects(targets), [targets])
+
+  if (targets.length === 0 || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className={`winner-tile-lift winner-tile-lift--${phase}`}
+      role="status"
+      aria-live="assertive"
+      aria-label={ariaLabel ?? caption}
+      data-winner-tile-lift-phase={phase}
+    >
+      <div className="winner-tile-lift__backdrop" aria-hidden="true" />
+      {targets.map((target, index) => {
+        const destination =
+          phase === 'captured'
+            ? target.sourceRect
+            : phase === 'returning'
+              ? target.returnRect
+              : stageRects[index]
+        const badgeActive = phase === 'awarded' || phase === 'returning'
+        return (
+          <div
+            key={target.id}
+            className="winner-tile-lift__tile"
+            style={rectStyle(destination)}
+            data-winner-tile-id={target.id}
+          >
+            <FrozenTile snapshot={target.snapshot} />
+            <div className="winner-tile-lift__glow" aria-hidden="true" />
+            {(target.tile.badgeImageSrc || target.tile.badge) && (
+              <div
+                className={`winner-tile-lift__badge ${
+                  badgeActive ? 'winner-tile-lift__badge--active' : ''
+                }`}
+                aria-label={target.tile.badgeLabel ?? `${target.tile.badge ?? 'Role'} badge`}
+              >
+                {target.tile.badgeImageSrc ? (
+                  <img
+                    className="ceremony-overlay__badge-image"
+                    src={target.tile.badgeImageSrc}
+                    alt=""
+                    aria-hidden="true"
+                  />
+                ) : (
+                  target.tile.badge
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+      <div className="winner-tile-lift__caption" aria-hidden="true">
+        <p>{caption}</p>
+        {subtitle && <span>{subtitle}</span>}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -58,7 +58,7 @@ import FloatingActionBar from '../../components/FloatingActionBar/FloatingAction
 import SpotlightEvictionOverlay from '../../components/Eviction/SpotlightEvictionOverlay'
 import DayStartShockPopup from '../../components/DayStartShockPopup/DayStartShockPopup'
 import CeremonyOverlay from '../../components/CeremonyOverlay/CeremonyOverlay'
-import SpotlightAnimation from '../../components/SpotlightAnimation/spotlight-animation'
+import WinnerTileLiftAnimation from '../../components/WinnerTileLiftAnimation/WinnerTileLiftAnimation'
 import ChatOverlay from '../../components/ChatOverlay/ChatOverlay'
 import SocialPanel from '../../components/SocialPanel/SocialPanel'
 import SocialPanelV2 from '../../components/SocialPanelV2/SocialPanelV2'
@@ -104,7 +104,7 @@ import {
 import { usePersistedPromptDate } from './gameScreenPersistence'
 import { requestFavoriteAudienceSurge } from './favoriteAudienceSurgeRequest'
 import { useResponsiveGameLayout } from './useResponsiveGameLayout'
-import { getCeremonyTileRect } from './ceremonyTileMeasurement'
+import { getCeremonyTileElement, getCeremonyTileRect } from './ceremonyTileMeasurement'
 import { useRefinedGameChrome } from '../../hooks/useRefinedGameChrome'
 import {
   hasSeenVoxNominationRevealIntro,
@@ -562,7 +562,6 @@ export default function GameScreen() {
     humanIsOutgoingHoh,
     spectatorReactEnabled,
     spectatorMode: settings.gameUX.spectatorMode,
-    getTileRect,
     dispatch,
   })
   const showAdvanceHohCeremony = advanceHohCeremonyEligible && pendingWinnerCeremony == null
@@ -1824,16 +1823,16 @@ export default function GameScreen() {
           <TravelingDots session={pendingMinigame} players={game.players} />
         )}
 
-        {/* ── SpotlightAnimation — LOH / POS winner reveal (viewport-tracking) ── */}
+        {/* ── Winner tile lift — LOH / POS result without coordinate-space cutouts ── */}
         {showWinnerCeremony && pendingWinnerCeremony && (
-          <SpotlightAnimation
+          <WinnerTileLiftAnimation
+            targetIds={pendingWinnerCeremony.targetIds}
             tiles={pendingWinnerCeremony.tiles}
             caption={pendingWinnerCeremony.caption}
             subtitle={pendingWinnerCeremony.subtitle}
             onDone={handleWinnerCeremonyDone}
             ariaLabel={pendingWinnerCeremony.ariaLabel}
-            layoutSignal={responsiveGameLayout.revision}
-            measureTiles={pendingWinnerCeremony.measureTiles}
+            resolveTarget={getCeremonyTileElement}
           />
         )}
 

--- a/src/screens/GameScreen/ceremonyTileMeasurement.ts
+++ b/src/screens/GameScreen/ceremonyTileMeasurement.ts
@@ -10,7 +10,25 @@ function escapePlayerIdForAttributeSelector(playerId: string): string {
   return playerId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
-export function getCeremonyTileRect(playerId: string, root: ParentNode = document): DOMRect | null {
+function scrollCeremonyTileIntoView(el: HTMLElement) {
+  const playerHost = el.closest<HTMLElement>('[data-player-id]') ?? el
+  const scrollRoot = playerHost.closest<HTMLElement>(ROSTER_SCROLL_SELECTOR)
+  if (!scrollRoot) return
+
+  const tileRect = el.getBoundingClientRect()
+  const scrollRect = scrollRoot.getBoundingClientRect()
+  const isOutsideVisibleRoster =
+    tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom
+
+  if (isOutsideVisibleRoster && typeof playerHost.scrollIntoView === 'function') {
+    playerHost.scrollIntoView({ block: 'center', inline: 'nearest' })
+  }
+}
+
+export function getCeremonyTileElement(
+  playerId: string,
+  root: ParentNode = document
+): HTMLElement | null {
   const escaped = escapePlayerIdForAttributeSelector(playerId)
   const roster =
     root instanceof Element && root.matches(HOUSEGUEST_ROSTER_SELECTOR)
@@ -23,17 +41,13 @@ export function getCeremonyTileRect(playerId: string, root: ParentNode = documen
   // the avatar wrapper independently during shared-layout transitions, so the
   // outer <li> can report a different rectangle from what the user sees.
   const el = playerHost.querySelector<HTMLElement>(CEREMONY_TILE_SELECTOR) ?? playerHost
+  scrollCeremonyTileIntoView(el)
+  return el
+}
 
-  const scrollRoot = playerHost.closest<HTMLElement>(ROSTER_SCROLL_SELECTOR)
-  if (scrollRoot) {
-    const tileRect = el.getBoundingClientRect()
-    const scrollRect = scrollRoot.getBoundingClientRect()
-    const isOutsideVisibleRoster = tileRect.top < scrollRect.top || tileRect.bottom > scrollRect.bottom
-
-    if (isOutsideVisibleRoster && typeof playerHost.scrollIntoView === 'function') {
-      playerHost.scrollIntoView({ block: 'center', inline: 'nearest' })
-    }
-  }
+export function getCeremonyTileRect(playerId: string, root: ParentNode = document): DOMRect | null {
+  const el = getCeremonyTileElement(playerId, root)
+  if (!el) return null
 
   const rect = el.getBoundingClientRect()
   return rect.width > 0 || rect.height > 0 ? rect : null

--- a/src/screens/GameScreen/flows/useCompetitionFlow.ts
+++ b/src/screens/GameScreen/flows/useCompetitionFlow.ts
@@ -21,8 +21,6 @@ import { rankPressurePlankResults } from '../../../components/PressurePlank/pres
 const LOH_BADGE_SRC = statusBadgeImageSrc('loh')
 const EXITED_PLAYER_SORT_VALUE = Number.NEGATIVE_INFINITY
 
-type GetTileRect = (playerId: string) => DOMRect | null
-
 interface UseCompetitionFlowOptions {
   game: RootState['game']
   humanPlayer: Player | undefined
@@ -31,7 +29,6 @@ interface UseCompetitionFlowOptions {
   humanIsOutgoingHoh: boolean
   spectatorReactEnabled: boolean
   spectatorMode: boolean
-  getTileRect: GetTileRect
   dispatch: AppDispatch
 }
 
@@ -47,29 +44,25 @@ export function useCompetitionFlow({
   humanIsOutgoingHoh,
   spectatorReactEnabled,
   spectatorMode,
-  getTileRect,
   dispatch,
 }: UseCompetitionFlowOptions) {
   const store = useStore<RootState>()
   const pendingChallenge = useAppSelector(selectPendingChallenge)
-  // ── CeremonyOverlay — deferred LOH / POS winner commit ─────────────────
-  // When MinigameHost reports a winner, we show the CeremonyOverlay with a
-  // spotlight cutout over the winner's tile and a badge (👑/🛡️) that
-  // flies from screen centre to the tile.  Only after the animation completes
-  // do we dispatch applyMinigameWinner.  When DOMRects are unavailable
-  // (tests / headless) the overlay fires onDone immediately so the store
-  // mutation still happens — just without the visual.
+  // ── Lifted-tile reveal — deferred LOH / POS winner commit ────────────────
+  // When MinigameHost reports a winner, the live roster tile is cloned into a
+  // fixed animation layer, awarded its badge, and returned to its newly measured
+  // roster position. Only then do we dispatch applyMinigameWinner. If the live
+  // tile is unavailable (tests / headless), the store mutation continues safely.
   //
   // pendingWinnerDispatchRef stores the deferred thunk so handleCeremonyDone
   // can call it without stale-closure issues.
   const [pendingWinnerCeremony, setPendingWinnerCeremony] = useState<{
     winnerId: string
+    targetIds: string[]
     tiles: CeremonyTile[]
     caption: string
     subtitle?: string
     ariaLabel: string
-    /** Rebuilds every cutout from the live post-minigame roster layout. */
-    measureTiles: () => CeremonyTile[]
   } | null>(null)
   const pendingWinnerDispatchRef = useRef<(() => void) | null>(null)
 
@@ -473,11 +466,6 @@ export function useCompetitionFlow({
         badgeStart: 'center',
         badgeLabel: `${winnerPlayer.name} wins ${winLabel}`,
       }))
-      const measureWinnerTiles = (): CeremonyTile[] =>
-        winnerTileMetadata.map((tile, index) => ({
-          ...tile,
-          rect: getTileRect(winnerPlayers[index].id),
-        }))
       const winnerNames = winnerPlayers.map((player) => player.name).join(' & ')
       pendingWinnerDispatchRef.current = () =>
         dispatch(
@@ -489,25 +477,16 @@ export function useCompetitionFlow({
         )
       setPendingWinnerCeremony({
         winnerId: finalWinnerId,
-        // Metadata is available immediately, but geometry is deliberately null
-        // until SpotlightAnimation measures after MinigameHost has unmounted.
+        targetIds: winnerIds,
+        // Geometry is deliberately absent: the lift animation resolves and
+        // snapshots the live roster element after MinigameHost has unmounted.
         tiles: winnerTileMetadata,
         caption: `${winnerNames} ${isCupidArrowActive(game) ? 'win' : 'wins'} ${winLabel}!`,
         subtitle: winSymbol,
         ariaLabel: `${winnerNames} ${isCupidArrowActive(game) ? 'win' : 'wins'} ${winLabel}`,
-        measureTiles: measureWinnerTiles,
       })
     },
-    [
-      aliveIds.length,
-      dispatch,
-      game,
-      getTileRect,
-      humanPlayer,
-      isF3MinigamePhase,
-      pendingChallenge,
-      store,
-    ]
+    [aliveIds.length, dispatch, game, humanPlayer, isF3MinigamePhase, pendingChallenge, store]
   )
 
   return {

--- a/tests/winnerTileLift.animation.test.tsx
+++ b/tests/winnerTileLift.animation.test.tsx
@@ -1,0 +1,172 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import WinnerTileLiftAnimation from '../src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation'
+
+describe('WinnerTileLiftAnimation', () => {
+  let animationFrames: FrameRequestCallback[]
+  let originalVisualViewport: VisualViewport | null
+
+  beforeEach(() => {
+    originalVisualViewport = window.visualViewport
+    vi.useFakeTimers()
+    animationFrames = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: originalVisualViewport,
+    })
+  })
+
+  function flushAnimationFrame() {
+    const callbacks = animationFrames.splice(0)
+    act(() => callbacks.forEach((callback) => callback(performance.now())))
+  }
+
+  it('lifts a frozen copy, attaches the badge, remeasures the return, and restores the source', () => {
+    const source = document.createElement('div')
+    source.dataset.ceremonyTile = 'true'
+    source.style.background = 'rgb(10, 20, 30)'
+    source.innerHTML = '<span>Alice</span>'
+    document.body.append(source)
+
+    let rect = new DOMRect(22, 48, 72, 72)
+    vi.spyOn(source, 'getBoundingClientRect').mockImplementation(() => rect)
+    const onDone = vi.fn()
+
+    render(
+      <WinnerTileLiftAnimation
+        targetIds={['alice']}
+        tiles={[{ rect: null, badge: '👑', badgeLabel: 'Alice wins LOH' }]}
+        caption="Alice wins Leader of the House!"
+        resolveTarget={() => source}
+        onDone={onDone}
+      />
+    )
+
+    flushAnimationFrame()
+
+    expect(source.style.visibility).toBe('hidden')
+    expect(source.dataset.ceremonyTileLifted).toBe('true')
+    expect(document.querySelector('.winner-tile-lift__snapshot')?.textContent).toContain('Alice')
+    expect(document.querySelector('.ceremony-overlay__dim')).toBeNull()
+
+    flushAnimationFrame()
+    flushAnimationFrame()
+    expect(document.querySelector('[data-winner-tile-lift-phase="lifted"]')).not.toBeNull()
+
+    act(() => vi.advanceTimersByTime(520))
+    expect(document.querySelector('[data-winner-tile-lift-phase="awarded"]')).not.toBeNull()
+    expect(document.querySelector('.winner-tile-lift__badge')?.textContent).toBe('👑')
+
+    rect = new DOMRect(108, 226, 64, 64)
+    act(() => vi.advanceTimersByTime(1720))
+    const liftedTile = document.querySelector<HTMLElement>('.winner-tile-lift__tile')
+    expect(document.querySelector('[data-winner-tile-lift-phase="returning"]')).not.toBeNull()
+    expect(liftedTile?.style.left).toBe('108px')
+    expect(liftedTile?.style.top).toBe('226px')
+    expect(liftedTile?.style.width).toBe('64px')
+
+    act(() => vi.advanceTimersByTime(560))
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(source.style.visibility).toBe('')
+    expect(source.dataset.ceremonyTileLifted).toBeUndefined()
+  })
+
+  it('finishes safely when the roster tile never becomes measurable', () => {
+    const onDone = vi.fn()
+    render(
+      <WinnerTileLiftAnimation
+        targetIds={['missing']}
+        tiles={[{ rect: null, badge: '🛡️' }]}
+        caption="Winner"
+        resolveTarget={() => null}
+        onDone={onDone}
+      />
+    )
+
+    for (let frame = 0; frame < 24; frame += 1) flushAnimationFrame()
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('.winner-tile-lift')).toBeNull()
+  })
+
+  it('fits paired winners inside a compact visual viewport', () => {
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: {
+        width: 320,
+        height: 640,
+        offsetLeft: 7,
+        offsetTop: 11,
+      },
+    })
+    const sources = ['Alice', 'Bob'].map((name, index) => {
+      const source = document.createElement('div')
+      source.textContent = name
+      source.getBoundingClientRect = vi.fn(() => new DOMRect(12 + index * 70, 90, 62, 62))
+      document.body.append(source)
+      return source
+    })
+
+    render(
+      <WinnerTileLiftAnimation
+        targetIds={['alice', 'bob']}
+        tiles={[
+          { rect: null, badge: '👑' },
+          { rect: null, badge: '👑' },
+        ]}
+        caption="Alice & Bob win!"
+        resolveTarget={(id) => sources[id === 'alice' ? 0 : 1]}
+        onDone={vi.fn()}
+      />
+    )
+
+    flushAnimationFrame()
+    flushAnimationFrame()
+    flushAnimationFrame()
+
+    const liftedTiles = [...document.querySelectorAll<HTMLElement>('.winner-tile-lift__tile')]
+    expect(liftedTiles).toHaveLength(2)
+    expect(liftedTiles.map((tile) => tile.style.width)).toEqual(['112px', '112px'])
+    expect(Number.parseFloat(liftedTiles[0].style.left)).toBeGreaterThanOrEqual(7)
+    expect(
+      Number.parseFloat(liftedTiles[1].style.left) + Number.parseFloat(liftedTiles[1].style.width)
+    ).toBeLessThanOrEqual(327)
+  })
+
+  it('restores the real tile if the animation is interrupted', () => {
+    const source = document.createElement('div')
+    source.getBoundingClientRect = vi.fn(() => new DOMRect(20, 40, 70, 70))
+    document.body.append(source)
+    const onDone = vi.fn()
+    const view = render(
+      <WinnerTileLiftAnimation
+        targetIds={['alice']}
+        tiles={[{ rect: null, badge: '👑' }]}
+        caption="Alice wins"
+        resolveTarget={() => source}
+        onDone={onDone}
+      />
+    )
+
+    flushAnimationFrame()
+    expect(source.style.visibility).toBe('hidden')
+
+    view.unmount()
+
+    expect(source.style.visibility).toBe('')
+    expect(source.dataset.ceremonyTileLifted).toBeUndefined()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

The post-minigame LOH/POS cutout remained misaligned on real Android devices even after normalizing overlay coordinates. This replaces that fragile winner-only path instead of adding more coordinate compensation.

## What changed

- Snapshot the actual painted winner tile after the minigame unmounts
- Hide the original without changing roster layout
- Lift the snapshot into a body-level fixed animation layer
- Attach the LOH/POS badge while the tile is spotlighted
- Re-measure the hidden live tile immediately before returning the snapshot
- Restore the original and only then commit the winner state
- Keep nomination and other working ceremony animations unchanged
- Safely restore originals on completion, missing geometry, or interruption
- Fit paired winners within compact visual viewports and scroll offscreen roster targets into view

## Validation

- 63 focused ceremony, competition, nomination, compact-layout, and measurement tests
- New tile-lift tests for return remeasurement, compact paired winners, missing geometry, and interruption cleanup
- TypeScript
- ESLint
- Changed-file formatting gate
- Android production build
- iOS production build