### PR TITLE
Hide lifted source tiles reliably on mobile

### DIFF
--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
@@ -7,6 +7,21 @@
   isolation: isolate;
 }
 
+/* Keep the real roster box measurable while guaranteeing that neither WebKit
+   nor Android's compositor can retain a separately promoted avatar layer. */
+[data-ceremony-tile-lifted='true'],
+[data-ceremony-tile-lifted='true'] * {
+  visibility: hidden !important;
+  opacity: 0 !important;
+}
+
+[data-ceremony-tile-lifted='true'] {
+  content-visibility: hidden !important;
+  clip-path: inset(50%) !important;
+  -webkit-clip-path: inset(50%) !important;
+  pointer-events: none !important;
+}
+
 .winner-tile-lift__backdrop {
   position: absolute;
   inset: 0;
@@ -60,14 +75,14 @@
 
 .winner-tile-lift__glow {
   position: absolute;
-  inset: -3px;
+  inset: 0;
   z-index: -1;
-  border-radius: 13px;
+  border-radius: 10px;
   opacity: 0;
   box-shadow:
-    0 0 0 2px rgba(255, 229, 133, 0.82),
-    0 0 30px 10px rgba(255, 203, 58, 0.48);
-  transition: opacity 240ms ease;
+    0 0 18px 4px rgba(255, 215, 0, 0.45),
+    inset 0 0 8px rgba(255, 215, 0, 0.2);
+  transition: opacity 350ms ease;
 }
 
 .winner-tile-lift--lifted .winner-tile-lift__glow,

--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
@@ -29,6 +29,24 @@ interface LiftTarget {
   tile: CeremonyTile
 }
 
+const SOURCE_HIDE_PROPERTIES = [
+  'visibility',
+  'opacity',
+  'content-visibility',
+  'clip-path',
+  '-webkit-clip-path',
+  'pointer-events',
+] as const
+
+type SourceHideProperty = (typeof SOURCE_HIDE_PROPERTIES)[number]
+
+interface InlineStyleValue {
+  value: string
+  priority: string
+}
+
+type LiftedSourceStyles = Record<SourceHideProperty, InlineStyleValue>
+
 export interface WinnerTileLiftAnimationProps {
   targetIds: string[]
   tiles: CeremonyTile[]
@@ -49,6 +67,47 @@ function isMeasurable(element: HTMLElement | null): element is HTMLElement {
 function stripDuplicateIds(root: HTMLElement) {
   root.removeAttribute('id')
   root.querySelectorAll<HTMLElement>('[id]').forEach((element) => element.removeAttribute('id'))
+}
+
+function captureLiftedSourceStyles(element: HTMLElement): LiftedSourceStyles {
+  return Object.fromEntries(
+    SOURCE_HIDE_PROPERTIES.map((property) => [
+      property,
+      {
+        value: element.style.getPropertyValue(property),
+        priority: element.style.getPropertyPriority(property),
+      },
+    ])
+  ) as LiftedSourceStyles
+}
+
+function hideLiftedSource(element: HTMLElement) {
+  // Mobile WebKit/Chromium can retain an independently composited avatar image
+  // after a parent-only visibility change. Combine layout-preserving paint
+  // suppression mechanisms and use !important so Framer Motion cannot replace
+  // the hidden state while the source remains the live layout anchor.
+  element.setAttribute('data-ceremony-tile-lifted', 'true')
+  element.style.setProperty('visibility', 'hidden', 'important')
+  element.style.setProperty('opacity', '0', 'important')
+  element.style.setProperty('content-visibility', 'hidden', 'important')
+  element.style.setProperty('clip-path', 'inset(50%)', 'important')
+  element.style.setProperty('-webkit-clip-path', 'inset(50%)', 'important')
+  element.style.setProperty('pointer-events', 'none', 'important')
+  // Force the native compositor to observe the paint suppression before the
+  // fixed snapshot starts its first frame.
+  element.getBoundingClientRect()
+}
+
+function restoreLiftedSourceStyles(element: HTMLElement, styles: LiftedSourceStyles) {
+  SOURCE_HIDE_PROPERTIES.forEach((property) => {
+    const { value, priority } = styles[property]
+    if (value) {
+      element.style.setProperty(property, value, priority)
+    } else {
+      element.style.removeProperty(property)
+    }
+  })
+  element.removeAttribute('data-ceremony-tile-lifted')
 }
 
 function freezeVisualStyles(source: HTMLElement, clone: HTMLElement) {
@@ -134,15 +193,14 @@ export default function WinnerTileLiftAnimation({
   const [targets, setTargets] = useState<LiftTarget[]>([])
   const [phase, setPhase] = useState<LiftPhase>('captured')
   const targetsRef = useRef<LiftTarget[]>([])
-  const originalVisibilityRef = useRef(new Map<HTMLElement, string>())
+  const originalStylesRef = useRef(new Map<HTMLElement, LiftedSourceStyles>())
   const finishedRef = useRef(false)
 
   const restoreOriginals = useCallback(() => {
-    originalVisibilityRef.current.forEach((visibility, element) => {
-      element.style.visibility = visibility
-      element.removeAttribute('data-ceremony-tile-lifted')
+    originalStylesRef.current.forEach((styles, element) => {
+      restoreLiftedSourceStyles(element, styles)
     })
-    originalVisibilityRef.current.clear()
+    originalStylesRef.current.clear()
   }, [])
 
   const finish = useCallback(() => {
@@ -166,9 +224,8 @@ export default function WinnerTileLiftAnimation({
           const sourceRect = currentRects[index]
           const snapshot = source.cloneNode(true) as HTMLElement
           freezeVisualStyles(source, snapshot)
-          originalVisibilityRef.current.set(source, source.style.visibility)
-          source.style.visibility = 'hidden'
-          source.setAttribute('data-ceremony-tile-lifted', 'true')
+          originalStylesRef.current.set(source, captureLiftedSourceStyles(source))
+          hideLiftedSource(source)
           return {
             id: targetIds[index],
             source,

--- a/tests/winnerTileLift.animation.test.tsx
+++ b/tests/winnerTileLift.animation.test.tsx
@@ -37,6 +37,7 @@ describe('WinnerTileLiftAnimation', () => {
     const source = document.createElement('div')
     source.dataset.ceremonyTile = 'true'
     source.style.background = 'rgb(10, 20, 30)'
+    source.style.opacity = '0.72'
     source.innerHTML = '<span>Alice</span>'
     document.body.append(source)
 
@@ -57,6 +58,12 @@ describe('WinnerTileLiftAnimation', () => {
     flushAnimationFrame()
 
     expect(source.style.visibility).toBe('hidden')
+    expect(source.style.getPropertyPriority('visibility')).toBe('important')
+    expect(source.style.opacity).toBe('0')
+    expect(source.style.getPropertyPriority('opacity')).toBe('important')
+    expect(source.style.getPropertyValue('content-visibility')).toBe('hidden')
+    expect(source.style.getPropertyValue('clip-path')).toBe('inset(50%)')
+    expect(window.getComputedStyle(source.querySelector('span')!).visibility).toBe('hidden')
     expect(source.dataset.ceremonyTileLifted).toBe('true')
     expect(document.querySelector('.winner-tile-lift__snapshot')?.textContent).toContain('Alice')
     expect(document.querySelector('.ceremony-overlay__dim')).toBeNull()
@@ -80,6 +87,10 @@ describe('WinnerTileLiftAnimation', () => {
     act(() => vi.advanceTimersByTime(560))
     expect(onDone).toHaveBeenCalledTimes(1)
     expect(source.style.visibility).toBe('')
+    expect(source.style.opacity).toBe('0.72')
+    expect(source.style.getPropertyPriority('opacity')).toBe('')
+    expect(source.style.getPropertyValue('content-visibility')).toBe('')
+    expect(source.style.getPropertyValue('clip-path')).toBe('')
     expect(source.dataset.ceremonyTileLifted).toBeUndefined()
   })
 


### PR DESCRIPTION
## Why

The lifted LOH/POS winner animation looks correct in desktop browsers, but iOS WKWebView and Android WebView can retain the original avatar's composited image layer after a parent-only visibility change. That makes the roster source appear duplicated while its snapshot is lifted.

## What changed

- Preserve the source tile's complete relevant inline style state
- Suppress source painting with important visibility, opacity, content visibility, clipping, and pointer-event rules
- Apply hiding to descendants so promoted avatar image layers cannot remain painted
- Force the native compositor to observe the hidden state before the snapshot moves
- Keep the source box measurable and restore every original style on completion or interruption
- Match the lifted winner glow to the nomination ceremony's softer gold blur and inner halo

## Validation

- Winner lift, restoration, compact roster, and GameScreen integration tests
- TypeScript and ESLint
- Changed-file formatting gate
- Android production build
- iOS production build