### PR TITLE
Fix Android game layout density

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -21,9 +21,10 @@ const config: CapacitorConfig = {
   },
 
   plugins: {
-    StatusBar: {
-      overlaysWebView: true,
-      backgroundColor: '#00000000',
+    SystemBars: {
+      style: 'DARK',
+      hidden: false,
+      insetsHandling: 'css',
     },
   },
 }

--- a/src/hooks/useGameMode.ts
+++ b/src/hooks/useGameMode.ts
@@ -1,33 +1,19 @@
-import { useEffect } from 'react';
-import { Capacitor } from '@capacitor/core';
+import { useEffect } from 'react'
 
 interface WakeLockSentinelLike {
-  released?: boolean;
-  release?: () => Promise<void>;
-  addEventListener?: (type: 'release', listener: () => void) => void;
-  removeEventListener?: (type: 'release', listener: () => void) => void;
+  released?: boolean
+  release?: () => Promise<void>
+  addEventListener?: (type: 'release', listener: () => void) => void
+  removeEventListener?: (type: 'release', listener: () => void) => void
 }
 
 interface WakeLockControllerLike {
-  request: (type: 'screen') => Promise<WakeLockSentinelLike>;
+  request: (type: 'screen') => Promise<WakeLockSentinelLike>
 }
 
 interface LockableOrientationLike {
-  lock?: (orientation: 'portrait') => Promise<void>;
-  unlock?: () => void;
-}
-
-interface NativeStatusBarLike {
-  hide?: () => Promise<void>;
-  show?: () => Promise<void>;
-  setOverlaysWebView?: (options: { overlay: boolean }) => Promise<void>;
-}
-
-function getNativeStatusBar(): NativeStatusBarLike | null {
-  if (!Capacitor.isNativePlatform()) return null;
-
-  const plugins = (Capacitor as unknown as { Plugins?: Record<string, unknown> }).Plugins;
-  return (plugins?.StatusBar as NativeStatusBarLike | undefined) ?? null;
+  lock?: (orientation: 'portrait') => Promise<void>
+  unlock?: () => void
 }
 
 /**
@@ -37,39 +23,36 @@ function getNativeStatusBar(): NativeStatusBarLike | null {
  * - requests a screen wake lock so the display stays awake during play
  * - re-requests the wake lock when the tab becomes visible again
  * - attempts to keep the experience portrait-locked when the platform allows it
- * - lets the native status bar overlay the WebView before hiding it so
- *   CSS remains the only safe-area layout owner
+ * - leaves system bars visible; Capacitor SystemBars supplies their measured
+ *   insets to CSS so every screen has one safe-area owner
  */
 export default function useGameMode(): void {
   useEffect(() => {
-    let isMounted = true;
-    let wakeLockSentinel: WakeLockSentinelLike | null = null;
-    let wakeLockRequestInFlight: Promise<void> | null = null;
-    let statusBarHidden = false;
-
-    const wakeLock = (navigator as Navigator & { wakeLock?: WakeLockControllerLike }).wakeLock;
-    const orientation = screen.orientation as LockableOrientationLike | undefined;
-    const statusBar = getNativeStatusBar();
+    let isMounted = true
+    let wakeLockSentinel: WakeLockSentinelLike | null = null
+    let wakeLockRequestInFlight: Promise<void> | null = null
+    const wakeLock = (navigator as Navigator & { wakeLock?: WakeLockControllerLike }).wakeLock
+    const orientation = screen.orientation as LockableOrientationLike | undefined
 
     function isWakeLockRequestAllowedByVisibility() {
-      return document.visibilityState === 'visible';
+      return document.visibilityState === 'visible'
     }
 
     const handleWakeLockRelease = () => {
-      wakeLockSentinel = null;
+      wakeLockSentinel = null
       if (isMounted && isWakeLockRequestAllowedByVisibility()) {
-        void requestWakeLock();
+        void requestWakeLock()
       }
-    };
+    }
 
     async function releaseWakeLock() {
-      const activeSentinel = wakeLockSentinel;
-      wakeLockSentinel = null;
+      const activeSentinel = wakeLockSentinel
+      wakeLockSentinel = null
 
-      activeSentinel?.removeEventListener?.('release', handleWakeLockRelease);
+      activeSentinel?.removeEventListener?.('release', handleWakeLockRelease)
 
       try {
-        await activeSentinel?.release?.();
+        await activeSentinel?.release?.()
       } catch {
         // Unsupported/rejected wake-lock releases are safe to ignore.
       }
@@ -77,40 +60,40 @@ export default function useGameMode(): void {
 
     async function requestWakeLock() {
       if (
-        !isMounted
-        || !isWakeLockRequestAllowedByVisibility()
-        || wakeLockSentinel != null
-        || wakeLockRequestInFlight != null
+        !isMounted ||
+        !isWakeLockRequestAllowedByVisibility() ||
+        wakeLockSentinel != null ||
+        wakeLockRequestInFlight != null
       ) {
-        return;
+        return
       }
 
       const pendingRequest = (async () => {
         try {
-          const sentinel = await wakeLock?.request('screen');
-          if (!sentinel) return;
+          const sentinel = await wakeLock?.request('screen')
+          if (!sentinel) return
 
           if (!isMounted || !isWakeLockRequestAllowedByVisibility()) {
-            await sentinel.release?.();
-            return;
+            await sentinel.release?.()
+            return
           }
 
-          wakeLockSentinel = sentinel;
-          sentinel.addEventListener?.('release', handleWakeLockRelease);
+          wakeLockSentinel = sentinel
+          sentinel.addEventListener?.('release', handleWakeLockRelease)
         } catch {
           // Browsers may reject wake lock requests unless the page is active.
         } finally {
-          wakeLockRequestInFlight = null;
+          wakeLockRequestInFlight = null
         }
-      })();
+      })()
 
-      wakeLockRequestInFlight = pendingRequest;
-      await pendingRequest;
+      wakeLockRequestInFlight = pendingRequest
+      await pendingRequest
     }
 
     async function lockOrientation() {
       try {
-        await orientation?.lock?.('portrait');
+        await orientation?.lock?.('portrait')
       } catch {
         // Orientation lock is best-effort and unsupported on many browsers.
       }
@@ -118,59 +101,30 @@ export default function useGameMode(): void {
 
     function unlockOrientation() {
       try {
-        orientation?.unlock?.();
+        orientation?.unlock?.()
       } catch {
         // Some browsers expose lock but not unlock; ignore cleanup failures.
       }
     }
 
-    async function hideStatusBar() {
-      if (!statusBar || statusBarHidden) return;
-
-      try {
-        // CSS owns safe-area layout; native APIs must not resize the WebView.
-        await statusBar.setOverlaysWebView?.({ overlay: true });
-        await statusBar.hide?.();
-        statusBarHidden = true;
-      } catch {
-        // CSS owns layout correctness even when native APIs fail.
-      }
-    }
-
-    async function showStatusBar() {
-      if (!statusBar || !statusBarHidden) return;
-
-      try {
-        await statusBar.show?.();
-      } catch {
-        // Native status bar restoration is best-effort during teardown.
-      } finally {
-        statusBarHidden = false;
-      }
-    }
-
     function handleVisibilityChange() {
       if (document.visibilityState === 'visible') {
-        void requestWakeLock();
-        void lockOrientation();
-        void hideStatusBar();
+        void requestWakeLock()
+        void lockOrientation()
       } else {
-        void releaseWakeLock();
-        void showStatusBar();
+        void releaseWakeLock()
       }
     }
 
-    void requestWakeLock();
-    void lockOrientation();
-    void hideStatusBar();
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+    void requestWakeLock()
+    void lockOrientation()
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
-      isMounted = false;
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      unlockOrientation();
-      void showStatusBar();
-      void releaseWakeLock();
-    };
-  }, []);
+      isMounted = false
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      unlockOrientation()
+      void releaseWakeLock()
+    }
+  }, [])
 }

--- a/src/index.css
+++ b/src/index.css
@@ -19,30 +19,33 @@
 /* ── Design Tokens ────────────────────────────────────────────────────────── */
 :root {
   /* Palette */
-  --color-bg:          #0d111a;
-  --color-card:        #141b26;
-  --color-card-2:      #1a2336;
-  --color-text:        rgba(255, 255, 255, 0.92);
-  --color-text-muted:  rgba(255, 255, 255, 0.48);
-  --color-accent:      #6366f1;
-  --color-accent-2:    #8b5cf6;
-  --color-line:        rgba(255, 255, 255, 0.08);
-  --color-gold-primary:   #fbbf24;
+  --color-bg: #0d111a;
+  --color-card: #141b26;
+  --color-card-2: #1a2336;
+  --color-text: rgba(255, 255, 255, 0.92);
+  --color-text-muted: rgba(255, 255, 255, 0.48);
+  --color-accent: #6366f1;
+  --color-accent-2: #8b5cf6;
+  --color-line: rgba(255, 255, 255, 0.08);
+  --color-gold-primary: #fbbf24;
   --color-gold-secondary: #f59e0b;
-  --color-gold-deep:      #d97706;
+  --color-gold-deep: #d97706;
 
   /* TV surface (used by TvZone) */
-  --tv-surface:        #0b121a;
+  --tv-surface: #0b121a;
 
   /* Safe-area layout */
-  --safe-top: env(safe-area-inset-top, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left: env(safe-area-inset-left, 0px);
-  --safe-right: env(safe-area-inset-right, 0px);
-  --safe-area-inset-top: var(--safe-top);
-  --safe-area-inset-left: var(--safe-left);
-  --safe-area-inset-right: var(--safe-right);
-  --safe-area-inset-bottom: var(--safe-bottom);
+  /* Capacitor SystemBars replaces these values with measured Android window
+     insets when the WebView draws edge-to-edge. Keeping the aliases separate
+     lets the same variables work in browsers, iOS and native Android. */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
+  --safe-top: var(--safe-area-inset-top);
+  --safe-bottom: var(--safe-area-inset-bottom);
+  --safe-left: var(--safe-area-inset-left);
+  --safe-right: var(--safe-area-inset-right);
   --app-safe-area-top-fallback: 0px;
   --app-safe-area-top: max(var(--app-safe-area-top-fallback), var(--safe-top));
   --app-safe-area-top-extra: max(0px, calc(var(--app-safe-area-top) - 16px));
@@ -66,7 +69,11 @@
   );
 
   /* Typography */
-  font-family: 'Montserrat', system-ui, -apple-system, sans-serif;
+  font-family:
+    'Montserrat',
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 500;
@@ -76,11 +83,14 @@
 }
 
 /* ── Reset ────────────────────────────────────────────────────────────────── */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   height: 100%;
@@ -94,14 +104,9 @@ html, body {
   height: 100%;
 }
 
-html.is-capacitor {
-  --app-safe-area-top-fallback: 16px;
-}
-
-html.is-chrome-android {
-  /* Clear centered punch-hole cameras before drawing the TV header edge. */
-  --app-safe-area-top-fallback: 44px;
-}
+/* Never infer an inset from the device user agent. Android reports its actual
+   system-bar/cutout inset through Capacitor SystemBars; a fixed Pixel fallback
+   creates a visible dead band on non-cutout devices such as Pixel XL. */
 
 /* ── Base elements ────────────────────────────────────────────────────────── */
 button {
@@ -109,7 +114,8 @@ button {
 }
 
 /* Remove default blue tap highlight on mobile */
-button, a {
+button,
+a {
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -175,9 +181,7 @@ button, a {
 .game-button--primary {
   --game-button-bg: linear-gradient(135deg, rgba(92, 100, 255, 0.96), rgba(136, 84, 255, 0.96));
   --game-button-border: rgba(255, 255, 255, 0.15);
-  --game-button-shadow:
-    0 12px 28px rgba(56, 70, 255, 0.24),
-    0 0 22px rgba(139, 92, 246, 0.12);
+  --game-button-shadow: 0 12px 28px rgba(56, 70, 255, 0.24), 0 0 22px rgba(139, 92, 246, 0.12);
 }
 
 .game-button--secondary {
@@ -260,12 +264,13 @@ button, a {
   width: 4px;
   height: 4px;
 }
-::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-track {
+  background: transparent;
+}
 ::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.15);
   border-radius: 4px;
 }
-
 
 /* ── Accessibility utilities ──────────────────────────────────────────────── */
 .visually-hidden {

--- a/src/screens/GameScreen/GameScreen.tsx
+++ b/src/screens/GameScreen/GameScreen.tsx
@@ -333,9 +333,7 @@ export default function GameScreen() {
   const [spectatingAfterElimination, setSpectatingAfterElimination] = useState(false)
   const humanPlayerEliminated = humanPlayer?.status === 'evicted' || humanPlayer?.status === 'jury'
   const preJuryGameOver =
-    game.mode !== 'survival' &&
-    humanPlayer?.status === 'evicted' &&
-    !spectatingAfterElimination
+    game.mode !== 'survival' && humanPlayer?.status === 'evicted' && !spectatingAfterElimination
   const isVoxPopuli = game.voxPopuli?.status === 'active'
   const isVoxFinalFour = isVoxPopuli && alivePlayers.length === 4
   const voxAudiencePreviewWindow =
@@ -536,11 +534,7 @@ export default function GameScreen() {
       ballots: { ...(game.voxPopuli?.nominationBallots ?? {}) },
       status: 'ready',
     })
-  }, [
-    game.voxPopuli?.nominationBallots,
-    game.week,
-    voxNominationRevealReady,
-  ])
+  }, [game.voxPopuli?.nominationBallots, game.week, voxNominationRevealReady])
 
   useEffect(() => {
     if (!voxNominationRevealReady || hasSeenVoxNominationRevealIntro()) return
@@ -1138,7 +1132,8 @@ export default function GameScreen() {
   // Final Three is a closed ceremony. Do not surface fresh social actions or
   // inbox requests once only three housemates remain.
   const isSocialPhase =
-    (isVoxPopuli && alivePlayers.length > 3) || (!isVoxPopuli && SOCIAL_INTERACTION_PHASES.has(game.phase))
+    (isVoxPopuli && alivePlayers.length > 3) ||
+    (!isVoxPopuli && SOCIAL_INTERACTION_PHASES.has(game.phase))
   const showSocialPanel = isSocialPhase && !!humanPlayer && isSocialModeEnabled(game.mode)
 
   // The individual controllers publish presentation signals; this coordinator
@@ -1147,7 +1142,10 @@ export default function GameScreen() {
   const showReplacementCeremony = pendingReplacementCeremony !== null || showAiReplacementAnim
   const showSaveCeremony = pendingSaveCeremony !== null
   const showFinal3Ceremony =
-    !isVoxPopuli && game.awaitingFinal3Plea === true && game.phase === 'final3_decision' && !!game.lohId
+    !isVoxPopuli &&
+    game.awaitingFinal3Plea === true &&
+    game.phase === 'final3_decision' &&
+    !!game.lohId
   const survivorTerminalActive = game.mode === 'survival' && isSurvivorRunTerminal(game)
   const favoriteAnnouncementPending =
     game.favoritePlayer?.active === true && game.favoritePlayer?.votingStarted !== true
@@ -1292,6 +1290,7 @@ export default function GameScreen() {
     playerCount: game.players.length,
     userCompactRoster: settings.gameUX.compactRoster,
     inlineLogVisible: !refinedGameChrome || game.mode === 'survival' || settings.gameUX.houseFeed,
+    freezeLayout: flowCoordination.activeFlow !== null,
   })
   const gameTvLogRows = responsiveGameLayout.tvLogRows
   const housemateOccupancyLabel = `${alivePlayers.length}/${game.players.length}`
@@ -1560,8 +1559,8 @@ export default function GameScreen() {
                 ? '🗳️ The secret nominations have been counted'
                 : nominationLabels[nomAnimPlayers[nomAnimPlayers.length - 1]?.id ?? ''] ===
                     'Last in LOH Comp'
-                ? '🎯 Nominations are set — including the LOH comp last-place finisher'
-                : '🎯 Nominations are set'
+                  ? '🎯 Nominations are set — including the LOH comp last-place finisher'
+                  : '🎯 Nominations are set'
             }
             onDone={showHumanNomAnim ? handleNomAnimDone : handleAiNomAnimDone}
             ariaLabel={`Nomination ceremony: ${nomAnimPlayers.map((n) => n.name).join(' and ')}`}
@@ -1871,9 +1870,7 @@ export default function GameScreen() {
                   badge: isVoxFinalFour ? '🏆' : isVoxPopuli ? '🛡️' : '👑',
                   badgeImageSrc: isVoxPopuli ? undefined : LOH_BADGE_SRC,
                   badgeVariant:
-                    !isVoxPopuli && isCupidArrowActive(game)
-                      ? ('cupid-kiss' as const)
-                      : undefined,
+                    !isVoxPopuli && isCupidArrowActive(game) ? ('cupid-kiss' as const) : undefined,
                   badgeStart: 'center' as const,
                   badgeLabel: `${winnerPlayer?.name ?? roleWinnerId} wins ${
                     isVoxFinalFour
@@ -1888,9 +1885,7 @@ export default function GameScreen() {
             caption={`${expandCupidIds(game, [game.lohId])
               .map((id) => game.players.find((player) => player.id === id)?.name)
               .filter(Boolean)
-              .join(' & ')} ${
-              !isVoxPopuli && isCupidArrowActive(game) ? 'win' : 'wins'
-            } ${
+              .join(' & ')} ${!isVoxPopuli && isCupidArrowActive(game) ? 'win' : 'wins'} ${
               isVoxFinalFour
                 ? 'the Final 4 competition!'
                 : isVoxPopuli
@@ -1969,8 +1964,7 @@ export default function GameScreen() {
               isVoxPopuli
                 ? `${activeReplacementAnimationTargetIds
                     .map((id) => {
-                      const name =
-                        game.players.find((player) => player.id === id)?.name ?? id
+                      const name = game.players.find((player) => player.id === id)?.name ?? id
                       const votes = game.voxPopuli?.nominationVoteCounts[id] ?? 0
                       return `${name} (${votes} vote${votes === 1 ? '' : 's'})`
                     })
@@ -1983,8 +1977,8 @@ export default function GameScreen() {
               isVoxPopuli
                 ? 'Next-highest secret-ballot rank'
                 : game.specialVeto?.activeType === 'diamond'
-                ? '😇 Halo Exchange names the backup nominee'
-                : '🎯 Nominations are set'
+                  ? '😇 Halo Exchange names the backup nominee'
+                  : '🎯 Nominations are set'
             }
             onDone={handleAiReplacementDone}
             ariaLabel="Backup nominee ceremony"
@@ -2152,9 +2146,7 @@ export default function GameScreen() {
           secondaryLabel={isVoxPopuli ? 'Return Home' : undefined}
           onConfirm={handleStartNewSeason}
           onCancel={
-            isVoxPopuli
-              ? () => setSpectatingAfterElimination(true)
-              : handlePreJuryReturnHome
+            isVoxPopuli ? () => setSpectatingAfterElimination(true) : handlePreJuryReturnHome
           }
           onSecondary={isVoxPopuli ? handlePreJuryReturnHome : undefined}
         />

--- a/src/screens/GameScreen/useResponsiveGameLayout.ts
+++ b/src/screens/GameScreen/useResponsiveGameLayout.ts
@@ -46,7 +46,6 @@ export interface ResponsiveGameLayoutInput {
   revision?: number
 }
 
-const ANDROID_TOP_SAFE_FALLBACK = 44
 const DEFAULT_NAV_HEIGHT = 60
 const COMPACT_NAV_HEIGHT = 46
 const DEFAULT_PHONE_WIDTH = 390
@@ -191,9 +190,10 @@ export function computeResponsiveGameLayout(
   const stageWidth = input.stageWidth || Math.min(viewportWidth, DEFAULT_PHONE_WIDTH)
   const stageHeight = input.stageHeight || viewportHeight
   const layoutSize = resolveLayoutSize(viewportWidth, viewportHeight)
-  const effectiveSafeTop = input.isAndroidLike
-    ? Math.max(input.safeTop, ANDROID_TOP_SAFE_FALLBACK)
-    : input.safeTop
+  // Safe insets are measured by the platform (or CSS env() in a browser).
+  // Do not infer a cutout from the Android user agent: that added a 44px dead
+  // band above the game on ordinary devices such as Pixel XL.
+  const effectiveSafeTop = input.safeTop
   const measuredNavHeight = input.navHeight || DEFAULT_NAV_HEIGHT + input.safeBottom
   const normalNavContentHeight = Math.max(DEFAULT_NAV_HEIGHT, measuredNavHeight - input.safeBottom)
   const compactNavContentHeight = Math.min(normalNavContentHeight, COMPACT_NAV_HEIGHT)
@@ -252,13 +252,17 @@ export function computeResponsiveGameLayout(
   // layout engine starts from the Log-only minimum and adds 0–3 rows only when
   // the measured surplus can contain them without crowding the roster.
   const tvLogRowHeight = viewportWidth <= 480 ? MOBILE_TV_LOG_ROW_HEIGHT : WIDE_TV_LOG_ROW_HEIGHT
-  const minTvHeight = minTvViewportHeight + TV_CHROME_HEIGHT + (input.inlineLogVisible ? tvLogRowHeight : 0)
+  const minTvHeight =
+    minTvViewportHeight + TV_CHROME_HEIGHT + (input.inlineLogVisible ? tvLogRowHeight : 0)
   const normalWithoutHeader = normalRosterHeight - ROSTER_HEADER_HEIGHT
   const compactWithoutHeader = compactRosterHeight - ROSTER_HEADER_HEIGHT
-  // Compact presentation is an explicit accessibility/display preference. A
-  // cramped viewport may scroll the roster, but must not silently opt the user
-  // into smaller tiles or controls.
-  const bottomControlsMode: BottomControlsMode = input.userCompactRoster ? 'compact' : 'normal'
+  // Degrade in deliberate stages. User compact mode remains a force-on
+  // preference, but a constrained viewport first compacts the chrome (labels
+  // disappear and the dock scales) before we make the roster scroll.
+  const normalStaticFits =
+    !shouldUseCompactBase && normalWithoutHeader + minTvHeight <= normalAvailableAfterTv
+  const bottomControlsMode: BottomControlsMode =
+    input.userCompactRoster || !normalStaticFits ? 'compact' : 'normal'
   const availableAfterTv =
     bottomControlsMode === 'normal' ? normalAvailableAfterTv : compactAvailableAfterTv
   const selectedNavHeight = bottomControlsMode === 'normal' ? normalNavHeight : compactNavHeight
@@ -266,12 +270,14 @@ export function computeResponsiveGameLayout(
     bottomControlsMode === 'normal' ? normalNavContentHeight : compactNavContentHeight
   const selectedDockHeight = bottomControlsMode === 'normal' ? normalDockHeight : compactDockHeight
   const dockClearance = bottomControlsMode === 'normal' ? normalDockClearance : compactDockClearance
+  const normalRosterFitsWithCompactChrome =
+    !shouldUseCompactBase && normalWithoutHeader + minTvHeight <= compactAvailableAfterTv
   const baseRosterMode: Exclude<ResponsiveRosterMode, 'scroll'> =
-    input.userCompactRoster ? 'compact-small' : 'normal'
-  const normalStaticFits =
-    !shouldUseCompactBase && normalWithoutHeader + minTvHeight <= normalAvailableAfterTv
-  const rosterMode: ResponsiveRosterMode =
-    !input.userCompactRoster && !normalStaticFits ? 'scroll' : baseRosterMode
+    input.userCompactRoster || !normalRosterFitsWithCompactChrome ? 'compact-small' : 'normal'
+  const selectedRosterWithoutHeader =
+    baseRosterMode === 'compact-small' ? compactWithoutHeader : normalWithoutHeader
+  const selectedRosterFits = selectedRosterWithoutHeader + minTvHeight <= availableAfterTv
+  const rosterMode: ResponsiveRosterMode = selectedRosterFits ? baseRosterMode : 'scroll'
   const baseAvatarTileSize = baseRosterMode === 'compact-small' ? compactTileSize : normalTileSize
   const baseRosterHeight =
     baseRosterMode === 'compact-small' ? compactRosterHeight : normalRosterHeight
@@ -298,21 +304,15 @@ export function computeResponsiveGameLayout(
     : resolveAutomaticTvLogRows(extraAfterFeature, tvLogRowHeight)
   const baseLogRows = input.inlineLogVisible ? 1 : 0
   const logRowsFromExtra = Math.max(0, tvLogRows - baseLogRows)
-  const remainingAfterLogRows = Math.max(
-    0,
-    extraAfterFeature - logRowsFromExtra * tvLogRowHeight
-  )
-  const breathingRoom = clamp(
-    remainingAfterLogRows,
-    0,
-    resolveTvViewportExpansionLimit(layoutSize)
-  )
+  const remainingAfterLogRows = Math.max(0, extraAfterFeature - logRowsFromExtra * tvLogRowHeight)
+  const breathingRoom = clamp(remainingAfterLogRows, 0, resolveTvViewportExpansionLimit(layoutSize))
   const tvHeight = minTvHeight + logRowsFromExtra * tvLogRowHeight + breathingRoom
   const tvViewportHeight = minTvViewportHeight + breathingRoom
   const compactRoster = baseRosterMode === 'compact-small'
-  const rosterMaxHeight = rosterMode === 'scroll'
-    ? Math.max(normalTileSize, availableAfterTv - minTvHeight)
-    : baseRosterHeightWithoutHeader
+  const rosterMaxHeight =
+    rosterMode === 'scroll'
+      ? Math.max(normalTileSize, availableAfterTv - minTvHeight)
+      : baseRosterHeightWithoutHeader
   const avatarTileSize = baseAvatarTileSize
   const avatarTileSizePx = Math.max(0, Math.floor(avatarTileSize))
   const actionDockScale = bottomControlsMode === 'normal' ? 1 : COMPACT_DOCK_SCALE
@@ -459,10 +459,18 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
     playerCount: number
     userCompactRoster: boolean
     inlineLogVisible: boolean
+    freezeLayout?: boolean
   }
 ) {
   const revisionRef = useRef(0)
-  const { hasDock, playerCount, userCompactRoster, inlineLogVisible } = options
+  const hasMeasuredRef = useRef(false)
+  const {
+    hasDock,
+    playerCount,
+    userCompactRoster,
+    inlineLogVisible,
+    freezeLayout = false,
+  } = options
   const [budget, setBudget] = useState<ResponsiveGameLayoutBudget>(() =>
     computeResponsiveGameLayout({
       viewportWidth: DEFAULT_PHONE_WIDTH,
@@ -482,6 +490,9 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
   )
 
   const measure = useCallback(() => {
+    // Tile-targeted ceremony and presentation animations use the current DOM
+    // geometry. Keep their density tier fixed until the flow releases it.
+    if (freezeLayout && hasMeasuredRef.current) return
     revisionRef.current += 1
     const next = computeResponsiveGameLayout(
       readViewportInput(
@@ -498,7 +509,8 @@ export function useResponsiveGameLayout<TStage extends HTMLElement>(
     setBudget((prev) =>
       prev.signature === next.signature && prev.debugLabel === next.debugLabel ? prev : next
     )
-  }, [hasDock, inlineLogVisible, playerCount, stageRef, userCompactRoster])
+    hasMeasuredRef.current = true
+  }, [freezeLayout, hasDock, inlineLogVisible, playerCount, stageRef, userCompactRoster])
 
   useEffect(() => {
     measure()

--- a/tests/unit/layout/responsiveGameLayout.test.ts
+++ b/tests/unit/layout/responsiveGameLayout.test.ts
@@ -28,23 +28,23 @@ function readCssPx(budget: ReturnType<typeof computeResponsiveGameLayout>, name:
 }
 
 describe('responsive game layout budget', () => {
-  it('uses a measured Android top-safe fallback when env safe-area is zero', () => {
+  it('uses the measured Android top inset without a device-wide fallback', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportHeight: 800,
         stageHeight: 700,
-        safeTop: 0,
+        safeTop: 24,
         safeBottom: 0,
         isAndroidLike: true,
       })
     )
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '44px',
+      '--game-safe-top': '24px',
     })
   })
 
-  it('does not enable compact mode without user consent on an iPhone Pro-like screen', () => {
+  it('compacts chrome before scrolling a constrained full roster', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportHeight: 852,
@@ -54,16 +54,16 @@ describe('responsive game layout budget', () => {
     )
 
     expect(budget.layoutSize).toBe('phone-large')
-    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.bottomControlsMode).toBe('compact')
     expect(budget.baseRosterMode).toBe('normal')
-    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.rosterMode).toBe('normal')
     expect(budget.rosterHeaderMode).toBe('tv-chip')
     expect(budget.compactRoster).toBe(false)
     expect(budget.cssVars).toMatchObject({
-      '--game-bottom-controls-mode': 'normal',
-      '--game-action-dock-scale': '1',
-      '--game-nav-height': '60px',
-      '--game-nav-item-label-display': 'block',
+      '--game-bottom-controls-mode': 'compact',
+      '--game-action-dock-scale': '0.9',
+      '--game-nav-height': '46px',
+      '--game-nav-item-label-display': 'none',
       '--game-roster-board-height': '335px',
     })
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
@@ -85,7 +85,7 @@ describe('responsive game layout budget', () => {
     expect(budget.rosterMode).toBe('normal')
   })
 
-  it('keeps user-selected normal controls stable across viewport measurements', () => {
+  it('keeps the selected automatic density tier stable across viewport measurements', () => {
     const normalMeasuredBudget = computeResponsiveGameLayout(
       makeInput({
         viewportHeight: 852,
@@ -105,8 +105,8 @@ describe('responsive game layout budget', () => {
       })
     )
 
-    expect(normalMeasuredBudget.bottomControlsMode).toBe('normal')
-    expect(compactMeasuredBudget.bottomControlsMode).toBe('normal')
+    expect(normalMeasuredBudget.bottomControlsMode).toBe('compact')
+    expect(compactMeasuredBudget.bottomControlsMode).toBe('compact')
     expect(compactMeasuredBudget.signature).toBe(normalMeasuredBudget.signature)
   })
 
@@ -140,7 +140,8 @@ describe('responsive game layout budget', () => {
       '--game-avatar-tile-size': `${dayEndBudget.avatarTileSize}px`,
     })
     expect(dayEndBudget.rosterMode).toBe('normal')
-    expect(liveVoteBudget.rosterMode).toBe('scroll')
+    expect(liveVoteBudget.rosterMode).toBe('normal')
+    expect(liveVoteBudget.bottomControlsMode).toBe('compact')
   })
 
   it('keeps normal premium controls on iPhone Pro Max-like screens when full roster fits', () => {
@@ -164,14 +165,14 @@ describe('responsive game layout budget', () => {
     })
   })
 
-  it('keeps Pixel 6 Android-style screens on a static full roster with protected service row', () => {
+  it('uses the measured Android service row and compact chrome for a static full roster', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportWidth: 393,
         viewportHeight: 851,
         stageWidth: 393,
         stageHeight: 700,
-        safeTop: 0,
+        safeTop: 24,
         safeBottom: 0,
         dockHeight: 70,
         isAndroidLike: true,
@@ -179,10 +180,10 @@ describe('responsive game layout budget', () => {
     )
 
     expect(budget.cssVars).toMatchObject({
-      '--game-safe-top': '44px',
+      '--game-safe-top': '24px',
     })
-    expect(budget.bottomControlsMode).toBe('normal')
-    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.bottomControlsMode).toBe('compact')
+    expect(budget.rosterMode).toBe('normal')
     expect(budget.compactRoster).toBe(false)
     expect(readCssPx(budget, '--game-screen-tv-viewport-min-height')).toBeGreaterThanOrEqual(144)
     const dockGap = readCssPx(budget, '--game-action-dock-gap')
@@ -191,7 +192,7 @@ describe('responsive game layout budget', () => {
     expect(dockClearance).toBe(dockHeight + dockGap * 2)
   })
 
-  it('uses scrolling rather than silently enabling compact mode on small old phones', () => {
+  it('uses scrolling only after compact chrome and roster density are exhausted', () => {
     const budget = computeResponsiveGameLayout(
       makeInput({
         viewportWidth: 320,
@@ -203,9 +204,9 @@ describe('responsive game layout budget', () => {
     )
 
     expect(budget.layoutSize).toBe('phone-small')
-    expect(budget.bottomControlsMode).toBe('normal')
+    expect(budget.bottomControlsMode).toBe('compact')
     expect(budget.rosterMode).toBe('scroll')
-    expect(budget.compactRoster).toBe(false)
+    expect(budget.compactRoster).toBe(true)
     expect(budget.rosterHeaderMode).toBe('tv-chip')
   })
 
@@ -223,7 +224,7 @@ describe('responsive game layout budget', () => {
 
     expect(budget.layoutSize).toBe('phone-medium')
     expect(budget.shellMaxWidth).toBe(480)
-    expect(budget.rosterMode).toBe('scroll')
+    expect(budget.rosterMode).toBe('compact-small')
     expect(budget.cssVars).toMatchObject({
       '--game-cabinet-max-width': '480px',
       '--game-shell-max-width': '480px',

--- a/tests/unit/layout/safeArea.styles.test.ts
+++ b/tests/unit/layout/safeArea.styles.test.ts
@@ -17,11 +17,11 @@ describe('safe-area layout styles', () => {
       readFileSync(resolve(process.cwd(), 'src/components/layout/AppShell.css'), 'utf8')
     )
 
-    expect(globalCss).toContain('--safe-top: env(safe-area-inset-top, 0px);')
-    expect(globalCss).toContain('--safe-bottom: env(safe-area-inset-bottom, 0px);')
-    expect(globalCss).toContain(
-      'html.is-chrome-android { /* Clear centered punch-hole cameras before drawing the TV header edge. */ --app-safe-area-top-fallback: 44px; }'
-    )
+    expect(globalCss).toContain('--safe-area-inset-top: env(safe-area-inset-top, 0px);')
+    expect(globalCss).toContain('--safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);')
+    expect(globalCss).toContain('--safe-top: var(--safe-area-inset-top);')
+    expect(globalCss).toContain('--safe-bottom: var(--safe-area-inset-bottom);')
+    expect(globalCss).not.toContain('html.is-chrome-android {')
     expect(existsSync(resolve(process.cwd(), 'src/components/layout/SafeGameViewport.tsx'))).toBe(
       false
     )
@@ -108,6 +108,7 @@ describe('safe-area layout styles', () => {
     expect(gameScreenTsx).toContain('occupancyChip={rosterOccupancyChip}')
     expect(houseguestGridCss).not.toContain('survivorTileSettle')
     expect(gameScreenTsx).toContain('useResponsiveGameLayout')
+    expect(gameScreenTsx).toContain('freezeLayout: flowCoordination.activeFlow !== null')
     expect(gameScreenTsx).toContain('layoutSignal={responsiveGameLayout.revision}')
     expect(ceremonyOverlayTsx).toContain('layoutSignal?: string | number')
     expect(tvLogCss).toContain('overflow-y: auto;')
@@ -160,11 +161,12 @@ describe('safe-area layout styles', () => {
       'utf8'
     )
 
-    expect(useGameModeTs).toContain('CSS remains the only safe-area layout owner')
-    expect(useGameModeTs).toContain('setOverlaysWebView?.({ overlay: true })')
-    expect(useGameModeTs).not.toContain('setOverlaysWebView?.({ overlay: false })')
+    expect(useGameModeTs).toContain('one safe-area owner')
+    expect(useGameModeTs).not.toContain('setOverlaysWebView')
     expect(capacitorConfigTs).toContain("contentInset: 'never'")
-    expect(capacitorConfigTs).toContain('overlaysWebView: true')
+    expect(capacitorConfigTs).toContain('SystemBars:')
+    expect(capacitorConfigTs).toContain("insetsHandling: 'css'")
+    expect(capacitorConfigTs).toContain('hidden: false')
     expect(viewportMetaTs).toContain('viewport-fit=cover')
   })
 


### PR DESCRIPTION
## Summary

- Use measured Android SystemBars insets instead of a fixed top fallback.
- Compact game chrome and the roster before falling back to roster scrolling.
- Hold responsive density steady during presentation flows so animations retain their geometry.

## Validation

- `npm test -- --run tests/unit/layout/responsiveGameLayout.test.ts tests/unit/layout/safeArea.styles.test.ts tests/unit/minigameResponsiveSafety.styles.test.ts`
- `npm run typecheck`
- `npm run sync:android`