### PR TITLE
Match winner animation badges to roster tiles

### DIFF
--- a/src/components/CeremonyOverlay/CeremonyOverlay.tsx
+++ b/src/components/CeremonyOverlay/CeremonyOverlay.tsx
@@ -36,6 +36,8 @@ export interface CeremonyTile {
   badge?: string
   /** Optional badge image source rendered instead of badge text. */
   badgeImageSrc?: string
+  /** Status code used to mirror the permanent roster badge presentation. */
+  badgeCode?: string
   /** A temporary, Cupid-only illustration used while a role badge is flying. */
   badgeVariant?: 'cupid-kiss' | 'cupid-hug'
   /** Optional role/context label shown as a pill above the spotlighted tile. */

--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.css
@@ -90,36 +90,20 @@
   opacity: 1;
 }
 
-.winner-tile-lift__badge {
-  position: absolute;
-  top: -11px;
-  right: -11px;
+.winner-tile-lift__badge-stack {
+  /* HouseguestGrid's shared badgeStack class supplies the exact 4px top-left
+     inset used by the permanent roster tile. */
   z-index: 5;
-  display: grid;
-  place-items: center;
-  width: 43px;
-  height: 43px;
-  border: 1px solid rgba(255, 243, 195, 0.74);
-  border-radius: 50%;
-  background: rgba(20, 23, 31, 0.94);
-  box-shadow:
-    0 4px 14px rgba(0, 0, 0, 0.58),
-    0 0 20px rgba(255, 209, 65, 0.48);
-  font-size: 25px;
-  line-height: 1;
+}
+
+.winner-tile-lift__badge {
   opacity: 0;
   transform: translate(-38px, -42px) scale(1.7) rotate(-12deg);
+  transform-origin: center;
 }
 
 .winner-tile-lift__badge--active {
   animation: winnerTileBadgeLand 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
-}
-
-.winner-tile-lift__badge img {
-  display: block;
-  width: 31px;
-  height: 31px;
-  object-fit: contain;
 }
 
 .winner-tile-lift__caption {

--- a/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
+++ b/src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import type { CeremonyTile } from '../CeremonyOverlay/CeremonyOverlay'
+import rosterStyles from '../HouseguestGrid/HouseguestGrid.module.css'
 import './WinnerTileLiftAnimation.css'
 
 const MAX_CAPTURE_FRAMES = 24
@@ -27,6 +28,7 @@ interface LiftTarget {
   sourceRect: DOMRect
   returnRect: DOMRect
   tile: CeremonyTile
+  compact: boolean
 }
 
 const SOURCE_HIDE_PROPERTIES = [
@@ -233,6 +235,7 @@ export default function WinnerTileLiftAnimation({
             sourceRect,
             returnRect: sourceRect,
             tile: tiles[index] ?? tiles[0] ?? { rect: sourceRect },
+            compact: Boolean(source.closest(`.${rosterStyles.compact}`)),
           }
         })
         targetsRef.current = captured
@@ -322,21 +325,38 @@ export default function WinnerTileLiftAnimation({
             <div className="winner-tile-lift__glow" aria-hidden="true" />
             {(target.tile.badgeImageSrc || target.tile.badge) && (
               <div
-                className={`winner-tile-lift__badge ${
-                  badgeActive ? 'winner-tile-lift__badge--active' : ''
+                className={`${rosterStyles.badgeStack} winner-tile-lift__badge-stack ${
+                  target.compact ? rosterStyles.compact : ''
                 }`}
-                aria-label={target.tile.badgeLabel ?? `${target.tile.badge ?? 'Role'} badge`}
+                role="list"
               >
-                {target.tile.badgeImageSrc ? (
-                  <img
-                    className="ceremony-overlay__badge-image"
-                    src={target.tile.badgeImageSrc}
-                    alt=""
-                    aria-hidden="true"
-                  />
-                ) : (
-                  target.tile.badge
-                )}
+                <span
+                  className={[
+                    rosterStyles.statusBadge,
+                    target.tile.badgeCode
+                      ? (rosterStyles[`badge_${target.tile.badgeCode}`] ?? '')
+                      : '',
+                    target.tile.badgeVariant === 'cupid-kiss' ? rosterStyles.cupidPermanentLoh : '',
+                    target.tile.badgeVariant === 'cupid-hug' ? rosterStyles.cupidPermanentPos : '',
+                    'winner-tile-lift__badge',
+                    badgeActive ? 'winner-tile-lift__badge--active' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  role="listitem"
+                  aria-label={target.tile.badgeLabel ?? `${target.tile.badge ?? 'Role'} badge`}
+                >
+                  {target.tile.badgeImageSrc ? (
+                    <img
+                      className={`${rosterStyles.statusBadgeImage} ceremony-overlay__badge-image`}
+                      src={target.tile.badgeImageSrc}
+                      alt=""
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    target.tile.badge
+                  )}
+                </span>
               </div>
             )}
           </div>

--- a/src/screens/GameScreen/flows/useCompetitionFlow.ts
+++ b/src/screens/GameScreen/flows/useCompetitionFlow.ts
@@ -19,6 +19,7 @@ import { expandCupidIds, isCupidArrowActive } from '../../../features/twists/cup
 import { rankPressurePlankResults } from '../../../components/PressurePlank/pressurePlankLogic'
 
 const LOH_BADGE_SRC = statusBadgeImageSrc('loh')
+const POS_BADGE_SRC = statusBadgeImageSrc('pos')
 const EXITED_PLAYER_SORT_VALUE = Number.NEGATIVE_INFINITY
 
 interface UseCompetitionFlowOptions {
@@ -348,6 +349,13 @@ export function useCompetitionFlow({
           : isHohComp
             ? 'Leader of the House'
             : 'Power of Safety'
+      const winBadgeCode = isVoxFinalFourComp
+        ? undefined
+        : isVoxImmunityComp
+          ? 'immune'
+          : isHohComp
+            ? 'loh'
+            : 'pos'
 
       // Prefer the canonical winner already committed to the store by the
       // game's feature thunk.  storeRef gives the live Redux state — not
@@ -456,7 +464,8 @@ export function useCompetitionFlow({
       const winnerTileMetadata: CeremonyTile[] = winnerPlayers.map((winnerPlayer) => ({
         rect: null,
         badge: winSymbol,
-        badgeImageSrc: isHohComp && !isVoxComp ? LOH_BADGE_SRC : undefined,
+        badgeImageSrc: !isVoxComp ? (isHohComp ? LOH_BADGE_SRC : POS_BADGE_SRC) : undefined,
+        badgeCode: winBadgeCode,
         badgeVariant:
           !isVoxComp && isCupidArrowActive(game)
             ? isHohComp

--- a/tests/unit/gameScreen/animationHardening.contract.test.ts
+++ b/tests/unit/gameScreen/animationHardening.contract.test.ts
@@ -8,6 +8,7 @@ function ceremonySources() {
     'src/screens/GameScreen/flows/useCompetitionFlow.ts',
     'src/screens/GameScreen/flows/useLohFlow.ts',
     'src/screens/GameScreen/flows/useSafetyFlow.ts',
+    'src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation.tsx',
   ]
     .map((path) => readFileSync(resolve(process.cwd(), path), 'utf8'))
     .join('\n')
@@ -17,8 +18,8 @@ describe('GameScreen ceremony animation contracts', () => {
   it('re-measures LOH/POS winner, nomination, replacement, save, and public-save targets', () => {
     const source = ceremonySources()
 
-    expect(source).toContain('measureA: () => getTileRect(finalWinnerId)')
-    expect(source).toContain('measureA={pendingWinnerCeremony.measureA}')
+    expect(source).toContain('resolveTarget={getCeremonyTileElement}')
+    expect(source).toContain('const rect = target.source.getBoundingClientRect()')
     expect(source).toContain('layoutSignal={responsiveGameLayout.revision}')
     expect(source).toContain('resolveTiles={pendingReplacementCeremony.resolveTiles}')
     expect(source).toContain('resolveTiles={pendingSaveCeremony.resolveTiles}')

--- a/tests/winnerTileLift.animation.test.tsx
+++ b/tests/winnerTileLift.animation.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import WinnerTileLiftAnimation from '../src/components/WinnerTileLiftAnimation/WinnerTileLiftAnimation'
+import rosterStyles from '../src/components/HouseguestGrid/HouseguestGrid.module.css'
 
 describe('WinnerTileLiftAnimation', () => {
   let animationFrames: FrameRequestCallback[]
@@ -74,7 +75,11 @@ describe('WinnerTileLiftAnimation', () => {
 
     act(() => vi.advanceTimersByTime(520))
     expect(document.querySelector('[data-winner-tile-lift-phase="awarded"]')).not.toBeNull()
-    expect(document.querySelector('.winner-tile-lift__badge')?.textContent).toBe('👑')
+    const animatedBadge = document.querySelector<HTMLElement>('.winner-tile-lift__badge')
+    const animatedBadgeStack = document.querySelector<HTMLElement>('.winner-tile-lift__badge-stack')
+    expect(animatedBadge?.textContent).toBe('👑')
+    expect(animatedBadgeStack?.classList.contains(rosterStyles.badgeStack)).toBe(true)
+    expect(animatedBadge?.classList.contains(rosterStyles.statusBadge)).toBe(true)
 
     rect = new DOMRect(108, 226, 64, 64)
     act(() => vi.advanceTimersByTime(1720))
@@ -92,6 +97,41 @@ describe('WinnerTileLiftAnimation', () => {
     expect(source.style.getPropertyValue('content-visibility')).toBe('')
     expect(source.style.getPropertyValue('clip-path')).toBe('')
     expect(source.dataset.ceremonyTileLifted).toBeUndefined()
+  })
+
+  it('renders the same compact safety badge asset used by the permanent roster tile', () => {
+    const sourceContainer = document.createElement('div')
+    sourceContainer.className = rosterStyles.compact
+    const source = document.createElement('div')
+    source.textContent = 'Alice'
+    source.getBoundingClientRect = vi.fn(() => new DOMRect(22, 48, 72, 72))
+    sourceContainer.append(source)
+    document.body.append(sourceContainer)
+
+    render(
+      <WinnerTileLiftAnimation
+        targetIds={['alice']}
+        tiles={[
+          {
+            rect: null,
+            badge: '🛡️',
+            badgeCode: 'pos',
+            badgeImageSrc: '/assets/avatar_badges/safety_badge.svg',
+          },
+        ]}
+        caption="Alice wins Power of Safety!"
+        resolveTarget={() => source}
+        onDone={vi.fn()}
+      />
+    )
+
+    flushAnimationFrame()
+
+    const badgeImage = document.querySelector<HTMLImageElement>('.winner-tile-lift__badge img')
+    const badgeStack = document.querySelector<HTMLElement>('.winner-tile-lift__badge-stack')
+    expect(badgeImage?.src).toContain('/assets/avatar_badges/safety_badge.svg')
+    expect(badgeImage?.classList.contains(rosterStyles.statusBadgeImage)).toBe(true)
+    expect(badgeStack?.classList.contains(rosterStyles.compact)).toBe(true)
   })
 
   it('finishes safely when the roster tile never becomes measurable', () => {


### PR DESCRIPTION
## Summary
- position lifted LOH/POS winner badges in the same top-left stack used by roster tiles
- reuse the roster's permanent badge and image classes, including compact-mode and Cupid styling
- animate the POS safety asset instead of a differently shaped emoji treatment
- refresh the animation hardening contract for the lifted-tile architecture

## Verification
- 23 focused winner/spotlight/integration tests
- TypeScript typecheck
- changed-file ESLint
- changed-file formatting gate
- Android production build
- iOS production build